### PR TITLE
Don't ship checks for Salesforce copyright headers in generated projects

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+    root: true,
+    rules: {
+        'header/header': [
+            2,
+            'block',
+            [
+                '',
+                {
+                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
+                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
+                },
+                ' * All rights reserved.',
+                ' * SPDX-License-Identifier: BSD-3-Clause',
+                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
+                ' '
+            ]
+        ]
+    }
+}

--- a/packages/hello-world/.eslintrc.js
+++ b/packages/hello-world/.eslintrc.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 module.exports = {
-    root: true,
     parser: 'babel-eslint',
     parserOptions: {
         ecmaVersion: 2017,
@@ -28,21 +27,6 @@ module.exports = {
         }
     },
     rules: {
-        'header/header': [
-            2,
-            'block',
-            [
-                '',
-                {
-                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
-                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
-                },
-                ' * All rights reserved.',
-                ' * SPDX-License-Identifier: BSD-3-Clause',
-                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
-                ' '
-            ]
-        ],
         'prettier/prettier': ['error'],
         'no-console': 'off',
         'no-unused-vars': ['error', {ignoreRestSiblings: true}]

--- a/packages/pwa-kit-create-app/.eslintrc.js
+++ b/packages/pwa-kit-create-app/.eslintrc.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 module.exports = {
-    root: true,
     parser: 'babel-eslint',
     parserOptions: {
         ecmaVersion: 2017,
@@ -28,21 +27,6 @@ module.exports = {
         }
     },
     rules: {
-        'header/header': [
-            2,
-            'block',
-            [
-                '',
-                {
-                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
-                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
-                },
-                ' * All rights reserved.',
-                ' * SPDX-License-Identifier: BSD-3-Clause',
-                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
-                ' '
-            ]
-        ],
         'prettier/prettier': ['error'],
         'no-console': 'off',
         'no-unused-vars': ['error', {ignoreRestSiblings: true}]

--- a/packages/pwa-kit-react-sdk/.eslintrc.js
+++ b/packages/pwa-kit-react-sdk/.eslintrc.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 module.exports = {
-    root: true,
     parser: 'babel-eslint',
     parserOptions: {
         ecmaVersion: 2017,
@@ -28,21 +27,6 @@ module.exports = {
         }
     },
     rules: {
-        'header/header': [
-            2,
-            'block',
-            [
-                '',
-                {
-                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
-                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
-                },
-                ' * All rights reserved.',
-                ' * SPDX-License-Identifier: BSD-3-Clause',
-                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
-                ' '
-            ]
-        ],
         'prettier/prettier': ['error'],
         'no-console': 'off',
         'no-unused-vars': ['error', {ignoreRestSiblings: true}]

--- a/packages/pwa/.eslintrc.js
+++ b/packages/pwa/.eslintrc.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 module.exports = {
-    root: true,
     parser: 'babel-eslint',
     parserOptions: {
         ecmaVersion: 2017,
@@ -28,21 +27,6 @@ module.exports = {
         }
     },
     rules: {
-        'header/header': [
-            2,
-            'block',
-            [
-                '',
-                {
-                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
-                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
-                },
-                ' * All rights reserved.',
-                ' * SPDX-License-Identifier: BSD-3-Clause',
-                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
-                ' '
-            ]
-        ],
         'prettier/prettier': ['error'],
         'no-console': 'off',
         'no-unused-vars': ['error', {ignoreRestSiblings: true}]

--- a/scripts/assets/.eslintrc.js
+++ b/scripts/assets/.eslintrc.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 module.exports = {
-    root: true,
     parser: 'babel-eslint',
     parserOptions: {
         ecmaVersion: 2017,
@@ -28,21 +27,6 @@ module.exports = {
         }
     },
     rules: {
-        'header/header': [
-            2,
-            'block',
-            [
-                '',
-                {
-                    pattern: '^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$',
-                    template: ' * Copyright (c) 2021, salesforce.com, inc.'
-                },
-                ' * All rights reserved.',
-                ' * SPDX-License-Identifier: BSD-3-Clause',
-                ' * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause',
-                ' '
-            ]
-        ],
         'prettier/prettier': ['error'],
         'no-console': 'off',
         'no-unused-vars': ['error', {ignoreRestSiblings: true}]


### PR DESCRIPTION
# Description

Our project templates include an `eslint` config that is generally good and useful! I think we recently added a config that checks that all of our JS files have a Salesforce copyright header, which I think makes sense for us, too. That being said, if I were a customer running my own business, I probably wouldn't want to add a Salesforce copyright header to new files that I add to my own project. I think here we have accidentally let a default setting in that makes sense for us, but not users.

# Types of Changes

- Move the eslint config for copyrights to the root of the repo so that (1) we continue to check our own work for copyright headers, but (2) users have this check turned off as soon as a project is generated.
- This works because the shared config exists at the root of the monorepo, but when a project is generated it is taken _out_ of the monorepo and away from the inherited config file!

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)



# How to Test-Drive This PR

- Generate a project
- Add a new, empty, JS file
- Run `npm lint`. You should see errors.

Compare with:

- Add a new, empty JS file to the pwa in the monorepo.
- Run `npm lint`. You should see the copyright error.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
