### PR TITLE
`<Section>`'s subtitle prop can be `PropTypes.node`

### DIFF
--- a/packages/pwa/app/components/section/index.jsx
+++ b/packages/pwa/app/components/section/index.jsx
@@ -50,7 +50,7 @@ Section.propTypes = {
     /**
      * Section component subtitle
      */
-    subtitle: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
+    subtitle: PropTypes.oneOfType([PropTypes.array, PropTypes.string, PropTypes.node]),
     /**
      * Section children node(s)
      */


### PR DESCRIPTION
In https://github.com/SalesforceCommerceCloud/pwa-kit/pull/252/files#diff-e0ea812c2f8e525485d0a8c5864aef81debdc02ab58da8b52b5a6925b90396c0L234-R252, we passed a React node in the `subtitle` prop of a `<Section>`. 

This causes a big nasty warning when rendering the homepage during local development.

## Testing

```
git checkout -t origin/fix-invalid-prop-type-on-homepage
npm start --prefix packages/pwa
```

* In a browser, open http://localhost:3000
* Open the devtools console, observe no giant proptypes warning.
* Look at the terminal, observe no giant proptypes warning.