### PR TITLE
Add `server_only` and `pretty_print` Rendering Flags

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.0-dev (Nov 18, 2021)
 
+-   Add `server_only` and `pretty_print` server rendering flags aliases. [#250](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/250)
 -   Do not show stack trace in remote environment windowGlobals [#230](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/230/files)
 -   `createApp` takes a new option `enableLegacyRemoteProxying` which defaults to `true`. When set to `false`, local development proxying is disabled when running remotely. In future, local development proxying will *always* be disabled when running remotely. [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
 

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.3.0-dev (Nov 18, 2021)
 
--   Add `server_only` and `pretty_print` server rendering flags aliases. [#250](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/250)
+-   Add `__server_only` and `__pretty_print` server rendering flags aliases. [#250](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/250)
 -   Do not show stack trace in remote environment windowGlobals [#230](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/230/files)
 -   `createApp` takes a new option `enableLegacyRemoteProxying` which defaults to `true`. When set to `false`, local development proxying is disabled when running remotely. In future, local development proxying will *always* be disabled when running remotely. [#205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/205)
 

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -207,8 +207,8 @@ export const render = async (req, res) => {
 const renderApp = (args) => {
     const {req, res, location, routes, appState, error, App} = args
 
-    const ssrOnly = 'mobify_server_only' in req.query
-    const prettyPrint = 'mobify_pretty' in req.query
+    const ssrOnly = 'mobify_server_only' in req.query || 'server_only' in req.query
+    const prettyPrint = 'mobify_pretty' in req.query || 'pretty_print' in req.query
     const indent = prettyPrint ? 8 : 0
     const deviceType = detectDeviceType(req)
     const routerContext = {}

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -207,8 +207,8 @@ export const render = async (req, res) => {
 const renderApp = (args) => {
     const {req, res, location, routes, appState, error, App} = args
 
-    const ssrOnly = 'mobify_server_only' in req.query || 'server_only' in req.query
-    const prettyPrint = 'mobify_pretty' in req.query || 'pretty_print' in req.query
+    const ssrOnly = 'mobify_server_only' in req.query || '__server_only' in req.query
+    const prettyPrint = 'mobify_pretty' in req.query || '__pretty_print' in req.query
     const indent = prettyPrint ? 8 : 0
     const deviceType = detectDeviceType(req)
     const routerContext = {}

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -439,20 +439,6 @@ describe('The Node SSR Environment', () => {
             }
         },
         {
-            description: `rendering PWA's in server-only mode should not execute scripts on the client`,
-            req: {url: '/pwa/', query: {__server_only: '1'}},
-            assertions: (res) => {
-                const html = res.text
-                const doc = parse(html)
-                const include = ['<div>This is a PWA</div>']
-                include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
-                doc.querySelectorAll('script').forEach((script) => {
-                    // application/json prevents execution!
-                    expect(script.getAttribute('type')).toBe('application/json')
-                })
-            }
-        },
-        {
             description: `404 when no route matches`,
             req: {url: '/this-should-404/'},
             assertions: (res) => {

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -385,7 +385,7 @@ describe('The Node SSR Environment', () => {
             }
         },
         {
-            description: `rendering PWA's in mobify-server-only mode should not execute scripts on the client`,
+            description: `rendering PWA's in "mobify-server-only" mode should not execute scripts on the client`,
             req: {url: '/pwa/', query: {mobify_server_only: '1'}},
             assertions: (res) => {
                 const html = res.text
@@ -399,8 +399,8 @@ describe('The Node SSR Environment', () => {
             }
         },
         {
-            description: `rendering PWA's in server-only mode should not execute scripts on the client`,
-            req: {url: '/pwa/', query: {server_only: '1'}},
+            description: `rendering PWA's in "__server-only" mode should not execute scripts on the client`,
+            req: {url: '/pwa/', query: {__server_only: '1'}},
             assertions: (res) => {
                 const html = res.text
                 const doc = parse(html)
@@ -426,8 +426,8 @@ describe('The Node SSR Environment', () => {
             }
         },
         {
-            description: `rendering PWA's with  "pretty_print" mode should print stylized global state`,
-            req: {url: '/pwa/', query: {mobify_pretty: '1'}},
+            description: `rendering PWA's with  "__pretty_print" mode should print stylized global state`,
+            req: {url: '/pwa/', query: {__pretty_print: '1'}},
             assertions: (res) => {
                 const html = res.text
                 const doc = parse(html)
@@ -440,7 +440,7 @@ describe('The Node SSR Environment', () => {
         },
         {
             description: `rendering PWA's in server-only mode should not execute scripts on the client`,
-            req: {url: '/pwa/', query: {server_only: '1'}},
+            req: {url: '/pwa/', query: {__server_only: '1'}},
             assertions: (res) => {
                 const html = res.text
                 const doc = parse(html)

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -339,6 +339,8 @@ describe('The Node SSR Environment', () => {
                 const doc = parse(html)
                 const include = ['<div>This is a PWA</div>']
                 const data = dataFromHTML(doc)
+                const dataScript = doc.querySelectorAll('script[id=mobify-data]')[0]
+                expect(dataScript.innerHTML.split(/\r\n|\r|\n/).length).toBe(1)
                 expect(data.__DEVICE_TYPE__).toEqual('DESKTOP')
                 include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
                 expect(scriptsAreSafe(doc)).toBe(true)
@@ -385,6 +387,60 @@ describe('The Node SSR Environment', () => {
         {
             description: `rendering PWA's in mobify-server-only mode should not execute scripts on the client`,
             req: {url: '/pwa/', query: {mobify_server_only: '1'}},
+            assertions: (res) => {
+                const html = res.text
+                const doc = parse(html)
+                const include = ['<div>This is a PWA</div>']
+                include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
+                doc.querySelectorAll('script').forEach((script) => {
+                    // application/json prevents execution!
+                    expect(script.getAttribute('type')).toBe('application/json')
+                })
+            }
+        },
+        {
+            description: `rendering PWA's in server-only mode should not execute scripts on the client`,
+            req: {url: '/pwa/', query: {server_only: '1'}},
+            assertions: (res) => {
+                const html = res.text
+                const doc = parse(html)
+                const include = ['<div>This is a PWA</div>']
+                include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
+                doc.querySelectorAll('script').forEach((script) => {
+                    // application/json prevents execution!
+                    expect(script.getAttribute('type')).toBe('application/json')
+                })
+            }
+        },
+        {
+            description: `rendering PWA's with legacy "mobify_pretty" mode should print stylized global state`,
+            req: {url: '/pwa/', query: {mobify_pretty: '1'}},
+            assertions: (res) => {
+                const html = res.text
+                const doc = parse(html)
+                const include = ['<div>This is a PWA</div>']
+                include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
+                const script = doc.querySelectorAll('script[id=mobify-data]')[0]
+
+                expect(script.innerHTML.split(/\r\n|\r|\n/).length).toBeGreaterThan(1)
+            }
+        },
+        {
+            description: `rendering PWA's with  "pretty_print" mode should print stylized global state`,
+            req: {url: '/pwa/', query: {mobify_pretty: '1'}},
+            assertions: (res) => {
+                const html = res.text
+                const doc = parse(html)
+                const include = ['<div>This is a PWA</div>']
+                include.forEach((s) => expect(html).toEqual(expect.stringContaining(s)))
+                const script = doc.querySelectorAll('script[id=mobify-data]')[0]
+
+                expect(script.innerHTML.split(/\r\n|\r|\n/).length).toBeGreaterThan(1)
+            }
+        },
+        {
+            description: `rendering PWA's in server-only mode should not execute scripts on the client`,
+            req: {url: '/pwa/', query: {server_only: '1'}},
             assertions: (res) => {
                 const html = res.text
                 const doc = parse(html)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

This is a long time overdue. This PR adds alternative named flags for `mobify_server_only` and `mobify_pretty`. The alternatives are `__server_only` and `__pretty_print`. 

To make this change a non-breaking change we retain the functionality of the existing flags, and add these new flags that are essentially alias's. 

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Added alternatively names flags for `mobify_server_only` and `mobify_pretty`.
- Added new tests to ensure both are working.

# How to Test-Drive This PR

- Run dev server locally

```
> git checkout update-rendering-flags
> npm ci 
> npm start
// Open http://localhost:3000/?__pretty_print in your browser and view that the globals object is formatted on multiple lines.
// Repeat for http://localhost:3000/?mobify_pretty 
```

```
> git checkout update-rendering-flags
> npm ci 
> npm start
// Search the html source for "main.js" type="application/json"" this means that the main script will not be executed.
// Repeat for http://localhost:3000/?mobify_server_only 
```

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
- [ ] Talk to Richard about making changes to docs

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
