### PR TITLE
Ensure generated projects ship with a working .gitignore file

### DIFF
--- a/packages/pwa-kit-create-app/.eslintignore
+++ b/packages/pwa-kit-create-app/.eslintignore
@@ -1,1 +1,0 @@
-template

--- a/packages/pwa-kit-create-app/.gitignore
+++ b/packages/pwa-kit-create-app/.gitignore
@@ -1,5 +1,4 @@
 generated-project
 local-npm-repo/storage
-template
-template-hello-world
+templates
 node_modules

--- a/packages/pwa-kit-create-app/package-lock.json
+++ b/packages/pwa-kit-create-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-create-app",
-	"version": "1.1.0-dev",
+	"version": "0.11.0-dev",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -3870,6 +3870,11 @@
 				}
 			}
 		},
+		"chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+		},
 		"ci-info": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -5938,6 +5943,14 @@
 				"graceful-fs": "^4.1.2",
 				"jsonfile": "^4.0.0",
 				"universalify": "^0.1.0"
+			}
+		},
+		"fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"requires": {
+				"minipass": "^3.0.0"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -9429,6 +9442,23 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
+		"minipass": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+			"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
+		"minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"requires": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			}
+		},
 		"mixin-deep": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
@@ -11695,6 +11725,26 @@
 			"integrity": "sha1-KcNXB8K3DlDQdIK10gLo7URtr9Q=",
 			"dev": true
 		},
+		"tar": {
+			"version": "6.1.11",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+			"integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+			"requires": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^3.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				}
+			}
+		},
 		"terminal-link": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -12560,8 +12610,7 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "15.4.1",

--- a/packages/pwa-kit-create-app/package.json
+++ b/packages/pwa-kit-create-app/package.json
@@ -11,8 +11,7 @@
   "bin": "scripts/create-mobify-app.js",
   "files": [
     "assets",
-    "template",
-    "template-hello-world"
+    "templates"
   ],
   "scripts": {
     "prepare": "node scripts/build.js",
@@ -25,7 +24,8 @@
     "deepmerge": "2.2.1",
     "fs-extra": "7.0.1",
     "inquirer": "6.5.2",
-    "shelljs": "^0.8.4"
+    "shelljs": "^0.8.4",
+    "tar": "^6.1.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.4",

--- a/packages/pwa-kit-create-app/scripts/build.js
+++ b/packages/pwa-kit-create-app/scripts/build.js
@@ -8,19 +8,26 @@ const p = require('path')
 const sh = require('shelljs')
 const fs = require('fs')
 const os = require('os')
+const tar = require('tar')
 
 sh.set('-e')
 sh.config.silent = false
 
 const monorepoRoot = p.resolve(__dirname, '..', '..', '..')
-const templatePath = p.resolve(__dirname, '..', 'template')
-const helloWorldTemplatePath = p.resolve(__dirname, '..', 'template-hello-world')
+const templatesDir = p.resolve(__dirname, '..', 'templates')
 
 const mkdtempSync = () => fs.mkdtempSync(p.resolve(os.tmpdir(), 'pwa-template-tmp'))
 
+const tarPathForPkg = (pkg) => p.resolve(templatesDir, `${pkg}.tar.gz`)
+
 const main = () => {
-    sh.rm('-rf', templatePath)
-    sh.rm('-rf', helloWorldTemplatePath)
+    const pkgNames = ['pwa', 'hello-world']
+
+    if (!sh.test('-d', templatesDir)) {
+        sh.mkdir('-p', templatesDir)
+    }
+
+    sh.rm('-rf', pkgNames.map(tarPathForPkg))
 
     const tmpDir = mkdtempSync()
     const checkoutDir = p.join(tmpDir, 'mobify-platform-sdks')
@@ -30,9 +37,17 @@ const main = () => {
             `--depth=1 file://${monorepoRoot} ${checkoutDir}`
     )
 
-    sh.cp('-R', p.join(checkoutDir, 'packages', 'pwa'), templatePath)
-    sh.cp('-R', p.join(checkoutDir, 'packages', 'hello-world'), helloWorldTemplatePath)
-    sh.rm('-rf', tmpDir)
+    return Promise.all(
+        pkgNames.map((pkgName) =>
+            tar.c(
+                {
+                    file: tarPathForPkg(pkgName),
+                    cwd: p.join(checkoutDir, 'packages')
+                },
+                [pkgName]
+            )
+        )
+    ).then(() => sh.rm('-rf', tmpDir))
 }
 
 main()


### PR DESCRIPTION
 **Linked PRs**: https://github.com/SalesforceCommerceCloud/pwa-kit/pull/82

While reviewing https://github.com/SalesforceCommerceCloud/pwa-kit/pull/82, @kevinxh noticed that the new `hello-world` projects were generated without a valid `.gitignore` file. The issue isn't unique to the `hello-world` template. If you peek at Slack, you'll see comments about the issue going back quite a while.

## Prerequesites

We need to ship https://github.com/SalesforceCommerceCloud/pwa-kit/pull/93 first, which needs a quick re-review.

## Cause

The cause of the issue is that NPM appears to ignore certain files by default when you publish a package – `.gitignore` is a sensible thing to be excluded by default, since you can imagine every developer in the world forgetting to exclude it, and every NPM package on earth accidentally including one.

There doesn't seem to be a good way to tell NPM _"hey, I actually want you to upload this .gitgnore file, as an exception"_ – we've already done the config in `package.json` to include the right files in the published generator package.

The fix here is to `gzip` the project templates that we publish as part of the generator. That reliably gets around any NPM default excludes we might otherwise be unaware of, and ensures generated projects contain exactly the contents we expect, given what is in the monorepo.

## Testing

```
npm ci
cd packages/pwa-kit-create-app
GENERATOR_PRESET=test-project ./scripts/create-mobify-app-dev.js --outputDir /tmp/project
cd /tmp/project
ls -la 
```

Check that the `.gitignore` file exists and that the project works as normal.

## History

If you're curious, we didn't realize that this was happening for a long time. Before @adamraya set up a local NPM repository to test publishing issues locally, the issue wasn't often visible to us – local runs of the generator wouldn't 100% match the behaviour of the generator as published on the public NPM repos.