### PR TITLE
[Localization] locale selector's messages

### DIFF
--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -35,7 +35,7 @@ import useCustomer from '../../commerce-api/hooks/useCustomer'
 import {AuthModal, useAuthModal} from '../../hooks/use-auth-modal'
 
 // Localization
-import {defineMessages, IntlProvider} from 'react-intl'
+import {IntlProvider} from 'react-intl'
 
 // Others
 import {watchOnlineStatus, flatten} from '../../utils/utils'
@@ -48,21 +48,6 @@ import useWishlist from '../../hooks/use-wishlist'
 
 const DEFAULT_NAV_DEPTH = 3
 const DEFAULT_ROOT_CATEGORY = 'root'
-
-/**
- *  Default messages for the supported locales.
- *  NOTE: Because the messages are statically analyzed, we have to maintain the list of locales asynchronously
- *  to those in the package.json.
- *  `locale` parameter format for OCAPI and Commerce API: <language code>-<country code>
- *  https://documentation.b2c.commercecloud.salesforce.com/DOC1/topic/com.demandware.dochelp/OCAPI/current/usage/Localization.html
- *  */
-export const defaultLocaleMessages = defineMessages({
-    'en-GB': {defaultMessage: 'English (United Kingdom)'},
-    'fr-FR': {defaultMessage: 'French (France)'},
-    'it-IT': {defaultMessage: 'Italian (Italy)'},
-    'zh-CN': {defaultMessage: 'Chinese (China)'},
-    'ja-JP': {defaultMessage: 'Japanese (Japan)'}
-})
 
 const App = (props) => {
     const {children, targetLocale, defaultLocale, messages, categories: allCategories = {}} = props
@@ -275,9 +260,9 @@ App.getProps = async ({api}) => {
         const message =
             rootCategory.title === 'Unsupported Locale'
                 ? `
-                
+
 🚫 This page isn’t working.
-It looks like the locale ‘${rootCategory.locale}’ hasn’t been set up, yet. 
+It looks like the locale ‘${rootCategory.locale}’ hasn’t been set up, yet.
 You can either follow this doc, https://sfdc.co/B4Z1m to enable it in business manager or define a different locale with the instructions for Localization in the README file.
 `
                 : rootCategory.detail

--- a/packages/pwa/app/components/footer/index.jsx
+++ b/packages/pwa/app/components/footer/index.jsx
@@ -27,7 +27,7 @@ import {useIntl} from 'react-intl'
 import LinksList from '../links-list'
 import SocialIcons from '../social-icons'
 import {HideOnDesktop, HideOnMobile} from '../responsive'
-import {localeSelectorMessages} from '../../constants'
+import {LOCALE_SELECTOR_MESSSAGES} from '../../constants'
 import {SUPPORTED_LOCALES} from '../../constants'
 import {buildUrlLocale} from '../../utils/url'
 
@@ -136,7 +136,7 @@ const Footer = ({...otherProps}) => {
                             >
                                 {SUPPORTED_LOCALES.map((locale) => (
                                     <option key={locale} value={locale}>
-                                        {intl.formatMessage(localeSelectorMessages[locale])}
+                                        {intl.formatMessage(LOCALE_SELECTOR_MESSSAGES[locale])}
                                     </option>
                                 ))}
                             </Select>

--- a/packages/pwa/app/components/footer/index.jsx
+++ b/packages/pwa/app/components/footer/index.jsx
@@ -27,7 +27,7 @@ import {useIntl} from 'react-intl'
 import LinksList from '../links-list'
 import SocialIcons from '../social-icons'
 import {HideOnDesktop, HideOnMobile} from '../responsive'
-import {defaultLocaleMessages} from '../_app'
+import {localeSelectorMessages} from '../../constants'
 import {SUPPORTED_LOCALES} from '../../constants'
 import {buildUrlLocale} from '../../utils/url'
 
@@ -136,7 +136,7 @@ const Footer = ({...otherProps}) => {
                             >
                                 {SUPPORTED_LOCALES.map((locale) => (
                                     <option key={locale} value={locale}>
-                                        {intl.formatMessage(defaultLocaleMessages[locale])}
+                                        {intl.formatMessage(localeSelectorMessages[locale])}
                                     </option>
                                 ))}
                             </Select>

--- a/packages/pwa/app/components/locale-selector/index.jsx
+++ b/packages/pwa/app/components/locale-selector/index.jsx
@@ -33,7 +33,7 @@ import {
     FlagJPIcon
 } from '../../components/icons'
 
-import {defaultLocaleMessages} from '../_app'
+import {localeSelectorMessages} from '../../constants'
 import {DEFAULT_LOCALE} from '../../constants'
 import {useIntl} from 'react-intl'
 
@@ -77,7 +77,7 @@ const LocaleSelector = ({
                                 {/* Display flag icon if one exists */}
                                 {flags[selectedLocale]}
                                 <Text {...styles.selectedText}>
-                                    {intl.formatMessage(defaultLocaleMessages[selectedLocale])}
+                                    {intl.formatMessage(localeSelectorMessages[selectedLocale])}
                                 </Text>
                             </AccordionButton>
                             <AccordionPanel>
@@ -94,7 +94,7 @@ const LocaleSelector = ({
                                                 {/* Locale name */}
                                                 <Text {...styles.optionText}>
                                                     {intl.formatMessage(
-                                                        defaultLocaleMessages[locale]
+                                                        localeSelectorMessages[locale]
                                                     )}
                                                 </Text>
 

--- a/packages/pwa/app/components/locale-selector/index.jsx
+++ b/packages/pwa/app/components/locale-selector/index.jsx
@@ -33,12 +33,13 @@ import {
     FlagJPIcon
 } from '../../components/icons'
 
-import {localeSelectorMessages} from '../../constants'
+import {LOCALE_SELECTOR_MESSSAGES} from '../../constants'
 import {DEFAULT_LOCALE} from '../../constants'
 import {useIntl} from 'react-intl'
 
 // NOTE: If you want to have flags shown next to a selectable locale, update this
 // mapping object with the short code as the key for the desired icon.
+// TODO: what to do with these icons?
 const flags = {
     'en-GB': <FlagGBIcon />,
     'fr-FR': <FlagFRIcon />,
@@ -77,7 +78,7 @@ const LocaleSelector = ({
                                 {/* Display flag icon if one exists */}
                                 {flags[selectedLocale]}
                                 <Text {...styles.selectedText}>
-                                    {intl.formatMessage(localeSelectorMessages[selectedLocale])}
+                                    {intl.formatMessage(LOCALE_SELECTOR_MESSSAGES[selectedLocale])}
                                 </Text>
                             </AccordionButton>
                             <AccordionPanel>
@@ -94,7 +95,7 @@ const LocaleSelector = ({
                                                 {/* Locale name */}
                                                 <Text {...styles.optionText}>
                                                     {intl.formatMessage(
-                                                        localeSelectorMessages[locale]
+                                                        LOCALE_SELECTOR_MESSSAGES[locale]
                                                     )}
                                                 </Text>
 

--- a/packages/pwa/app/constants.js
+++ b/packages/pwa/app/constants.js
@@ -6,6 +6,7 @@
  */
 
 import packageInfo from '../package.json'
+import {defineMessages} from 'react-intl'
 
 // Constants used in the used for product searching.
 export const DEFAULT_SEARCH_PARAMS = {limit: 25, offset: 0, sort: 'best-matches', refine: []}
@@ -48,5 +49,26 @@ export const HOME_HREF = '/'
 // TODO: You can update these locales in 'pwa/package.json' file
 export const SUPPORTED_LOCALES = packageInfo.l10n.supportedLocales
 export const DEFAULT_LOCALE = packageInfo.l10n.defaultLocale
+
+/**
+ *  Default messages for the supported locales.
+ *  NOTE: Because the messages are statically analyzed, we have to maintain the list of locales asynchronously
+ *  to those in the package.json.
+ *  `locale` parameter format for OCAPI and Commerce API: <language code>-<country code>
+ *  https://documentation.b2c.commercecloud.salesforce.com/DOC1/topic/com.demandware.dochelp/OCAPI/current/usage/Localization.html
+ *  */
+export const localeSelectorMessages = defineMessages({
+    'en-GB': {defaultMessage: 'English (United Kingdom)'},
+    'en-US': {defaultMessage: 'English (United States)'},
+    'en-CA': {defaultMessage: 'English (Canada)'},
+    'fr-FR': {defaultMessage: 'French (France)'},
+    'fr-CA': {defaultMessage: 'French (Canada)'},
+    'it-IT': {defaultMessage: 'Italian (Italy)'},
+    'zh-CN': {defaultMessage: 'Chinese (China)'},
+    'ja-JP': {defaultMessage: 'Japanese (Japan)'},
+    'nl-NL': {defaultMessage: 'Dutch (Netherlands)'},
+    'de-DE': {defaultMessage: 'German (Germany)'},
+    'es-ES': {defaultMessage: 'Spanish (Spain)'}
+})
 
 export const MAX_ORDER_QUANTITY = 10

--- a/packages/pwa/app/constants.js
+++ b/packages/pwa/app/constants.js
@@ -5,8 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import packageInfo from '../package.json'
-import {defineMessages} from 'react-intl'
+import {localizationConfig} from './localization.config'
 
 // Constants used in the used for product searching.
 export const DEFAULT_SEARCH_PARAMS = {limit: 25, offset: 0, sort: 'best-matches', refine: []}
@@ -46,29 +45,11 @@ export const API_ERROR_MESSAGE = 'Something went wrong. Try again!'
 
 export const HOME_HREF = '/'
 
-// TODO: You can update these locales in 'pwa/package.json' file
-export const SUPPORTED_LOCALES = packageInfo.l10n.supportedLocales
-export const DEFAULT_LOCALE = packageInfo.l10n.defaultLocale
-
-/**
- *  Default messages for the supported locales shown in the locale selector.
- *  NOTE: Because the messages are statically analyzed, we have to maintain the list of locales asynchronously
- *  to those in the package.json.
- *  `locale` parameter format for OCAPI and Commerce API: <language code>-<country code>
- *  https://documentation.b2c.commercecloud.salesforce.com/DOC1/topic/com.demandware.dochelp/OCAPI/current/usage/Localization.html
- *  */
-export const localeSelectorMessages = defineMessages({
-    'de-DE': {defaultMessage: 'German (Germany)'},
-    'en-CA': {defaultMessage: 'English (Canada)'},
-    'en-GB': {defaultMessage: 'English (United Kingdom)'},
-    'en-US': {defaultMessage: 'English (United States)'},
-    'es-ES': {defaultMessage: 'Spanish (Spain)'},
-    'fr-CA': {defaultMessage: 'French (Canada)'},
-    'fr-FR': {defaultMessage: 'French (France)'},
-    'it-IT': {defaultMessage: 'Italian (Italy)'},
-    'ja-JP': {defaultMessage: 'Japanese (Japan)'},
-    'nl-NL': {defaultMessage: 'Dutch (Netherlands)'},
-    'zh-CN': {defaultMessage: 'Chinese (China)'}
-})
+export const SUPPORTED_LOCALES = localizationConfig.supportedLocales.map((locale) => locale.id)
+export const DEFAULT_LOCALE = localizationConfig.defaultLocale
+export const LOCALE_SELECTOR_MESSSAGES = localizationConfig.supportedLocales.reduce(
+    (messages, locale) => ({...messages, [locale.id]: locale.message}),
+    {}
+)
 
 export const MAX_ORDER_QUANTITY = 10

--- a/packages/pwa/app/constants.js
+++ b/packages/pwa/app/constants.js
@@ -51,24 +51,24 @@ export const SUPPORTED_LOCALES = packageInfo.l10n.supportedLocales
 export const DEFAULT_LOCALE = packageInfo.l10n.defaultLocale
 
 /**
- *  Default messages for the supported locales.
+ *  Default messages for the supported locales shown in the locale selector.
  *  NOTE: Because the messages are statically analyzed, we have to maintain the list of locales asynchronously
  *  to those in the package.json.
  *  `locale` parameter format for OCAPI and Commerce API: <language code>-<country code>
  *  https://documentation.b2c.commercecloud.salesforce.com/DOC1/topic/com.demandware.dochelp/OCAPI/current/usage/Localization.html
  *  */
 export const localeSelectorMessages = defineMessages({
+    'de-DE': {defaultMessage: 'German (Germany)'},
+    'en-CA': {defaultMessage: 'English (Canada)'},
     'en-GB': {defaultMessage: 'English (United Kingdom)'},
     'en-US': {defaultMessage: 'English (United States)'},
-    'en-CA': {defaultMessage: 'English (Canada)'},
-    'fr-FR': {defaultMessage: 'French (France)'},
+    'es-ES': {defaultMessage: 'Spanish (Spain)'},
     'fr-CA': {defaultMessage: 'French (Canada)'},
+    'fr-FR': {defaultMessage: 'French (France)'},
     'it-IT': {defaultMessage: 'Italian (Italy)'},
-    'zh-CN': {defaultMessage: 'Chinese (China)'},
     'ja-JP': {defaultMessage: 'Japanese (Japan)'},
     'nl-NL': {defaultMessage: 'Dutch (Netherlands)'},
-    'de-DE': {defaultMessage: 'German (Germany)'},
-    'es-ES': {defaultMessage: 'Spanish (Spain)'}
+    'zh-CN': {defaultMessage: 'Chinese (China)'}
 })
 
 export const MAX_ORDER_QUANTITY = 10

--- a/packages/pwa/app/localization.config.js
+++ b/packages/pwa/app/localization.config.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {defineMessage} from 'react-intl'
+import packageJson from '../package.json'
+
+export const localizationConfig = {
+    defaultLocale: packageJson.l10n.defaultLocale,
+    supportedLocales: [
+        {
+            id: 'en-GB',
+            message: defineMessage({defaultMessage: 'English (United Kingdom)'})
+        },
+        {
+            id: 'fr-FR',
+            message: defineMessage({defaultMessage: 'French (France)'})
+        },
+        {
+            id: 'it-IT',
+            message: defineMessage({defaultMessage: 'Italian (Italy)'})
+        },
+        {
+            id: 'zh-CN',
+            message: defineMessage({defaultMessage: 'Chinese (China)'})
+        },
+        {
+            id: 'ja-JP',
+            message: defineMessage({defaultMessage: 'Japanese (Japan)'})
+        }
+    ]
+}

--- a/packages/pwa/app/localization.config.js
+++ b/packages/pwa/app/localization.config.js
@@ -8,6 +8,12 @@
 import {defineMessage} from 'react-intl'
 import packageJson from '../package.json'
 
+/**
+ * @property {string} defaultLocale
+ * @property {Object[]} supportedLocales
+ * @property {string} supportedLocales[].id - OCAPI and Commerce API require that id follows the format: <language code>-<country code>. See {@link https://documentation.b2c.commercecloud.salesforce.com/DOC1/topic/com.demandware.dochelp/OCAPI/current/usage/Localization.html}
+ * @property {Object} supportedLocales[].message - Translation object for your locale selector UI
+ */
 export const localizationConfig = {
     defaultLocale: packageJson.l10n.defaultLocale,
     supportedLocales: [

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -183,13 +183,6 @@
         "last 4 ChromeAndroid versions"
     ],
     "l10n": {
-        "supportedLocales": [
-            "en-GB",
-            "fr-FR",
-            "it-IT",
-            "zh-CN",
-            "ja-JP"
-        ],
         "defaultLocale": "en-GB"
     }
 }


### PR DESCRIPTION

# Description

For new developers, they might not be aware that adding a new locale or updating existing one would require making the same change elsewhere. There were 2 places where the supported locales were defined: one in package.json and another one in App (for locale selector UI's messages). An example of when a developer didn't know about the one in the App: https://salesforce-internal.slack.com/archives/C01JSFFE3HQ/p1631637341058900?thread_ts=1631581328.055000&cid=C01JSFFE3HQ

GUS ticket: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000008vKWsYAM/view

Initially, the ticket was asking for the locales in the App to be expanded so that it includes all of the typical common locales. But I think it would be better to refactor it such that there is only a _single_ place where you make updates to. 

My suggestion is to extract the localization config from package.json and move it into its own file. I'm thinking of mimicking the way we currently have config files for Einstein and Commerce API.

What do you think of that? Does it make sense to refactor the code in that way? Would it still satisfy the original intent of the ticket?

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
