### PR TITLE
Loadable extractor fix for hot reloading

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -221,10 +221,12 @@ const ruleForBabelLoader = (babelPlugins) => {
 }
 
 const enableReactRefresh = (config) => {
+    if (mode !== development) {
+        return config
+    }
+
     const rules = [
-        ruleForBabelLoader(
-            [mode === development && require.resolve('react-refresh/babel')].filter(Boolean)
-        ),
+        ruleForBabelLoader([require.resolve('react-refresh/babel')]),
         ...config.module.rules.slice(1)
     ]
 
@@ -236,21 +238,22 @@ const enableReactRefresh = (config) => {
         },
         entry: {
             ...config.entry,
-            main: [mode === development && 'webpack-hot-middleware/client?path=/__mrt/hmr', './app/main'].filter(
-                Boolean
-            )
+            main: ['webpack-hot-middleware/client?path=/__mrt/hmr', './app/main']
         },
         plugins: [
             ...config.plugins,
 
-            mode === development && new webpack.HotModuleReplacementPlugin(),
-            mode === development &&
-                new ReactRefreshWebpackPlugin({
-                    overlay: {
-                        sockIntegration: 'whm'
-                    }
-                })
-        ].filter(Boolean)
+            new webpack.HotModuleReplacementPlugin(),
+            new ReactRefreshWebpackPlugin({
+                overlay: {
+                    sockIntegration: 'whm'
+                }
+            })
+        ],
+        output: {
+            ...config.output,
+            publicPath: '/mobify/bundle/development/'
+        }
     }
 }
 

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -236,7 +236,7 @@ const enableReactRefresh = (config) => {
         },
         entry: {
             ...config.entry,
-            main: [mode === development && 'webpack-hot-middleware/client', './app/main'].filter(
+            main: [mode === development && 'webpack-hot-middleware/client?path=/__mrt/hmr', './app/main'].filter(
                 Boolean
             )
         },
@@ -250,13 +250,7 @@ const enableReactRefresh = (config) => {
                         sockIntegration: 'whm'
                     }
                 })
