### PR TITLE
[Retail App] Show applied promotion codes case sensitive issue *FIXED*

### DIFF
--- a/packages/pwa/app/components/order-summary/index.jsx
+++ b/packages/pwa/app/components/order-summary/index.jsx
@@ -240,12 +240,7 @@ const OrderSummary = ({
                             <Stack>
                                 {basket.couponItems.map((item) => (
                                     <Flex key={item.couponItemId} alignItems="center">
-                                        <Text
-                                            flex="1"
-                                            fontSize="sm"
-                                            textTransform="uppercase"
-                                            color="gray.800"
-                                        >
+                                        <Text flex="1" fontSize="sm" color="gray.800">
                                             {item.code}
                                         </Text>
                                         {!basket.orderNo && (


### PR DESCRIPTION

# Description
The promo code entered by the customer was always appearing as Capitalized. This was because of the property textTransform="uppercase"

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Removed the textTransform="uppercase" from the code

# How to Test-Drive This PR

1. npm start
2. Add any product to cart and use the promo code orderLevel

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [x] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [x] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [x] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
