### PR TITLE
Remove the `X-Powered-By` header

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.js
@@ -65,11 +65,7 @@ import {
     X_MOBIFY_REQUEST_CLASS
 } from '../../utils/ssr-proxying'
 
-const sdkVersion = pkg.version
-
 const SET_COOKIE = 'set-cookie'
-const X_POWERED_BY = 'x-powered-by'
-export const POWERED_BY = `Mobify ${sdkVersion}`
 
 const CACHE_CONTROL = 'cache-control'
 export const NO_CACHE = 'max-age=0, nocache, nostore, must-revalidate'
@@ -1239,20 +1235,11 @@ const setLocalAssetHeaders = (res, assetPath) => {
  * Set default headers on a response. The arguments to this function
  * are the same as those for the responseHook function.
  *
- * By default, this function sets the X-Powered-By to a value identifying
- * the SDK version and the X-Mobify-Request-Class (if and only if the
- * request has a defined class).
- *
  * @private
  */
 const setDefaultHeaders = (req, res) => {
-    // Override 'x-powered-by: express' header
-    res.set(X_POWERED_BY, POWERED_BY)
-
-    // If there's a requestClass, add an response header for it
     const requestClass = res.locals.requestClass
     if (requestClass) {
-        // If there's a requestClass, add an response header for it
         res.set(X_MOBIFY_REQUEST_CLASS, requestClass)
     }
 }
@@ -1369,7 +1356,6 @@ const serveServiceWorker = (req, res) => {
     // Serve the file, with a strong ETag
     res.set('etag', getHashForString(content))
     res.set(CONTENT_TYPE, 'application/javascript')
-    res.set(X_POWERED_BY, POWERED_BY)
     res.send(content)
 }
 
@@ -1405,6 +1391,7 @@ const errorHandlerMiddleware = (err, req, res, next) => {
 
 const createExpressApp = (options) => {
     const app = express()
+    app.disable('x-powered-by')
 
     const mixin = {
         options,

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.test.js
@@ -390,8 +390,8 @@ describe('SSRServer operation', () => {
         return request(app)
             .get('/')
             .expect(200)
-            .expect('x-powered-by', POWERED_BY)
             .then((res) => {
+                expect(res.headers['x-powered-by']).toBeUndefined()
                 expect(res.text).toBe(body)
                 expect(route).toHaveBeenCalled()
             })

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.test.js
@@ -22,7 +22,6 @@ jest.mock('../static/assets.json', () => mockStaticAssets, {virtual: true})
 const {
     RESOLVED_PROMISE,
     REMOTE_REQUIRED_ENV_VARS,
-    POWERED_BY,
     NO_CACHE,
     generateCacheKey,
     createApp,

--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## To be released
 
+-   Remove `x-powered-by` HTTP response header [#165](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/165)
 -   For search engine crawlers, add `hreflang` links to the current page's html [#137](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/137)
--   Use the preferred currency when switching locales. [#105](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/105) 
+-   Use the preferred currency when switching locales. [#105](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/105)
 -   Integrate wishlist with einstein recommended products. [#131](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/131)
 
 ## v1.1.0 (Sep 27, 2021)


### PR DESCRIPTION
By default, Express adds a `x-powered-by: Express` header to HTTP responses. We sort of override this, adding the version of the PWA Kit npm package to some routes:

```
$ curl -so/dev/null -D- 'https://pwa-kit.mobify-storefront.com' | grep 'x-powered-by'
x-powered-by: Mobify 1.2.0-dev

$ curl -so/dev/null -D- 'https://pwa-kit.mobify-storefront.com/favicon.ico' | grep 'x-powered-by'
x-powered-by: Express
```

We'd rather not leak this information.

https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000001tucLYAQ/view

# Types of Changes

- [x] **Bug fix**

# Changes

- Remove `x-powered-by` HTTP header from responses

# How to Test-Drive This PR

```sh
git checkout -t origin/remove-powered-by
npm start --prefix packages/pwa
```

Now double check that the header doesn't show up:

```sh
curl -so/dev/null -D- 'http://localhost:3000' | grep 'x-powered-by'
curl -so/dev/null -D- 'http://localhost:3000/favicon.ico' | grep 'x-powered-by'
```

# Checklists

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

- [x] There are no changes to UI