-        ].filter(Boolean),
-        output: {
-            ...config.output,
-            // So that client-side hot reloading works properly,
-            // we'll need to prepend the *.hot-update.json urls with this publicPath
-            ...(mode === development ? {publicPath: '/mobify/bundle/development/'} : {})
-        }
+        ].filter(Boolean)
     }
 }
 

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -139,10 +139,12 @@ export const DevServerMixin = {
 
         app.use('/mobify/bundle/development', app.__devMiddleware)
 
+        app.__hmrMiddleware = (_, res) => res.status(409).send('Hot Module Reloading is disabled.')
         const clientCompiler = app.__compiler.compilers.find((compiler) => compiler.name === CLIENT)
         if (clientCompiler) {
-            app.use('/__mrt/hmr', webpackHotMiddleware(clientCompiler, {path: '/'}))
+            app.__hmrMiddleware = webpackHotMiddleware(clientCompiler, {path: '/'})
         }
+        app.use('/__mrt/hmr', app.__hmrMiddleware)
 
         app.use('/__mrt/status', (req, res) => {
             return res.json({ready: app.__webpackReady()})

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -141,7 +141,7 @@ export const DevServerMixin = {
 
         const clientCompiler = app.__compiler.compilers.find((compiler) => compiler.name === CLIENT)
         if (clientCompiler) {
-            app.use(webpackHotMiddleware(clientCompiler))
+            app.use('/__mrt/hmr', webpackHotMiddleware(clientCompiler, {path: '/'}))
         }
 
         app.use('/__mrt/status', (req, res) => {

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -139,7 +139,7 @@ export const DevServerMixin = {
 
         app.use('/mobify/bundle/development', app.__devMiddleware)
 
-        app.__hmrMiddleware = (_, res) => res.status(409).send('Hot Module Reloading is disabled.')
+        app.__hmrMiddleware = (_, res) => res.status(501).send('Hot Module Reloading is disabled.')
         const clientCompiler = app.__compiler.compilers.find((compiler) => compiler.name === CLIENT)
         if (clientCompiler) {
             app.__hmrMiddleware = webpackHotMiddleware(clientCompiler, {path: '/'})

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -17,7 +17,7 @@ import {ChunkExtractor} from '@loadable/server'
 import {StaticRouter as Router, matchPath} from 'react-router-dom'
 import serialize from 'serialize-javascript'
 
-import {getAssetUrl} from '../universal/utils'
+import {getAssetUrl, getPublicPath} from '../universal/utils'
 import DeviceContext from '../universal/device-context'
 
 import Document from '../universal/components/_document'
@@ -129,6 +129,7 @@ const initAppState = async ({App, component, match, route, req, res, location}) 
  * @return {Promise}
  */
 export const render = async (req, res, next) => {
+    debugger
     // Get the application config which should have been stored at this point.
     const config = getConfig()
 
@@ -228,7 +229,8 @@ const renderAppHtml = (req, res, error, appData) => {
 const renderApp = (args) => {
     const {req, res, appStateError, App, appState, location, routes, config} = args
     const deviceType = detectDeviceType(req)
-    const extractor = new ChunkExtractor({statsFile: BUNDLES_PATH})
+    debugger
+    const extractor = new ChunkExtractor({statsFile: BUNDLES_PATH, publicPath: getPublicPath()})
     const routerContext = {}
     const appData = {App, appState, location, routes, routerContext, deviceType, extractor}
 
@@ -260,7 +262,7 @@ const renderApp = (args) => {
             React.cloneElement(el, {
                 ...el.props,
                 ...scriptProps,
-                src: el.props.src && getAssetUrl(el.props.src.slice(1))
+                src: el.props.src && el.props.src.slice(1)
             })
         )
     }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -260,7 +260,7 @@ const renderApp = (args) => {
             React.cloneElement(el, {
                 ...el.props,
                 ...scriptProps,
-                src: el.props.src && el.props.src.slice(1)
+                src: el.props.src
             })
         )
     }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -129,7 +129,6 @@ const initAppState = async ({App, component, match, route, req, res, location}) 
  * @return {Promise}
  */
 export const render = async (req, res, next) => {
-    debugger
     // Get the application config which should have been stored at this point.
     const config = getConfig()
 
@@ -229,7 +228,6 @@ const renderAppHtml = (req, res, error, appData) => {
 const renderApp = (args) => {
     const {req, res, appStateError, App, appState, location, routes, config} = args
     const deviceType = detectDeviceType(req)
-    debugger
     const extractor = new ChunkExtractor({statsFile: BUNDLES_PATH, publicPath: getPublicPath()})
     const routerContext = {}
     const appData = {App, appState, location, routes, routerContext, deviceType, extractor}

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -17,7 +17,7 @@ import {ChunkExtractor} from '@loadable/server'
 import {StaticRouter as Router, matchPath} from 'react-router-dom'
 import serialize from 'serialize-javascript'
 
-import {getAssetUrl, getPublicPath} from '../universal/utils'
+import {getAssetUrl} from '../universal/utils'
 import DeviceContext from '../universal/device-context'
 
 import Document from '../universal/components/_document'
@@ -228,7 +228,7 @@ const renderAppHtml = (req, res, error, appData) => {
 const renderApp = (args) => {
     const {req, res, appStateError, App, appState, location, routes, config} = args
     const deviceType = detectDeviceType(req)
-    const extractor = new ChunkExtractor({statsFile: BUNDLES_PATH, publicPath: getPublicPath()})
+    const extractor = new ChunkExtractor({statsFile: BUNDLES_PATH, publicPath: getAssetUrl()})
     const routerContext = {}
     const appData = {App, appState, location, routes, routerContext, deviceType, extractor}
 

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
@@ -12,6 +12,18 @@ import {proxyConfigs} from 'pwa-kit-runtime/utils/ssr-shared'
 const onClient = typeof window !== 'undefined'
 
 /**
+ * Get the path that should be used to load an asset from the bundle.
+ *
+ * @returns {string}
+ */
+export const getPublicPath = () => {
+    /* istanbul ignore next */
+    return onClient
+        ? `${window.Progressive.buildOrigin}`
+        : `/mobify/bundle/${process.env.BUNDLE_ID || 'development'}/`
+}
+
+/**
  * Get the URL that should be used to load an asset from the bundle.
  *
  * @param {string} path - relative path from the build directory to the asset
@@ -20,9 +32,7 @@ const onClient = typeof window !== 'undefined'
  */
 export const getAssetUrl = (path) => {
     /* istanbul ignore next */
-    return onClient
-        ? `${window.Progressive.buildOrigin}${path}`
-        : `/mobify/bundle/${process.env.BUNDLE_ID || 'development'}/${path}`
+    return `${getPublicPath}${path}`
 }
 
 /**

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
@@ -19,9 +19,6 @@ const onClient = typeof window !== 'undefined'
  * @returns {string}
  */
 export const getAssetUrl = (path) => {
-    if (/^\/?mobify\/bundle\//.test(path)) {
-        return path
-    }
     /* istanbul ignore next */
     return onClient
         ? `${window.Progressive.buildOrigin}${path}`

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
@@ -12,18 +12,6 @@ import {proxyConfigs} from 'pwa-kit-runtime/utils/ssr-shared'
 const onClient = typeof window !== 'undefined'
 
 /**
- * Get the path that should be used to load an asset from the bundle.
- *
- * @returns {string}
- */
-export const getPublicPath = () => {
-    /* istanbul ignore next */
-    return onClient
-        ? `${window.Progressive.buildOrigin}`
-        : `/mobify/bundle/${process.env.BUNDLE_ID || 'development'}/`
-}
-
-/**
  * Get the URL that should be used to load an asset from the bundle.
  *
  * @param {string} path - relative path from the build directory to the asset
@@ -32,7 +20,10 @@ export const getPublicPath = () => {
  */
 export const getAssetUrl = (path) => {
     /* istanbul ignore next */
-    return `${getPublicPath}${path}`
+    const publicPath = onClient
+        ? `${window.Progressive.buildOrigin}`
+        : `/mobify/bundle/${process.env.BUNDLE_ID || 'development'}/`
+    return path ? `${publicPath}${path}` : publicPath
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

This is a patch fix for https://github.com/SalesforceCommerceCloud/pwa-kit/pull/630. We found an issue that after adding hot reloading feature, loadable assets have incorrect path:

```
<script async="" data-chunk="main" src="/mobify/bundle/development/mobify/bundle/development/vendor.js"></script>
<script async="" data-chunk="main" src="/mobify/bundle/development/mobify/bundle/development/main.js"></script>
<script async="" data-chunk="pages-home" src="/mobify/bundle/development/mobify/bundle/development/pages-home.js"></script>
```

this PR fixes the issue by not prepending the asset path manually, instead, we let loadable extractor to know the public path.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
