### PR TITLE
POC: Add Connection Reuse in SDK

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/server/express.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/express.js
@@ -158,7 +158,10 @@ export const createApp = (options) => {
         // be no use-case for SDK users to set this.
         strictSSL: true,
 
-        enableLegacyRemoteProxying: true
+        enableLegacyRemoteProxying: true,
+
+        // Custom agent options, if falsey, the node global agent will be used.
+        agentOptions: false
     }
 
     options = Object.assign({}, defaults, options)
@@ -1682,11 +1685,13 @@ const applyPatches = once((options) => {
     // Patch the http.request/get and https.request/get
     // functions to allow us to intercept them (since
     // there are multiple ways to make requests in Node).
-    const getAppHost = () => options.appHostname
-    http.request = outgoingRequestHook(http.request, getAppHost)
-    http.get = outgoingRequestHook(http.get, getAppHost)
-    https.request = outgoingRequestHook(https.request, getAppHost)
-    https.get = outgoingRequestHook(https.get, getAppHost)
+
+    // TODO: Figure out what the significance of making this a function.
+    // const getAppHost = () => options.appHostname
+    http.request = outgoingRequestHook(http.request, options)
+    http.get = outgoingRequestHook(http.get, options)
+    https.request = outgoingRequestHook(https.request, options)
+    https.get = outgoingRequestHook(https.get, options)
 
     // Patch the ExpressJS Response class's redirect function to suppress
     // the creation of a body (DESKTOP-485). Including the body may

--- a/packages/pwa-kit-react-sdk/src/utils/ssr-server.js
+++ b/packages/pwa-kit-react-sdk/src/utils/ssr-server.js
@@ -248,11 +248,6 @@ export const outgoingRequestHook = (wrapped, options) => {
             }
         }
 
-        if (!workingOptions) {
-            // No options were supplied, so we add them
-            workingOptions = {headers: {}}
-        }
-
         if (agentOptions) {
             const {httpAgent, httpsAgent} = getAgents(agentOptions)
 
@@ -278,6 +273,11 @@ export const outgoingRequestHook = (wrapped, options) => {
 
         if (!(appHostname && accessKey)) {
             return wrapped.apply(this, workingArgs) // eslint-disable-line prefer-rest-params
+        }
+
+        if (!workingOptions) {
+            // No options were supplied, so we add them
+            workingOptions = {headers: {}}
         }
 
         // We need to identify loopback requests: requests that are

--- a/packages/pwa-kit-react-sdk/src/utils/ssr-server.js
+++ b/packages/pwa-kit-react-sdk/src/utils/ssr-server.js
@@ -252,10 +252,14 @@ export const outgoingRequestHook = (wrapped, options) => {
             const {httpAgent, httpsAgent} = getAgents(agentOptions)
 
             // Add default agent to global connection reuse.
-            workingOptions.agent =
-                workingUrl.startsWith('http:') || workingOptions.protocol === 'http:'
-                    ? httpAgent
-                    : httpsAgent
+
+            workingOptions = {
+                ...workingOptions,
+                agent:
+                    workingUrl.startsWith('http:') || workingOptions?.protocol === 'http:'
+                        ? httpAgent
+                        : httpsAgent
+            }
 
             // node-fetch and potentially other libraries add connection: close heaaders
             // remove them to keep the connection alive. NOTE: There are variations in

--- a/packages/pwa-kit-react-sdk/src/utils/ssr-server.test.js
+++ b/packages/pwa-kit-react-sdk/src/utils/ssr-server.test.js
@@ -845,7 +845,15 @@ describe('outgoingRequestHook tests', () => {
 
     testCases.forEach((testCase) =>
         test(testCase.name, () => {
-            const hook = outgoingRequestHook(mockRequest, {appHostname})
+            const patchOptions = {appHostname}
+
+            if (testCase.addAgent) {
+                patchOptions.agentOptions = {
+                    keepAlive: true
+                }
+            }
+
+            const hook = outgoingRequestHook(mockRequest, patchOptions)
 
             const args = []
             const hookOptions = {}
@@ -884,8 +892,6 @@ describe('outgoingRequestHook tests', () => {
                 args.push(fakeCallback)
             }
 
-            // TODO: Add test for checking if the agent was applied or not below:
-
             process.env.X_MOBIFY_ACCESS_KEY = accessKey
             hook(...args)
             expect(mockRequest.calledOnce).toBe(true)
@@ -916,7 +922,7 @@ describe('outgoingRequestHook tests', () => {
                 }
             }
 
-            if (testCase.addCallback) {
+            if (testCase.addCallback && !testCase.addAgent) {
                 expect(called[0]).toBe(fakeCallback)
             }
         })

--- a/packages/pwa-kit-react-sdk/src/utils/ssr-server.test.js
+++ b/packages/pwa-kit-react-sdk/src/utils/ssr-server.test.js
@@ -775,7 +775,7 @@ describe('outgoingRequestHook tests', () => {
         mockRequest.reset()
     })
 
-    const appHost = 'localhost:3444'
+    const appHostname = 'localhost:3444'
     const otherHost = 'somewhere.com'
     const accessKey = 'abcdefghijklm'
     const fakeCallback = () => false
@@ -788,14 +788,14 @@ describe('outgoingRequestHook tests', () => {
     })
 
     test('fall-though when empty appHost', () => {
-        const hook = outgoingRequestHook(mockRequest, () => null)
+        const hook = outgoingRequestHook(mockRequest, {})
         const args = ['a', {a: 123}, () => false]
         hook(...args)
         expect(mockRequest.calledWith(...args)).toBe(true)
     })
 
     test('fall-though when no access key', () => {
-        const hook = outgoingRequestHook(mockRequest, () => appHost)
+        const hook = outgoingRequestHook(mockRequest, {appHostname})
         const args = ['a', {a: 123}, () => false]
         process.env.X_MOBIFY_ACCESS_KEY = undefined
         hook(...args)
@@ -810,7 +810,7 @@ describe('outgoingRequestHook tests', () => {
         },
         {
             name: 'loopback',
-            hostname: appHost,
+            hostname: appHostname,
             expectHeader: true
         }
     ]
@@ -819,21 +819,25 @@ describe('outgoingRequestHook tests', () => {
 
     const withHeaders = [true, false]
     const withCallback = withHeaders
+    const withAgent = withCallback
 
     const testCases = []
     baseTestCases.forEach((baseTestCase) =>
         testMethods.forEach((testMethod) =>
             withHeaders.forEach((addHeaders) =>
                 withCallback.forEach((addCallback) => {
-                    const testCase = {...baseTestCase}
-                    testCase.name =
-                        `${testCase.name} via ${testMethod} ` +
-                        `${addHeaders ? 'with' : 'without'} headers, ` +
-                        `${addCallback ? 'with' : 'without'} callback`
-                    testCase.testMethod = testMethod
-                    testCase.addHeaders = addHeaders
-                    testCase.addCallback = addCallback
-                    testCases.push(testCase)
+                    withAgent.forEach((addAgent) => {
+                        const testCase = {...baseTestCase}
+                        testCase.name =
+                            `${testCase.name} via ${testMethod} ` +
+                            `${addHeaders ? 'with' : 'without'} headers, ` +
+                            `${addCallback ? 'with' : 'without'} callback`
+                        testCase.testMethod = testMethod
+                        testCase.addHeaders = addHeaders
+                        testCase.addCallback = addCallback
+                        testCase.addAgent = addAgent
+                        testCases.push(testCase)
+                    })
                 })
             )
         )
@@ -841,7 +845,7 @@ describe('outgoingRequestHook tests', () => {
 
     testCases.forEach((testCase) =>
         test(testCase.name, () => {
-            const hook = outgoingRequestHook(mockRequest, () => appHost)
+            const hook = outgoingRequestHook(mockRequest, {appHostname})
 
             const args = []
             const hookOptions = {}
@@ -879,6 +883,8 @@ describe('outgoingRequestHook tests', () => {
             if (testCase.addCallback) {
                 args.push(fakeCallback)
             }
+
+            // TODO: Add test for checking if the agent was applied or not below:
 
             process.env.X_MOBIFY_ACCESS_KEY = accessKey
             hook(...args)

--- a/packages/pwa/app/ssr.js
+++ b/packages/pwa/app/ssr.js
@@ -39,7 +39,13 @@ const app = createApp({
     // Note that http://localhost is treated as a secure context for development.
     protocol: 'http',
 
-    enableLegacyRemoteProxying: false
+    enableLegacyRemoteProxying: false,
+
+    // Use a global agent for all connections with these options.
+    agentOptions: {
+        keepAlive: true,
+        keepAliveMsecs: 3 * 60 * 1000 // 3 minutes
+    }
 })
 
 // Set HTTP security headers


### PR DESCRIPTION
# Description

This is an evolving PR. As it sits now it's a small dirty proof of concept that we can reuse connections using an agent in the SDK. The benefit is that this is consumable by existing projects. Meaning they can update their SDK, enable this feature and reap the benefits of connection reuse in the form of faster network data access during the server rendering pipeline. 

This solution is also greatly simplified as we don't have to worry about writing isomorphic code. We are writing for the server and don't have to deal with conditionally adding agents while on the client.

As this PR evolves I'll work with @johnboxall to shore up the ssr options interface. We can take the easier road and create an option like "reuseConnections: false|true" or break that down to 2 options concerning themselves with outgoing connections to third party api's, or those being looped back to the server.

_**UPDATE 1**_

I have had the following changes:

1. Refactored the `outgoingRequestHook` to make it more generic to monkey patching the provided http/http get/request method and not be specific to adding accessKey headers.
2. Added a new feature option for the ssr server. It's called `agentOptions`, it's the same shape as the object you use to create an agent (gives you full control). Its default is false, meaning no custom agent will be used to reuse connections. 

# Known Issue(s)

1. Server refreshes still cause a single new connection to be made. I'm unsure if this is expected, but John's #264 does not do this. So more investigation will have to be done.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Add new `agentOptions` config to createApp/ssr server
- Update private function `outgoingRequestHook` to accept the app options and inject a global agent when the above config is defined.

# TODOs
- Fix tests to properly check that the optionally created agent gets added to the options argument.

# How to Test-Drive This PR

Follow the steps detailed in John's comment:
[#244 (comment)](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/244#issuecomment-989331030)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->
