### PR TITLE
Remove error stack trace if error exists in a remote environment

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.0-dev (Nov 18, 2021)
 
+-   Do not show stack trace in remote environment windowGlobals [#230](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/230/files)
 -   `createApp` takes a new option `enableLegacyRemoteProxying` which defaults to `true`. When set to `false`, local development proxying is disabled when running remotely. In future, local development proxying will *always* be disabled when running remotely. [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
 
 ## v1.2.0 (Nov 18, 2021)

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -256,6 +256,12 @@ const renderApp = (args) => {
 
     const helmet = Helmet.renderStatic()
 
+    // Remove the stacktrace when executing remotely as to not leak any important
+    // information to users about our system.
+    if (error && isRemote()) {
+        delete error.stack
+    }
+
     // Do not include *dynamic*, executable inline scripts – these cause issues with
     // strict CSP headers that customers often want to use. Avoid inline scripts,
     // full-stop, whenever possible.
@@ -267,7 +273,7 @@ const renderApp = (args) => {
     const windowGlobals = {
         __DEVICE_TYPE__: deviceType,
         __PRELOADED_STATE__: appState,
-        __ERROR__: error && isRemote() ? {...error, stack: undefined} : error,
+        __ERROR__: error,
         // `window.Progressive` has a long history at Mobify and some
         // client-side code depends on it. Maintain its name out of tradition.
         Progressive: getWindowProgressive(req, res)

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -28,7 +28,7 @@ import AppConfig from '../universal/components/_app-config'
 import Switch from '../universal/components/switch'
 import {getRoutes, routeComponent} from '../universal/components/route-component'
 import * as errors from '../universal/errors'
-import {detectDeviceType} from '../../utils/ssr-server'
+import {detectDeviceType, isRemote} from '../../utils/ssr-server'
 import {proxyConfigs} from '../../utils/ssr-shared'
 
 import sprite from 'svg-sprite-loader/runtime/sprite.build'
@@ -267,7 +267,7 @@ const renderApp = (args) => {
     const windowGlobals = {
         __DEVICE_TYPE__: deviceType,
         __PRELOADED_STATE__: appState,
-        __ERROR__: error,
+        __ERROR__: error && isRemote() ? {...error, stack: undefined} : error,
         // `window.Progressive` has a long history at Mobify and some
         // client-side code depends on it. Maintain its name out of tradition.
         Progressive: getWindowProgressive(req, res)

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -294,7 +294,7 @@ jest.mock('../../utils/ssr-server', () => {
     }
 })
 
-describe.only('The Node SSR Environment', () => {
+describe('The Node SSR Environment', () => {
     const OLD_ENV = process.env
 
     beforeAll(() => {

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -13,6 +13,7 @@ import {createApp} from './express'
 import request from 'supertest'
 import {parse} from 'node-html-parser'
 import path from 'path'
+import {isRemote} from '../../utils/ssr-server'
 
 const opts = (overrides = {}) => {
     const fixtures = path.join(__dirname, '..', '..', 'ssr', 'server', 'test_fixtures')
@@ -285,6 +286,14 @@ jest.mock('../universal/routes', () => {
     }
 })
 
+jest.mock('../../utils/ssr-server', () => {
+    const actual = jest.requireActual('../../utils/ssr-server')
+    return {
+        ...actual,
+        isRemote: jest.fn()
+    }
+})
+
 describe('The Node SSR Environment', () => {
     /**
      * Scripts are "safe" if they are external, not executable or on our allow list of
@@ -454,7 +463,7 @@ describe('The Node SSR Environment', () => {
                 const data = dataFromHTML(doc)
 
                 expect(data.__ERROR__.message).toEqual('Internal Server Error')
-                expect(typeof data.__ERROR__.stack).toEqual('string')
+                expect(typeof data.__ERROR__.stack).toEqual(isRemote() ? 'undefined' : 'string')
                 expect(data.__ERROR__.status).toEqual(500)
                 expect(res.statusCode).toBe(500)
             }
@@ -515,16 +524,23 @@ describe('The Node SSR Environment', () => {
         }
     ]
 
-    cases.forEach(({description, req, assertions}) => {
-        test(`renders PWA pages properly (${description})`, () => {
-            const {url, headers, query} = req
-            const app = createApp(opts())
-            app.get('/*', render)
-            return request(app)
-                .get(url)
-                .set(headers || {})
-                .query(query || {})
-                .then((res) => assertions(res))
+    const isRemoteValues = [true, false]
+
+    isRemoteValues.forEach((value) => {
+        isRemote.mockReturnValue(value)
+
+        // Run test cases
+        cases.forEach(({description, req, assertions}) => {
+            test(`renders PWA pages properly (${description})`, () => {
+                const {url, headers, query} = req
+                const app = createApp(opts())
+                app.get('/*', render)
+                return request(app)
+                    .get(url)
+                    .set(headers || {})
+                    .query(query || {})
+                    .then((res) => assertions(res))
+            })
         })
     })
 })


### PR DESCRIPTION
Resubmission of #230 with a fix so that` __ERROR__` is not set to {} when error is undefined in a remote environment

GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000KAC67YAH/view

# Description

Stack trace data and SSR options are visible on error pages when viewing page source. This change stops this data from being displayed in page source.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# How to Test-Drive This PR

- npm ci at root to rebuild sdk
- Overwrite getProps method in app/components/_app.jsx inside to throw an error.
```
App.getProps = () => {
  throw new Error('this is an error')
}

```
- Start Retail React App locally & verify you can see the error stack trace
- Deploy the Retail React App to Managed Runtime and verify you cannot see the error stack trace

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [X] Changes are covered by test cases
- [X] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)