### PR TITLE
Wrap AppConfig with ErrorBoundary

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/browser/main.jsx
@@ -12,6 +12,7 @@ import DeviceContext from '../universal/device-context'
 import App from '../universal/components/_app'
 import AppConfig from '../universal/components/_app-config'
 import Switch from '../universal/components/switch'
+import AppErrorBoundary from '../universal/components/app-error-boundary'
 import {getRoutes, routeComponent} from '../universal/components/route-component'
 import {loadableReady} from '@loadable/component'
 
@@ -74,16 +75,17 @@ export const start = () => {
         .then(() => {
             ReactDOM.hydrate(
                 <Router>
-                    <DeviceContext.Provider value={{type: window.__DEVICE_TYPE__}}>
-                        <AppConfig locals={locals}>
-                            <Switch
-                                error={error}
-                                appState={window.__PRELOADED_STATE__}
-                                routes={routes}
-                                App={WrappedApp}
-                            />
-                        </AppConfig>
-                    </DeviceContext.Provider>
+                    <AppErrorBoundary error={error}>
+                        <DeviceContext.Provider value={{type: window.__DEVICE_TYPE__}}>
+                            <AppConfig locals={locals}>
+                                <Switch
+                                    appState={window.__PRELOADED_STATE__}
+                                    routes={routes}
+                                    App={WrappedApp}
+                                />
+                            </AppConfig>
+                        </DeviceContext.Provider>
+                    </AppErrorBoundary>
                 </Router>,
                 rootEl,
                 () => {

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -26,6 +26,7 @@ import Throw404 from '../universal/components/throw-404'
 
 import AppConfig from '../universal/components/_app-config'
 import Switch from '../universal/components/switch'
+import AppErrorBoundary from '../universal/components/app-error-boundary'
 import {getRoutes, routeComponent} from '../universal/components/route-component'
 import * as errors from '../universal/errors'
 import {detectDeviceType, isRemote} from '../../utils/ssr-server'
@@ -211,11 +212,13 @@ const renderApp = (args) => {
     let bundles = []
     let appJSX = (
         <Router location={location} context={routerContext}>
-            <DeviceContext.Provider value={{type: deviceType}}>
-                <AppConfig locals={res.locals}>
-                    <Switch error={error} appState={appState} routes={routes} App={App} />
-                </AppConfig>
-            </DeviceContext.Provider>
+            <AppErrorBoundary error={error}>
+                <DeviceContext.Provider value={{type: deviceType}}>
+                    <AppConfig locals={res.locals}>
+                        <Switch appState={appState} routes={routes} App={App} />
+                    </AppConfig>
+                </DeviceContext.Provider>
+            </AppErrorBoundary>
         </Router>
     )
 

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/switch/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/switch/index.jsx
@@ -7,7 +7,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Switch as RouterSwitch, Route} from 'react-router-dom'
-import AppErrorBoundary from '../app-error-boundary'
 import {UIDReset, UIDFork} from 'react-uid'
 
 /**
@@ -20,33 +19,28 @@ import {UIDReset, UIDFork} from 'react-uid'
  * @private
  */
 const Switch = (props) => {
-    const {error, appState, routes, App} = props
+    const {appState, routes, App} = props
     return (
         <UIDReset>
-            <AppErrorBoundary error={error}>
-                {!error && (
-                    <App preloadedProps={appState.appProps}>
-                        <RouterSwitch>
-                            {routes.map((route, i) => {
-                                const {component: Component, ...routeProps} = route
-                                return (
-                                    <Route key={i} {...routeProps}>
-                                        <UIDFork>
-                                            <Component preloadedProps={appState.pageProps} />
-                                        </UIDFork>
-                                    </Route>
-                                )
-                            })}
-                        </RouterSwitch>
-                    </App>
-                )}
-            </AppErrorBoundary>
+            <App preloadedProps={appState.appProps}>
+                <RouterSwitch>
+                    {routes.map((route, i) => {
+                        const {component: Component, ...routeProps} = route
+                        return (
+                            <Route key={i} {...routeProps}>
+                                <UIDFork>
+                                    <Component preloadedProps={appState.pageProps} />
+                                </UIDFork>
+                            </Route>
+                        )
+                    })}
+                </RouterSwitch>
+            </App>
         </UIDReset>
     )
 }
 
 Switch.propTypes = {
-    error: PropTypes.object,
     appState: PropTypes.object,
     routes: PropTypes.array,
     App: PropTypes.func,

--- a/packages/pwa/app/components/_app-config/index.jsx
+++ b/packages/pwa/app/components/_app-config/index.jsx
@@ -72,7 +72,7 @@ const getLocale = (locals = {}) => {
 const AppConfig = ({children, locals = {}}) => {
     const [basket, setBasket] = useState(null)
     const [customer, setCustomer] = useState(null)
-
+    throw new Error('this is an error!!!!')
     return (
         <CommerceAPIProvider value={locals.api}>
             <CustomerProvider value={{customer, setCustomer}}>

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -7,10 +7,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Helmet} from 'react-helmet'
-import {Box, Button, Flex, Heading, IconButton, Stack, Text} from '@chakra-ui/react'
-
-import {BrandLogo, FileIcon} from '../icons'
-import {useHistory} from 'react-router-dom'
 
 // <Error> is rendered when:
 //
@@ -22,111 +18,16 @@ import {useHistory} from 'react-router-dom'
 
 const Error = (props) => {
     const {message, stack} = props
-    const history = useHistory()
 
     const title = "This page isn't working"
     return (
-        <Flex id="sf-app" flex={1} direction="column" minWidth={'375px'}>
+        <div>
             <Helmet>
                 <title>{title}</title>
             </Helmet>
-            <Box as="header" width="full" boxShadow="base" backgroundColor="white">
-                <Box
-                    maxWidth="container.xxxl"
-                    marginLeft="auto"
-                    marginRight="auto"
-                    px={[4, 4, 6, 8]}
-                    paddingTop={[1, 1, 2, 4]}
-                    paddingBottom={[3, 3, 2, 4]}
-                >
-                    <IconButton
-                        aria-label="logo"
-                        icon={<BrandLogo width={[8, 8, 8, 12]} height={[6, 6, 6, 8]} />}
-                        marginBottom={[1, 1, 2, 0]}
-                        variant="unstyled"
-                        onClick={() => history.push('/')}
-                    />
-                </Box>
-            </Box>
-            <Box
-                as="main"
-                id="app-main"
-                role="main"
-                layerStyle="page"
-                padding={{lg: 8, md: 6, sm: 0, base: 0}}
-                flex={1}
-            >
-                <Flex
-                    direction={'column'}
-                    justify="center"
-                    px={{base: 4, md: 6, lg: 50}}
-                    py={{base: 20, md: 24}}
-                >
-                    <Flex align="center" direction="column">
-                        <FileIcon boxSize={['30px', '32px']} mb={8} />
-                        <Heading as="h2" fontSize={['xl', '2xl', '2xl', '3xl']} mb={2}>
-                            {title}
-                        </Heading>
-                        <Box maxWidth="440px" marginBottom={8}>
-                            <Text align="center">
-                                An error has occurred. Try refreshing the page or if you need
-                                immediate help please contact support.
-                            </Text>
-                            {message && (
-                                <Box
-                                    as="pre"
-                                    mt={4}
-                                    fontSize="sm"
-                                    background="gray.50"
-                                    borderColor="gray.200"
-                                    borderStyle="solid"
-                                    borderWidth="1px"
-                                    overflow="auto"
-                                    padding={4}
-                                >
-                                    {message}
-                                </Box>
-                            )}
-                        </Box>
-                        <Stack direction={['column', 'row']} spacing={4} width={['100%', 'auto']}>
-                            <Button
-                                variant="outline"
-                                bg="white"
-                                as="a"
-                                borderColor={'gray.200'}
-                                target="_blank"
-                                href="https://help.salesforce.com/s/support"
-                            >
-                                Contact Support
-                            </Button>
-                            <Button onClick={() => window.location.reload()}>
-                                Refresh the page
-                            </Button>
-                        </Stack>
-                    </Flex>
-                    {stack && (
-                        <Box marginTop={20}>
-                            <Text fontWeight="bold" fontSize="md">
-                                Stack Trace
-                            </Text>
-                            <Box
-                                as="pre"
-                                mt={4}
-                                fontSize="sm"
-                                background="gray.50"
-                                borderColor="gray.200"
-                                borderStyle="solid"
-                                borderWidth="1px"
-                                overflow="auto"
-                                padding={4}
-                            >
-                                {stack}
-                            </Box>
-                        </Box>
-                    )}
-                </Flex>
-            </Box>
-        </Flex>
+            <h1>{message}</h1>
+            {stack && <p>{stack}</p>}
+        </div>
     )
 }
 

--- a/packages/pwa/app/components/_error/index.jsx
+++ b/packages/pwa/app/components/_error/index.jsx
@@ -7,27 +7,136 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Helmet} from 'react-helmet'
+import {ChakraProvider} from '@chakra-ui/react'
+import {Box, Button, Flex, Heading, IconButton, Stack, Text} from '@chakra-ui/react'
+
+import theme from '../../theme'
+import {BrandLogo, FileIcon} from '../icons'
+import {useHistory} from 'react-router-dom'
 
 // <Error> is rendered when:
 //
 // 1. A user requests a page that is not routable from `app/routes.jsx`.
 // 2. A routed component throws an error in `getProps()`.
 // 3. A routed component throws an error in `render()`.
+// 4. AppConfig component throws an error in `render()`.
 //
 // It must not throw an error. Keep it as simple as possible.
+// Error Component is NOT wrapped by the App component nor the AppConfig component.
 
 const Error = (props) => {
     const {message, stack} = props
+    const history = useHistory()
 
     const title = "This page isn't working"
     return (
-        <div>
-            <Helmet>
-                <title>{title}</title>
-            </Helmet>
-            <h1>{message}</h1>
-            {stack && <p>{stack}</p>}
-        </div>
+        <ChakraProvider theme={theme}>
+            <Flex id="sf-app" flex={1} direction="column" minWidth={'375px'}>
+                <Helmet>
+                    <title>{title}</title>
+                </Helmet>
+                <Box as="header" width="full" boxShadow="base" backgroundColor="white">
+                    <Box
+                        maxWidth="container.xxxl"
+                        marginLeft="auto"
+                        marginRight="auto"
+                        px={[4, 4, 6, 8]}
+                        paddingTop={[1, 1, 2, 4]}
+                        paddingBottom={[3, 3, 2, 4]}
+                    >
+                        <IconButton
+                            aria-label="logo"
+                            icon={<BrandLogo width={[8, 8, 8, 12]} height={[6, 6, 6, 8]} />}
+                            marginBottom={[1, 1, 2, 0]}
+                            variant="unstyled"
+                            onClick={() => history.push('/')}
+                        />
+                    </Box>
+                </Box>
+                <Box
+                    as="main"
+                    id="app-main"
+                    role="main"
+                    layerStyle="page"
+                    padding={{lg: 8, md: 6, sm: 0, base: 0}}
+                    flex={1}
+                >
+                    <Flex
+                        direction={'column'}
+                        justify="center"
+                        px={{base: 4, md: 6, lg: 50}}
+                        py={{base: 20, md: 24}}
+                    >
+                        <Flex align="center" direction="column">
+                            <FileIcon boxSize={['30px', '32px']} mb={8} />
+                            <Heading as="h2" fontSize={['xl', '2xl', '2xl', '3xl']} mb={2}>
+                                {title}
+                            </Heading>
+                            <Box maxWidth="440px" marginBottom={8}>
+                                <Text align="center">
+                                    An error has occurred. Try refreshing the page or if you need
+                                    immediate help please contact support.
+                                </Text>
+                                {message && (
+                                    <Box
+                                        as="pre"
+                                        mt={4}
+                                        fontSize="sm"
+                                        background="gray.50"
+                                        borderColor="gray.200"
+                                        borderStyle="solid"
+                                        borderWidth="1px"
+                                        overflow="auto"
+                                        padding={4}
+                                    >
+                                        {message}
+                                    </Box>
+                                )}
+                            </Box>
+                            <Stack
+                                direction={['column', 'row']}
+                                spacing={4}
+                                width={['100%', 'auto']}
+                            >
+                                <Button
+                                    variant="outline"
+                                    bg="white"
+                                    as="a"
+                                    borderColor={'gray.200'}
+                                    target="_blank"
+                                    href="https://help.salesforce.com/s/support"
+                                >
+                                    Contact Support
+                                </Button>
+                                <Button onClick={() => window.location.reload()}>
+                                    Refresh the page
+                                </Button>
+                            </Stack>
+                        </Flex>
+                        {stack && (
+                            <Box marginTop={20}>
+                                <Text fontWeight="bold" fontSize="md">
+                                    Stack Trace
+                                </Text>
+                                <Box
+                                    as="pre"
+                                    mt={4}
+                                    fontSize="sm"
+                                    background="gray.50"
+                                    borderColor="gray.200"
+                                    borderStyle="solid"
+                                    borderWidth="1px"
+                                    overflow="auto"
+                                    padding={4}
+                                >
+                                    {stack}
+                                </Box>
+                            </Box>
+                        )}
+                    </Flex>
+                </Box>
+            </Flex>
+        </ChakraProvider>
     )
 }
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

Currently there is an issue where if an error is thrown from `AppConfig`, the error will not be caught and cause the app to hang.

To reproduce this issue, add `throw new Error('error')` to your AppConfig render method.

This PR propose that we move the error boundary up in the component hierarchy, 


```jsx
// previous component hierarchy
        <Router>
            <DeviceContext.Provider>
                <AppConfig>
                    <Switch>
                       <AppErrorBoundary>{children}</AppErrorBoundary>
                    </Switch>
                </AppConfig>
            </DeviceContext.Provider>
        </Router>
```

```jsx
// new component hierarchy
        <Router>
            <AppErrorBoundary>
                <DeviceContext.Provider>
                    <AppConfig>
                        <Switch>{children}</Switch>
                    </AppConfig>
                </DeviceContext.Provider>
            </AppErrorBoundary>
        </Router>
```

The side effect of this change is, the Error component is no longer wrapped within AppConfig, which means Error component cannot use anything that requires to be wrapped in AppConfig. For the retail react app, this means Error component cannot use any Chakra component nor access global data from various commerce api providers. (unless you add the providers inside the Error component)


![Screen Shot 2022-01-13 at 2 03 07 PM](https://user-images.githubusercontent.com/10948652/149416212-80589b27-6e9e-4edb-bba9-2c976a715bfa.png)
(screenshot of error page after this change)

Q: do we consider this change as a breaking change? (this may break the Error component for existing projects.)

- [ ] TODO: add tests and changelog if this proposal is accepted

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [x] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Move `AppErrorBoundary` up in the component hierarchy
- Add `ChakraProvider` in Error component inside pwa

# How to Test-Drive This PR

- add `throw new Error()` in `packages/pwa/app/components/_error` return method
- `cd packages/pwa && npm start`
- go to localhost:3000 you should see error page is rendered with correct error messages/stack

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
