### PR TITLE
[Circle CI] Skip job steps on forked PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,6 +147,19 @@ commands:
               # that would prevent Lerna from publishing (Lerna gets this right).
               git diff --exit-code
 
+  early_return_for_forked_pull_requests:
+    description: >-
+      If this build is from a fork, stop executing the current job and return success.
+      This is useful to avoid steps that will fail due to missing credentials.
+    steps:
+      - run:
+          name: Early return if this build is from a forked PR
+          command: |
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Nothing else to do for forked PRs, so marking this step successful"
+              circleci step halt
+            fi
+
 jobs:
   testNode12:
     docker:
@@ -186,6 +199,7 @@ jobs:
       - runtests
       - lighthouse-ci
       - smoketestscripts
+      - early_return_for_forked_pull_requests
       - run:
           name: Push Bundle
           command: |
@@ -286,6 +300,7 @@ jobs:
       - slack/status:
           fail_only: true
           only_for_branches: develop
+      - early_return_for_forked_pull_requests
       - run:
           name: Push Bundle
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,10 @@ commands:
       - run:
           name: Early return if this build is from a forked PR
           command: |
-              echo "Forked PR number: $CIRCLE_PR_NUMBER"
+            if [ -n "$CIRCLE_PR_NUMBER" ]; then
               echo "Nothing else to do for forked PRs, so marking this step successful"
               circleci step halt
-
+            fi
 
 jobs:
   testNode12:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,10 +155,10 @@ commands:
       - run:
           name: Early return if this build is from a forked PR
           command: |
-            if [ -n "$CIRCLE_PR_NUMBER" ]; then
+              echo "Forked PR number: $CIRCLE_PR_NUMBER"
               echo "Nothing else to do for forked PRs, so marking this step successful"
               circleci step halt
-            fi
+
 
 jobs:
   testNode12:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000005hxgWYAQ/view
# Description

This PR skips the Circle CI steps _Push bundle_ and _Publish to NPM_ on forked pull requests. Otherwise, these steps will fail on forked PRs because they don't have access to the environment variables used in the steps.

If a Circle CI build it's triggered from a fork pull request, the step `early_return_for_forked_pull_requests` will stop executing the rest of the steps in the current job and return a successful exit.

The approach is following this Circle CI article: https://circleci.com/blog/managing-secrets-when-you-have-pull-requests-from-outside-contributors/

We use the Circle CI built-in environment variable [`CIRCLE_PR_NUMBER`](https://circleci.com/docs/2.0/env-vars/#built-in-environment-variables) only available on forked PRs to verify if we're in a build triggered from a forked PR and if so, we stop the rest of the steps in the job by running the Circle CI cli command `circleci-agent step halt`.

After merging this PR, we'll enable the Circle CI setting to build external prs. This would allow running the Circle CI jobs on the external contributions PRs without sharing environment variables.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Updated Circle CI configuration to skip the _Push bundle_ and _Publish to NPM_ steps on forked pull request.

# How to Test-Drive This PR
We can not test this properly until we merge this configuration, and then we create a new fork pr to verify that the steps are not executed in the Circle CI build. But we can do these tests:

1. Open the Circle CI jobs `testNode14` and `generatedSFCCProjectTest` by clicking the links on the **Checks** tab of this specific test commit "Test circleci step halt" https://github.com/SalesforceCommerceCloud/pwa-kit/pull/237/commits/db4ee781862c29438284fd12f8431b2a35ef450d
👀 Verify: The build stopped executing without executing the _Push bundle_ and _Publish to NPM_ steps from the `testNode14` and `generatedSFCCProjectTest` jobs when the external forked pr conditional was removed. 

    - `testNode14`: https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/pwa-kit/1454/workflows/3168ead4-be12-477d-91c5-17ee077424ab/jobs/4811?invite=true#step-109-1
    - `generatedSFCCProjectTest`: https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/pwa-kit/1454/workflows/3168ead4-be12-477d-91c5-17ee077424ab/jobs/4813?invite=true#step-115-1

2. Open the Circle CI jobs `testNode14` and `generatedSFCCProjectTest`by clicking the links on the **Checks** tab of the latest commit https://github.com/SalesforceCommerceCloud/pwa-kit/pull/237/commits/1167567cb5fda2fc28733415fc987231669669f2
👀 Verify: The build did **not** stop executing the steps _Push bundle_ and _Publish to NPM_ steps from the `testNode14` and `generatedSFCCProjectTest` jobs of the current not forked pull request https://github.com/SalesforceCommerceCloud/pwa-kit/pull/237.

    - `testNode14`: https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/pwa-kit/1455/workflows/9192e1e3-66ca-4975-a866-9785af4c08a8/jobs/4815
    - `generatedSFCCProjectTest`: https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/pwa-kit/1455/workflows/9192e1e3-66ca-4975-a866-9785af4c08a8/jobs/4817


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
