### PR TITLE
Fix swatches for different locales

### DIFF
--- a/packages/pwa/app/pages/product-list/partials/color-refinements.jsx
+++ b/packages/pwa/app/pages/product-list/partials/color-refinements.jsx
@@ -66,7 +66,8 @@ const ColorRefinements = ({filter, toggleFilter, selectedFilters}) => {
                                                 cssColorGroups[value.presentationId.toLowerCase()]
                                             }
                                             background={
-                                                value.presentationId.toLowerCase() === 'miscellaneous' &&
+                                                value.presentationId.toLowerCase() ===
+                                                    'miscellaneous' &&
                                                 cssColorGroups[value.presentationId.toLowerCase()]
                                             }
                                         />


### PR DESCRIPTION
presentationId stays the same across all locales

 **GUS**: (https://gus.my.salesforce.com/a07EE00000323eWYAQ)

## How to test-drive this PR
- Checkout and run
- Confirm the swatch colors in PLP filters are displayed correctly across locales
- If locale work hasn't been merged, make sure they still work on the default

## Changes
- Change `value` to `presentationId`


