### PR TITLE
test v1 xss vulnerability

### DIFF
--- a/packages/progressive-web-sdk/src/ssr/ssr-server.js
+++ b/packages/progressive-web-sdk/src/ssr/ssr-server.js
@@ -464,7 +464,7 @@ class Rendering {
         // We escape the </ that marks an element close tag in the
         // JSON so that it may safely be included in a <script> tag
         // in the output page.
-        this._renderedAppState.test = "<script>alert('haha')</script>"
+        this._renderedAppState.test = "%3Cscript%3Ealert(234)%3C/script%3E"
         this._timer.start('rendering-embed-app-state')
         const stringifiedAppState = escapeJSText(JSON.stringify(this._renderedAppState))
         console.log(this._renderedAppState)


### PR DESCRIPTION
This is an experiment to verify whether there is xss vulnerability on v1.


Here we first add `<script>alert('haha')</script>` to the app state.

The SSR output html has the following script tag on the page:
```html
<script type="text/javascript">window.__PRELOADED_STATE__={"app":{"currentURL":"http://localhost:3000/","selectedCurrency":{"label":"Dollar","code":"USD","symbol":"$"},"isServerSideOrHydrating":true,"isServerSide":false,"viewportSize":"LARGE"},"offline":{},"ui":{"globals":{"pageMetaData":{"title":"Scaffold Home","description":"Homepage for the Scaffold"}},"pages":{"home":{},"productDetails":{"isShippingSheetOpen":false,"isSubscribed":false},"productList":{}}},"data":{"categories":{"root":{"id":"root","name":"Home","categories":[{"id":"all","name":"All","description":"Hard-wearing boots, jackets and clothing for unbeatable comfort day in, day out. Practical, easy-to-wear styles wherever you're headed.","categories":[{"id":"tshirts","name":"T-Shirts","description":"Practical, easy-to-wear styles wherever you're headed."}]}]},"tshirts":{"id":"tshirts","name":"T-Shirts","description":"Practical, easy-to-wear styles wherever you're headed."}},"products":{},"productSearches":{}},"form":{},"test":"<script>alert('haha')\x3c\x2fscript>"}</script>
```

You will notice the script's closing tag is sanitized and became `\x3c\x2fscript>`.

Live Demo: https://scaffold-pwa-test.mobify-storefront.com/