### PR TITLE
Remove `pwa-kit.config.json` from PWA

### DIFF
--- a/packages/pwa-kit-create-app/assets/pwa/default.js
+++ b/packages/pwa-kit-create-app/assets/pwa/default.js
@@ -47,7 +47,7 @@ exports.template = ({commerceApi, einsteinApi}) => `module.exports = {
                 path: 'ocapi'
             },
             {
-                host: 'api.cquotien.com',
+                host: 'api.cquotient.com',
                 path: 'einstein'
             }
         ]

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -31,10 +31,10 @@ See the [Localization README.md](./app/translations/README.md) for important set
 
 ## URL Customization
 
-You can customize how storefront URLs are formatted in the `pwa-kit-config.json` file.
+You can customize how storefront URLs are formatted in the you applications configuration file.
 
 ```json
-// pwa-kit.config.json
+// config/default.js
 {
     "url": {
         "locale": "path|query_param|none"
@@ -42,7 +42,7 @@ You can customize how storefront URLs are formatted in the `pwa-kit-config.json`
 }
 ```
 
-You can choose how the current locale appears (or doesn’t appear) in the URL by setting `url.locale` in `pwa-kit-config.json` to one of the following values:
+You can choose how the current locale appears (or doesn’t appear) in the URL by setting `url.locale` to one of the following values:
 
 -   `path`: Locale is included in the URL path. Example: `/en-US/women/dress`
 -   `query_param`: Locale is included as a query parameter. Example: `/women/dress?locale=en-US`

--- a/packages/pwa/README.md
+++ b/packages/pwa/README.md
@@ -31,7 +31,7 @@ See the [Localization README.md](./app/translations/README.md) for important set
 
 ## URL Customization
 
-You can customize how storefront URLs are formatted in the you applications configuration file.
+You can customize how storefront URLs are formatted in your application's configuration file.
 
 ```json
 // config/default.js

--- a/packages/pwa/app/utils/test-utils.js
+++ b/packages/pwa/app/utils/test-utils.js
@@ -157,7 +157,7 @@ export const renderWithProviders = (children, options) =>
 /**
  * This is used to obtain the URL pathname that would include
  * or not include the locale shortcode in the URL according to
- * the locale type configuration set in the pwa-kit.config.json
+ * the locale type configuration set in the application configuration
  * file.
  * @param path The pathname that we want to use
  * @returns {`${string|string}${string}`} URL pathname for the given path

--- a/packages/pwa/app/utils/utils.js
+++ b/packages/pwa/app/utils/utils.js
@@ -159,6 +159,6 @@ export const capitalize = (text) => {
 
 /**
  * A util to return current url configuration
- * @returns {object} - url object from the pwa-kit.config.json file
+ * @returns {object} - url object from the application configuration file
  */
 export const getUrlConfig = () => getConfig().app.url

--- a/packages/pwa/config/default.js
+++ b/packages/pwa/config/default.js
@@ -49,7 +49,7 @@ module.exports = {
                 path: 'ocapi'
             },
             {
-                host: 'api.cquotien.com',
+                host: 'api.cquotient.com',
                 path: 'einstein'
             }
         ]

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -3,40 +3,6 @@
     "version": "1.5.0-dev",
     "license": "See license in LICENSE",
     "private": true,
-    "mobify": {
-        "externals": [],
-        "pageNotFoundURL": "/page-not-found",
-        "ssrEnabled": true,
-        "ssrOnly": [
-            "ssr.js",
-            "ssr.js.map",
-            "node_modules/**/*.*"
-        ],
-        "ssrShared": [
-            "static/ico/favicon.ico",
-            "static/robots.txt",
-            "**/*.js",
-            "**/*.js.map",
-            "**/*.json"
-        ],
-        "ssrParameters": {
-            "ssrFunctionNodeVersion": "14.x",
-            "proxyConfigs": [
-                {
-                    "host": "kv7kzm78.api.commercecloud.salesforce.com",
-                    "path": "api"
-                },
-                {
-                    "host": "zzrf-001.sandbox.us01.dx.commercecloud.salesforce.com",
-                    "path": "ocapi"
-                },
-                {
-                    "host": "api.cquotient.com",
-                    "path": "einstein"
-                }
-            ]
-        }
-    },
     "engines": {
         "node": "^12.0.0 || ^14.0.0",
         "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/packages/pwa/pwa-kit.config.json
+++ b/packages/pwa/pwa-kit.config.json
@@ -1,5 +1,0 @@
-{
-    "url": {
-        "locale": "path"
-    }
-}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

With the change of our configuration setup, we no longer need the `app/pwa-kit.config.json` file, nor the config located at the mobify key in the package.json file. The new config located at `config/default.js` is the single place for it. I also fixed a typo in one of the api urls. 

Code have been deployed [here](https://scaffold-pwa-staging.mobify-storefront.com/) to ensure that it works properly in a production environment.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Remove `pwa-kit.config.json` from the PWA project.
- Remove the `mobify` key from the PWA project package.json file.
- FIx typo in cquotient url.

# How to Test-Drive This PR

- Quick smoke test of the PWA and of a generated project validating that the `pwa-kit.config.json` doesn't exist in either.
- Validate that there are no errors coming from einstein when viewing products. 
```
GENERATOR_PRESET=test-project node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir /tmp/generated-project
```
