### PR TITLE
[DO NOT MERGE] Suggestion for URL customization spike

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
@@ -67,14 +67,14 @@ export const start = () => {
     window.__HYDRATING__ = true
 
     const WrappedApp = routeComponent(App, false, locals)
-    const {basePath} = locals
+    const {basePath, locale} = locals
     const error = window.__ERROR__
 
     return Promise.resolve()
         .then(() => new Promise((resolve) => loadableReady(resolve)))
         .then(() => {
             ReactDOM.hydrate(
-                <Router basename={basePath}>
+                <Router>
                     <DeviceContext.Provider value={{type: window.__DEVICE_TYPE__}}>
                         <AppConfig locals={locals}>
                             <Switch
@@ -82,6 +82,7 @@ export const start = () => {
                                 appState={window.__PRELOADED_STATE__}
                                 routes={routes}
                                 App={WrappedApp}
+                                locale={locale}
                             />
                         </AppConfig>
                     </DeviceContext.Provider>

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -151,14 +151,15 @@ export const render = async (req, res) => {
     let route
     let match
 
-    const {basePath} = res.locals
+    const {basePath, locale} = res.locals
 
     routes.some((_route) => {
-        const _path = req.path.replace(basePath, '')
+        // const _path = req.path.replace(basePath, '')
+        _route.path = _route.localized ? `/${locale}${_route.path}` : _route.path
         const _match = matchPath(req.path, _route)
         if (_match) {
             match = _match
-            route = {..._route, path: _path}
+            route = _route
         }
         return !!match
     })
@@ -216,16 +217,23 @@ const renderApp = (args) => {
     const deviceType = detectDeviceType(req)
     const routerContext = {}
 
-    const {basePath} = res.locals
+    const {basePath, locale} = res.locals
     console.log('basenamePath', basePath)
+    console.log('locale', locale)
 
     let extractor
     let bundles = []
     let appJSX = (
-        <Router location={location} context={routerContext} basename={basePath}>
+        <Router location={location} context={routerContext}>
             <DeviceContext.Provider value={{type: deviceType}}>
                 <AppConfig locals={res.locals}>
-                    <Switch error={error} appState={appState} routes={routes} App={App} />
+                    <Switch
+                        error={error}
+                        appState={appState}
+                        routes={routes}
+                        App={App}
+                        locale={locale}
+                    />
                 </AppConfig>
             </DeviceContext.Provider>
         </Router>

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/switch/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/switch/index.jsx
@@ -20,7 +20,7 @@ import {UIDReset, UIDFork} from 'react-uid'
  * @private
  */
 const Switch = (props) => {
-    const {error, appState, routes, App} = props
+    const {error, appState, routes, App, locale} = props
     return (
         <UIDReset>
             <AppErrorBoundary error={error}>
@@ -28,9 +28,12 @@ const Switch = (props) => {
                     <App preloadedProps={appState.appProps}>
                         <RouterSwitch>
                             {routes.map((route, i) => {
-                                const {component: Component, ...routeProps} = route
+                                const {component: Component, path, localized, ...routeProps} = route
+
+                                let localizedPath = localized ? `/${locale}${path}` : path
+
                                 return (
-                                    <Route key={i} {...routeProps}>
+                                    <Route key={i} path={localizedPath} {...routeProps}>
                                         <UIDFork>
                                             <Component preloadedProps={appState.pageProps} />
                                         </UIDFork>

--- a/packages/pwa/app/components/_app-config/index.jsx
+++ b/packages/pwa/app/components/_app-config/index.jsx
@@ -98,6 +98,7 @@ AppConfig.restore = (locals = {}) => {
 
     locals.api = new CommerceAPI({...apiConfig, locale, currency})
     locals.basePath = basePath
+    locals.locale = locale
 }
 
 AppConfig.freeze = () => undefined

--- a/packages/pwa/app/routes.jsx
+++ b/packages/pwa/app/routes.jsx
@@ -81,7 +81,8 @@ const routes = [
     },
     {
         path: '/product/:productId',
-        component: ProductDetail
+        component: ProductDetail,
+        localized: true
     },
     {
         path: '/search',


### PR DESCRIPTION
In https://github.com/SalesforceCommerceCloud/pwa-kit/pull/183, we are exploring a new feature: url customization.

In that PR, @alexvuong has done a good job of showing what the potential solution might look like, however there is a limitation where all routes must either have a basename or none of the routes has a basename, it's an all or nothing situation. This limits the projects to have ability to create custom routes while maintaining a localized app.

The main cause of the limitation is the solution leverages `basename` prop from [React Router](https://v5.reactrouter.com/web/api/BrowserRouter/basename-string):
```jsx
<Router basename={basePath}>
```
The `basename` property prepend a base path for every single routes under the root router. While this approach is smart and take advantage of what React router has to offer, the side effect of "all or none" is something we don't want.

### suggestion

Instead of adding a `basename` at the router level, this PR suggests that we extend the `Switch` component in our SDK, to dynamically calculate route paths based on the route configurations.


