### PR TITLE
Return clone instead of modifying original runtime.

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/express.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.js
@@ -479,7 +479,7 @@ export const getRuntime = () => {
     // we bind every single method to have the context of the object itself
     const boundRuntime = {...runtime}
     for (const property of Object.keys(boundRuntime)) {
-        if (boundRuntime[property] instanceof Function) {
+        if (typeof boundRuntime[property] === 'function') {
             boundRuntime[property] = boundRuntime[property].bind(boundRuntime)
         }
     }

--- a/packages/pwa-kit-runtime/src/ssr/server/express.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.js
@@ -460,6 +460,10 @@ export const respondFromBundle = ({req, res, path, redirect = 301}) => {
     res.redirect(workingRedirect, location)
 }
 
+/**
+ * Get the appropriate runtime object for the current environment (remote or development)
+ * @returns Shallow of the runtime object with bound methods
+ */
 export const getRuntime = () => {
     const runtime = isRemote()
         ? RemoteServerFactory
@@ -473,11 +477,12 @@ export const getRuntime = () => {
     // Sometimes the runtime APIs are invoked directly as express middlewares.
     // In order to make sure the "this" keyword always have the correct context,
     // we bind every single method to have the context of the object itself
-    for (const property in runtime) {
-        if (runtime[property] instanceof Function) {
-            runtime[property] = runtime[property].bind(runtime)
+    const boundRuntime = {...runtime}
+    for (const property of Object.keys(boundRuntime)) {
+        if (boundRuntime[property] instanceof Function) {
+            boundRuntime[property] = boundRuntime[property].bind(boundRuntime)
         }
     }
 
-    return runtime
+    return boundRuntime
 }

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -987,9 +987,7 @@ describe('getRuntime', () => {
     const matchExceptFunctionValues = (obj) => {
         const entries = Object.entries(obj)
         const matchers = entries.map(([key, value]) => {
-            const matcher = typeof value === 'function'
-                ? expect.any(Function)
-                : value
+            const matcher = typeof value === 'function' ? expect.any(Function) : value
             return [key, matcher]
         })
         return Object.fromEntries(matchers)

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -984,6 +984,17 @@ describe('getRuntime', () => {
         }
     })
 
+    const matchExceptFunctionValues = (obj) => {
+        const entries = Object.entries(obj)
+        const matchers = entries.map(([key, value]) => {
+            const matcher = typeof value === 'function'
+                ? expect.any(Function)
+                : value
+            return [key, matcher]
+        })
+        return Object.fromEntries(matchers)
+    }
+
     const cases = [
         {
             env: {},
@@ -1017,11 +1028,11 @@ describe('getRuntime', () => {
         'should return a remote/development runtime $msg',
         ({env, expectedRuntime}) => {
             process.env = {...process.env, ...env}
-            expect(getRuntime()).toBe(expectedRuntime)
+            expect(getRuntime()).toMatchObject(matchExceptFunctionValues(expectedRuntime))
         }
     )
 
-    test('should return a remote/development runtime with the correct context', () => {
+    test('should return a remote/development runtime bound to the correct context', () => {
         const mockDevRuntime = getRuntime()
         const func = mockDevRuntime.returnMyName
         expect(func()).toBe(MockDevServerFactory.name)


### PR DESCRIPTION
Quick follow up to #598. This changes the return value from the original runtime object to a shallow clone. The benefit of this is that (a) we avoid conditionally modifying the exports of another file and (2) we avoid modifying an object that was previously returned.

I also changed the `for...in` to `for...of` so that we only enumerate the object's own properties, rather than own and inherited properties.

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
