### PR TITLE
Add `REFINEMENT_DISALLOW_LIST` for PLP

### DIFF
--- a/packages/pwa/app/pages/product-list/index.jsx
+++ b/packages/pwa/app/pages/product-list/index.jsx
@@ -66,6 +66,10 @@ import useNavigation from '../../hooks/use-navigation'
 import LoadingSpinner from '../../components/loading-spinner'
 import {API_ERROR_MESSAGE} from '../../constants'
 
+// NOTE: You can ignore certain refinements on a template level by updating the below
+// list of ignored refinements.
+const REFINEMENT_DISALLOW_LIST = ['c_isNew']
+
 /*
  * This is a simple product listing page. It displays a paginated list
  * of product hit objects. Allowing for sorting and filtering based on the
@@ -609,6 +613,11 @@ ProductList.getProps = async ({res, params, location, api}) => {
             parameters: searchParams
         })
     ])
+
+    // Apply disallow list to refinements.
+    productSearchResult.refinements = productSearchResult.refinements.filter(
+        ({attributeId}) => !REFINEMENT_DISALLOW_LIST.includes(attributeId)
+    )
 
     // The `isomorphic-sdk` returns error objects when they occur, so we
     // need to check the category type and throw if required.


### PR DESCRIPTION
As a result of GA testing we noticed that the `isNew` refinement isn't working or displaying as intended. This PR adds a generic way to globally ignore certain refinements for the PLP template to get around showing the `isNew` refinement. In the future we'll refactor that page and ensure all types of refinements work. 