### PR TITLE
Fix Verbose ShellJS Command

### DIFF
--- a/packages/pwa-kit-dev/bin/pwa-kit-dev.js
+++ b/packages/pwa-kit-dev/bin/pwa-kit-dev.js
@@ -119,6 +119,7 @@ const main = () => {
             const webpackConf = fs.existsSync(projectWebpack)
                 ? projectWebpack
                 : p.join(__dirname, '..', 'configs', 'webpack', 'config.js')
+            const silentState = sh.config.silent
             sh.rm('-rf', './build')
             execSync(`${webpack} --config ${webpackConf}`, {
                 env: {
@@ -134,7 +135,9 @@ const main = () => {
             const config = p.resolve('config')
             if (fs.existsSync(config)) {
                 sh.cp('-R', config, './build')
+                sh.config.silent = true
                 sh.rm('./build/config/local.*')
+                sh.config.silent = silentState
             }
 
             // This file is required by MRT, for historical reasons.


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

When building a template's bundle we remove the `local.*` configurations just in case. By default `shelljs` will be verbose when running the `rm` command if there are no files found. This PR corrects that by temporarily silencing all the output before running that command and re-setting it back to it's original value. This way if the project doesn't have local configurations you won't see an error in the terminal.
