### PR TITLE
Fix `pwa-kit-dev` "Mobify" references

### DIFF
--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.1.0-dev (May 16, 2022)
+-   Replace `Mobify` references/links with proper PWA Kit values.
 ## v2.0.0 (May 16, 2022)
 -   Make the createApp API idiomatic for Express, fix service-worker loading. [#536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/536)
 -   Remove lodash and bluebird. [#534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/534)

--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v2.1.0-dev (May 16, 2022)
--   Replace `Mobify` references/links with proper PWA Kit values.
+-   Replace `Mobify` references/links with proper PWA Kit values. [#619](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/619)
 ## v2.0.0 (May 16, 2022)
 -   Make the createApp API idiomatic for Express, fix service-worker loading. [#536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/536)
 -   Remove lodash and bluebird. [#534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/534)

--- a/packages/pwa-kit-dev/scripts/utils.js
+++ b/packages/pwa-kit-dev/scripts/utils.js
@@ -19,7 +19,7 @@ const Matcher = require('../dist/utils/glob').Matcher
 
 const SDK_VERSION = require('../package.json').version
 const DEFAULT_DOCS_URL =
-    'https://dev.mobify.com/v2.x/how-to-guides/categories/deployment/pushing-and-publishing-bundles'
+    'https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/pushing-and-deploying-bundles.html'
 
 const Utils = {}
 
@@ -221,7 +221,7 @@ Utils.setDefaultMessage = () => {
         if (err.code === 'ENOENT') {
             console.log('Please run "git init" to initialize a new Git repository.')
         }
-        return 'Mobify Bundle'
+        return 'PWA Kit Bundle'
     }
 }
 
@@ -241,7 +241,7 @@ Utils.requestErrorMessage = {
         'You do not have permission to perform this actions.\nPlease double check your command to make sure the option values are correct.', //  wrong project name.
     code404:
         'Resource not found.\nPlease double check your command to make sure the option values are correct.', // wrong target name
-    code500: 'Internal Server Error. Please report this to Mobify support team.'
+    code500: 'Internal Server Error. Please report this to the Salesforce support team.'
 }
 
 module.exports = Utils

--- a/packages/pwa-kit-dev/scripts/utils.test.js
+++ b/packages/pwa-kit-dev/scripts/utils.test.js
@@ -72,7 +72,7 @@ describe('setDefaultMessage', () => {
             throw new Error('Failwhale')
         })
 
-        expect(Utils.setDefaultMessage()).toBe('Mobify Bundle')
+        expect(Utils.setDefaultMessage()).toBe('PWA Kit Bundle')
     })
 
     test('Bundle message defaults properly if git short fails', () => {
@@ -80,7 +80,7 @@ describe('setDefaultMessage', () => {
             throw new Error('Failwhale')
         })
 
-        expect(Utils.setDefaultMessage()).toBe('Mobify Bundle')
+        expect(Utils.setDefaultMessage()).toBe('PWA Kit Bundle')
     })
 
     test('Test message is printed if we have an ENOENT', () => {


### PR DESCRIPTION
# Description

After looking into another issue with the build tools we noticed that there are still some mobify references and links leying around. This PR replaces them with the correct values.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [x] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Update doc link in dev tools
- Replace Mobify text with correct PWA Kit or Salesforce values.
