### PR TITLE
Fix invalid refresh token error

### DIFF
--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -101,7 +101,7 @@ class Auth {
         }
         const storeageKey =
             type === 'registered' ? refreshTokenStorageKey : refreshTokenGuestStorageKey
-        this._storage.set(storeageKey, token)
+        this._storage.set(storeageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
     }
 
     get usid() {

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -29,7 +29,7 @@ import Cookies from 'js-cookie'
 const usidStorageKey = 'usid'
 const encUserIdStorageKey = 'enc-user-id'
 const tokenStorageKey = 'token'
-const refreshTokenStorageKey = 'cc-nx'
+const refreshTokenRegisteredStorageKey = 'cc-nx'
 const refreshTokenGuestStorageKey = 'cc-nx-g'
 const oidStorageKey = 'oid'
 const dwSessionIdKey = 'dwsid'
@@ -95,7 +95,7 @@ class Auth {
     }
 
     get userType() {
-        return this._storage.get(refreshTokenStorageKey)
+        return this._storage.get(refreshTokenRegisteredStorageKey)
             ? Auth.USER_TYPE.REGISTERED
             : Auth.USER_TYPE.GUEST
     }
@@ -103,7 +103,7 @@ class Auth {
     get refreshToken() {
         const storageKey =
             this.userType === Auth.USER_TYPE.REGISTERED
-                ? refreshTokenStorageKey
+                ? refreshTokenRegisteredStorageKey
                 : refreshTokenGuestStorageKey
         return this._storage.get(storageKey)
     }
@@ -139,11 +139,16 @@ class Auth {
      * @param {USER_TYPE} type Type of the user.
      */
     _saveRefreshToken(token, type) {
-        const storageKey =
-            type === Auth.USER_TYPE.REGISTERED
-                ? refreshTokenStorageKey
-                : refreshTokenGuestStorageKey
-        this._storage.set(storageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
+        if (type === Auth.USER_TYPE.REGISTERED) {
+            this._storage.set(refreshTokenRegisteredStorageKey, token, {
+                expires: REFRESH_TOKEN_COOKIE_AGE
+            })
+            this._storage.delete(refreshTokenGuestStorageKey)
+            return
+        }
+
+        this._storage.set(refreshTokenGuestStorageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
+        this._storage.delete(refreshTokenRegisteredStorageKey)
     }
 
     /**
@@ -458,7 +463,7 @@ class Auth {
      */
     _clearAuth() {
         this._storage.delete(tokenStorageKey)
-        this._storage.delete(refreshTokenStorageKey)
+        this._storage.delete(refreshTokenRegisteredStorageKey)
         this._storage.delete(refreshTokenGuestStorageKey)
         this._storage.delete(usidStorageKey)
         this._storage.delete(encUserIdStorageKey)

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -456,41 +456,35 @@ class Storage {
 class CookieStorage extends Storage {
     constructor(...args) {
         super(args)
-        this._avaliable = false
         if (typeof document === 'undefined') {
-            console.warn('CookieStorage is not avaliable on the current environment.')
-            return
+            throw new Error('CookieStorage is not avaliable on the current environment.')
         }
-        this._avaliable = true
     }
     set(key, value, options) {
-        this._avaliable && Cookies.set(key, value, {secure: true, ...options})
+        Cookies.set(key, value, {secure: true, ...options})
     }
     get(key) {
-        return this._avaliable ? Cookies.get(key) : undefined
+        return Cookies.get(key)
     }
     delete(key) {
-        this._avaliable && Cookies.remove(key)
+        Cookies.remove(key)
     }
 }
 
 class LocalStorage extends Storage {
     constructor(...args) {
         super(args)
-        this._avaliable = false
         if (typeof window === 'undefined') {
-            console.warn('LocalStorage is not avaliable on the current environment.')
-            return
+            throw new Error('LocalStorage is not avaliable on the current environment.')
         }
-        this._avaliable = true
     }
     set(key, value) {
-        this._avaliable && window.localStorage.setItem(key, value)
+        window.localStorage.setItem(key, value)
     }
     get(key) {
-        return this._avaliable ? window.localStorage.getItem(key) : undefined
+        return window.localStorage.getItem(key)
     }
     delete(key) {
-        this._avaliable && window.localStorage.removeItem(key)
+        window.localStorage.removeItem(key)
     }
 }

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -35,6 +35,9 @@ const oidStorageKey = 'oid'
 const dwSessionIdKey = 'dwsid'
 const REFRESH_TOKEN_COOKIE_AGE = 90 // 90 days. This value matches SLAS cartridge.
 
+const EXPIRED_TOKEN = 'EXPIRED_TOKEN'
+const INVALID_TOKEN = 'invalid refresh_token'
+
 /**
  * A  class that provides auth functionality for pwa.
  */
@@ -202,7 +205,7 @@ class Auth {
             }
             return this[authorizationMethod](credentials)
                 .catch((error) => {
-                    const retryErrors = ['invalid refresh_token', 'EXPIRED_TOKEN']
+                    const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
                     if (retries === 0 && retryErrors.includes(error.message)) {
                         retries = 1 // we only retry once
                         this._clearAuth()

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -53,13 +53,13 @@ class Auth {
         this._storage = this._onClient ? new LocalStorage() : new Map()
 
         const configOid = api._config.parameters.organizationId
-        if (!this._oid) {
-            this._oid = configOid
+        if (!this.oid) {
+            this.oid = configOid
         }
 
-        if (this._oid !== configOid) {
+        if (this.oid !== configOid) {
             this._clearAuth()
-            this._oid = configOid
+            this.oid = configOid
         }
 
         this.login = this.login.bind(this)
@@ -74,22 +74,22 @@ class Auth {
         return this._pendingLogin
     }
 
-    get _authToken() {
+    get authToken() {
         return this._storage.get(tokenStorageKey)
     }
 
-    set _authToken(token) {
+    set authToken(token) {
         this._storage.set(tokenStorageKey, token)
     }
 
-    get _refreshToken() {
+    get refreshToken() {
         return (
             this._storage.get(refreshTokenStorageKey) ||
             this._storage.get(refreshTokenGuestStorageKey)
         )
     }
 
-    set _refreshToken(obj = {}) {
+    set refreshToken(obj = {}) {
         const {type, token} = obj
         if (!type || !token) {
             throw new Error(
@@ -101,27 +101,27 @@ class Auth {
         this._storage.set(storeageKey, token)
     }
 
-    get _usid() {
+    get usid() {
         return this._storage.get(usidStorageKey)
     }
 
-    set _usid(usid) {
+    set usid(usid) {
         this._storage.set(usidStorageKey, usid)
     }
 
-    get _encUserId() {
+    get encUserId() {
         return this._storage.get(encUserIdStorageKey)
     }
 
-    set _encUserId(encUserId) {
+    set encUserId(encUserId) {
         this._storage.set(encUserIdStorageKey, encUserId)
     }
 
-    get _oid() {
+    get oid() {
         return this._storage.get(oidStorageKey)
     }
 
-    set _oid(oid) {
+    set oid(oid) {
         this._storage.set(oidStorageKey, oid)
     }
 
@@ -175,7 +175,7 @@ class Auth {
             {
                 method: 'POST',
                 headers: {
-                    Authorization: this._authToken
+                    Authorization: this.authToken
                 }
             }
         )
@@ -197,7 +197,7 @@ class Auth {
             let authorizationMethod = '_loginAsGuest'
             if (credentials) {
                 authorizationMethod = '_loginWithCredentials'
-            } else if (this._refreshToken) {
+            } else if (this.refreshToken) {
                 authorizationMethod = '_refreshAccessToken'
             }
             return this[authorizationMethod](credentials)
@@ -233,7 +233,7 @@ class Auth {
     async logout(shouldLoginAsGuest = true) {
         const options = {
             parameters: {
-                refresh_token: this._refreshToken,
+                refresh_token: this.refreshToken,
                 client_id: this._config.parameters.clientId,
                 channel_id: this._config.parameters.siteId
             }
@@ -260,15 +260,15 @@ class Auth {
             id_token
         } = tokenResponse
         this._customerId = customer_id
-        this._authToken = `Bearer ${access_token}`
-        this._usid = usid
+        this.authToken = `Bearer ${access_token}`
+        this.usid = usid
 
         // we use id_token to distinguish guest and registered users
         if (id_token.length > 0) {
-            this._encUserId = enc_user_id
-            this._refreshToken = {type: 'registered', token: refresh_token}
+            this.encUserId = enc_user_id
+            this.refreshToken = {type: 'registered', token: refresh_token}
         } else {
-            this._refreshToken = {type: 'guest', token: refresh_token}
+            this.refreshToken = {type: 'guest', token: refresh_token}
         }
 
         if (this._onClient) {
@@ -403,7 +403,7 @@ class Auth {
     async _refreshAccessToken() {
         const data = new URLSearchParams()
         data.append('grant_type', 'refresh_token')
-        data.append('refresh_token', this._refreshToken)
+        data.append('refresh_token', this.refreshToken)
         data.append('client_id', this._config.parameters.clientId)
 
         const options = {

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -53,13 +53,13 @@ class Auth {
         this._storage = this._onClient ? new LocalStorage() : new Map()
 
         const configOid = api._config.parameters.organizationId
-        if (!this.oid) {
-            this.oid = configOid
+        if (!this._oid) {
+            this._oid = configOid
         }
 
         if (this._oid !== configOid) {
             this._clearAuth()
-            this.oid = configOid
+            this._oid = configOid
         }
 
         this.login = this.login.bind(this)

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -137,9 +137,9 @@ class Auth {
      * @param {USER_TYPE} type Type of the user.
      */
     _saveRefreshToken(token, type) {
-        const storeageKey =
+        const storageKey =
             type === USER_TYPE.REGISTERED ? refreshTokenStorageKey : refreshTokenGuestStorageKey
-        this._storage.set(storeageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
+        this._storage.set(storageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
     }
 
     /**

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -176,7 +176,8 @@ class Auth {
             }
             return this[authorizationMethod](credentials)
                 .catch((error) => {
-                    if (retries === 0 && error.message === 'EXPIRED_TOKEN') {
+                    const retryErrors = ['invalid refresh_token', 'EXPIRED_TOKEN']
+                    if (retries === 0 && retryErrors.includes(error.message)) {
                         retries = 1 // we only retry once
                         this._clearAuth()
                         return startLoginFlow()

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -39,15 +39,6 @@ const EXPIRED_TOKEN = 'EXPIRED_TOKEN'
 const INVALID_TOKEN = 'invalid refresh_token'
 
 /**
- * Enum for user types
- * @enum {string}
- */
-const USER_TYPE = {
-    REGISTERED: 'registered',
-    GUEST: 'guest'
-}
-
-/**
  * A  class that provides auth functionality for pwa.
  */
 const slasCallbackEndpoint = '/callback'
@@ -79,6 +70,15 @@ class Auth {
     }
 
     /**
+     * Enum for user types
+     * @enum {string}
+     */
+    static USER_TYPE = {
+        REGISTERED: 'registered',
+        GUEST: 'guest'
+    }
+
+    /**
      * Returns the api client configuration
      * @returns {boolean}
      */
@@ -95,12 +95,14 @@ class Auth {
     }
 
     get userType() {
-        return this._storage.get(refreshTokenStorageKey) ? USER_TYPE.REGISTERED : USER_TYPE.GUEST
+        return this._storage.get(refreshTokenStorageKey)
+            ? Auth.USER_TYPE.REGISTERED
+            : Auth.USER_TYPE.GUEST
     }
 
     get refreshToken() {
         const storageKey =
-            this.userType === USER_TYPE.REGISTERED
+            this.userType === Auth.USER_TYPE.REGISTERED
                 ? refreshTokenStorageKey
                 : refreshTokenGuestStorageKey
         return this._storage.get(storageKey)
@@ -138,7 +140,9 @@ class Auth {
      */
     _saveRefreshToken(token, type) {
         const storageKey =
-            type === USER_TYPE.REGISTERED ? refreshTokenStorageKey : refreshTokenGuestStorageKey
+            type === Auth.USER_TYPE.REGISTERED
+                ? refreshTokenStorageKey
+                : refreshTokenGuestStorageKey
         this._storage.set(storageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
     }
 
@@ -283,9 +287,9 @@ class Auth {
         // we use id_token to distinguish guest and registered users
         if (id_token.length > 0) {
             this.encUserId = enc_user_id
-            this._saveRefreshToken(refresh_token, USER_TYPE.REGISTERED)
+            this._saveRefreshToken(refresh_token, Auth.USER_TYPE.REGISTERED)
         } else {
-            this._saveRefreshToken(refresh_token, USER_TYPE.GUEST)
+            this._saveRefreshToken(refresh_token, Auth.USER_TYPE.GUEST)
         }
 
         if (this._onClient) {
@@ -333,7 +337,7 @@ class Auth {
         const {customer_id} = await this.getLoggedInToken(tokenBody)
         const customer = {
             customerId: customer_id,
-            authType: 'registered'
+            authType: Auth.USER_TYPE.REGISTERED
         }
 
         return customer
@@ -388,7 +392,7 @@ class Auth {
 
         // A guest customerId will never return a customer from the customer endpoint
         const customer = {
-            authType: 'guest',
+            authType: Auth.USER_TYPE.GUEST,
             customerId: customer_id
         }
 
@@ -438,12 +442,12 @@ class Auth {
 
         const {id_token, enc_user_id, customer_id} = response
         let customer = {
-            authType: 'guest',
+            authType: Auth.USER_TYPE.GUEST,
             customerId: customer_id
         }
         // Determining if registered customer or guest
         if (id_token.length > 0 && enc_user_id.length > 0) {
-            customer.authType = 'registered'
+            customer.authType = Auth.USER_TYPE.REGISTERED
         }
         return customer
     }

--- a/packages/pwa/app/commerce-api/index.test.js
+++ b/packages/pwa/app/commerce-api/index.test.js
@@ -219,8 +219,8 @@ describe('CommerceAPI', () => {
     test('refreshes existing logged in token', async () => {
         const _CommerceAPI = require('./index').default
         const api = new _CommerceAPI(apiConfig)
-        api.auth._saveAccessToken(mockExampleTokenResponse.access_token)
-        api.auth._saveRefreshToken(mockExampleTokenResponse.refresh_token)
+        api.auth.authToken = mockExampleTokenResponse.access_token
+        api.auth._saveRefreshToken(mockExampleTokenResponse.refresh_token, 'registered')
         const customer = await api.auth.login()
         expect(customer).toBeDefined()
         expect(customer.authType).toEqual('registered')
@@ -230,44 +230,44 @@ describe('CommerceAPI', () => {
         const _CommerceAPI = require('./index').default
         const api = new _CommerceAPI(apiConfig)
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         expect(`Bearer ${mockExampleTokenResponse.access_token}`).toEqual(existingToken)
-        api.auth._saveAccessToken(mockExampleTokenReponseForRefresh)
+        api.auth.authToken = mockExampleTokenReponseForRefresh.access_token
         const existingCustomerId = api.auth._customerId
         await api.auth.login()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(mockExampleTokenReponseForRefresh)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(mockExampleTokenReponseForRefresh)
         expect(api.auth._customerId).toEqual(existingCustomerId)
     })
     test('re-authorizes as guest when existing token is expired', async () => {
         const api = getAPI()
         await api.auth.login()
         const existingCustomerId = api.auth._customerId
-        api.auth._saveAccessToken(expiredAuthToken)
-        api.auth._saveRefreshToken(mockExampleTokenResponse.refresh_token)
+        api.auth.authToken = expiredAuthToken
+        api.auth._saveRefreshToken(mockExampleTokenResponse.refresh_token, 'registered')
         await api.auth.login()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(expiredAuthToken)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(expiredAuthToken)
         expect(api.auth._customerId).toEqual(existingCustomerId)
     })
 
     test('logs back in as new guest after log out', async () => {
         const api = getAPI()
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         const existingCustomerId = api.auth._customerId
         expect(existingToken).toBeDefined()
         expect(existingCustomerId).toBeDefined()
         await api.auth.logout()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(mockExampleTokenReponseForRefresh)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(mockExampleTokenReponseForRefresh)
         expect(api.auth._customerId).toBeDefined()
     })
 
     test('clears all auth data upon logout and does not log back in as guest', async () => {
         const api = getAPI()
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         const existingCustomerId = api.auth._customerId
         expect(existingToken).toBeDefined()
         expect(existingCustomerId).toBeDefined()
@@ -276,13 +276,13 @@ describe('CommerceAPI', () => {
     })
     test('automatically authorizes customer when calling sdk methods', async () => {
         const api = getAPI()
-        api.auth._authToken = undefined
+        api.auth.authToken = undefined
         api.auth._customerId = undefined
         await Promise.all([
             api.shopperProducts.getProduct({parameters: {id: '10048'}}),
             api.shopperProducts.getProduct({parameters: {id: '10048'}})
         ])
-        expect(api.auth._authToken).toBeDefined()
+        expect(api.auth.authToken).toBeDefined()
         expect(api.auth._customerId).toBeDefined()
     })
     test('calling login while its already pending returns existing promise', () => {
@@ -371,12 +371,12 @@ describe('CommerceAPI', () => {
             examplePKCEVerifier
         )
         await api.auth.getLoggedInToken(tokenBody)
-        expect(api.auth._authToken).toEqual(`Bearer ${mockExampleTokenResponse.access_token}`)
-        expect(api.auth._refreshToken).toEqual(mockExampleTokenResponse.refresh_token)
+        expect(api.auth.authToken).toEqual(`Bearer ${mockExampleTokenResponse.access_token}`)
+        expect(api.auth.refreshToken).toEqual(mockExampleTokenResponse.refresh_token)
     })
     test('saves access token in local storage if window exists', async () => {
         const api = getAPI()
-        api.auth._saveAccessToken(mockExampleTokenResponse.access_token)
+        api.auth.authToken = mockExampleTokenResponse.access_token
         expect(api.auth.authToken).toEqual(mockExampleTokenResponse.access_token)
     })
     test('saves refresh token in local storage if window exists', async () => {
@@ -386,12 +386,12 @@ describe('CommerceAPI', () => {
     })
     test('saves encUserId in local storage if window exists', async () => {
         const api = getAPI()
-        api.auth._saveEncUserId(mockExampleTokenResponse.enc_user_id)
+        api.auth.encUserId = mockExampleTokenResponse.enc_user_id
         expect(api.auth.encUserId).toEqual(mockExampleTokenResponse.enc_user_id)
     })
     test('saves usid in local storage if window exists', async () => {
         const api = getAPI()
-        api.auth._saveUsid(mockExampleTokenResponse.usid)
+        api.auth.usid = mockExampleTokenResponse.usid
         expect(api.auth.usid).toEqual(mockExampleTokenResponse.usid)
     })
     test('test onClient is true if window exists', async () => {

--- a/packages/pwa/jest-setup.js
+++ b/packages/pwa/jest-setup.js
@@ -27,7 +27,7 @@ class LocalStorageMock {
         return this.store[key] || null
     }
     setItem(key, value) {
-        this.store[key] = value.toString()
+        this.store[key] = value?.toString()
     }
     removeItem(key) {
         delete this.store[key]


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

The PR tries to fix the `invalid refresh_token` error. 

![Screen Shot 2022-04-07 at 3 49 56 PM](https://user-images.githubusercontent.com/10948652/162332152-549870ab-a721-44a4-bc21-512ea338f40c.png)

Refresh token is one time use only, once you use the refresh token to exchange a JWT, the refresh token becomes invalid.

The theory of the root cause is, this issue could be caused by having multiple browser tabs open at the same time. Since we store the shopper JWT **in memory** when the app starts up, in `this.refreshToken` , see [here](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa/app/commerce-api/auth.js#L62). It is possible for the values stored in memory to be out of sync. When the refresh tokens are out of sync, you will get this `invalid refresh_token` error.

This PR updates the auth.js class getters/setters, to always store/access from the storages (localstorage or cookie) directly. We no longer copy the tokens in memory.

This branch is deployed on https://scaffold-pwa-test-env.mobify-storefront.com/

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- update getter/setters for the following properties: `authToken`, `refreshToken`, `usid`, `encUserId`, `oid`, make them talks to storage directly.
- use `Map` as storage on server side
- handle `invalid refresh_token` and if it happens, re-run the guest login flow.
- Replace storage method `remove` with `delete`, so Map can be use as an alternative.

# How to reproduce this issue?
Open 2 browser tabs, go to https://pwa-kit.mobify-storefront.com/ , quickly refresh both tabs

https://user-images.githubusercontent.com/10948652/163865852-84344e85-f194-470d-9854-3a5a3b9e2eea.mov



# How to Test-Drive This PR

- go to the site https://scaffold-pwa-test-env.mobify-storefront.com/ or pull this branch locally and `npm start` go to http://localhost:3000
- repeat the steps in "How to reproduce this issue?" section above
- verify you don't see errors

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
