### PR TITLE
[V2] Fix source maps cannot be found when debugging the server

### DIFF
--- a/packages/pwa-kit-cli/src/configs/webpack/config.js
+++ b/packages/pwa-kit-cli/src/configs/webpack/config.js
@@ -102,8 +102,9 @@ const baseConfig = (target) => {
                     minimize: mode === production
                 },
                 // Always use source map, makes debugging the server much easier.
-                // set to false in develop so the SourceMapDevToolPlugin could take place
-                devtool: mode === development ? false : 'source-map',
+                // Use eval-source-map for server debugging in development mode
+                devtool:
+                    mode === development && target === 'node' ? 'eval-source-map' : 'source-map',
                 output: {
                     publicPath: '',
                     path: buildDir
@@ -134,13 +135,6 @@ const baseConfig = (target) => {
                         WEBPACK_TARGET: `'${target}'`,
                         ['global.GENTLY']: false
                     }),
-
-                    mode === development &&
-                        new webpack.SourceMapDevToolPlugin({
-                            filename: '[name].js.map',
-                            publicPath: 'http://localhost:3000/mobify/bundle/development/',
-                            fileContext: 'build'
-                        }),
                     mode === development && new webpack.NoEmitOnErrorsPlugin(),
 
                     createModuleReplacementPlugin(projectDir),

--- a/packages/pwa-kit-cli/src/configs/webpack/config.js
+++ b/packages/pwa-kit-cli/src/configs/webpack/config.js
@@ -101,10 +101,6 @@ const baseConfig = (target) => {
                 optimization: {
                     minimize: mode === production
                 },
-                // Always use source map, makes debugging the server much easier.
-                // Use eval-source-map for server debugging in development mode
-                devtool:
-                    mode === development && target === 'node' ? 'eval-source-map' : 'source-map',
                 output: {
                     publicPath: '',
                     path: buildDir
@@ -226,6 +222,8 @@ const client =
                 ...config,
                 // Must be named "client". See - https://www.npmjs.com/package/webpack-hot-server-middleware#usage
                 name,
+                // use source map to make debugging easier
+                devtool: mode === development ? 'source-map' : false,
                 entry: {
                     main: './app/main'
                 },
@@ -274,6 +272,9 @@ const renderer =
                 // Must be named "server". See - https://www.npmjs.com/package/webpack-hot-server-middleware#usage
                 name: 'server',
                 entry: 'pwa-kit-react-sdk/ssr/server/react-rendering.js',
+                // use source map to make debugging easier
+                // use eval-source-map for server-side debugging
+                devtool: mode === development ? 'eval-source-map' : false,
                 output: {
                     path: buildDir,
                     filename: 'server-renderer.js',

--- a/packages/pwa-kit-cli/src/configs/webpack/config.js
+++ b/packages/pwa-kit-cli/src/configs/webpack/config.js
@@ -102,7 +102,8 @@ const baseConfig = (target) => {
                     minimize: mode === production
                 },
                 // Always use source map, makes debugging the server much easier.
-                devtool: 'source-map',
+                // set to false in develop so the SourceMapDevToolPlugin could take place
+                devtool: mode === development ? false : 'source-map',
                 output: {
                     publicPath: '',
                     path: buildDir
@@ -134,6 +135,12 @@ const baseConfig = (target) => {
                         ['global.GENTLY']: false
                     }),
 
+                    mode === development &&
+                        new webpack.SourceMapDevToolPlugin({
+                            filename: '[name].js.map',
+                            publicPath: 'http://localhost:3000/mobify/bundle/development/',
+                            fileContext: 'build'
+                        }),
                     mode === development && new webpack.NoEmitOnErrorsPlugin(),
 
                     createModuleReplacementPlugin(projectDir),

--- a/packages/pwa-kit-cli/src/configs/webpack/config.js
+++ b/packages/pwa-kit-cli/src/configs/webpack/config.js
@@ -255,6 +255,8 @@ const clientOptional = baseConfig('web')
                 ...optional('core-polyfill', resolve(projectDir, 'node_modules', 'core-js')),
                 ...optional('fetch-polyfill', resolve(projectDir, 'node_modules', 'whatwg-fetch'))
             },
+            // use source map to make debugging easier
+            devtool: mode === development ? 'source-map' : false,
             plugins: [
                 ...config.plugins,
                 analyzeBundle && getBundleAnalyzerPlugin('client-optional')
@@ -272,7 +274,6 @@ const renderer =
                 // Must be named "server". See - https://www.npmjs.com/package/webpack-hot-server-middleware#usage
                 name: 'server',
                 entry: 'pwa-kit-react-sdk/ssr/server/react-rendering.js',
-                // use source map to make debugging easier
                 // use eval-source-map for server-side debugging
                 devtool: mode === development ? 'eval-source-map' : false,
                 output: {
@@ -353,6 +354,8 @@ const requestProcessor =
                     filename: 'request-processor.js',
                     libraryTarget: 'commonjs2'
                 },
+                // use eval-source-map for server-side debugging
+                devtool: mode === development ? 'eval-source-map' : false,
                 plugins: [
                     ...config.plugins,
                     analyzeBundle && getBundleAnalyzerPlugin('request-processor')

--- a/packages/pwa-kit-cli/src/configs/webpack/config.js
+++ b/packages/pwa-kit-cli/src/configs/webpack/config.js
@@ -135,6 +135,7 @@ const baseConfig = (target) => {
                         WEBPACK_TARGET: `'${target}'`,
                         ['global.GENTLY']: false
                     }),
+
                     mode === development && new webpack.NoEmitOnErrorsPlugin(),
 
                     createModuleReplacementPlugin(projectDir),


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
In V2, when you run debugger for server side, the source maps are not available. As a result, it is impossible to do any debugging in the server side code. 
![image](https://user-images.githubusercontent.com/52219283/164321306-a496dafe-8880-48bf-a287-eda5d5e90724.png)

To address this issue, we can switch to `eval-source-map` to create an inline source map for server-side bundles, which makes the debugging possible


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- `npm run build` in packages/pwa-kit-cli
- `npm run start:inspect` in packages/template-retail-react-app
- Go to `localhost:3000`, open your node debugger
- Verify that you can set break points to debug the code, and source mapping is working

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
