### PR TITLE
Create `noop` for CommerceAPI Utils

### DIFF
--- a/packages/pwa/app/commerce-api/utils.js
+++ b/packages/pwa/app/commerce-api/utils.js
@@ -291,3 +291,11 @@ export const isError = (jsonResponse) => {
 export const convertSnakeCaseToSentenceCase = (text) => {
     return text.split('_').join(' ')
 }
+
+/**
+ * No operation function. You can use this
+ * empty function when you wish to pass
+ * around a function that will do nothing.
+ * Usually used as default for event handlers.
+ */
+export const noop = () => {}


### PR DESCRIPTION
Small bug in one of the hooks referencing the `noop` function what is in the app utils file. I decided to duplicate the noop function and place it in the commerce-api utils file as we are trying to keep that part of the code contained for future refactors.

 **GUS**: None
 **Linked PRs**: None