### PR TITLE
Fixing "See full details" link in Product View

### DIFF
--- a/packages/pwa/app/hooks/use-product-view-modal.js
+++ b/packages/pwa/app/hooks/use-product-view-modal.js
@@ -15,7 +15,6 @@ import {API_ERROR_MESSAGE} from '../pages/account/constant'
  * This hooks is responsible for fetching a product detail based on the variation selection
  * and managing the variation params on the url when the modal is open/close
  * @param initialProduct - the initial product when the modal is first open
- * @param isNavigating {React.MutableRefObject<undefined>} - the flag to navigate user to other page
  * @returns object
  */
 export const useProductViewModal = (initialProduct) => {


### PR DESCRIPTION
The bug: Clicking on "See full details" from `ProductView` does not navigate to a PDP

The root cause:
Inside product view modal hook, when the modal is unmounted, it will do a [clean up work](https://github.com/SalesforceCommerceCloud/pwa-kit/compare/fix/product-view-full-link?expand=1#diff-944201717cde0b986112709b021b976fb57385fe5f1e5057d421e2128dd74553R30) to remove all the url params related to current product view. When the user click on "See full details", it does direct the user to the PDP, but since useEffect is asynchronous, the `cleanUpVariantParams` will run after that and replace the url back to its previous page. 

Solution: We need to a logic to detect whether the user is navigating to a different page. If yes, there is  no need to run the clean up function. 

 **JIRA**: https://gus.lightning.force.com/a07AH000000TPbXYAW
 **Linked PRs**: (links to corresponding PRs, optional)

## How to test-drive this PR
- `npm start`
- Add an item to cart
- Go to cart page
- Click edit an cart item
- Click on "See full details"
- You should be directed to PDP page

## Changes
- use-product-view-modal.js

## Todos

### General
- [ ] Add a high-level description of your changes to relevant CHANGELOG.md files (**not** required for doc updates)
- [ ] The code changes are covered by test cases
- [ ] Analytics events instrumented to measure impact of change

### Backwards Compatibility
- [ ] This PR contains no breaking changes or breaking changes have been approved by Product Management/Engineering as necessary.

> Breaking changes include:
> * Removing a public function/Component/Prop
> * Adding required arguments to functions
> * Changing the data-types of function params or return values

### Accessibility Compliance
You must check off all items in **one** of the follow two lists:
- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

### Documentation

- [ ] If you've updated documentation, have someone review it using the [documentation reviewer's checklist](https://docs.google.com/document/d/1m3hn7EaGVnkb9yDqj_WdiJ9sgnGtx6DESOXoonzd8uE/edit)

> Documentation and comments should follow the [Mobify Content Style Guide](https://docs.google.com/a/mobify.me/document/d/1jlcg5boC3MUHN7fy2n3Yu_FBGzGgTUPrnMoePzQtqE4/edit?usp=sharing) and [Mobify's Capitalization and Spelling List](https://docs.google.com/document/d/1LO7RAr2vD3LFs_bj5j0vIFMKsVFrOFfEjpCheYEH3Lg/edit?usp=sharing)
