### PR TITLE
Skip an extra request during SLAS logins

### DIFF
--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -219,7 +219,7 @@ class Auth {
                 channel_id: this._config.parameters.siteId,
                 client_id: this._config.parameters.clientId,
                 code_challenge,
-                redirect_uri,
+                redirect_uri
             }
         }
 
@@ -231,14 +231,10 @@ class Auth {
 
         let tokenURL = response.url
         if (!this._onClient) {
-            tokenURL = response.headers.get("location")
+            tokenURL = response.headers.get('location')
         }
 
-        const tokenBody = createGetTokenBody(
-            tokenURL,
-            redirect_uri,
-            codeVerifier
-        )
+        const tokenBody = createGetTokenBody(tokenURL, redirect_uri, codeVerifier)
 
         const {customer_id} = await this.getLoggedInToken(tokenBody)
         const customer = {
@@ -269,8 +265,8 @@ class Auth {
                 code_challenge,
                 hint: 'guest',
                 redirect_uri,
-                response_type: 'code',
-            },
+                response_type: 'code'
+            }
         }
 
         const response = await this._api.shopperLogin.authorizeCustomer(options, true)
@@ -290,14 +286,10 @@ class Auth {
         // I believe this is b/c Commerce SDK doesn't respect `fetchOptions` in browser.
         let tokenURL = response.url
         if (!this._onClient) {
-            tokenURL = response.headers.get("location")
+            tokenURL = response.headers.get('location')
         }
 
-        const tokenRequestBody = createGetTokenBody(
-            tokenURL,
-            redirect_uri,
-            codeVerifier
-        )
+        const tokenRequestBody = createGetTokenBody(tokenURL, redirect_uri, codeVerifier)
 
         const {customer_id} = await this.getLoggedInToken(tokenRequestBody)
         const customer = {

--- a/packages/pwa/app/commerce-api/index.js
+++ b/packages/pwa/app/commerce-api/index.js
@@ -81,9 +81,13 @@ class CommerceAPI {
             shopperGiftCertificates: {
                 api: sdk.ShopperGiftCertificates
             },
-            shopperLogin: {api: sdk.ShopperLogin, sendLocale: false, fetchOptions: {
-                redirect: 'manual'
-            }},
+            shopperLogin: {
+                api: sdk.ShopperLogin,
+                sendLocale: false,
+                fetchOptions: {
+                    redirect: 'manual'
+                }
+            },
             shopperOrders: {api: OcapiShopperOrders},
             shopperProducts: {
                 api: sdk.ShopperProducts,
@@ -100,7 +104,7 @@ class CommerceAPI {
 
         // Create SDK class proxies and create getters from our api mapping.
         // The proxy handlers are called when accessing any of the mapped SDK class
-        // proxies, executing hooks to tap into or modify 
+        // proxies, executing hooks to tap into or modify
         // the outgoing method parameters and/or incoming SDK responses
         const self = this
 
@@ -111,12 +115,12 @@ class CommerceAPI {
 
             let config = this._config
             if (apiConfigs[key].fetchOptions) {
-               config = {
-                   ...{
-                       fetchOptions: apiConfigs[key].fetchOptions
-                   }, 
-                   ...config
-                } 
+                config = {
+                    ...{
+                        fetchOptions: apiConfigs[key].fetchOptions
+                    },
+                    ...config
+                }
             }
 
             const proxy = new Proxy(new SDKClass(config), {
@@ -143,7 +147,7 @@ class CommerceAPI {
                         const includeGlobalLocale = Array.isArray(sendLocale)
                             ? sendLocale.includes(prop)
                             : !!sendLocale
-                        
+
                         const includeGlobalCurrency = Array.isArray(sendCurrency)
                             ? sendCurrency.includes(prop)
                             : !!sendCurrency

--- a/packages/pwa/app/commerce-api/index.test.js
+++ b/packages/pwa/app/commerce-api/index.test.js
@@ -340,12 +340,12 @@ describe('CommerceAPI', () => {
             slasCallbackEndpoint,
             examplePKCEVerifier
         )
-        const {grantType, code, usid, codeVerifier, redirectUri} = tokenBody
-        expect(grantType).toBeDefined()
+        const {grant_type, code, usid, code_verifier, redirect_uri} = tokenBody
+        expect(grant_type).toBeDefined()
         expect(code).toBeDefined()
         expect(usid).toBeDefined()
-        expect(codeVerifier).toBeDefined()
-        expect(redirectUri).toBeDefined()
+        expect(code_verifier).toBeDefined()
+        expect(redirect_uri).toBeDefined()
     })
     test('should return a code verifier of 128 chracters', () => {
         const codeVerifier = createCodeVerifier()

--- a/packages/pwa/app/commerce-api/utils.js
+++ b/packages/pwa/app/commerce-api/utils.js
@@ -32,12 +32,12 @@ export function isTokenValid(token) {
 // Returns request body for use with ShopperLogin.getToken
 export function createGetTokenBody(urlString, redirect_uri, code_verifier) {
     const {usid, code} = Object.fromEntries(new URL(urlString).searchParams)
-    return {        
+    return {
         code,
         code_verifier,
         grant_type: 'authorization_code_pkce',
         redirect_uri,
-        usid,
+        usid
     }
 }
 

--- a/packages/pwa/app/commerce-api/utils.js
+++ b/packages/pwa/app/commerce-api/utils.js
@@ -29,18 +29,15 @@ export function isTokenValid(token) {
     return false
 }
 
-// Returns fomrulated body for SopperLogin getToken endpoint
-export function createGetTokenBody(urlString, slasCallbackEndpoint, codeVerifier) {
-    const url = new URL(urlString)
-    const urlParams = new URLSearchParams(url.search)
-    const usid = urlParams.get('usid')
-    const code = urlParams.get('code')
-    return {
-        grantType: 'authorization_code_pkce',
+// Returns request body for use with ShopperLogin.getToken
+export function createGetTokenBody(urlString, redirect_uri, code_verifier) {
+    const {usid, code} = Object.fromEntries(new URL(urlString).searchParams)
+    return {        
         code,
+        code_verifier,
+        grant_type: 'authorization_code_pkce',
+        redirect_uri,
         usid,
-        codeVerifier: codeVerifier,
-        redirectUri: slasCallbackEndpoint
     }
 }
 


### PR DESCRIPTION
To login with SLAS, you go through two steps:

1. You generate a code verifier / code challenge and use them to call `ShopperLogin.authorizeCustomer()`
2. You call `ShopperLogin. getAccessToken()` with the `code` and `usid` in the response from 1.

Under the covers, `ShopperLogin.authorizeCustomer()` calls the SLAS `/authorize` endpoint.

This endpoint returns a HTTP response `303 See Other`. It's `Location` header includes the `code` and `usid` you need to call `ShopperLogin. getAccessToken()`.

By default, [`fetch` follows redirects](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options), meaning it will automatically issue a request for the URL in the `Location` header.

But, we don't need to, because all the information we need is already present in that header.

This change does not follow the redirect and instead gets the information needed to move forward from the `Location` header.

* Server side, this saves an extra request against our servers will logging in as guest.
* Client side, this will also save an extra request, however it appears there is currently a bug (?) in `commerce-sdk-isomorphic` that prevents `fetchOptions` from being correctly used in client side `fetch` calls.

# Type of Change

- [x] **Bug fix** (non-breaking change that fixes an issue)

# Changes

* Don't request the `/callback` endpoint during SLAS logins.. -->

# How to Test-Drive This PR

Terminal 1: Run the devserver

```sh
cd ~/git/pwa-kit
git checkout -t origin/fix-extra-slas-network-request
npm start --prefix packages/pwa
```

Terminal 2: Make a request to the hompage

```sh
curl localhost:3000
```

Review the devserver logs and observe `/callback` isn't called.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

---

This change is almost ready to go, but I'd like to see if a) it is easy to test and b) whether there truly is an issue passing fetch options to `commerce-sdk-isomorphic`.