### PR TITLE
[V2] Service worker loading for dev server

### DIFF
--- a/packages/pwa-kit-build/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-build/src/ssr/server/build-dev-server.js
@@ -121,19 +121,19 @@ export const DevServerMixin = {
         const middleware = webpackHotServerMiddleware(app.__compiler)
 
         app.get('/worker.js', (req, res) => {
-            const compiled = DevServerFactory._getWebpackAsset(req, 'pwa-others', 'worker.js')
-            if (compiled) {
-                res.type('.js')
-                res.send(compiled)
-            }
+            app.__devMiddleware.waitUntilValid(() => {
+                const compiled = DevServerFactory._getWebpackAsset(req, 'pwa-others', 'worker.js')
+                    res.type('.js')
+                    res.send(compiled)
+            })
         })
 
         app.get('/worker.js.map', (req, res) => {
-            const compiled = DevServerFactory._getWebpackAsset(req, 'pwa-others', 'worker.js.map')
-            if (compiled) {
-                res.type('.js.map')
-                res.send(compiled)
-            }
+            app.__devMiddleware.waitUntilValid(() => {
+                const compiled = DevServerFactory._getWebpackAsset(req, 'pwa-others', 'worker.js.map')
+                    res.type('.js.map')
+                    res.send(compiled)
+            })
         })
 
         app.use('/', (req, res, next) => {

--- a/packages/pwa-kit-build/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-build/src/ssr/server/build-dev-server.js
@@ -125,8 +125,6 @@ export const DevServerMixin = {
             if (compiled) {
                 res.type('.js')
                 res.send(compiled)
-            } else {
-                res.status(404).send('Not found')
             }
         })
 
@@ -135,8 +133,6 @@ export const DevServerMixin = {
             if (compiled) {
                 res.type('.js.map')
                 res.send(compiled)
-            } else {
-                res.status(404).send('Not found')
             }
         })
 

--- a/packages/pwa/app/ssr.js
+++ b/packages/pwa/app/ssr.js
@@ -47,7 +47,7 @@ const {handler} = runtime.createHandler(options, (app) => {
                 useDefaults: true,
                 directives: {
                     'img-src': ["'self'", '*.commercecloud.salesforce.com', 'data:'],
-                    'script-src': ["'self'", "'unsafe-eval'"],
+                    'script-src': ["'self'", "'unsafe-eval'", "storage.googleapis.com"],
 
                     // Do not upgrade insecure requests for local development
                     'upgrade-insecure-requests': isRemote() ? [] : null

--- a/packages/pwa/worker/main.js
+++ b/packages/pwa/worker/main.js
@@ -22,6 +22,9 @@ workbox.setConfig({debug: DEBUG})
 // Place your Workbox route configurations here, eg:
 // workbox.routing.registerRoute(...)
 
+// Never cache dev-server internals.
+workbox.routing.registerRoute(/^http:\/\/localhost:3000\/__mrt/, new workbox.strategies.NetworkOnly())
+
 // Minimum viable configuration to get offline mode.
 workbox.routing.registerRoute(/^http:\/\/localhost:3000/, new workbox.strategies.NetworkFirst())
 workbox.routing.registerRoute(


### PR DESCRIPTION
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000mQKZ3YAO/view

# Description

This PR adds a `waitUntilValid` on the loading of `worker.js` and `worker.js.map`.

This addresses the issue of requests to `worker.js` and `worker.js.map` being made before webpack has finished compiling by making these requests wait until `worker.js` and `worker.js.map` can be served.


This PR contains a 2nd change to add `storage.googleapis.com` to the CSP header. This addresses a CSP error in the browser console and allows the service worker to install.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- In build-dev-server.js, adds a `waitUntilValid` on the loading of `worker.js` and `worker.js.map`
- Add `storage.googleapis.com` to the CSP header in the pwa's ssr.js

# How to Test-Drive This PR

- Start the app
- In a 2nd terminal, run `curl localhost:300/worker.js`
- In your terminal, verify an HTTP 404 status does not appear for worker.js and worker.js.map
- Once the pwa loads in the browser:
  - Check that the service worker has installed and is running
  - Check the console and verify there are no CSP errors related to the loading of the service worker
  - In the terminal you ran `curl`, see that the response has returned the service worker
  - In the terminal you started the app, see that the requests to worker.js and worker.js.map logged with an HTTP 200.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
