### PR TITLE
[V1] Fix invalid refresh token

### DIFF
--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -52,8 +52,8 @@ class Auth {
 
         // To store tokens as cookies
         // change the next line to
-        // this._storage = new CookieStorage()
-        this._storage = new LocalStorage()
+        // this._storage = this._onClient ? new CookieStorage() : new Map()
+        this._storage = this._onClient ? new LocalStorage() : new Map()
         const configOid = api._config.parameters.organizationId
         this._oid = this._storage.get(oidStorageKey) || configOid
 
@@ -408,9 +408,7 @@ class Auth {
      * @param {string} token - A JWT auth token.
      */
     _saveAccessToken(token) {
-        if (this._onClient) {
-            this._storage.set(tokenStorageKey, token)
-        }
+        this._storage.set(tokenStorageKey, token)
     }
 
     /**
@@ -419,9 +417,7 @@ class Auth {
      * @param {string} usid - Unique shopper Id.
      */
     _saveUsid(usid) {
-        if (this._onClient) {
-            this._storage.set(usidStorageKey, usid)
-        }
+        this._storage.set(usidStorageKey, usid)
     }
 
     /**
@@ -430,9 +426,7 @@ class Auth {
      * @param {string} encUserId - Logged in Shopper reference for Einstein API.
      */
     _saveEncUserId(encUserId) {
-        if (this._onClient) {
-            this._storage.set(encUserIdStorageKey, encUserId)
-        }
+        this._storage.set(encUserIdStorageKey, encUserId)
     }
 
     /**
@@ -442,9 +436,7 @@ class Auth {
      */
     _saveOid(oid) {
         this._oid = oid
-        if (this._onClient) {
-            this._storage.set(oidStorageKey, oid)
-        }
+        this._storage.set(oidStorageKey, oid)
     }
 
     /**
@@ -453,14 +445,12 @@ class Auth {
      */
     _clearAuth() {
         this._customerId = undefined
-        if (this._onClient) {
-            this._storage.remove(tokenStorageKey)
-            this._storage.remove(refreshTokenStorageKey)
-            this._storage.remove(refreshTokenGuestStorageKey)
-            this._storage.remove(usidStorageKey)
-            this._storage.remove(encUserIdStorageKey)
-            this._storage.remove(dwSessionIdKey)
-        }
+        this._storage.delete(tokenStorageKey)
+        this._storage.delete(refreshTokenStorageKey)
+        this._storage.delete(refreshTokenGuestStorageKey)
+        this._storage.delete(usidStorageKey)
+        this._storage.delete(encUserIdStorageKey)
+        this._storage.delete(dwSessionIdKey)
     }
 
     /**
@@ -473,13 +463,13 @@ class Auth {
             this._storage.set(refreshTokenStorageKey, refreshToken, {
                 expires: REFRESH_TOKEN_COOKIE_AGE
             })
-            this._storage.remove(refreshTokenGuestStorageKey)
+            this._storage.delete(refreshTokenGuestStorageKey)
             return
         }
         this._storage.set(refreshTokenGuestStorageKey, refreshToken, {
             expires: REFRESH_TOKEN_COOKIE_AGE
         })
-        this._storage.remove(refreshTokenStorageKey)
+        this._storage.delete(refreshTokenStorageKey)
     }
 }
 
@@ -488,7 +478,7 @@ export default Auth
 class Storage {
     set(key, value, options) {}
     get(key) {}
-    remove(key) {}
+    delete(key) {}
 }
 
 class CookieStorage extends Storage {
@@ -507,7 +497,7 @@ class CookieStorage extends Storage {
     get(key) {
         return this._avaliable ? Cookies.get(key) : undefined
     }
-    remove(key) {
+    delete(key) {
         this._avaliable && Cookies.remove(key)
     }
 }
@@ -528,7 +518,7 @@ class LocalStorage extends Storage {
     get(key) {
         return this._avaliable ? window.localStorage.getItem(key) : undefined
     }
-    remove(key) {
+    delete(key) {
         this._avaliable && window.localStorage.removeItem(key)
     }
 }

--- a/packages/pwa/app/commerce-api/auth.js
+++ b/packages/pwa/app/commerce-api/auth.js
@@ -35,6 +35,9 @@ const oidStorageKey = 'oid'
 const dwSessionIdKey = 'dwsid'
 const REFRESH_TOKEN_COOKIE_AGE = 90 // 90 days. This value matches SLAS cartridge.
 
+const EXPIRED_TOKEN = 'EXPIRED_TOKEN'
+const INVALID_TOKEN = 'invalid refresh_token'
+
 /**
  * A  class that provides auth functionality for pwa.
  */
@@ -57,13 +60,6 @@ class Auth {
         if (this._oid !== configOid) {
             this._clearAuth()
             this._saveOid(configOid)
-        } else {
-            this._authToken = this._storage.get(tokenStorageKey)
-            this._refreshToken =
-                this._storage.get(refreshTokenStorageKey) ||
-                this._storage.get(refreshTokenGuestStorageKey)
-            this._usid = this._storage.get(usidStorageKey)
-            this._encUserId = this._storage.get(encUserIdStorageKey)
         }
 
         this.login = this.login.bind(this)
@@ -79,23 +75,26 @@ class Auth {
     }
 
     get authToken() {
-        return this._authToken
+        return this._storage.get(tokenStorageKey)
     }
 
     get refreshToken() {
-        return this._refreshToken
+        return (
+            this._storage.get(refreshTokenStorageKey) ||
+            this._storage.get(refreshTokenGuestStorageKey)
+        )
     }
 
     get usid() {
-        return this._usid
+        return this._storage.get(usidStorageKey)
     }
 
     get encUserId() {
-        return this._encUserId
+        return this._storage.get(encUserIdStorageKey)
     }
 
     get oid() {
-        return this._oid
+        return this._storage.get(oidStorageKey)
     }
 
     /**
@@ -148,7 +147,7 @@ class Auth {
             {
                 method: 'POST',
                 headers: {
-                    Authorization: this._authToken
+                    Authorization: this.authToken
                 }
             }
         )
@@ -171,12 +170,13 @@ class Auth {
             let authorizationMethod = '_loginAsGuest'
             if (credentials) {
                 authorizationMethod = '_loginWithCredentials'
-            } else if (this._refreshToken) {
+            } else if (this.refreshToken) {
                 authorizationMethod = '_refreshAccessToken'
             }
             return this[authorizationMethod](credentials)
                 .catch((error) => {
-                    if (retries === 0 && error.message === 'EXPIRED_TOKEN') {
+                    const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
+                    if (retries === 0 && retryErrors.includes(error.message)) {
                         retries = 1 // we only retry once
                         this._clearAuth()
                         return startLoginFlow()
@@ -375,7 +375,7 @@ class Auth {
     async _refreshAccessToken() {
         const data = new URLSearchParams()
         data.append('grant_type', 'refresh_token')
-        data.append('refresh_token', this._refreshToken)
+        data.append('refresh_token', this.refreshToken)
         data.append('client_id', this._config.parameters.clientId)
 
         const options = {
@@ -408,7 +408,6 @@ class Auth {
      * @param {string} token - A JWT auth token.
      */
     _saveAccessToken(token) {
-        this._authToken = token
         if (this._onClient) {
             this._storage.set(tokenStorageKey, token)
         }
@@ -420,7 +419,6 @@ class Auth {
      * @param {string} usid - Unique shopper Id.
      */
     _saveUsid(usid) {
-        this._usid = usid
         if (this._onClient) {
             this._storage.set(usidStorageKey, usid)
         }
@@ -432,7 +430,6 @@ class Auth {
      * @param {string} encUserId - Logged in Shopper reference for Einstein API.
      */
     _saveEncUserId(encUserId) {
-        this._encUserId = encUserId
         if (this._onClient) {
             this._storage.set(encUserIdStorageKey, encUserId)
         }
@@ -456,10 +453,6 @@ class Auth {
      */
     _clearAuth() {
         this._customerId = undefined
-        this._authToken = undefined
-        this._refreshToken = undefined
-        this._usid = undefined
-        this._encUserId = undefined
         if (this._onClient) {
             this._storage.remove(tokenStorageKey)
             this._storage.remove(refreshTokenStorageKey)
@@ -476,12 +469,17 @@ class Auth {
      * @param {string} refreshToken - A JWT refresh token.
      */
     _saveRefreshToken(refreshToken, type) {
-        this._refreshToken = refreshToken
-        const storeageKey =
-            type === 'registered' ? refreshTokenStorageKey : refreshTokenGuestStorageKey
-        if (this._onClient) {
-            this._storage.set(storeageKey, refreshToken, {expires: REFRESH_TOKEN_COOKIE_AGE})
+        if (type === 'registered') {
+            this._storage.set(refreshTokenStorageKey, refreshToken, {
+                expires: REFRESH_TOKEN_COOKIE_AGE
+            })
+            this._storage.remove(refreshTokenGuestStorageKey)
+            return
         }
+        this._storage.set(refreshTokenGuestStorageKey, refreshToken, {
+            expires: REFRESH_TOKEN_COOKIE_AGE
+        })
+        this._storage.remove(refreshTokenStorageKey)
     }
 }
 

--- a/packages/pwa/app/commerce-api/index.test.js
+++ b/packages/pwa/app/commerce-api/index.test.js
@@ -230,13 +230,13 @@ describe('CommerceAPI', () => {
         const _CommerceAPI = require('./index').default
         const api = new _CommerceAPI(apiConfig)
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         expect(`Bearer ${mockExampleTokenResponse.access_token}`).toEqual(existingToken)
         api.auth._saveAccessToken(mockExampleTokenReponseForRefresh)
         const existingCustomerId = api.auth._customerId
         await api.auth.login()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(mockExampleTokenReponseForRefresh)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(mockExampleTokenReponseForRefresh)
         expect(api.auth._customerId).toEqual(existingCustomerId)
     })
     test('re-authorizes as guest when existing token is expired', async () => {
@@ -246,28 +246,28 @@ describe('CommerceAPI', () => {
         api.auth._saveAccessToken(expiredAuthToken)
         api.auth._saveRefreshToken(mockExampleTokenResponse.refresh_token)
         await api.auth.login()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(expiredAuthToken)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(expiredAuthToken)
         expect(api.auth._customerId).toEqual(existingCustomerId)
     })
 
     test('logs back in as new guest after log out', async () => {
         const api = getAPI()
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         const existingCustomerId = api.auth._customerId
         expect(existingToken).toBeDefined()
         expect(existingCustomerId).toBeDefined()
         await api.auth.logout()
-        expect(api.auth._authToken).toBeDefined()
-        expect(api.auth._authToken).not.toEqual(mockExampleTokenReponseForRefresh)
+        expect(api.auth.authToken).toBeDefined()
+        expect(api.auth.authToken).not.toEqual(mockExampleTokenReponseForRefresh)
         expect(api.auth._customerId).toBeDefined()
     })
 
     test('clears all auth data upon logout and does not log back in as guest', async () => {
         const api = getAPI()
         await api.auth.login()
-        const existingToken = api.auth._authToken
+        const existingToken = api.auth.authToken
         const existingCustomerId = api.auth._customerId
         expect(existingToken).toBeDefined()
         expect(existingCustomerId).toBeDefined()
@@ -276,13 +276,11 @@ describe('CommerceAPI', () => {
     })
     test('automatically authorizes customer when calling sdk methods', async () => {
         const api = getAPI()
-        api.auth._authToken = undefined
-        api.auth._customerId = undefined
         await Promise.all([
             api.shopperProducts.getProduct({parameters: {id: '10048'}}),
             api.shopperProducts.getProduct({parameters: {id: '10048'}})
         ])
-        expect(api.auth._authToken).toBeDefined()
+        expect(api.auth.authToken).toBeDefined()
         expect(api.auth._customerId).toBeDefined()
     })
     test('calling login while its already pending returns existing promise', () => {
@@ -371,8 +369,8 @@ describe('CommerceAPI', () => {
             examplePKCEVerifier
         )
         await api.auth.getLoggedInToken(tokenBody)
-        expect(api.auth._authToken).toEqual(`Bearer ${mockExampleTokenResponse.access_token}`)
-        expect(api.auth._refreshToken).toEqual(mockExampleTokenResponse.refresh_token)
+        expect(api.auth.authToken).toEqual(`Bearer ${mockExampleTokenResponse.access_token}`)
+        expect(api.auth.refreshToken).toEqual(mockExampleTokenResponse.refresh_token)
     })
     test('saves access token in local storage if window exists', async () => {
         const api = getAPI()


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relavant context. -->

The PR tries to fix the `invalid refresh_token` error. 

![Screen Shot 2022-04-07 at 3 49 56 PM](https://user-images.githubusercontent.com/10948652/162332152-549870ab-a721-44a4-bc21-512ea338f40c.png)

Refresh token is one time use only, once you use the refresh token to exchange a JWT, the refresh token becomes invalid.

The theory of the root cause is, this issue could be caused by having multiple browser tabs open at the same time. Since we store the shopper JWT **in memory** when the app starts up, in `this.refreshToken` , see [here](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa/app/commerce-api/auth.js#L62). It is possible for the values stored in memory to be out of sync. When the refresh tokens are out of sync, you will get this `invalid refresh_token` error.

This PR updates the auth.js class getters/setters, to always store/access from the storages (localstorage or cookie) directly. We no longer copy the tokens in memory.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- update getter/setters for the following properties: `authToken`, `refreshToken`, `usid`, `encUserId`, `oid`, make them talks to storage directly.
- use `Map` as storage on server side
- handle `invalid refresh_token` and if it happens, re-run the guest login flow.
- Replace storage method `remove` with `delete`, so Map can be use as an alternative.

# How to reproduce this issue?
Open 2 browser tabs, go to https://pwa-kit.mobify-storefront.com/ , quickly refresh both tabs

https://user-images.githubusercontent.com/10948652/163865852-84344e85-f194-470d-9854-3a5a3b9e2eea.mov



# How to Test-Drive This PR

- pull this branch locally and `npm start` go to http://localhost:3000
- repeat the steps in "How to reproduce this issue?" section above
- verify you don't see errors

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
