### PR TITLE
[V2] Loading page: avoid seeing infinite reloads

### DIFF
--- a/packages/pwa-kit-cli/CHANGELOG.md
+++ b/packages/pwa-kit-cli/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## v2.0.0-dev.4 (Apr 06, 2022)
+
+-   Loading page: avoid seeing infinite reloads [#532](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/532)
+
 ## v2.0.0-dev.3 (Apr 01, 2022)
 ## v2.0.0-dev.2 (Feb 10, 2022)
 

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
@@ -153,7 +153,7 @@ export const DevServerMixin = {
             if (app.__webpackReady()) {
                 middleware(req, res, next)
             } else {
-                this._onAllRequestsBeforeWebpackReady(req, res, next)
+                this._redirectToLoadingScreen(req, res, next)
             }
         })
 
@@ -174,7 +174,7 @@ export const DevServerMixin = {
     },
 
     // eslint-disable-next-line no-unused-vars
-    _onAllRequestsBeforeWebpackReady(req, res, next) {
+    _redirectToLoadingScreen(req, res, next) {
         res.redirect('/__mrt/loading-screen/index.html?loading=1')
     },
 

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
@@ -153,7 +153,7 @@ export const DevServerMixin = {
             if (app.__webpackReady()) {
                 middleware(req, res, next)
             } else {
-                res.redirect(301, '/__mrt/loading-screen/index.html?loading=1')
+                res.redirect('/__mrt/loading-screen/index.html?loading=1')
             }
         })
 

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.js
@@ -127,8 +127,6 @@ export const DevServerMixin = {
             })
         )
 
-        const middleware = webpackHotServerMiddleware(app.__compiler)
-
         app.get('/worker.js', (req, res) => {
             app.__devMiddleware.waitUntilValid(() => {
                 const compiled = DevServerFactory._getWebpackAsset(req, 'pwa-others', 'worker.js')
@@ -149,13 +147,8 @@ export const DevServerMixin = {
             })
         })
 
-        app.use('/', (req, res, next) => {
-            if (app.__webpackReady()) {
-                middleware(req, res, next)
-            } else {
-                res.redirect('/__mrt/loading-screen/index.html?loading=1')
-            }
-        })
+        const middleware = webpackHotServerMiddleware(app.__compiler)
+        this._useWebpackHotServerMiddleware(app, middleware)
 
         app.use((req, res, next) => {
             const done = () => {
@@ -170,6 +163,16 @@ export const DevServerMixin = {
             res.on('finish', done)
             res.on('close', done)
             next()
+        })
+    },
+
+    _useWebpackHotServerMiddleware(app, middleware) {
+        app.use('/', (req, res, next) => {
+            if (app.__webpackReady()) {
+                middleware(req, res, next)
+            } else {
+                res.redirect('/__mrt/loading-screen/index.html?loading=1')
+            }
         })
     },
 

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
@@ -137,12 +137,12 @@ describe('DevServer loading page', () => {
         // Simulate when webpack build is not ready
         app.__webpackReady = () => false
 
-        const middleware = () => {}  // no-op
+        const middleware = () => {} // no-op
         DevServerFactory._useWebpackHotServerMiddleware(app, middleware)
 
         return request(app)
             .get('/')
-            .expect(302)  // Expecting the 302 temporary redirect (not 301)
+            .expect(302) // Expecting the 302 temporary redirect (not 301)
             .then((response) => {
                 expect(response.headers.location).toBe('/__mrt/loading-screen/index.html?loading=1')
             })

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
@@ -131,7 +131,7 @@ describe('DevServer startup', () => {
 })
 
 describe('DevServer loading page', () => {
-    test('requesting homepage would temporarily redirect to the loading page, when build is not ready', async () => {
+    test('should redirect to the loading screen with an HTTP 302', async () => {
         const options = opts()
         const app = NoWebpackDevServerFactory.createApp(options)
         app.use('/', DevServerFactory._onAllRequestsBeforeWebpackReady)

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
@@ -134,11 +134,7 @@ describe('DevServer loading page', () => {
     test('requesting homepage would temporarily redirect to the loading page, when build is not ready', async () => {
         const options = opts()
         const app = NoWebpackDevServerFactory.createApp(options)
-        // Simulate when webpack build is not ready
-        app.__webpackReady = () => false
-
-        const middleware = () => {} // no-op
-        DevServerFactory._useWebpackHotServerMiddleware(app, middleware)
+        app.use('/', DevServerFactory._onAllRequestsBeforeWebpackReady)
 
         return request(app)
             .get('/')

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
@@ -130,6 +130,25 @@ describe('DevServer startup', () => {
     })
 })
 
+describe('DevServer loading page', () => {
+    test('requesting homepage would temporarily redirect to the loading page, when build is not ready', async () => {
+        const options = opts()
+        const app = NoWebpackDevServerFactory.createApp(options)
+        // Simulate when webpack build is not ready
+        app.__webpackReady = () => false
+
+        const middleware = () => {}  // no-op
+        DevServerFactory._useWebpackHotServerMiddleware(app, middleware)
+
+        return request(app)
+            .get('/')
+            .expect(302)  // Expecting the 302 temporary redirect (not 301)
+            .then((response) => {
+                expect(response.headers.location).toBe('/__mrt/loading-screen/index.html?loading=1')
+            })
+    })
+})
+
 describe('DevServer request processor support', () => {
     const helloWorld = '<div>hello world</div>'
 
@@ -230,7 +249,7 @@ describe('DevServer request processor support', () => {
     })
 })
 
-describe('DevServer startup', () => {
+describe('DevServer listening on http/https protocol', () => {
     let server
     let originalEnv
 

--- a/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-cli/src/ssr/server/build-dev-server.test.js
@@ -134,7 +134,7 @@ describe('DevServer loading page', () => {
     test('should redirect to the loading screen with an HTTP 302', async () => {
         const options = opts()
         const app = NoWebpackDevServerFactory.createApp(options)
-        app.use('/', DevServerFactory._onAllRequestsBeforeWebpackReady)
+        app.use('/', DevServerFactory._redirectToLoadingScreen)
 
         return request(app)
             .get('/')


### PR DESCRIPTION
# Description

Ticket: W-11025868

It's possible that the loading page to be reloading infinitely. At a glance, the issue seems to be the loading page infinitely reloading itself. But what happens is actually it redirects to the homepage, which then redirect you back to the loading page → infinite loop

Bug in action:
https://user-images.githubusercontent.com/847300/164569459-1cf72af3-9c18-4acb-ae10-1f6c0bfb0de8.mp4

There are 2 possible redirects between the loading page and homepage:
- loading page → homepage: this happens when the webpack build is ready
- homepage → loading page: this happens when the build is NOT ready

If you somehow trigger the 2nd redirect above, the browser would cache the redirect to the loading page. Then afterwards it's possible for you to run into the infinite loop.

The fix is by making sure that the redirect is using 302 temporary redirect (and not the permanent 301).

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Converted the redirect from homepage to loading page to use 302
- Added a test to make sure it's 302 redirect

# How to Test-Drive This PR

1. `npm ci` at the root
2. `cd /packages/template-typescript-minimal`
3. `npm start`
4. When the loading page shows up in your browser, quickly navigate to the homepage by typing `localhost:3000` into the address bar.
5. You'll get redirected back to the loading page, since the webpack build is NOT ready yet
6. Now that the build is ready, you'll get redirected to the homepage
7. Verify that you are now at the homepage (and not seeing the infinite loop)

# Checklists

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
