### PR TITLE
Use SLAS for Guest Login on Server-Side - Ben's Version

### DIFF
--- a/packages/pwa-kit-react-sdk/src/webpack/config.js
+++ b/packages/pwa-kit-react-sdk/src/webpack/config.js
@@ -171,8 +171,7 @@ const common = {
             process: 'process/browser'
         },
         fallback: {
-            crypto: require.resolve('crypto-browserify'),
-            stream: require.resolve('stream-browserify')
+            crypto: false
         }
     },
 

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -5,12 +5,7 @@
 /* eslint-disable no-unused-vars */
 import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
 import {HTTPError} from 'pwa-kit-react-sdk/ssr/universal/errors'
-import {
-    createCodeVerifier,
-    generateCodeChallenge,
-    createCodeVerifierServer,
-    generateCodeChallengeServer
-} from './pkce'
+import {createCodeVerifier, generateCodeChallenge} from './pkce'
 import {createGetTokenBody} from './utils'
 
 /**
@@ -241,10 +236,8 @@ class Auth {
      * @returns {object} - a guest customer object
      */
     async _loginAsGuest() {
-        const codeVerifier = this._onClient ? createCodeVerifier() : createCodeVerifierServer()
-        const codeChallenge = this._onClient
-            ? await generateCodeChallenge(codeVerifier)
-            : await generateCodeChallengeServer(codeVerifier)
+        const codeVerifier = createCodeVerifier()
+        const codeChallenge = await generateCodeChallenge(codeVerifier)
 
         if (this._onClient) {
             sessionStorage.setItem('codeVerifier', codeVerifier)

--- a/packages/pwa/app/commerce-api/pkce.js
+++ b/packages/pwa/app/commerce-api/pkce.js
@@ -5,37 +5,44 @@ import {nanoid} from 'nanoid'
 import {encode as base64encode} from 'base64-arraybuffer'
 
 // Server Side
-const crypto = require('crypto')
 const randomstring = require('randomstring')
-// This needs to be defined or the browser will complain
 
-import * as Buffer from 'Buffer' // eslint-disable-line
+// Globals
+const isServer = typeof window === 'undefined'
 
-// Creates Code Verifier
-export const createCodeVerifier = () => nanoid(128)
+/**
+ * Creates Code Verifier use for PKCE auth flow.
+ *
+ * @returns {String} The 128 character length code verifier.
+ */
+export const createCodeVerifier = () => {
+    return isServer ? randomstring.generate(128) : nanoid(128)
+}
 
-// Creates Code Challenge based on Code Verifier
+/**
+ * Creates Code Challenge based on Code Verifier
+ *
+ * @param {String} codeVerifier
+ * @returns {String}
+ */
 export const generateCodeChallenge = async (codeVerifier) => {
-    const encoder = new TextEncoder()
-    const data = encoder.encode(codeVerifier)
-    const digest = await window.crypto.subtle.digest('SHA-256', data)
-    const base64Digest = base64encode(digest)
-    // you can extract this replacing code to a function
-    return base64Digest
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=/g, '')
-}
+    let base64Digest
 
-export const createCodeVerifierServer = () => {
-    return randomstring.generate(128)
-}
+    if (isServer) {
+        await import('crypto').then((module) => {
+            const crypto = module.default
+            base64Digest = crypto
+                .createHash('sha256')
+                .update(codeVerifier)
+                .digest('base64')
+        })
+    } else {
+        const encoder = new TextEncoder()
+        const data = encoder.encode(codeVerifier)
+        const digest = await window.crypto.subtle.digest('SHA-256', data)
 
-export const generateCodeChallengeServer = async (codeVerifier) => {
-    const base64Digest = crypto
-        .createHash('sha256')
-        .update(codeVerifier)
-        .digest('base64')
+        base64Digest = base64encode(digest)
+    }
 
     return base64Digest
         .replace(/\+/g, '-')


### PR DESCRIPTION
Hey @jkeanesf here is my take on this PR. Let me know how things look to you. This is probably the best option going forward, aside from using the client server secret flow. 

So what I changed. 

When you imported `crypto` for the first time when implementing the server side function I'm sure webpack yelled at you a little and told you to use a fallback. This probably lead you down the wrong path if you didn't read the entire warning. Closer to the end, it says something like "if you don't want to have a fallback simply use the value `false`".  And in our case this is exactly what we want to do. We don't want to use the `crypto-browserify` library because it's huge (+200kb to our vendor.js file). We are also only using `crypto-browserify` on the server only, which is weird. It probably has an internal switch to use node cryto if its on the server anyway. 

So, what did I do. Well, since we aren't using `crypto-browserify` on the browser and we are providing our own implementation for verifier and challenge functions it give use the opportunity to simple not use a fallback. So thats what I did. On top of that, I made the verifier/challenge functions isomophic, and doing so, meant that if we are on the server I can simply dynamically import nodes `crypto` library and use it's function. But when we are on the client, we don't change anything and use the same function we were using before.

What does this mean? Well we didn't increase the bundle side at all and things just work without many code changes.

I by no means tested this thoroughly, so if you want to take it for a spin let me know how she drives and we can talk after that.




 **Linked PRs**: #35 

## How to test-drive this PR
- (step1)

## Changes
- (change1)
