### PR TITLE
Add `bundlesize` test back into CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,7 @@ commands:
 
             sudo npm install -g npm@7
             npm ci
+            npm run build
       - save_cache:
           key: npm-cache
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,6 @@ commands:
 
             sudo npm install -g npm@7
             npm ci
-            npm run build
       - save_cache:
           key: npm-cache
           paths:
@@ -121,6 +120,9 @@ commands:
 
             # Note: Each of these test commands need to be exposed on the monorepo
             # root and *also* on the PWA package. This section is run on both.
+
+            # Before testing the build artifacts we need to create them.
+            npm run build
 
             # Ensure bundlesize is in check
             npm run test:max-file-size

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,9 +121,6 @@ commands:
             # Note: Each of these test commands need to be exposed on the monorepo
             # root and *also* on the PWA package. This section is run on both.
 
-            # Before testing the build artifacts we need to create them.
-            npm run lerna -- run build --scope "retail-react-app"
-
             # Ensure bundlesize is in check
             npm run test:max-file-size
 
@@ -172,7 +169,6 @@ commands:
             set GENERATOR_PRESET=test-project
             node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir generated-project
             cd generated-project
-            npm run build
           no_output_timeout: 5m
       - runtests:
           cwd: generated-project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ commands:
             # root and *also* on the PWA package. This section is run on both.
 
             # Before testing the build artifacts we need to create them.
-            npm run build
+            npm run lerna -- run build --scope "retail-react-app"
 
             # Ensure bundlesize is in check
             npm run test:max-file-size

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ commands:
             # Note: Each of these test commands need to be exposed on the monorepo
             # root and *also* on the PWA package. This section is run on both.
 
+            # Ensure bundlesize is in check
+            npm run test:max-file-size
+
             # Always run fast unit tests
             npm run test
   smoketestscripts:

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -83,7 +83,7 @@
         },
         {
             "path": "build/vendor.js",
-            "maxSize": "245 kB"
+            "maxSize": "265 kB"
         }
     ],
     "browserslist": [

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -74,7 +74,7 @@
         "start:pseudolocale": "npm run extract-default-translations && npm run compile-translations:pseudo && cross-env USE_PSEUDOLOCALE=true npm run start",
         "test": "pwa-kit-dev test",
         "test:lighthouse": "cross-env NODE_ENV=production lhci autorun --config=tests/lighthouserc.js",
-        "test:max-file-size": "bundlesize"
+        "test:max-file-size": "npm run build && bundlesize"
     },
     "bundlesize": [
         {

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -83,7 +83,7 @@
         },
         {
             "path": "build/vendor.js",
-            "maxSize": "265 kB"
+            "maxSize": "270 kB"
         }
     ],
     "browserslist": [


### PR DESCRIPTION
# Description

Packages in the monorepo can define a `test:max-file-size` script to pass or fail the CI pipeline depending on the value it returns. Currently only the `template-retail-react-app` defines this script, in which it uses the third party dependency `bundlesize` to check that the built files in the bundle are in check. 

This feature was removed, probably on accident, when we were doing work with windows builds. This PR ensures that this script is run for all the jobs on CI. 

There was one hurdle, and that is during the time it was missing, we implemented V2 and there aren't any files in the build folder unless you explicitly build the project. To remedy this I ensured that the build script is run before we check the bundle sizes.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Ensure `test:max-file-size` is run for all jobs.

# How to Test-Drive This PR

- Look at [this](https://app.circleci.com/pipelines/github/SalesforceCommerceCloud/pwa-kit/3910/workflows/8ef1e151-4116-46fe-9d53-ea24228898b9/jobs/20658?invite=true#step-107-19) link to see that the test is being run.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

