### PR TITLE
[Proposal] Add new `getDerivedConfigFromRequest` API method

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
@@ -54,7 +54,7 @@ export const start = () => {
 
     // AppConfig.restore *must* come before getRoutes()
     AppConfig.restore(locals, window.__PRELOADED_STATE__.__STATE_MANAGEMENT_LIBRARY)
-    const routes = getRoutes(locals)
+    const routes = getRoutes(locals, window.__DERIVED_CONFIG__)
 
     // We need to tell the routeComponent HOC when the app is hydrating in order to
     // prevent pages from re-fetching data on the first client-side render. The
@@ -66,8 +66,7 @@ export const start = () => {
     // been warned.
     window.__HYDRATING__ = true
 
-    const WrappedApp = routeComponent(App, false, locals)
-    const WrappedAppConfig = routeComponent(AppConfig, false, locals)
+    const WrappedApp = routeComponent(App, false, locals, window.__DERIVED_CONFIG__)
 
     const error = window.__ERROR__
 
@@ -77,14 +76,14 @@ export const start = () => {
             ReactDOM.hydrate(
                 <Router>
                     <DeviceContext.Provider value={{type: window.__DEVICE_TYPE__}}>
-                        <WrappedAppConfig locals={locals}>
+                        <AppConfig locals={locals} derivedConfig={window.__DERIVED_CONFIG__}>
                             <Switch
                                 error={error}
                                 appState={window.__PRELOADED_STATE__}
                                 routes={routes}
                                 App={WrappedApp}
                             />
-                        </WrappedAppConfig>
+                        </AppConfig>
                     </DeviceContext.Provider>
                 </Router>,
                 rootEl,

--- a/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
@@ -67,6 +67,8 @@ export const start = () => {
     window.__HYDRATING__ = true
 
     const WrappedApp = routeComponent(App, false, locals)
+    const WrappedAppConfig = routeComponent(AppConfig, false, locals)
+
     const error = window.__ERROR__
 
     return Promise.resolve()
@@ -75,14 +77,14 @@ export const start = () => {
             ReactDOM.hydrate(
                 <Router>
                     <DeviceContext.Provider value={{type: window.__DEVICE_TYPE__}}>
-                        <AppConfig locals={locals}>
+                        <WrappedAppConfig locals={locals}>
                             <Switch
                                 error={error}
                                 appState={window.__PRELOADED_STATE__}
                                 routes={routes}
                                 App={WrappedApp}
                             />
-                        </AppConfig>
+                        </WrappedAppConfig>
                     </DeviceContext.Provider>
                 </Router>,
                 rootEl,

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/_app-config/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/_app-config/index.jsx
@@ -65,6 +65,22 @@ class AppConfig extends React.Component {
     }
 
     /**
+     * Returned pojo will be passed to the AppConfig component as a prop named
+     * `derivedConfig`. The intended purpose of this method is to provide a configuration
+     * object to be used by various provider components in the AppConfig.
+     *
+     * This is similar to `getProps` but will only be called once during rendering server-side
+     * and once during app start on the client.
+     *
+     * @param req - the request.
+     * @return {Object}
+     */
+    // eslint-disable-next-line no-unused-vars
+    static getDerivedConfigFromRequest(req) {
+        return {}
+    }
+
+    /**
      * This class is a React Component in order to provide this hook, which lets
      * you set up context Providers for a state-management library such as Redux.
      */

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/route-component/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/route-component/index.js
@@ -53,8 +53,8 @@ const withErrorHandling = (Wrapped) => {
  * route-config. It provides an interface, via static methods on React components,
  * that can be used to fetch data on the server and on the client, seamlessly.
  */
-export const routeComponent = (Wrapped, isPage, locals) => {
-    const extraArgs = AppConfig.extraGetPropsArgs(locals)
+export const routeComponent = (Wrapped, isPage, locals, derivedConfig = {}) => {
+    const extraArgs = AppConfig.extraGetPropsArgs(locals, derivedConfig)
 
     /* istanbul ignore next */
     const wrappedComponentName = Wrapped.displayName || Wrapped.name
@@ -409,11 +409,13 @@ export const routeComponent = (Wrapped, isPage, locals) => {
  *
  * @private
  */
-export const getRoutes = (locals) => {
+export const getRoutes = (locals, derivedConfig) => {
     const allRoutes = [...routes, {path: '*', component: Throw404}]
     return allRoutes.map(({component, ...rest}) => {
         return {
-            component: component ? routeComponent(component, true, locals) : component,
+            component: component
+                ? routeComponent(component, true, locals, derivedConfig)
+                : component,
             ...rest
         }
     })

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -273,9 +273,9 @@ App.getProps = async ({api}) => {
             // we can use it's value to load the correct messages for the application.
             // Take a look at the `app/components/_app-config` component on how the
             // preferred locale was derived.
-            const {locale} = api.getConfig()
+            // const {locale} = api.getConfig()
 
-            return [locale]
+            return ['en-GB']
         }
     })
 


### PR DESCRIPTION
# Description

This PR adds a new API method to the AppConfig component called `getDerivedConfigFromRequest`. The purpose of this method is to allow us to pass a derived configuration to any component (typically providers) defined in the PWA's `_app-config` definition. This method will have the request object as an argument so you can conditionally determine config values based on the information inside it (like the `originalURL`). 

This async method runs on the server and its return value will be frozen in HTML to be used on the client side (this is transparent to the end user). The object returned is made available to the `AppConfig` component as a property called `derivedConfig`. Additionally the resultant config object will be passed to the `AppConfig.extraGetPropsArgs` method where it can be used for any kind of argument initialization there.

This new method is essentially a slimmed down version of `getProps`.

This is not a breaking change, but does change the signature to the following methods by adding `derivedConfig` as an additional argument:

- getRoutes
- routeComponent
- extraGetPropsArgs

## Why `getDerivedConfgFromRequest` over `getProps`

- Adding `getProps` to the AppConfig component starts to blur the lines between with the App component, and there starts to be no obvious reason why those 2 can't be the same component.
- Also, making AppConfig a routeComponent brings a long other API methods like `shouldGetProps` which imply we might want the application to have a different configuration from one page to the next, which doesn't feel right.
- `getDerivedConfgFromRequest` is self explanatory and narrow in its focus, it allows you to define a derived config to be applied to components in the SDK.
- It also only happens one time, during in the application rendering on the server, on the client it will simply use it's frozen configuration state.
