### PR TITLE
Fixed loading correct amount of skeletons

### DIFF
--- a/packages/template-retail-react-app/app/hooks/use-search-params.js
+++ b/packages/template-retail-react-app/app/hooks/use-search-params.js
@@ -12,7 +12,8 @@ import queryString from 'query-string'
 import {DEFAULT_SEARCH_PARAMS} from '../constants'
 
 const PARSE_OPTIONS = {
-    parseBooleans: true
+    parseBooleans: true,
+    parseNumbers: true
 }
 
 /*

--- a/packages/template-retail-react-app/app/hooks/use-search-params.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-search-params.test.js
@@ -51,7 +51,7 @@ describe('The useSearchParams', () => {
         )
 
         expect(wrapper.getByTestId('limits').text).toEqual(
-            '{"limit":"25","offset":"0","sort":"best-matches","refine":{"c_refinementColor":["Black","Purple"]}}'
+            '{"limit":25,"offset":0,"sort":"best-matches","refine":{"c_refinementColor":["Black","Purple"]}}'
         )
     })
 
@@ -78,8 +78,8 @@ describe('The useSearchParams', () => {
         const parsedString = parse(stringToParse)
         expect(parsedString).toEqual(
             {
-                limit: '25',
-                offset: '0',
+                limit: 25,
+                offset: 0,
                 refine: {c_refinementColor: ['Black', 'Purple']},
                 sort: 'best-matches'
             } // eslint-disable-line


### PR DESCRIPTION
This PR ports the changes from #525 into the V2 branch.

More information is available on #525 but to summarize, this PR fixes an issue where an incorrect amount of skeletons are displayed in the PLP after applying a filter. 

Credit for this code goes to @JonasReniers

Test steps:
- Navigate to the PLP
- Apply a filter
- Verify the amount of skeletons that appears matches the limit
