### PR TITLE
Fixed loading correct amount of skeletons (#387)

### DIFF
--- a/packages/pwa/app/hooks/use-search-params.js
+++ b/packages/pwa/app/hooks/use-search-params.js
@@ -12,7 +12,8 @@ import queryString from 'query-string'
 import {DEFAULT_SEARCH_PARAMS} from '../constants'
 
 const PARSE_OPTIONS = {
-    parseBooleans: true
+    parseBooleans: true,
+    parseNumbers: true
 }
 
 /*

--- a/packages/pwa/app/hooks/use-search-params.test.js
+++ b/packages/pwa/app/hooks/use-search-params.test.js
@@ -51,7 +51,7 @@ describe('The useSearchParams', () => {
         )
 
         expect(wrapper.getByTestId('limits').text).toEqual(
-            '{"limit":"25","offset":"0","sort":"best-matches","refine":{"c_refinementColor":["Black","Purple"]}}'
+            '{"limit":25,"offset":0,"sort":"best-matches","refine":{"c_refinementColor":["Black","Purple"]}}'
         )
     })
 
@@ -78,8 +78,8 @@ describe('The useSearchParams', () => {
         const parsedString = parse(stringToParse)
         expect(parsedString).toEqual(
             {
-                limit: '25',
-                offset: '0',
+                limit: 25,
+                offset: 0,
                 refine: {c_refinementColor: ['Black', 'Purple']},
                 sort: 'best-matches'
             } // eslint-disable-line


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Hi there!

Since this is my first PR, I will shortly introduce myself. I'm Jonas, 25 years old, from Belgium. I started working at FORWARD (Salesforce Partner) almost a year ago as a B2C Commerce Cloud Developer. I'm mainly working with SFRA. As a software enthusiast, I would love to contribute to this project to make it better and to gain more experience with React. If you have any questions, feel free to ask! 🙂

This PR fixes the issue with the incorrect amount of skeletons getting displayed after applying a filter. After digging into this I found that the problem lies in the object that is getting merged in the useSearchParams hook. After the merge, the limit property becomes a string. As a side effect, an array with only one element is getting created.

To deal with this I added a parseNumbers option so that if the value of a query parameter is of type number that it is parsed that way, and not as a string.

Merge:
<img width="479" alt="image" src="https://user-images.githubusercontent.com/24227631/164306467-f393f719-b09e-4ca2-bcd4-da2cca926379.png">

Calling limit property from searchParamsHook:
<img width="465" alt="image" src="https://user-images.githubusercontent.com/24227631/164307267-85f52a40-46fc-45a0-98dc-237e5f69aeb3.png">


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- PARSE_OPTIONS object: a parseNumbers property with a value of true has been added to the PARSE_OPTIONS object to make sure that numbers still have the correct type after merging with the search params query string.

# How to Test-Drive This PR

- Open the PLP.
- Apply a filter.
- Check if the amount of skeletons is matching the limit.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the following two lists:

- [ ] There are no changes to UI

_or..._

- [ x] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ x] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [x ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
