### PR TITLE
Footer: locale selector's options no longer appear blank on Windows

### DIFF
--- a/packages/pwa/CHANGELOG.md
+++ b/packages/pwa/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.5.0-dev (Jan 28, 2022)
 -   Make sure the forgot-password modal also shows up in the checkout flow [#373](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/373)
+-   On Windows, the locale selector dropdown in the footer now showing all of the options properly [#381](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/381)
 
 ## v1.4.0 (Jan 27, 2022)
 

--- a/packages/pwa/app/components/footer/index.jsx
+++ b/packages/pwa/app/components/footer/index.jsx
@@ -148,6 +148,7 @@ const Footer = ({...otherProps}) => {
                                             value={locale}
                                             shortCode={locale}
                                             key={locale}
+                                            {...styles.localeDropdownOption}
                                         />
                                     ))}
                                 </Select>

--- a/packages/pwa/app/theme/components/project/footer.js
+++ b/packages/pwa/app/theme/components/project/footer.js
@@ -62,6 +62,9 @@ export default {
                 background: 'whiteAlpha.500'
             }
         },
+        localeDropdownOption: {
+            color: 'black'
+        },
         bottomHalf: {
             maxWidth: {base: '34.5rem', lg: '100%'}
         },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Ticket: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07AH000000L4bVYAS/view

On Windows, the locale selector's options were rendered with white text and white background. Thus, users couldn't read them. On Mac, however, these css styles do not matter, as the default native UI ignores them.

The fix is simply to set the option text to 'black'. Why was it 'white' in the first place? Because the footer's text is all in white, and this color got inherited down to the options too.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# How to Test-Drive This PR

You'll need to test on Windows:
1. I've published the fix to https://scaffold-pwa-translations.mobify-storefront.com/
2. Go down to the site footer
3. Select an option from the locale selector dropdown
4. Verify that all of the options are readable/visible

If you don't have access to Windows machine, here's a video I recorded recently. It's showing the dropdown options on Windows Edge browser. I've also tested in other browsers and they look similar/same.

https://user-images.githubusercontent.com/847300/152869604-074ea884-6c77-432a-a83a-6315eb687f30.mov



# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
