### PR TITLE
Fix Empty Image Gallery for Certain Products

### DIFF
--- a/packages/pwa/app/components/add-to-cart-modal/index.jsx
+++ b/packages/pwa/app/components/add-to-cart-modal/index.jsx
@@ -42,7 +42,7 @@ const AddToCartModal = ({product, variant, quantity, isOpen, onClose, ...props})
     const lineItemPrice =
         productItems?.find((item) => item.productId === productId)?.basePrice * quantity
     const image = findImageGroupBy(product.imageGroups, {
-        size: 'small',
+        viewType: 'small',
         selectedVariationAttributes: variationValues
     })?.images?.[0]
 

--- a/packages/pwa/app/components/cart-item-variant/item-image.jsx
+++ b/packages/pwa/app/components/cart-item-variant/item-image.jsx
@@ -24,7 +24,7 @@ const ItemImage = ({imageProps, ratio = 1, ...props}) => {
 
     // We find the 'small' images in the variant's image groups based on variationValues and pick the first one
     const image = findImageGroupBy(variant?.imageGroups, {
-        size: 'small',
+        viewType: 'small',
         selectedVariationAttributes: variant?.variationValues
     })?.images?.[0]
 

--- a/packages/pwa/app/components/image-gallery/index.jsx
+++ b/packages/pwa/app/components/image-gallery/index.jsx
@@ -71,7 +71,7 @@ const ImageGallery = ({imageGroups = [], selectedVariationAttributes = {}, size}
     const heroImageGroup = useMemo(
         () =>
             findImageGroupBy(imageGroups, {
-                size: LARGE,
+                viewType: LARGE,
                 selectedVariationAttributes
             }),
         [selectedVariationAttributes]
@@ -88,7 +88,7 @@ const ImageGallery = ({imageGroups = [], selectedVariationAttributes = {}, size}
     const thumbnailImageGroup = useMemo(
         () =>
             findImageGroupBy(imageGroups, {
-                size: SMALL,
+                viewType: SMALL,
                 selectedVariationAttributes
             }),
         [selectedVariationAttributes]

--- a/packages/pwa/app/utils/image-groups-utils.js
+++ b/packages/pwa/app/utils/image-groups-utils.js
@@ -15,10 +15,12 @@
  * @returns {Object} - The ImageGroup matching the search criteria
  */
 export const findImageGroupBy = (imageGroups = [], options) => {
-    let {size, selectedVariationAttributes = {}} = options
+    let {viewType, selectedVariationAttributes = {}} = options
 
     // Start by filtering out any imageGroup that isn't the correct viewType.
-    imageGroups = imageGroups.filter(({viewType}) => viewType === size)
+    imageGroups = imageGroups.filter(
+        ({viewType: imageGroupViewType}) => imageGroupViewType === viewType
+    )
 
     // Not all variation attributes are reflected in images. For example, you probably
     // won't have a separate image group for various sizes, but you might for colors. For that

--- a/packages/pwa/app/utils/image-groups-utils.test.js
+++ b/packages/pwa/app/utils/image-groups-utils.test.js
@@ -12,17 +12,17 @@ it.each([undefined, []])('returns undefined', (groups) => {
 })
 
 test('returns undefined for image groups with no size match', () => {
-    expect(findImageGroupBy([{viewType: 'small'}], {size: 'large'})).toBeUndefined()
+    expect(findImageGroupBy([{viewType: 'small'}], {viewType: 'large'})).toBeUndefined()
 })
 
 test('returns first match for image groups with no variationAttributes', () => {
     const groups = [{viewType: 'small'}]
-    expect(findImageGroupBy(groups, {size: 'small'})).toBe(groups[0])
+    expect(findImageGroupBy(groups, {viewType: 'small'})).toBe(groups[0])
 })
 
 test('returns first match for image groups with empty variationAttributes', () => {
     const groups = [{viewType: 'small', variationAttributes: []}]
-    expect(findImageGroupBy(groups, {size: 'small'})).toBe(groups[0])
+    expect(findImageGroupBy(groups, {viewType: 'small'})).toBe(groups[0])
 })
 
 test('returns first match for image groups with no selectedVariationAttributes', () => {
@@ -41,7 +41,7 @@ test('returns first match for image groups with no selectedVariationAttributes',
             ]
         }
     ]
-    expect(findImageGroupBy(groups, {size: 'small'})).toBe(groups[0])
+    expect(findImageGroupBy(groups, {viewType: 'small'})).toBe(groups[0])
 })
 
 test('returns first match for image groups with matching selectedVariationAttributes', () => {
@@ -59,7 +59,7 @@ test('returns first match for image groups with matching selectedVariationAttrib
             variationAttributes: [variation]
         }
     ]
-    expect(findImageGroupBy(groups, {size: 'small', selectedVariationValues: variation})).toBe(
+    expect(findImageGroupBy(groups, {viewType: 'small', selectedVariationValues: variation})).toBe(
         groups[0]
     )
 })


### PR DESCRIPTION
## Problem

When viewing specific products on the retail react app, making variation attribute selections sometimes causes the Image Gallery component to not display images. The root of this issue lies in the data processing for a given products image groups. When selecting attributes that don't have representation in the form of a image group those extra attributes causes the image group filtering to be too aggressive, resulting in not finding a matched image group.

The simple explanation is that any product attribute has the potential to be assigned to an image group, but in reality this isn't always the case. You wouldn't have a different image set for different size values, but technically you could. So we need to account for this.

## Solution

The solution is simple to explain, but gets a little difficult to implement. The idea it to find the image group what matched the search criteria. If I say I want the "small" images with color "black", I get that image group, but if I pass in the viewType "small", color "black" and size "L" I don't want to use the size criteria, because it's not represented in any of the groups.

So before I search I first get a list of what attributes are represented in the groups and ensure I can only search with those.

 **GUS**: [W-9676503](https://gus.lightning.force.com/lightning/_classic/%2Fa07AH000000SZjDYAW)
 **Linked PRs**: None

## How to test-drive this PR
- Run PWA
- View this product (http://localhost:3000/en/product/apple-ipod-touchM)
- Ensure that selecting a memory size doesn't effect the image gallery.

## Changes
- Fix and rename the `filterImageGroups` function.
