### PR TITLE
fix slow tests that caused time out

### DIFF
--- a/packages/pwa/app/pages/cart/index.test.js
+++ b/packages/pwa/app/pages/cart/index.test.js
@@ -197,9 +197,8 @@ test('Can update item quantity from product view modal', async () => {
     expect(within(cartItem).getByRole('combobox')).toHaveValue('2')
     const editCartButton = within(cartItem).getByRole('button', {name: 'Edit'})
     userEvent.click(editCartButton)
-    const productView = await screen.findByTestId('product-view')
+    const productView = screen.getByTestId('product-view')
     expect(productView).toBeInTheDocument()
-
     // update item quantity
     userEvent.selectOptions(within(productView).getByRole('combobox'), ['3'])
     userEvent.click(within(productView).getAllByText(/Update/)[0])


### PR DESCRIPTION
This PR fixed the failed test due to timeout on cart page. 

The problem: using `findByTestId` is incorrect in this case since the open the modal isn't async. This will cause the increase in running the test, which cause the test to timeout
Solution: using `getByTestId` which isn't async should fix it