### PR TITLE
[V2] Clearing cache and service worker when starting dev server

### DIFF
--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -143,6 +143,12 @@ export const DevServerMixin = {
                 dotFiles: 'deny'
             })
         )
+
+        app.get('/__mrt/clear-browser-data', (_, res) => {
+            console.log(chalk.cyan('Clearing browser data'), '(cache, service worker, web storage for browsers supporting Clear-Site-Data header)')
+            res.set('Clear-Site-Data', '"cache", "storage"')
+            res.send()
+        })
     },
 
     /**

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -146,6 +146,9 @@ export const DevServerMixin = {
 
         app.get('/__mrt/clear-browser-data', (_, res) => {
             console.log(chalk.cyan('Clearing browser data'), '(cache, service worker, web storage for browsers supporting Clear-Site-Data header)')
+
+            // Note: this header value needs the double quotes.
+            // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
             res.set('Clear-Site-Data', '"cache", "storage"')
             res.send()
         })

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -145,7 +145,10 @@ export const DevServerMixin = {
         )
 
         app.get('/__mrt/clear-browser-data', (_, res) => {
-            console.log(chalk.cyan('Clearing browser data'), '(cache, service worker, web storage for browsers supporting Clear-Site-Data header)')
+            console.log(
+                chalk.cyan('Clearing browser data'),
+                '(cache, service worker, web storage for browsers supporting Clear-Site-Data header)'
+            )
 
             // Note: this header value needs the double quotes.
             // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -149,9 +149,12 @@ export const DevServerMixin = {
                 chalk.cyan('Clearing browser data'),
                 '(cache, service worker, web storage for browsers supporting Clear-Site-Data header)'
             )
+            console.log(
+                'For more info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data#browser_compatibility'
+            )
+            console.log('')
 
             // Note: this header value needs the double quotes.
-            // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data
             res.set('Clear-Site-Data', '"cache", "storage"')
             res.send()
         })

--- a/packages/pwa-kit-dev/src/ssr/server/loading-screen/index.html
+++ b/packages/pwa-kit-dev/src/ssr/server/loading-screen/index.html
@@ -120,5 +120,11 @@
             animateFacts()
         })()
     </script>
+
+    <script>
+        (function() {
+            fetch('/__mrt/clear-browser-data')
+        })()
+    </script>
 </body>
 </html>


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

When switching either branches or projects during _local development_, your browser cache or even the service worker may introduce unexpected issues. For example:
- A cache-control header set on the homepage would cause homepage of a previous branch/project to be reused 
- A service worker registered with a previous project would still be active in the new project

This PR proposed a progressive enhancement for those browsers that do support [`Clear-Site-Data`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Clear-Site-Data) header. With this header, we can ask the browsers to clear their cache and service worker.

Related PR: #607 

Ticket W-11087303

## Alternatives 

Other alternative were explored, including having a cache breaker. Please see #587.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
