### PR TITLE
[Localization] Fix regression on loading the correct translation file

### DIFF
--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   Enable adding wishlist item to the cart. [#158](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/158)
 -   Enabling pseudo locale now affects only the loading of the translation messages. The rest of the app still knows about English and the other locales. [#177](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/177)
 -   Allow individual Commerce API calls to pass in a different locale/currency and override the global value. [#177](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/177)
+-   Fix regression with loading the correct translation file
 
 ## v1.1.0 (Sep 27, 2021)
 

--- a/packages/pwa/app/components/_app-config/index.jsx
+++ b/packages/pwa/app/components/_app-config/index.jsx
@@ -48,7 +48,7 @@ const getLocale = (locals = {}) => {
     const {pathname} = new URL(`http://hostname${originalUrl}`)
     let shortCode = pathname.split('/')[1]
 
-    // Ensure that the locale is in the seported list, otherwise return the default.
+    // Ensure that the locale is in the supported list, otherwise return the default.
     shortCode = getSupportedLocales().includes(shortCode) ? shortCode : DEFAULT_LOCALE
 
     return shortCode

--- a/packages/pwa/app/components/_app-config/index.jsx
+++ b/packages/pwa/app/components/_app-config/index.jsx
@@ -22,7 +22,7 @@ import {
 import {commerceAPIConfig} from '../../commerce-api.config'
 import {einsteinAPIConfig} from '../../einstein-api.config'
 import {DEFAULT_LOCALE, DEFAULT_CURRENCY} from '../../constants'
-import {getPreferredCurrency, getSupportedLocales} from '../../utils/locale'
+import {getPreferredCurrency, getSupportedLocalesIds} from '../../utils/locale'
 
 const apiConfig = {
     ...commerceAPIConfig,
@@ -49,7 +49,7 @@ const getLocale = (locals = {}) => {
     let shortCode = pathname.split('/')[1]
 
     // Ensure that the locale is in the supported list, otherwise return the default.
-    shortCode = getSupportedLocales().includes(shortCode) ? shortCode : DEFAULT_LOCALE
+    shortCode = getSupportedLocalesIds().includes(shortCode) ? shortCode : DEFAULT_LOCALE
 
     return shortCode
 }

--- a/packages/pwa/app/components/_app-config/index.jsx
+++ b/packages/pwa/app/components/_app-config/index.jsx
@@ -21,8 +21,8 @@ import {
 } from '../../commerce-api/contexts'
 import {commerceAPIConfig} from '../../commerce-api.config'
 import {einsteinAPIConfig} from '../../einstein-api.config'
-import {DEFAULT_LOCALE, SUPPORTED_LOCALES, DEFAULT_CURRENCY} from '../../constants'
-import {getPreferredCurrency} from '../../utils/locale'
+import {DEFAULT_LOCALE, DEFAULT_CURRENCY} from '../../constants'
+import {getPreferredCurrency, getSupportedLocales} from '../../utils/locale'
 
 const apiConfig = {
     ...commerceAPIConfig,
@@ -49,9 +49,7 @@ const getLocale = (locals = {}) => {
     let shortCode = pathname.split('/')[1]
 
     // Ensure that the locale is in the seported list, otherwise return the default.
-    shortCode = SUPPORTED_LOCALES.find((locale) => locale.id === shortCode)
-        ? shortCode
-        : DEFAULT_LOCALE
+    shortCode = getSupportedLocales().includes(shortCode) ? shortCode : DEFAULT_LOCALE
 
     return shortCode
 }

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -42,8 +42,8 @@ import {IntlProvider} from 'react-intl'
 // Others
 import {watchOnlineStatus, flatten} from '../../utils/utils'
 import {homeUrlBuilder, getUrlWithLocale} from '../../utils/url'
-import {getLocaleConfig, getPreferredCurrency} from '../../utils/locale'
-import {DEFAULT_CURRENCY, HOME_HREF, SUPPORTED_LOCALES} from '../../constants'
+import {getLocaleConfig, getPreferredCurrency, getSupportedLocales} from '../../utils/locale'
+import {DEFAULT_CURRENCY, HOME_HREF} from '../../constants'
 
 import Seo from '../seo'
 import useWishlist from '../../hooks/use-wishlist'
@@ -163,12 +163,12 @@ const App = (props) => {
 
                             {/* Urls for all localized versions of this page (including current page)
                             For more details on hrefLang, see https://developers.google.com/search/docs/advanced/crawling/localized-versions */}
-                            {SUPPORTED_LOCALES.map((locale) => (
+                            {getSupportedLocales().map((locale) => (
                                 <link
                                     rel="alternate"
-                                    hrefLang={locale.id.toLowerCase()}
-                                    href={`${appOrigin}${getUrlWithLocale(locale.id, {location})}`}
-                                    key={locale.id}
+                                    hrefLang={locale.toLowerCase()}
+                                    href={`${appOrigin}${getUrlWithLocale(locale, {location})}`}
+                                    key={locale}
                                 />
                             ))}
                             {/* A general locale as fallback. For example: "en" if default locale is "en-GB" */}

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -42,7 +42,7 @@ import {IntlProvider} from 'react-intl'
 // Others
 import {watchOnlineStatus, flatten} from '../../utils/utils'
 import {homeUrlBuilder, getUrlWithLocale} from '../../utils/url'
-import {getLocaleConfig, getPreferredCurrency, getSupportedLocales} from '../../utils/locale'
+import {getLocaleConfig, getPreferredCurrency, getSupportedLocalesIds} from '../../utils/locale'
 import {DEFAULT_CURRENCY, HOME_HREF} from '../../constants'
 
 import Seo from '../seo'
@@ -163,7 +163,7 @@ const App = (props) => {
 
                             {/* Urls for all localized versions of this page (including current page)
                             For more details on hrefLang, see https://developers.google.com/search/docs/advanced/crawling/localized-versions */}
-                            {getSupportedLocales().map((locale) => (
+                            {getSupportedLocalesIds().map((locale) => (
                                 <link
                                     rel="alternate"
                                     hrefLang={locale.toLowerCase()}

--- a/packages/pwa/app/components/_app/index.test.js
+++ b/packages/pwa/app/components/_app/index.test.js
@@ -10,7 +10,8 @@ import {Helmet} from 'react-helmet'
 
 import App from './index.jsx'
 import {renderWithProviders} from '../../utils/test-utils'
-import {DEFAULT_LOCALE, SUPPORTED_LOCALES} from '../../constants'
+import {DEFAULT_LOCALE} from '../../constants'
+import {getSupportedLocales} from '../../utils/locale.js'
 
 let windowSpy
 
@@ -66,7 +67,7 @@ describe('App', () => {
         const hasGeneralLocale = ({hrefLang}) => hrefLang === DEFAULT_LOCALE.slice(0, 2)
 
         // `length + 2` because one for a general locale and the other with x-default value
-        expect(hreflangLinks.length).toBe(SUPPORTED_LOCALES.length + 2)
+        expect(hreflangLinks.length).toBe(getSupportedLocales().length + 2)
 
         expect(hreflangLinks.some((link) => hasGeneralLocale(link))).toBe(true)
         expect(hreflangLinks.some((link) => link.hrefLang === 'x-default')).toBe(true)

--- a/packages/pwa/app/components/_app/index.test.js
+++ b/packages/pwa/app/components/_app/index.test.js
@@ -11,7 +11,7 @@ import {Helmet} from 'react-helmet'
 import App from './index.jsx'
 import {renderWithProviders} from '../../utils/test-utils'
 import {DEFAULT_LOCALE} from '../../constants'
-import {getSupportedLocales} from '../../utils/locale.js'
+import {getSupportedLocalesIds} from '../../utils/locale.js'
 
 let windowSpy
 
@@ -67,7 +67,7 @@ describe('App', () => {
         const hasGeneralLocale = ({hrefLang}) => hrefLang === DEFAULT_LOCALE.slice(0, 2)
 
         // `length + 2` because one for a general locale and the other with x-default value
-        expect(hreflangLinks.length).toBe(getSupportedLocales().length + 2)
+        expect(hreflangLinks.length).toBe(getSupportedLocalesIds().length + 2)
 
         expect(hreflangLinks.some((link) => hasGeneralLocale(link))).toBe(true)
         expect(hreflangLinks.some((link) => link.hrefLang === 'x-default')).toBe(true)

--- a/packages/pwa/app/components/drawer-menu/index.jsx
+++ b/packages/pwa/app/components/drawer-menu/index.jsx
@@ -52,7 +52,7 @@ import useCustomer from '../../commerce-api/hooks/useCustomer'
 import LoadingSpinner from '../loading-spinner'
 
 import useNavigation from '../../hooks/use-navigation'
-import {getSupportedLocales} from '../../utils/locale'
+import {getSupportedLocalesIds} from '../../utils/locale'
 
 // The FONT_SIZES and FONT_WEIGHTS constants are used to control the styling for
 // the accordion buttons as their current depth. In the below definition we assign
@@ -256,7 +256,7 @@ const DrawerMenu = ({isOpen, onClose = noop, onLogoClick = noop, root}) => {
                                 <LocaleSelector
                                     {...styles.localeSelector}
                                     selectedLocale={intl.locale}
-                                    locales={getSupportedLocales()}
+                                    locales={getSupportedLocalesIds()}
                                     onSelect={(newLocale) => {
                                         // Update the `locale` in the URL.
                                         const newUrl = getUrlWithLocale(newLocale, {

--- a/packages/pwa/app/components/drawer-menu/index.jsx
+++ b/packages/pwa/app/components/drawer-menu/index.jsx
@@ -256,7 +256,7 @@ const DrawerMenu = ({isOpen, onClose = noop, onLogoClick = noop, root}) => {
                                 <LocaleSelector
                                     {...styles.localeSelector}
                                     selectedLocale={intl.locale}
-                                    locales={SUPPORTED_LOCALES}
+                                    locales={SUPPORTED_LOCALES.map((locale) => locale.id)}
                                     onSelect={(newLocale) => {
                                         // Update the `locale` in the URL.
                                         const newUrl = getUrlWithLocale(newLocale, {

--- a/packages/pwa/app/components/drawer-menu/index.jsx
+++ b/packages/pwa/app/components/drawer-menu/index.jsx
@@ -52,7 +52,7 @@ import useCustomer from '../../commerce-api/hooks/useCustomer'
 import LoadingSpinner from '../loading-spinner'
 
 import useNavigation from '../../hooks/use-navigation'
-import {SUPPORTED_LOCALES} from '../../constants'
+import {getSupportedLocales} from '../../utils/locale'
 
 // The FONT_SIZES and FONT_WEIGHTS constants are used to control the styling for
 // the accordion buttons as their current depth. In the below definition we assign
@@ -256,7 +256,7 @@ const DrawerMenu = ({isOpen, onClose = noop, onLogoClick = noop, root}) => {
                                 <LocaleSelector
                                     {...styles.localeSelector}
                                     selectedLocale={intl.locale}
-                                    locales={SUPPORTED_LOCALES.map((locale) => locale.id)}
+                                    locales={getSupportedLocales()}
                                     onSelect={(newLocale) => {
                                         // Update the `locale` in the URL.
                                         const newUrl = getUrlWithLocale(newLocale, {

--- a/packages/pwa/app/components/footer/index.jsx
+++ b/packages/pwa/app/components/footer/index.jsx
@@ -29,7 +29,7 @@ import SocialIcons from '../social-icons'
 import {HideOnDesktop, HideOnMobile} from '../responsive'
 import {getUrlWithLocale} from '../../utils/url'
 import LocaleText from '../locale-text'
-import {getSupportedLocales} from '../../utils/locale'
+import {getSupportedLocalesIds} from '../../utils/locale'
 
 const Footer = ({...otherProps}) => {
     const styles = useMultiStyleConfig('Footer')
@@ -140,7 +140,7 @@ const Footer = ({...otherProps}) => {
                                 variant="filled"
                                 {...styles.localeDropdown}
                             >
-                                {getSupportedLocales().map((locale) => (
+                                {getSupportedLocalesIds().map((locale) => (
                                     <LocaleText
                                         as="option"
                                         value={locale}

--- a/packages/pwa/app/components/footer/index.jsx
+++ b/packages/pwa/app/components/footer/index.jsx
@@ -27,9 +27,9 @@ import {useIntl} from 'react-intl'
 import LinksList from '../links-list'
 import SocialIcons from '../social-icons'
 import {HideOnDesktop, HideOnMobile} from '../responsive'
-import {SUPPORTED_LOCALES} from '../../constants'
 import {getUrlWithLocale} from '../../utils/url'
 import LocaleText from '../locale-text'
+import {getSupportedLocales} from '../../utils/locale'
 
 const Footer = ({...otherProps}) => {
     const styles = useMultiStyleConfig('Footer')
@@ -140,12 +140,12 @@ const Footer = ({...otherProps}) => {
                                 variant="filled"
                                 {...styles.localeDropdown}
                             >
-                                {SUPPORTED_LOCALES.map((locale) => (
+                                {getSupportedLocales().map((locale) => (
                                     <LocaleText
                                         as="option"
-                                        value={locale.id}
-                                        shortCode={locale.id}
-                                        key={locale.id}
+                                        value={locale}
+                                        shortCode={locale}
+                                        key={locale}
                                     />
                                 ))}
                             </Select>

--- a/packages/pwa/app/components/locale-selector/index.jsx
+++ b/packages/pwa/app/components/locale-selector/index.jsx
@@ -78,18 +78,18 @@ const LocaleSelector = ({
                             <AccordionPanel>
                                 <Accordion allowToggle={true} {...styles.accordion}>
                                     {locales.map((locale) => (
-                                        <AccordionItem border="none" key={locale.id}>
+                                        <AccordionItem border="none" key={locale}>
                                             <AccordionButton
                                                 {...styles.optionButton}
-                                                onClick={() => onSelect(locale.id)}
+                                                onClick={() => onSelect(locale)}
                                             >
                                                 {/* Display flag icon if one exists */}
-                                                {flags[locale.id]}
+                                                {flags[locale]}
 
                                                 {/* Locale name */}
                                                 <LocaleText
                                                     {...styles.optionText}
-                                                    shortCode={locale.id}
+                                                    shortCode={locale}
                                                 />
 
                                                 {/* Selection indicator */}
@@ -115,7 +115,7 @@ LocaleSelector.propTypes = {
     /**
      * A complete list of all the locales supported. This array must have content.
      */
-    locales: PropTypes.array.isRequired,
+    locales: PropTypes.arrayOf(PropTypes.string).isRequired,
     /**
      * The current locales shortcode.
      */

--- a/packages/pwa/app/components/locale-selector/index.test.js
+++ b/packages/pwa/app/components/locale-selector/index.test.js
@@ -9,28 +9,7 @@ import {fireEvent} from '@testing-library/react'
 import LocaleSelector from './index'
 import {renderWithProviders} from '../../utils/test-utils'
 
-const supportedLocales = [
-    {
-        id: 'en-GB',
-        preferredCurrency: 'GBP'
-    },
-    {
-        id: 'fr-FR',
-        preferredCurrency: 'EUR'
-    },
-    {
-        id: 'it-IT',
-        preferredCurrency: 'EUR'
-    },
-    {
-        id: 'zh-CN',
-        preferredCurrency: 'CNY'
-    },
-    {
-        id: 'ja-JP',
-        preferredCurrency: 'JPY'
-    }
-]
+const supportedLocales = ['en-GB', 'fr-FR', 'it-IT', 'zh-CN', 'ja-JP']
 
 test('Renders LocaleSelector', () => {
     renderWithProviders(<LocaleSelector selectedLocale="en-GB" locales={supportedLocales} />)

--- a/packages/pwa/app/utils/locale.js
+++ b/packages/pwa/app/utils/locale.js
@@ -12,7 +12,7 @@ const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
 /**
  * @returns {string[]} short codes of all the app's supported locales
  */
-export const getSupportedLocales = () => supportedLocales
+export const getSupportedLocalesIds = () => supportedLocales
 
 /**
  * Dynamically import the translations/messages for a given locale

--- a/packages/pwa/app/utils/locale.js
+++ b/packages/pwa/app/utils/locale.js
@@ -7,8 +7,11 @@
 
 import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 
+const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
+
 /**
  * Dynamically import the translations/messages for a given locale
+ * @private
  * @param {string} locale - The locale code
  * @returns {Promise<Object>} The messages (compiled in AST format) in the given locale. If locale is not found, returns the default locale's messages.
  */
@@ -16,7 +19,7 @@ export const loadLocaleData = async (locale) => {
     // NOTE: the pseudo locale in this case is actually `en-XB` from react-intl. For more details:
     // - see our npm script `compile-translations:pseudo`
     // - and this react-intl PR: https://github.com/formatjs/formatjs/pull/2708
-    const locales = [...SUPPORTED_LOCALES, 'en-XB']
+    const locales = [...supportedLocales, 'en-XB']
     let localeToLoad
 
     if (locales.includes(locale)) {
@@ -48,7 +51,7 @@ export const loadLocaleData = async (locale) => {
  */
 export const getLocaleConfig = async ({getUserPreferredLocales} = {}) => {
     const preferredLocales = getUserPreferredLocales ? getUserPreferredLocales() : [DEFAULT_LOCALE]
-    const targetLocale = whichLocaleToLoad(preferredLocales, SUPPORTED_LOCALES, DEFAULT_LOCALE)
+    const targetLocale = whichLocaleToLoad(preferredLocales, supportedLocales, DEFAULT_LOCALE)
 
     const messages = await loadLocaleData(
         typeof window === 'undefined'
@@ -60,7 +63,7 @@ export const getLocaleConfig = async ({getUserPreferredLocales} = {}) => {
 
     return {
         app: {
-            supportedLocales: SUPPORTED_LOCALES,
+            supportedLocales,
             defaultLocale: DEFAULT_LOCALE,
             targetLocale
         },
@@ -73,16 +76,14 @@ export const getLocaleConfig = async ({getUserPreferredLocales} = {}) => {
 
 /**
  * Decide which locale to load
+ * @private
  * @param {string[]} preferredLocales - All locales that the user prefers
  * @param {string[]} supportedLocales - All locales that your app supports
  * @param {string} fallbackLocale - App's default locale
  * @returns {string} The target locale if there's a match. Otherwise, returns `fallbackLocale`.
  */
 export const whichLocaleToLoad = (preferredLocales, supportedLocales, fallbackLocale) => {
-    const targetLocale = preferredLocales.filter((perfLocale) =>
-        supportedLocales.some((locale) => locale.id === perfLocale)
-    )[0]
-
+    const targetLocale = preferredLocales.filter((locale) => supportedLocales.includes(locale))[0]
     return targetLocale || fallbackLocale
 }
 

--- a/packages/pwa/app/utils/locale.js
+++ b/packages/pwa/app/utils/locale.js
@@ -10,6 +10,11 @@ import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
 
 /**
+ * @returns {string[]} short codes of all the app's supported locales
+ */
+export const getSupportedLocales = () => supportedLocales
+
+/**
  * Dynamically import the translations/messages for a given locale
  * @private
  * @param {string} locale - The locale code

--- a/packages/pwa/app/utils/locale.test.js
+++ b/packages/pwa/app/utils/locale.test.js
@@ -10,12 +10,12 @@ import {
     loadLocaleData,
     getLocaleConfig,
     getPreferredCurrency,
-    getSupportedLocales
+    getSupportedLocalesIds
 } from './locale'
 
 import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 
-const supportedLocales = getSupportedLocales()
+const supportedLocales = getSupportedLocalesIds()
 const nonSupportedLocale = 'nl-NL'
 // Make sure this supported locale is not the default locale.
 // Otherwise, our code would fall back to default and incorrectly pass the tests

--- a/packages/pwa/app/utils/locale.test.js
+++ b/packages/pwa/app/utils/locale.test.js
@@ -5,15 +5,21 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {whichLocaleToLoad, loadLocaleData, getLocaleConfig, getPreferredCurrency} from './locale'
+import {
+    whichLocaleToLoad,
+    loadLocaleData,
+    getLocaleConfig,
+    getPreferredCurrency,
+    getSupportedLocales
+} from './locale'
 
 import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 
-const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
+const supportedLocales = getSupportedLocales()
 const nonSupportedLocale = 'nl-NL'
 // Make sure this supported locale is not the default locale.
 // Otherwise, our code would fall back to default and incorrectly pass the tests
-const supportedLocale = SUPPORTED_LOCALES[1].id
+const supportedLocale = supportedLocales[1]
 
 const testId1 = 'login-redirect.message.welcome'
 const testId2 = 'homepage.message.welcome'

--- a/packages/pwa/app/utils/locale.test.js
+++ b/packages/pwa/app/utils/locale.test.js
@@ -9,6 +9,7 @@ import {whichLocaleToLoad, loadLocaleData, getLocaleConfig, getPreferredCurrency
 
 import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 
+const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
 const nonSupportedLocale = 'nl-NL'
 // Make sure this supported locale is not the default locale.
 // Otherwise, our code would fall back to default and incorrectly pass the tests
@@ -18,13 +19,12 @@ const testId1 = 'login-redirect.message.welcome'
 const testId2 = 'homepage.message.welcome'
 
 test('our assumptions before further testing', () => {
-    expect(SUPPORTED_LOCALES.map((locale) => locale.id).includes(nonSupportedLocale)).toBe(false)
+    expect(supportedLocales.includes(nonSupportedLocale)).toBe(false)
     expect(DEFAULT_LOCALE).toBe('en-GB')
+    expect(supportedLocale).not.toBe(DEFAULT_LOCALE)
 })
 
 describe('whichLocaleToLoad', () => {
-    const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
-
     test('default to fallback locale', () => {
         const locale = whichLocaleToLoad([nonSupportedLocale], supportedLocales, DEFAULT_LOCALE)
         expect(locale).toBe(DEFAULT_LOCALE)
@@ -49,9 +49,9 @@ describe('loadLocaleData', () => {
         expect(messages[testId1][0].value).toMatch(/^\[!! Ļŏĝĝĝíń Ŕèḋḋḋíŕèèèćṭ !!]$/)
     })
     test('handling a not-found translation file', async () => {
-        expect(SUPPORTED_LOCALES[1].id).not.toBe(DEFAULT_LOCALE)
+        expect(supportedLocale).not.toBe(DEFAULT_LOCALE)
 
-        jest.mock(`../translations/compiled/${SUPPORTED_LOCALES[1].id}.json`, () => {
+        jest.mock(`../translations/compiled/${supportedLocale}.json`, () => {
             throw new Error()
         })
 
@@ -60,11 +60,11 @@ describe('loadLocaleData', () => {
             importDefaultLocale = true
         })
 
-        await loadLocaleData(SUPPORTED_LOCALES[1].id)
+        await loadLocaleData(supportedLocale)
         expect(importDefaultLocale).toBe(true)
 
         // Reset
-        jest.unmock(`../translations/compiled/${SUPPORTED_LOCALES[1].id}.json`)
+        jest.unmock(`../translations/compiled/${supportedLocale}.json`)
         jest.unmock(`../translations/compiled/${DEFAULT_LOCALE}.json`)
     })
 })
@@ -87,7 +87,7 @@ describe('getLocaleConfig', () => {
         expect(config.app.targetLocale).toBe(DEFAULT_LOCALE)
     })
     test('with getUserPreferredLocales parameter', async () => {
-        const locale = SUPPORTED_LOCALES[1].id
+        const locale = supportedLocale
         expect(locale).not.toBe(DEFAULT_LOCALE)
 
         const config = await getLocaleConfig({

--- a/packages/pwa/app/utils/locale.test.js
+++ b/packages/pwa/app/utils/locale.test.js
@@ -10,45 +10,43 @@ import {whichLocaleToLoad, loadLocaleData, getLocaleConfig, getPreferredCurrency
 import {SUPPORTED_LOCALES, DEFAULT_LOCALE} from '../constants'
 
 const nonSupportedLocale = 'nl-NL'
-const supportedLocale = SUPPORTED_LOCALES[0]
-const testMessageId = 'login-redirect.message.welcome'
+// Make sure this supported locale is not the default locale.
+// Otherwise, our code would fall back to default and incorrectly pass the tests
+const supportedLocale = SUPPORTED_LOCALES[1].id
+
+const testId1 = 'login-redirect.message.welcome'
+const testId2 = 'homepage.message.welcome'
 
 test('our assumptions before further testing', () => {
-    expect(SUPPORTED_LOCALES.includes(nonSupportedLocale)).toBe(false)
+    expect(SUPPORTED_LOCALES.map((locale) => locale.id).includes(nonSupportedLocale)).toBe(false)
     expect(DEFAULT_LOCALE).toBe('en-GB')
 })
 
 describe('whichLocaleToLoad', () => {
+    const supportedLocales = SUPPORTED_LOCALES.map((locale) => locale.id)
+
     test('default to fallback locale', () => {
-        const locale = whichLocaleToLoad([nonSupportedLocale], SUPPORTED_LOCALES, DEFAULT_LOCALE)
+        const locale = whichLocaleToLoad([nonSupportedLocale], supportedLocales, DEFAULT_LOCALE)
         expect(locale).toBe(DEFAULT_LOCALE)
     })
     test('matches one of the supported locales', () => {
-        const locale = whichLocaleToLoad([supportedLocale], SUPPORTED_LOCALES, DEFAULT_LOCALE)
-        expect(locale).toBe(supportedLocale.id)
-    })
-    test('case-insensitivity', () => {
-        const locale = whichLocaleToLoad(
-            [supportedLocale.id.toUpperCase()],
-            SUPPORTED_LOCALES,
-            DEFAULT_LOCALE
-        )
-        expect(locale).toBe(supportedLocale.id)
+        const locale = whichLocaleToLoad([supportedLocale], supportedLocales, DEFAULT_LOCALE)
+        expect(locale).toBe(supportedLocale)
     })
 })
 
 describe('loadLocaleData', () => {
     test('default to English as the fallback locale', async () => {
         const messages = await loadLocaleData(nonSupportedLocale)
-        expect(messages[testMessageId][0].value).toMatch(/login redirect/i)
+        expect(messages[testId1][0].value).toMatch(/login redirect/i)
     })
     test('loading one of the supported locales', async () => {
         const messages = await loadLocaleData(supportedLocale)
-        expect(messages[testMessageId]).toBeDefined()
+        expect(messages[testId2]).toBeDefined()
     })
     test('loading the pseudo locale', async () => {
         const messages = await loadLocaleData('en-XB')
-        expect(messages[testMessageId][0].value).toMatch(/^\[!! Ļŏĝĝĝíń Ŕèḋḋḋíŕèèèćṭ !!]$/)
+        expect(messages[testId1][0].value).toMatch(/^\[!! Ļŏĝĝĝíń Ŕèḋḋḋíŕèèèćṭ !!]$/)
     })
     test('handling a not-found translation file', async () => {
         expect(SUPPORTED_LOCALES[1].id).not.toBe(DEFAULT_LOCALE)
@@ -107,13 +105,13 @@ describe('getLocaleConfig', () => {
         // The app should still think its target locale is the default one
         expect(config.app.targetLocale).toBe(DEFAULT_LOCALE)
         // But the actual translation should be using the pseudo locale
-        expect(config.messages[testMessageId][0].value).toMatch(/^\[!! Ļŏĝĝĝíń Ŕèḋḋḋíŕèèèćṭ !!]$/)
+        expect(config.messages[testId1][0].value).toMatch(/^\[!! Ļŏĝĝĝíń Ŕèḋḋḋíŕèèèćṭ !!]$/)
     })
 })
 
 describe('getCurrency', () => {
     test('returns the preferred currency for a supported locale', () => {
-        const currency = getPreferredCurrency(supportedLocale.id)
+        const currency = getPreferredCurrency(SUPPORTED_LOCALES[0].id)
         expect(currency).toBe(SUPPORTED_LOCALES[0].preferredCurrency)
     })
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Ticket: https://gus.lightning.force.com/lightning/r/a07EE00000Ng1YxYAJ/view

There was a regression in which we kept on loading the default English translations, regardless of whether the users have chosen other languages or not. It turns out that the root cause is the recent change to the shape of package.json's `supportedLocales`: from array of strings to an array of objects (that contains currencies). Not all of our code that work with supported locales have been updated.

The main change of this PR is: as much as possible, decouple our code from the shape of package.json's `supportedLocales`. For components or other things that do not deal with currencies, they'll be served with simply the locale codes only.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# How to Test-Drive This PR

1. Load http://localhost:3000/fr-FR
2. In your browser console, run `__PRELOADED_STATE__.appProps.messages`
3. You should see 1 message in French (and not the default English translations)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
