### PR TITLE
[Hybrid] Add `<Link />` component to SDK - SDK approach

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -14,10 +14,10 @@ import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import {Helmet} from 'react-helmet'
 import {ChunkExtractor} from '@loadable/server'
-import {StaticRouter as Router, matchPath} from 'react-router-dom'
+import {StaticRouter as Router} from 'react-router-dom'
 import serialize from 'serialize-javascript'
 
-import {getAssetUrl, getConfig} from '../universal/utils'
+import {getAssetUrl, getConfig, matchRoute} from '../universal/utils'
 import DeviceContext from '../universal/device-context'
 
 import Document from '../universal/components/_document'
@@ -145,17 +145,7 @@ export const render = async (req, res, next) => {
     }
 
     // Step 1 - Find the match.
-    let route
-    let match
-
-    routes.some((_route) => {
-        const _match = matchPath(req.path, _route)
-        if (_match) {
-            match = _match
-            route = _route
-        }
-        return !!match
-    })
+    const {route, match} = matchRoute(req.path, routes)
 
     // Step 2 - Get the component
     const component = await route.component.getComponent()

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
@@ -9,7 +9,6 @@ import PropTypes from 'prop-types'
 import {Link as RouterLink} from 'react-router-dom'
 import {matchRoute} from '../../utils'
 import routes from '../../routes'
-import {getAppOrigin} from '../../../../utils/url'
 
 /**
  *  The Link component match the URL with the paths defined in routes.jsx
@@ -17,26 +16,33 @@ import {getAppOrigin} from '../../../../utils/url'
  *  react-router component with a relative URL.
  *
  */
