### PR TITLE
Always Search For Target Configurations

### DIFF
--- a/packages/pwa-kit-react-sdk/src/utils/config.js
+++ b/packages/pwa-kit-react-sdk/src/utils/config.js
@@ -45,7 +45,7 @@ export const loadConfig = () => {
 
     // Combined search places.
     const searchPlaces = [
-        ...(isRemote ? targetSearchPlaces : []),
+        targetSearchPlaces,
         ...(!isRemote ? localeSearchPlaces : []),
         ...defaultSearchPlaces,
         'package.json'

--- a/packages/pwa-kit-react-sdk/src/utils/config.js
+++ b/packages/pwa-kit-react-sdk/src/utils/config.js
@@ -45,7 +45,7 @@ export const loadConfig = () => {
 
     // Combined search places.
     const searchPlaces = [
-        targetSearchPlaces,
+        ...targetSearchPlaces,
         ...(!isRemote ? localeSearchPlaces : []),
         ...defaultSearchPlaces,
         'package.json'


### PR DESCRIPTION
Previously we weren't searching target named configuration files when developing locally. I think this is a bad idea and hinders developers from testing other "remote only" configurations with a easy setting of the `DEPLOY_TARGET` environment variable. 