### PR TITLE
[Generator] Change generator questions

### DIFF
--- a/packages/pwa-kit-create-app/package-lock.json
+++ b/packages/pwa-kit-create-app/package-lock.json
@@ -10141,6 +10141,11 @@
 				"is-fullwidth-code-point": "^3.0.0"
 			}
 		},
+		"slugify": {
+			"version": "1.6.5",
+			"resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
+			"integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ=="
+		},
 		"snapdragon": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",

--- a/packages/pwa-kit-create-app/package.json
+++ b/packages/pwa-kit-create-app/package.json
@@ -29,6 +29,7 @@
     "fs-extra": "7.0.1",
     "inquirer": "7.0.5",
     "shelljs": "^0.8.5",
+    "slugify": "^1.6.5",
     "tar": "^6.1.11"
   },
   "devDependencies": {

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -177,7 +177,7 @@ const runGenerator = (answers, {outputDir}) => {
         p.resolve(outputDir, 'app', 'api.config.js')
     )
 
-    console.log('Installing dependencies for the generated project (this can take a while)')
+    console.log('Installing dependencies for the generated project...')
     sh.exec(`npm install --no-progress`, {
         env: process.env,
         cwd: outputDir,
@@ -224,23 +224,21 @@ const retailReactAppPrompts = () => {
         {
             name: 'projectId',
             validate: validProjectId,
-            message: 'What is your project ID (example-project) in Managed Runtime Admin?'
+            message: 'What is the name of your Project?'
         },
         {
             name: 'instanceUrl',
-            message:
-                'What is the URL (https://example_instance_id.sandbox.us01.dx.commercecloud.salesforce.com) for your B2C Commerce instance?',
+            message: 'What is the URL for your Commerce Cloud instance?',
             validate: validUrl
         },
         {
             name: 'clientId',
-            message: 'What is your API client ID?',
+            message: 'What is your Commerce API client ID in Account Manager?',
             validate: validClientId
         },
         {
             name: 'siteId',
-            message:
-                "What is your site's ID (examples: RefArch, RefArchGlobal) in Business Manager?",
+            message: "What is your site's ID in Business Manager?",
             validate: validSiteId
         },
         {
@@ -355,7 +353,7 @@ const generateHelloWorld = ({projectId}, {outputDir}) => {
     const finalPkgData = merge(pkgJSON, {name: projectId})
     writeJson(pkgJsonPath, finalPkgData)
 
-    console.log('Installing dependencies for the generated project (this can take a while)')
+    console.log('Installing dependencies for the generated project...')
     sh.exec(`npm install --no-progress`, {
         env: process.env,
         cwd: outputDir,
@@ -367,9 +365,18 @@ const presetPrompt = () => {
     const questions = [
         {
             name: 'preset',
-            message: 'Choose a project preset to get started:',
+            message: 'Choose a project to get started:',
             type: 'list',
-            choices: PUBLIC_PRESETS
+            choices: [
+                {
+                    name: 'The Retail app with demo Commerce Cloud sandbox',
+                    value: RETAIL_REACT_APP_DEMO
+                },
+                {
+                    name: 'The Retail app using your own Commerce Cloud sandbox',
+                    value: RETAIL_REACT_APP
+                }
+            ]
         }
     ]
     return inquirer.prompt(questions).then((answers) => answers['preset'])

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -208,8 +208,6 @@ const retailReactAppPrompts = () => {
     // https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values.
     const defaultCommerceAPIError =
         'Invalid format. Use docs to find more information about valid configurations: https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values'
-    const defaultEinsteinAPIError =
-        'Invalid format. Use docs to find more information about valid configurations: https://developer.salesforce.com/docs/commerce/einstein-api/references#einstein-recommendations:Summary'
     const validShortCode = (s) => /(^[0-9A-Z]{8}$)/i.test(s) || defaultCommerceAPIError
     const validClientId = (s) =>
         /(^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}$)/i.test(s) ||
@@ -217,10 +215,6 @@ const retailReactAppPrompts = () => {
         defaultCommerceAPIError
     const validOrganizationId = (s) =>
         /^(f_ecom)_([A-Z]{4})_(prd|stg|dev|[0-9]{3}|s[0-9]{2})$/i.test(s) || defaultCommerceAPIError
-    const validEinsteinId = (s) =>
-        /(^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}$)/i.test(s) ||
-        s === '' ||
-        defaultEinsteinAPIError
 
     const questions = [
         {
@@ -252,13 +246,7 @@ const retailReactAppPrompts = () => {
             name: 'shortCode',
             message: 'What is your Commerce API short code in Business Manager?',
             validate: validShortCode
-        },
-        {
-            name: 'einsteinId',
-            message: 'What is your API Client ID in the Einstein Configurator? (optional)',
-            validate: validEinsteinId
         }
-        // NOTE: there's no question about Einstein's _site_ id because we currently assume that the site id will be the same for both Commerce API and Einstein
     ]
 
     return inquirer.prompt(questions).then((answers) => buildAnswers(answers))

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -51,8 +51,6 @@ sh.set('-e')
 
 const GENERATED_PROJECT_VERSION = '0.0.1'
 
-const PROJECT_ID_MAX_LENGTH = 20
-
 const HELLO_WORLD_TEST_PROJECT = 'hello-world-test-project'
 const HELLO_WORLD = 'hello-world'
 const TEST_PROJECT = 'test-project' // TODO: This will be replaced with the `isomorphic-client` config.
@@ -65,6 +63,8 @@ const PRESETS = PRIVATE_PRESETS.concat(PUBLIC_PRESETS)
 
 const DEFAULT_OUTPUT_DIR = p.join(process.cwd(), 'pwa-kit-starter-project')
 
+const PROJECT_ID_MAX_LENGTH = 20
+
 const SDK_VERSION = generatorPkg.version
 
 const readJson = (path) => JSON.parse(sh.cat(path))
@@ -73,6 +73,13 @@ const writeJson = (path, data) => new sh.ShellString(JSON.stringify(data, null, 
 
 const replaceJSON = (path, replacements) =>
     writeJson(path, Object.assign(readJson(path), replacements))
+
+const slugifyName = (name) => {
+    return slugify(name, {
+        lower: true,
+        strict: true
+    }).slice(0, PROJECT_ID_MAX_LENGTH)
+}
 
 /**
  * Deeply merge two objects in such a way that all array entries in b replace array
@@ -188,43 +195,37 @@ const runGenerator = (answers, {outputDir}) => {
     })
 }
 
+// Validations
 const validProjectName = (s) => {
     const regex = new RegExp(`^[a-zA-Z0-9-\\s]{1,${PROJECT_ID_MAX_LENGTH}}$`)
     return regex.test(s) || 'Value can only contain letters, numbers, space and hyphens.'
 }
 
-const slugifyName = (projectName) => {
-    return slugify(projectName, {
-        lower: true,
-        strict: true
-    }).slice(0, PROJECT_ID_MAX_LENGTH)
+const validUrl = (s) => {
+    try {
+        new URL(s)
+        return true
+    } catch (err) {
+        return 'Value must be an absolute URL'
+    }
 }
 
+const validSiteId = (s) =>
+    /^[a-z0-9_-]+$/i.test(s) || 'Valid characters are alphanumeric, hyphen, or underscore'
+
+// To see definitions for Commerce API configuration values, go to
+// https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values.
+const defaultCommerceAPIError =
+    'Invalid format. Use docs to find more information about valid configurations: https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values'
+const validShortCode = (s) => /(^[0-9A-Z]{8}$)/i.test(s) || defaultCommerceAPIError
+const validClientId = (s) =>
+    /(^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}$)/i.test(s) ||
+    s === 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ||
+    defaultCommerceAPIError
+const validOrganizationId = (s) =>
+    /^(f_ecom)_([A-Z]{4})_(prd|stg|dev|[0-9]{3}|s[0-9]{2})$/i.test(s) || defaultCommerceAPIError
+
 const retailReactAppPrompts = () => {
-    const validUrl = (s) => {
-        try {
-            new URL(s)
-            return true
-        } catch (err) {
-            return 'Value must be an absolute URL'
-        }
-    }
-
-    const validSiteId = (s) =>
-        /^[a-z0-9_-]+$/i.test(s) || 'Valid characters are alphanumeric, hyphen, or underscore'
-
-    // To see definitions for Commerce API configuration values, go to
-    // https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values.
-    const defaultCommerceAPIError =
-        'Invalid format. Use docs to find more information about valid configurations: https://developer.salesforce.com/docs/commerce/commerce-api/guide/commerce-api-configuration-values'
-    const validShortCode = (s) => /(^[0-9A-Z]{8}$)/i.test(s) || defaultCommerceAPIError
-    const validClientId = (s) =>
-        /(^[0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12}$)/i.test(s) ||
-        s === 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' ||
-        defaultCommerceAPIError
-    const validOrganizationId = (s) =>
-        /^(f_ecom)_([A-Z]{4})_(prd|stg|dev|[0-9]{3}|s[0-9]{2})$/i.test(s) || defaultCommerceAPIError
-
     const questions = [
         {
             name: 'projectName',

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -384,7 +384,7 @@ const presetPrompt = () => {
                     value: RETAIL_REACT_APP_DEMO
                 },
                 {
-                   name: 'The Retail app using your own Commerce Cloud instance',
+                    name: 'The Retail app using your own Commerce Cloud instance',
                     value: RETAIL_REACT_APP
                 }
             ]

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -235,12 +235,12 @@ const retailReactAppPrompts = () => {
         },
         {
             name: 'clientId',
-            message: 'What is your Commerce API client ID in Account Manager?',
+            message: 'What is your SLAS API Client ID in Account Manager?',
             validate: validClientId
         },
         {
             name: 'siteId',
-            message: "What is your site's ID in Business Manager?",
+            message: 'What is your Site ID in Business Manager?',
             validate: validSiteId
         },
         {

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -50,6 +50,7 @@ const program = new Command()
 sh.set('-e')
 
 const GENERATED_PROJECT_VERSION = '0.0.1'
+
 const PROJECT_ID_MAX_LENGTH = 20
 
 const HELLO_WORLD_TEST_PROJECT = 'hello-world-test-project'
@@ -187,10 +188,19 @@ const runGenerator = (answers, {outputDir}) => {
     })
 }
 
+const slugifyName = (projectName) => {
+    return slugify(projectName, {
+        lower: true,
+        strict: true
+    }).slice(0, PROJECT_ID_MAX_LENGTH)
+}
+
+const validProjectName = (s) => {
+    const regex = new RegExp(`^[a-zA-Z0-9-\\s]{1,${PROJECT_ID_MAX_LENGTH}}$`)
+    return regex.test(s) || 'Value can only contain letters, numbers, space and hyphens.'
+}
+
 const retailReactAppPrompts = () => {
-    const validProjectName = (s) =>
-        /^[a-zA-Z0-9-\s]{1,20}$/.test(s) ||
-        'Value can only contain letters, numbers, space and hyphens.'
 
     const validUrl = (s) => {
         try {
@@ -250,13 +260,6 @@ const retailReactAppPrompts = () => {
     ]
 
     return inquirer.prompt(questions).then((answers) => buildAnswers(answers))
-}
-
-const slugifyName = (projectName) => {
-    return slugify(projectName, {
-        lower: true,
-        strict: true
-    }).slice(0, PROJECT_ID_MAX_LENGTH)
 }
 
 const buildAnswers = ({
@@ -332,9 +335,6 @@ const demoProjectAnswers = () => {
 }
 
 const helloWorldPrompts = () => {
-    const validProjectName = (s) =>
-        /^[a-zA-Z0-9-\s]{1,20}$/.test(s) ||
-        'Value can only contain letters, numbers, space and hyphens.'
     const questions = [
         {
             name: 'projectName',

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -384,7 +384,7 @@ const presetPrompt = () => {
                     value: RETAIL_REACT_APP_DEMO
                 },
                 {
-                    name: 'The Retail app using your own Commerce Cloud sandbox',
+                   name: 'The Retail app using your own Commerce Cloud instance',
                     value: RETAIL_REACT_APP
                 }
             ]


### PR DESCRIPTION
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000h2ZqYYAU/view

<!--- Provide a short summary of your changes in the Title field above -->

# Description
This PR updates the copy of the App Generator questions.

The new questions copy:
```
> Choose a project to get started:

[1] The Retail app with demo Commerce Cloud sandbox
[2] The Retail app using your own Commerce Cloud sandbox

? What is the name of your Project?
? What is the URL for your Commerce Cloud instance? 
? What is your Commerce API client ID in Account Manager? 
? What is your site's ID in Business Manager? 
? What is your Commerce API organization ID in Business Manager?
? What is your Commerce API short code in Business Manager?
```

The first question has been updated to ask for the Project name instead of the Project id.
`What is the name of your Project?`

The Project Id is now obtained by slugifying the Project name provided by the user using the NPM package [`slugify`](https://www.npmjs.com/package/slugify). This is the same method that we use today in MRT Admin UI.
https://github.com/SalesforceCommerceCloud/pwa-kit/blob/003806b78f43e70550e66a3b6623a810dfc41856/packages/pwa-kit-create-app/scripts/create-mobify-app.js#L267-L271

The assumption for the Project name validation is that we want to allow names _e.g "The Super Project"_ but also ids _e.g "the-super-project"._ 
https://github.com/SalesforceCommerceCloud/pwa-kit/blob/003806b78f43e70550e66a3b6623a810dfc41856/packages/pwa-kit-create-app/scripts/create-mobify-app.js#L191-L193

#### ✅ `slugify` 3PP Approved: 
https://gus.lightning.force.com/lightning/r/ADM_Third_Party_Software__c/a0qEE0000001mPBYAY/view

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [X] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Generator questions copy updated.
- Added slugify logic to generate Project Id from Project name.

# How to Test-Drive This PR


#### Test the `retail-react-app` preset.

1. Run from the root of the monorepo:
```
node packages/pwa-kit-create-app/scripts/create-mobify-app.js --outputDir /tmp/project
```
2. Use the down arrow key to select the project `The Retail app using your own Commerce Cloud sandbox`.
3. Fill the first answer ` What is the name of your Project?` testing different values names. Use the default answers for the rest of the questions.
https://github.com/SalesforceCommerceCloud/pwa-kit/blob/003806b78f43e70550e66a3b6623a810dfc41856/packages/pwa-kit-create-app/scripts/create-mobify-app.js#L316-L326
4. Verify the generated project it's created in the specified `outputDir` and it has the expected project id in the `package.json` file. 


#### Test the `hello-world` preset.

1. Run from the root of the monorepo:
```
GENERATOR_PRESET=hello-world node packages/pwa-kit-create-app/scripts/create-mobify-app.js --outputDir /tmp/project2
```
2. Fill the first answer ` What is the name of your Project?` testing different values names. 
3. Verify the generated project it's created in the specified `outputDir` and it has the expected project id in the `package.json` file. 

#### Tests the same presets (`retail-react-app` and `hello-world`) without the `--outputDir` flag
- Verify the generated project it's created in the folder name using the slugified Project name.
----
#### Test the rest of the presets ( `retail-react-app-demo`, `hello-world-test-project`, `test-project` ) without using the `--outputDir` flag
- Verify the generated project it's created in the folder using the default folder name `pwa-kit-starter-project`.

#### Test the rest of the presets ( `retail-react-app-demo`, `hello-world-test-project`, `test-project` ) using the `--outputDir` flag
- Verify the generated project it's created in the specified `outputDir`.
 
# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
