### PR TITLE
Proxy SCAPI requests using `http-proxy-middleware`

### DIFF
--- a/packages/pwa/app/commerce-api.config.js
+++ b/packages/pwa/app/commerce-api.config.js
@@ -5,7 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export const commerceAPIConfig = {
-    proxyPath: `/mobify/proxy/api`,
+    // Use the workaround proxy.
+    proxyPath: `/scapi-proxy`,
+    // proxyPath: `/mobify/proxy/api`,
     parameters: {
         clientId: 'c9c45bfd-0ed3-4aa2-9971-40f88962b836',
         organizationId: 'f_ecom_zzrf_001',

--- a/packages/pwa/server.js
+++ b/packages/pwa/server.js
@@ -1,0 +1,24 @@
+// Basic, working proxying implementation.
+const express = require('express')
+const HPM = require('http-proxy-middleware')
+
+const scapiProxy = HPM.createProxyMiddleware({
+    target: 'https://8o7m175y.api.commercecloud.salesforce.com',
+    // target: 'https://httpbin.org/',
+    changeOrigin: true,
+    secure: true,
+    pathRewrite: {
+        '^/scapi-proxy/': '/'
+    },
+    onProxyReq: function(proxyReq) {
+        delete proxyReq['origin']
+    }
+})
+
+const app = express()
+app.all('/scapi-proxy/*', scapiProxy)
+
+const HTTP_PORT = 3000
+app.listen(HTTP_PORT, () => {
+    console.log(`Example app listening at http://localhost:${HTTP_PORT}`)
+})


### PR DESCRIPTION
In some circumstances we've observed the Salesforce Commerce API can misbehave when the HTTP request header `Origin` is present.

SCAPI calls return a HTTP 200, but the underlying call fails, and the response body echos the original request.

This issue appears to impact a small number of realms.

It is possible to work around the problem by routing SCAPI requests through the App Server, which can drop the `Origin` header, avoiding the issue.

This workaround uses the [`http-proxy-middleware`](https://github.com/chimurai/http-proxy-middleware) package and is not suitable for deployment to production.

Internal Issue Reference: [W-9687897](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000SnhVYAS/view)