### PR TITLE
Disable local development proxy when running remotely

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,8 +1,11 @@
 ## v1.3.0-dev (Nov 18, 2021)
+
+-   [Proxying is disabled when not running locally](https://sfdc.co/cc-mrt-proxy-setup). [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
+
 ## v1.2.0 (Nov 18, 2021)
 
 -   Security package updates
--   Upgrade `copy-webpack-plugin` to latest `^9.0.1` version. [3191](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/181)
+-   Upgrade `copy-webpack-plugin` to latest `^9.0.1` version. [#3191](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/181)
 
 ## v1.1.0 (Sep 27, 2021)
 

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.3.0-dev (Nov 18, 2021)
 
--   [Proxying is disabled when not running locally](https://sfdc.co/cc-mrt-proxy-setup). [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
+-   `createApp` takes a new option `enableLegacyRemoteProxying` which defaults to `true`. When set to `false`, local development proxying is disabled when running remotely. In future, local development proxying will *always* be disabled when running remotely. [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
 
 ## v1.2.0 (Nov 18, 2021)
 

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.js
@@ -266,7 +266,8 @@ export const createApp = (options) => {
     } else {
         app.all('/mobify/proxy/*', (_, res) => {
             return res.status(501).json({
-                message: 'Environment proxies are not set: https://sfdc.co/managed-runtime-setup-proxies'
+                message:
+                    'Environment proxies are not set: https://sfdc.co/managed-runtime-setup-proxies'
             })
         })
     }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.js
@@ -127,6 +127,9 @@ export const REMOTE_REQUIRED_ENV_VARS = [
  * @param {String} options.sslFilePath - the absolute path to a PEM format
  * certificate file to be used by the local development server. This should
  * contain both the certificate and the private key.
+ * @param {Boolean} [options.enableLegacyRemoteProxying=true] - When running remotely (as
+ * oppsed to locally), enables legacy proxying behaviour, allowing "proxy" requests to route through
+ * the express server. In the future, this behaviour and setting will be removed.
  */
 
 export const createApp = (options) => {
@@ -413,7 +416,7 @@ const validateConfiguration = (options) => {
         console.warn(
             'Legacy proxying behaviour is enabled. ' +
                 'This behaviour is deprecated and will be removed in the future.' +
-                'To disable it, set `options.enableLegacyRemoteProxying: false`.'
+                'To disable it, pass `createApp({ enableLegacyRemoteProxying: false` })'
         )
     }
 }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.js
@@ -266,7 +266,7 @@ export const createApp = (options) => {
     } else {
         app.all('/mobify/proxy/*', (_, res) => {
             return res.status(501).json({
-                error: 'Environment proxies are not set: https://sfdc.co/cc-mrt-proxy-setup'
+                message: 'Environment proxies are not set: https://sfdc.co/managed-runtime-setup-proxies'
             })
         })
     }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.lambda.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.lambda.test.js
@@ -195,11 +195,8 @@ describe('SSRServer Lambda integration', () => {
             name: 'proxied text response',
             path: '/mobify/proxy/base/test1',
             validate: (response) => {
-                expect(response.statusCode).toBe(200)
-                expect(response.isBase64Encoded).toBe(false)
-                expect(response.headers['content-type']).toEqual('text/plain')
-                expect(response.headers['content-encoding']).toBeFalsy()
-                expect(response.body).toEqual('success1')
+                // Proxying is disabled for remote execution.
+                expect(response.statusCode).toBe(501)
             },
             route: () => {
                 throw new Error('Should never hit this line')
@@ -244,7 +241,8 @@ describe('SSRServer Lambda integration', () => {
                 port: TEST_PORT,
                 fetchAgents: {
                     https: httpsAgent
-                }
+                },
+                enableLegacyRemoteProxying: false
             })
             app.get('/*', testCase.route)
 

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -278,10 +278,16 @@ class Auth {
         }
 
         const response = await this._api.shopperLogin.authorizeCustomer(options, true)
-
         if (response.status >= 400) {
-            const json = await response.json()
-            throw new HTTPError(response.status, json.message)
+            let text = await response.text()
+            let errorMessage = text
+            try {
+                const data = JSON.parse(text)
+                if (data.message) {
+                    errorMessage = data.message
+                }
+            } catch {} // eslint-disable-line no-empty
+            throw new HTTPError(response.status, errorMessage)
         }
 
         const tokenBody = createGetTokenBody(

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -135,7 +135,7 @@ Error.propTypes = {
     stack: PropTypes.string,
     // HTTP status code: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
     status: PropTypes.number,
-    // A description of the error, if available.
+    // A description of the error, if available
     message: PropTypes.string
 }
 

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -135,7 +135,7 @@ Error.propTypes = {
     stack: PropTypes.string,
     // HTTP status code: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
     status: PropTypes.number,
-    // A description of the error, if available. 
+    // A description of the error, if available.
     message: PropTypes.string
 }
 

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -89,11 +89,11 @@ const Error = (props) => {
                             </Button>
                         </Stack>
                     </Flex>
-                    <Box marginTop={20}>
-                        <Text fontWeight="bold" fontSize="md">
-                            Stack Trace
-                        </Text>
-                        {stack && (
+                    {stack && (
+                        <Box marginTop={20}>
+                            <Text fontWeight="bold" fontSize="md">
+                                Stack Trace
+                            </Text>
                             <Box
                                 as="pre"
                                 mt={4}
@@ -107,8 +107,8 @@ const Error = (props) => {
                             >
                                 {stack}
                             </Box>
-                        )}
-                    </Box>
+                        </Box>
+                    )}
                 </Flex>
             </Box>
         </Flex>

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -21,7 +21,7 @@ import {useHistory} from 'react-router-dom'
 // It must not throw an error. Keep it as simple as possible.
 
 const Error = (props) => {
-    const {stack} = props
+    const {message, stack} = props
     const history = useHistory()
 
     const title = "This page isn't working"
@@ -72,6 +72,21 @@ const Error = (props) => {
                                 An error has occurred. Try refreshing the page or if you need
                                 immediate help please contact support.
                             </Text>
+                            {message && (
+                                <Box
+                                    as="pre"
+                                    mt={4}
+                                    fontSize="sm"
+                                    background="gray.50"
+                                    borderColor="gray.200"
+                                    borderStyle="solid"
+                                    borderWidth="1px"
+                                    overflow="auto"
+                                    padding={4}
+                                >
+                                    {message}
+                                </Box>
+                            )}
                         </Box>
                         <Stack direction={['column', 'row']} spacing={4} width={['100%', 'auto']}>
                             <Button
@@ -119,7 +134,9 @@ Error.propTypes = {
     // JavaScript error stack trace: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack
     stack: PropTypes.string,
     // HTTP status code: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-    status: PropTypes.number
+    status: PropTypes.number,
+    // A description of the error, if available. 
+    message: PropTypes.string
 }
 
 export default Error

--- a/packages/pwa/app/ssr.js
+++ b/packages/pwa/app/ssr.js
@@ -35,7 +35,9 @@ const app = createApp({
 
     // The protocol on which the development Express app listens.
     // Note that http://localhost is treated as a secure context for development.
-    protocol: 'http'
+    protocol: 'http',
+
+    enableLegacyRemoteProxying: false
 })
 
 // Handle the redirect from SLAS as to avoid error


### PR DESCRIPTION
To support local development, we provide a "mock" of Managed Runtime's proxy feature in the Express server.

In Managed Runtime, when configured correctly, proxies are *not* handled by the Express server and instead are routed through the CDN.

Currently, we always run the "mock" proxy, even in the context of Managed Runtime. 

When folks forget to configure their proxies in Managed Runtime (which is easier to do!), this leads to subtle bugs:

* duplicate query string parameters are not respected
* it is slow

This issue may not be clear until after a project has launched.

This change adds a new parameter `enableLegacyRemoteProxying` to `createApp` whose value defaults to `true`.

When set to `false`, local development proxies are _not_  added when the code is running in Managed Runtime. Folks that have not configured their proxies get a loud error and navigating directly to the proxy endpoints make it clear they are not configured correctly.

## For Discussion

Ideally, we be able to show a clear error message to developers in the context of the 500 page that will be returned from the SSR server, but as the stack trace is not available when running remotely, it isn't immediately obvious how to do that. It would be good to discuss how we'd like to propagate this sort of information to users.

## Types of Changes

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

- Adds a new parameter `createApp({enableLegacyRemoteProxying})` that defaults to `true`. _New projects created with `pwa-kit-create-app` have the value set to `false` in `ssr.js`_.

## How to Test-Drive This PR

- Run the code locally, check that the PWA Kit still works.
- Review these two test environments:
- https://demo-proxies-enabled.mobify-storefront.com/ - has proxies set. Observe it still works.
- https://demo-proxies-disabled.mobify-storefront.com/ - does NOT have proxy set. Observe it is broken.
- https://demo-proxies-disabled.mobify-storefront.com/mobify/proxy/api/hello - Observe the custom error for sites without proxies setup correctly.

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes