### PR TITLE
Fix Missing Locale Param for Commerce API Calls

### DIFF
--- a/packages/pwa/app/commerce-api/index.js
+++ b/packages/pwa/app/commerce-api/index.js
@@ -138,7 +138,7 @@ class CommerceAPI {
                                         : !!sendCurrency
 
                                     // Ensure we don't send the pseudo locale.
-                                    if (locale !== 'en-XB') {
+                                    if (locale === 'en-XB') {
                                         sendLocale = false
                                     }
 


### PR DESCRIPTION
## BUG

The locale param wasn't being sent to the server. This was a oversight when we refactored the logic for the commerce api and how it sends the currency and locale information. We had code like:

```
if (locale !== 'en-XB') {
    sendLocale = false
}
```

When it clearly should have been:

```
if (locale === 'en-XB') {
    sendLocale = false
}
```

We do this because the pseudo local short code if sent to the api will complain. 