### PR TITLE
[V2] Clarify that service worker does not have to be hosted at the root

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -688,10 +688,10 @@ export const RemoteServerFactory = {
     },
 
     /**
-     * Serve the /worker.js file.
+     * Serve the service worker at `req.path`
      *
-     * The service worker must be served at the root of the site and must
-     * not be a redirect. We set a long value for s-maxage (to allow CDN
+     * For best results, serve the service worker at the root of the site and
+     * it must not be a redirect. We set a long value for s-maxage (to allow CDN
      * caching), plus a strong etag (for CDN-only revalidation), and to set
      * maxage to 0 to prevent browser caching.
      *

--- a/packages/template-retail-react-app/app/main.jsx
+++ b/packages/template-retail-react-app/app/main.jsx
@@ -7,6 +7,7 @@
 import {start, registerServiceWorker} from 'pwa-kit-react-sdk/ssr/browser/main'
 
 const main = () => {
+    // The path to your service worker should match what is set up in ssr.js
     return Promise.all([start(), registerServiceWorker('/worker.js')])
 }
 

--- a/packages/template-typescript-minimal/app/ssr.js
+++ b/packages/template-typescript-minimal/app/ssr.js
@@ -39,7 +39,6 @@ const {handler} = runtime.createHandler(options, (app) => {
 
     app.get('/favicon.ico', runtime.serveStaticFile('static/favicon.ico'))
 
-    app.get('/worker.js(.map)?', runtime.serveServiceWorker)
     app.get('*', runtime.render)
 })
 


### PR DESCRIPTION
# Description

Given the recent update to ssr.js API, developers now have control over where the service worker file is hosted. This PR clarifies that:
- the service worker does not have to be hosted at the root, although it's best to be at the root
- the path given to `registerServiceWorker()` should match what's set up in ssr.js

Reference: about scope and location of service worker, see https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers#registering_your_worker

## How to test
1. Update ssr.js for Retail React App,  so that the service worker is hosted at `/foo/worker.js`
2. Update `registerServiceWorker()` call (in app/main.jsx) with `/foo/worker.js` too
3. `npm start` to load the site
4. Verify in your web inspector that the service worker is registered/installed at the expected location

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [x] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
