### PR TITLE
Fix/258 forgotpassword not implemented in checkout 2

### DIFF
--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v1.5.0-dev (Jan 28, 2022)
+-   Make sure the forgot-password modal also shows up in the checkout flow [#373](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/373)
+
 ## v1.4.0 (Jan 27, 2022)
 
 -  Do not send HSTS header during local development [#288](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/288)

--- a/packages/pwa/app/hooks/use-auth-modal.js
+++ b/packages/pwa/app/hooks/use-auth-modal.js
@@ -167,6 +167,9 @@ export const AuthModal = ({
         }
     }, [customer])
 
+    const onBackToSignInClick = () =>
+        initialView === PASSWORD_VIEW ? props.onClose() : setCurrentView(LOGIN_VIEW)
+
     const PasswordResetSuccess = () => (
         <Stack justify="center" align="center" spacing={6}>
             <BrandLogo width="60px" height="auto" />
@@ -189,7 +192,7 @@ export const AuthModal = ({
                     />
                 </Text>
 
-                <Button onClick={() => setCurrentView(LOGIN_VIEW)}>
+                <Button onClick={onBackToSignInClick}>
                     <FormattedMessage
                         defaultMessage="Back to Sign In"
                         id="auth_modal.password_reset_success.button.back_to_sign_in"
@@ -217,14 +220,14 @@ export const AuthModal = ({
                         <RegisterForm
                             form={form}
                             submitForm={submitForm}
-                            clickSignIn={() => setCurrentView(LOGIN_VIEW)}
+                            clickSignIn={onBackToSignInClick}
                         />
                     )}
                     {!form.formState.isSubmitSuccessful && currentView === PASSWORD_VIEW && (
                         <ResetPasswordForm
                             form={form}
                             submitForm={submitForm}
-                            clickSignIn={() => setCurrentView(LOGIN_VIEW)}
+                            clickSignIn={onBackToSignInClick}
                         />
                     )}
                     {form.formState.isSubmitSuccessful && currentView === PASSWORD_VIEW && (

--- a/packages/pwa/app/hooks/use-auth-modal.test.js
+++ b/packages/pwa/app/hooks/use-auth-modal.test.js
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React from 'react'
+import PropTypes from 'prop-types'
 import {screen, within, waitFor} from '@testing-library/react'
 import user from '@testing-library/user-event'
 import {renderWithProviders, getPathname} from '../utils/test-utils'
@@ -116,8 +117,10 @@ jest.mock('../commerce-api/pkce', () => {
     }
 })
 
-const MockedComponent = () => {
-    const authModal = useAuthModal()
+let authModal = undefined
+const MockedComponent = (props) => {
+    const {initialView} = props
+    authModal = initialView ? useAuthModal(initialView) : useAuthModal()
     const match = {
         params: {pageName: 'profile'}
     }
@@ -131,9 +134,13 @@ const MockedComponent = () => {
         </Router>
     )
 }
+MockedComponent.propTypes = {
+    initialView: PropTypes.string
+}
 
 // Set up and clean up
 beforeEach(() => {
+    authModal = undefined
     jest.useFakeTimers()
 })
 afterEach(() => {
@@ -217,6 +224,27 @@ test('Allows customer to generate password token', async () => {
     // wait for success state
     expect(await screen.findByText(/password reset/i)).toBeInTheDocument()
     expect(screen.getByText(/foo@test.com/i)).toBeInTheDocument()
+})
+
+test('Allows customer to open generate password token modal from everywhere', () => {
+    // render our test component
+    renderWithProviders(<MockedComponent initialView="password" />)
+
+    // open the modal
+    const trigger = screen.getByText(/open modal/i)
+    user.click(trigger)
+    expect(authModal.isOpen).toBe(true)
+
+    const withinForm = within(screen.getByTestId('sf-auth-modal-form'))
+
+    expect(withinForm.getByText(/Reset Password/i)).toBeInTheDocument()
+
+    // close the modal
+    const switchToSignIn = screen.getByText(/Sign in/i)
+    user.click(switchToSignIn)
+
+    // check that the modal is closed
+    expect(authModal.isOpen).toBe(false)
 })
 
 test('Allows customer to create an account', async () => {

--- a/packages/pwa/app/pages/checkout/partials/contact-info.jsx
+++ b/packages/pwa/app/pages/checkout/partials/contact-info.jsx
@@ -28,10 +28,12 @@ import {useCheckout} from '../util/checkout-context'
 import useLoginFields from '../../../components/forms/useLoginFields'
 import {ToggleCard, ToggleCardEdit, ToggleCardSummary} from '../../../components/toggle-card'
 import Field from '../../../components/field'
+import {AuthModal, useAuthModal} from '../../../hooks/use-auth-modal'
 
 const ContactInfo = () => {
     const {formatMessage} = useIntl()
     const history = useHistory()
+    const authModal = useAuthModal('password')
 
     const {
         customer,
@@ -80,6 +82,11 @@ const ContactInfo = () => {
         setShowPasswordField(!showPasswordField)
         setIsGuestCheckout(!isGuestCheckout)
     }
+
+    const onForgotPasswordClick = () => {
+        authModal.onOpen()
+    }
+
     return (
         <ToggleCard
             id="step-0"
@@ -121,7 +128,11 @@ const ContactInfo = () => {
                                     <Stack>
                                         <Field {...fields.password} />
                                         <Box>
-                                            <Button variant="link" size="sm">
+                                            <Button
+                                                variant="link"
+                                                size="sm"
+                                                onClick={onForgotPasswordClick}
+                                            >
                                                 <FormattedMessage
                                                     defaultMessage="Forgot password?"
                                                     id="contact_info.link.forgot_password"
@@ -163,6 +174,7 @@ const ContactInfo = () => {
                         </Stack>
                     </form>
                 </Container>
+                <AuthModal {...authModal} />
             </ToggleCardEdit>
             <ToggleCardSummary>
                 <Text>{basket?.customerInfo?.email || customer?.email}</Text>

--- a/packages/pwa/app/pages/checkout/partials/contact-info.test.js
+++ b/packages/pwa/app/pages/checkout/partials/contact-info.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen, within} from '@testing-library/react'
+import user from '@testing-library/user-event'
+
+import ContactInfo from './contact-info'
+import {renderWithProviders} from '../../../utils/test-utils'
+
+jest.mock('../util/checkout-context', () => {
+    return {
+        useCheckout: jest.fn().mockReturnValue({
+            customer: null,
+            basket: {},
+            isGuestCheckout: true,
+            setIsGuestCheckout: jest.fn(),
+            step: 0,
+            login: null,
+            setCheckoutStep: null,
+            goToNextStep: null
+        })
+    }
+})
+
+test('renders component', () => {
+    renderWithProviders(<ContactInfo />)
+
+    // switch to login
+    const trigger = screen.getByText(/Already have an account\? Log in/i)
+    user.click(trigger)
+
+    // open forgot password modal
+    const withinCard = within(screen.getByTestId('sf-toggle-card-step-0'))
+    const openModal = withinCard.getByText(/Forgot password\?/i)
+    user.click(openModal)
+
+    // check that forgot password modal is open
+    const withinForm = within(screen.getByTestId('sf-auth-modal-form'))
+    expect(withinForm.getByText(/Reset Password/i)).toBeInTheDocument()
+})


### PR DESCRIPTION
Added existing forgot password modal to the checkout and Fixes #258 

Related PR: #261 

# Description

Added forgot password functionality to customer info card in checkout. Used and extended the existing auth modal.

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- in packages/pwa/app/pages/checkout/partials/contact-info.jsx
  - added AuthModal to the ContactInfo card in checkout
- in packages/pwa/app/hooks/use-auth-modal.js
  - extended AuthModal - ResetPassword
  - if initialView is password then clicking the "Back to Sign in" closes the modal instead of switching to login view
- extended / added unit tests

# How to Test-Drive This PR

- Add an item to cart.
- Go to cart and checkout.
- Switch to Already have an account? Login
- Click Forgot Password?

# Checklists

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
