### PR TITLE
Don't send the HSTS header in local development

### DIFF
--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Next
+
+-  Do not send HSTS header during local development [#288](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/288)
+
 ## v1.3.0-dev (Nov 18, 2021)
 
 -   Set common HTTP security headers [#263](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/263)

--- a/packages/pwa/app/ssr.js
+++ b/packages/pwa/app/ssr.js
@@ -54,7 +54,8 @@ app.use(
                 // Do not upgrade insecure requests for local development
                 'upgrade-insecure-requests': isRemote() ? [] : null
             }
-        }
+        },
+        hsts: isRemote()
     })
 )
 

--- a/packages/pwa/cypress/integration/pages/home.spec.js
+++ b/packages/pwa/cypress/integration/pages/home.spec.js
@@ -36,7 +36,6 @@ describe('Home Page', () => {
                     expect(res.headers['expect-ct']).to.equal('max-age=0')
                     expect(res.headers).to.have.property('referrer-policy')
                     expect(res.headers['referrer-policy']).to.equal('no-referrer')
-                    expect(res.headers).to.have.property('strict-transport-security')
                     expect(res.headers).to.have.property('x-content-type-options')
                     expect(res.headers['x-content-type-options']).to.equal('nosniff')
                     expect(res.headers).to.have.property('x-dns-prefetch-control')


### PR DESCRIPTION
**This change disables HSTS when we are running locally.**

Safari, unlike Chrome, redirects http://localhost to HTTPS if the "Strict-Transport-Security" ([HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)) header is present.

This is surprising because `localhost` is _supposed_ to be a secure context:

> Locally-delivered resources such as those with http://127.0.0.1 URLs, http://localhost and  http://*.localhost URLs (e.g. http://dev.whatever.localhost/), and file:// URLs are also considered to have been delivered securely.

https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts#when_is_a_context_considered_secure

Since the devserver normally runs on HTTP, this breaks things.

# Types of Changes

- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# How to Test-Drive This PR

```sh
git checkout -t origin/disable-hsts-in-devserver
npm start --prefix packages/pwa
```

In another tab, confirm the HSTS header is not present in responses from the devserver:

```sh
curl -D- -so/dev/null 'http://localhost:3000'  | grep 'Strict-Transport-Security'
```

# Checklists

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI