### PR TITLE
Adds constants for `<meta theme-color|apple-mobile-web-app-title>` tags

### DIFF
--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.4.0-dev
+
+-   Add constants for `<meta>` tags `theme-color` and `apple-mobile-web-app-title` [#287](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/287)
+
 ## v1.3.0-dev (Nov 18, 2021)
 
 -   Set common HTTP security headers [#263](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/263)

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -43,7 +43,7 @@ import {IntlProvider} from 'react-intl'
 import {watchOnlineStatus, flatten} from '../../utils/utils'
 import {homeUrlBuilder, getUrlWithLocale, buildPathWithUrlConfig} from '../../utils/url'
 import {getLocaleConfig, getPreferredCurrency, getSupportedLocalesIds} from '../../utils/locale'
-import {DEFAULT_CURRENCY, HOME_HREF} from '../../constants'
+import {APPLE_MOBILE_WEB_APP_TITLE, DEFAULT_CURRENCY, HOME_HREF, THEME_COLOR} from '../../constants'
 
 import Seo from '../seo'
 import useWishlist from '../../hooks/use-wishlist'
@@ -153,11 +153,8 @@ const App = (props) => {
                 <CategoriesProvider categories={allCategories}>
                     <CurrencyProvider currency={currency}>
                         <Seo>
-                            <meta name="theme-color" content="#0288a7" />
-                            <meta
-                                name="apple-mobile-web-app-title"
-                                content="PWA-Kit-Retail-React-App"
-                            />
+                            <meta name="theme-color" content={THEME_COLOR} />
+                            <meta name="apple-mobile-web-app-title" content={APPLE_MOBILE_WEB_APP_TITLE} />
                             <link
                                 rel="apple-touch-icon"
                                 href={getAssetUrl('static/img/global/apple-touch-icon.png')}

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -154,7 +154,10 @@ const App = (props) => {
                     <CurrencyProvider currency={currency}>
                         <Seo>
                             <meta name="theme-color" content={THEME_COLOR} />
-                            <meta name="apple-mobile-web-app-title" content={APPLE_MOBILE_WEB_APP_TITLE} />
+                            <meta
+                                name="apple-mobile-web-app-title"
+                                content={APPLE_MOBILE_WEB_APP_TITLE}
+                            />
                             <link
                                 rel="apple-touch-icon"
                                 href={getAssetUrl('static/img/global/apple-touch-icon.png')}

--- a/packages/pwa/app/components/_app/index.jsx
+++ b/packages/pwa/app/components/_app/index.jsx
@@ -43,7 +43,7 @@ import {IntlProvider} from 'react-intl'
 import {watchOnlineStatus, flatten} from '../../utils/utils'
 import {homeUrlBuilder, getUrlWithLocale, buildPathWithUrlConfig} from '../../utils/url'
 import {getLocaleConfig, getPreferredCurrency, getSupportedLocalesIds} from '../../utils/locale'
-import {APPLE_MOBILE_WEB_APP_TITLE, DEFAULT_CURRENCY, HOME_HREF, THEME_COLOR} from '../../constants'
+import {DEFAULT_CURRENCY, DEFAULT_SITE_TITLE, HOME_HREF, THEME_COLOR} from '../../constants'
 
 import Seo from '../seo'
 import useWishlist from '../../hooks/use-wishlist'
@@ -154,10 +154,7 @@ const App = (props) => {
                     <CurrencyProvider currency={currency}>
                         <Seo>
                             <meta name="theme-color" content={THEME_COLOR} />
-                            <meta
-                                name="apple-mobile-web-app-title"
-                                content={APPLE_MOBILE_WEB_APP_TITLE}
-                            />
+                            <meta name="apple-mobile-web-app-title" content={DEFAULT_SITE_TITLE} />
                             <link
                                 rel="apple-touch-icon"
                                 href={getAssetUrl('static/img/global/apple-touch-icon.png')}

--- a/packages/pwa/app/constants.js
+++ b/packages/pwa/app/constants.js
@@ -41,6 +41,11 @@ export const cssColorGroups = {
     miscellaneous: 'linear-gradient(to right, orange , yellow, green, cyan, blue, violet)'
 }
 
+// Color to use for the UI surrounding the page in browsers.
+export const THEME_COLOR = '#0176D3'
+// On iOS, the title for the launch icon.
+export const APPLE_MOBILE_WEB_APP_TITLE = 'PWA Kit | Retail React App'
+
 export const FILTER_ACCORDION_SATE = 'filters-expanded-index'
 
 export const API_ERROR_MESSAGE = defineMessage({

--- a/packages/pwa/app/constants.js
+++ b/packages/pwa/app/constants.js
@@ -43,8 +43,6 @@ export const cssColorGroups = {
 
 // Color to use for the UI surrounding the page in browsers.
 export const THEME_COLOR = '#0176D3'
-// On iOS, the title for the launch icon.
-export const APPLE_MOBILE_WEB_APP_TITLE = 'PWA Kit | Retail React App'
 
 export const FILTER_ACCORDION_SATE = 'filters-expanded-index'
 


### PR DESCRIPTION
Introduce constants for the `<meta>` tags for `theme-color` and `apple-mobile-web-app-title`:

<img width="829" alt="Screen Shot 2022-01-06 at 8 19 12 PM" src="https://user-images.githubusercontent.com/28967/148491018-7360b7a1-f4a0-40d6-beba-12f5bec14df4.png">

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color


<img width="1096" alt="Screen Shot 2022-01-06 at 8 18 38 PM" src="https://user-images.githubusercontent.com/28967/148490971-eb2dd217-9ad2-4156-a8b7-08ab9e448edc.png">

https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html

This makes the app look nicer when you install it on desktop or mobile:

<img width="1386" alt="Screen Shot 2022-01-06 at 8 19 50 PM" src="https://user-images.githubusercontent.com/28967/148491123-e7268ad3-1121-43e1-87b0-b660e83c41aa.png">


# Types of Changes

- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# How to Test-Drive This PR

```sh
git checkout -t origin/move-theme-colour-to-constants
npm start --prefix packages/pwa
```

* Now in Chrome, navigate to http://localhost:3000. 
* In the top right of your address bar, click the prompt to install the app
* Open the app, observe the color bar is branded.