-const Link = (props) => {
-    const {to, toHostname = getAppOrigin(), ...rest} = props
+const Link = ({to, ...props}) => {
     let _routes = routes
     if (typeof routes === 'function') {
         _routes = routes()
     }
 
-    //TODO: Extend Link to use {Link as RouterLink} OR {NavLink as RouterNavLink} from react-router
+    //TODO: Extend Link to accept prop to use react-router {Link as RouterLink} OR {NavLink as RouterNavLink}.
 
-    // Remove routes with * path
-    // TODO: Use a RegExp
+    // Remove wildcard routes with * path
+    // TODO: Use a RegExp to match all the wildcard combinations: '*', '/*', '/*/'.
     _routes = _routes.filter((_route) => _route.path !== '*')
 
     const isMatch = matchRoute(to, _routes).match
-    return isMatch ? <RouterLink to={to} {...rest} /> : <a href={`${toHostname}${to}`} {...rest} />
+    return isMatch ? (
+        // This link will be resolved by the PWA react-router.
+        <RouterLink to={to} {...props} />
+    ) : (
+        // This link will be resolved by eCDN, thus it can be resolved by an external origin.
+        //TODO: The hostname is only for testing the POC locally.
+        // During production the domain will be the same for the PWA and the external origin.
+        // During development we'll use a reverse proxy.
+        <a href={`https://development-internal-ccdemo.demandware.net${to}`} {...props} />
+    )
 }
 
 Link.propTypes = {
-    to: PropTypes.string,
-    toHostname: PropTypes.string
+    to: PropTypes.string
 }
 
 export default Link

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import PropTypes from 'prop-types'
+import {Link as RouterLink} from 'react-router-dom'
+import {matchRoute} from '../../utils'
+import routes from '../../routes'
+import {getAppOrigin} from '../../../../utils/url'
+
+/**
+ *  The Link component match the URL with the paths defined in routes.jsx
+ *  if the URL doesn't match returns an anchor element. if it match returns a
+ *  react-router component with a relative URL.
+ *
+ */
+const Link = (props) => {
+    const {to, toHostname = getAppOrigin(), ...rest} = props
+    let _routes = routes
+    if (typeof routes === 'function') {
+        _routes = routes()
+    }
+
+    // Remove routes with * path
+    _routes = _routes.filter((_route) => _route.path !== '*')
+
+    const isMatch = matchRoute(to, _routes).match
+    return isMatch ? <RouterLink to={to} {...rest} /> : <a href={`${toHostname}${to}`} {...rest} />
+}
+
+Link.propTypes = {
+    to: PropTypes.string,
+    toHostname: PropTypes.string
+}
+
+export default Link

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
@@ -16,24 +16,24 @@ import routes from '../../routes'
  *  react-router component with a relative URL.
  *
  */
+//TODO: Extend Link to accept prop to use react-router {Link as RouterLink} OR {NavLink as RouterNavLink}.
 const Link = ({to, ...props}) => {
     let _routes = routes
     if (typeof routes === 'function') {
         _routes = routes()
     }
 
-    //TODO: Extend Link to accept prop to use react-router {Link as RouterLink} OR {NavLink as RouterNavLink}.
+    const routePath = matchRoute(to, _routes)
 
-    // Remove wildcard routes with * path
+    // Routes matching wildcard * path are consider not routables
     // TODO: Use a RegExp to match all the wildcard combinations: '*', '/*', '/*/'.
-    _routes = _routes.filter((_route) => _route.path !== '*')
+    const isRoutable = routePath.match && routePath.route.path !== '*'
 
-    const isMatch = matchRoute(to, _routes).match
-    return isMatch ? (
-        // This link will be resolved by the PWA react-router.
+    return isRoutable ? (
+        // The link will be resolved by the PWA react-router.
         <RouterLink to={to} {...props} />
     ) : (
-        // This link will be resolved by eCDN, thus it can be resolved by an external origin.
+        // The link will be resolved by eCDN, thus it can be resolved by an external origin.
         //TODO: The hostname is only for testing the POC locally.
         // During production the domain will be the same for the PWA and the external origin.
         // During development we'll use a reverse proxy.

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/link/index.jsx
@@ -24,7 +24,10 @@ const Link = (props) => {
         _routes = routes()
     }
 
+    //TODO: Extend Link to use {Link as RouterLink} OR {NavLink as RouterNavLink} from react-router
+
     // Remove routes with * path
+    // TODO: Use a RegExp
     _routes = _routes.filter((_route) => _route.path !== '*')
 
     const isMatch = matchRoute(to, _routes).match

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
@@ -8,6 +8,29 @@
  * @module progressive-web-sdk/ssr/universal/utils
  */
 import {proxyConfigs} from '../../utils/ssr-shared'
+import {matchPath} from 'react-router-dom'
+
+/**
+ * Checks if a URL path matches a route inside an array of routes.
+ * @param path URL pathname
+ * @param routes array of react-router route objects
+ * @returns {{route, match}} route object matching the URL pathname, match boolean
+ */
+export const matchRoute = (path, routes) => {
+    let match
+    let route
+
+    routes.some((_route) => {
+        const _match = matchPath(path, _route)
+        if (_match) {
+            match = _match
+            route = _route
+        }
+        return !!match
+    })
+
+    return {route, match}
+}
 
 const onClient = typeof window !== 'undefined'
 let _config

--- a/packages/pwa/app/components/link/index.jsx
+++ b/packages/pwa/app/components/link/index.jsx
@@ -17,9 +17,6 @@ const Link = React.forwardRef(({href, to, useNavLink = false, ...props}, ref) =>
     const site = useSite()
     const locale = useLocale()
 
-    //TODO: Add configuration value to the default.js config defining the SFRA hostname
-    const urlHostname = 'https://development-internal-ccdemo.demandware.net'
-
     // if alias is not defined, use site id
     const updatedHref = buildPathWithUrlConfig(_href, {
         locale: locale.alias || locale.id,
@@ -30,7 +27,6 @@ const Link = React.forwardRef(({href, to, useNavLink = false, ...props}, ref) =>
         <ChakraLink
             as={SDKLink}
             to={updatedHref}
-            toHostname={urlHostname}
             {...(useNavLink && {exact: true})}
             {...props}
             ref={ref}

--- a/packages/pwa/app/components/link/index.jsx
+++ b/packages/pwa/app/components/link/index.jsx
@@ -7,7 +7,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {Link as ChakraLink} from '@chakra-ui/react'
-import {Link as SPALink, NavLink as NavSPALink} from 'react-router-dom'
 import {buildPathWithUrlConfig} from '../../utils/url'
 import useSite from '../../hooks/use-site'
 import useLocale from '../../hooks/use-locale'
@@ -20,8 +19,6 @@ const Link = React.forwardRef(({href, to, useNavLink = false, ...props}, ref) =>
 
     //TODO: Add configuration value to the default.js config defining the SFRA hostname
     const urlHostname = 'https://development-internal-ccdemo.demandware.net'
-
-    const linkType = useNavLink ? NavSPALink : SPALink
 
     // if alias is not defined, use site id
     const updatedHref = buildPathWithUrlConfig(_href, {

--- a/packages/pwa/app/components/link/index.jsx
+++ b/packages/pwa/app/components/link/index.jsx
@@ -11,23 +11,31 @@ import {Link as SPALink, NavLink as NavSPALink} from 'react-router-dom'
 import {buildPathWithUrlConfig} from '../../utils/url'
 import useSite from '../../hooks/use-site'
 import useLocale from '../../hooks/use-locale'
+import SDKLink from 'pwa-kit-react-sdk/ssr/universal/components/link'
 
 const Link = React.forwardRef(({href, to, useNavLink = false, ...props}, ref) => {
     const _href = to || href
     const site = useSite()
     const locale = useLocale()
 
+    //TODO: Add configuration value to the default.js config defining the SFRA hostname
+    const urlHostname = 'https://development-internal-ccdemo.demandware.net'
+
+    const linkType = useNavLink ? NavSPALink : SPALink
+
     // if alias is not defined, use site id
     const updatedHref = buildPathWithUrlConfig(_href, {
         locale: locale.alias || locale.id,
         site: site.alias || site.id
     })
+
     return (
         <ChakraLink
-            as={useNavLink ? NavSPALink : SPALink}
+            as={SDKLink}
+            to={updatedHref}
+            toHostname={urlHostname}
             {...(useNavLink && {exact: true})}
             {...props}
-            to={_href === '/' ? '/' : updatedHref}
             ref={ref}
         />
     )

--- a/packages/pwa/app/partials/product-view/index.jsx
+++ b/packages/pwa/app/partials/product-view/index.jsx
@@ -219,8 +219,11 @@ const ProductView = ({
                                 selectedVariationAttributes={variationParams}
                             />
                             <HideOnMobile>
-                                {showFullLink && product && (
-                                    <Link to={`/product/${product.master.masterId}`}>
+                                {//TODO: Change for testing purposes. Link with external path pointing to SFRA site.
+                                product && (
+                                    <Link
+                                        to={`/path-not-matching-pwa-routes/${product.master.masterId}`}
+                                    >
                                         <Text color="blue.600">
                                             {intl.formatMessage({
                                                 defaultMessage: 'See full details',


### PR DESCRIPTION
GUS: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000t0GJqYAM/view

**Related PRs:**
- https://github.com/SalesforceCommerceCloud/pwa-kit/pull/478
- https://github.com/SalesforceCommerceCloud/pwa-kit/pull/468

<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

## Problem
We want to reduce the number of manual steps to implementing Hybrid in the PWA.

## Solution SDK approach
This PR adds a minimal `<Link />` component to the SDK that will help hybrid projects to automate routable links pointing to the PWA and non-routable links pointing to the external origin.

The `<Link />` component matches the `to` prop URL with the paths defined in `routes.jsx` file.
- If the URL doesn't match returns an anchor element. The link will be resolved by eCDN, and thus it's possible to point it to the external origin.
- If it matches returns a react-router Link component with a relative URL. The PWA react-router will resolve the link.

The `<Link />` component props:
- `to`: path for the link. The value can be an absolute URL or a relative URL.
<!--- `toHostname` (optional): Replaces the URL hostname used in the URL. Allows users to point links to remote origins during development. -->

## Result
### Reduced manual work
1. Users will need to use the SDK Link component in their PWA.
2. Users will need to remove the routes that they don't want to be resolved by PWA from `routes.jsx` file.
3.  (Optional) All URLs not matching the PWA routes will point to eCDN. Update eCDN rules to point the URL to the appropriate external original URL.



For example, imagine we want to use the Cart page from SFRA, and in the PWA, we have multiple links pointing to the PWA Cart page `/cart`.
1. We assume we’re using the SDK `<Link />` component in the PWA.
2. We remove the path `/cart` from `routes.jsx` file.
Now all the links [example-domain.com/cart](http://example-domain.com/cart) point outside the PWA to eCDN by using an anchor link in the PWA.
4. (Optional) Update eCDN rule, point [example-domain.com/cart](http://example-domain.com/cart) to [example-domain.com/s/RefArch/cart?lang=en_US](http://example-domain.com/s/RefArch/cart?lang=en_US)


## TODO

- [ ] Extend Link to use {Link as RouterLink} OR {NavLink as RouterNavLink} from react-router
- [ ] Use a RegExp to match the wildcard path.
- [ ] Cover all the absolute/relative URLs potential combinations.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Extracted `matchPath` to a SDK util called `matchRoute`.
- Added Link component to the SDK.
- Use SDK Link component in the PWA Link component.

# How to Test-Drive This PR

1. Checkout this branch `hybrid-sdk-link-component`
2. Run `npm ci`
5. Run `npm run start --prefix packages/pwa`

#### Verify:
- Internal links work as expected by navigating through the App.

- Links that have a path that doesn't match a PWA route, point to the external origin. 
Navigate to the PDP and click the "Show full details" link below the photo gallery.


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
