### PR TITLE
Spike/swr

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/universal/server-effects.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/server-effects.js
@@ -27,15 +27,17 @@ export const getAllContexts = () => (allContexts)
  * @param {*} effect 
  * @returns 
  */
-function useServerEffect (initial, didUpdate, source) {
+function useServerEffect(initial, didUpdate, source, cacheKey) {
+    let key
     // Function overloading.
     if (typeof initial === 'function') {
+        key = source
         source = didUpdate
         didUpdate = initial
         initial = {}
     }
 
-    const key = `uh_${useUID()}`
+    key = key || cacheKey || `uh_${useUID()}`
     const location = useLocation()
     const params = useParams()
     const {req, res} = useExpress()

--- a/packages/template-typescript-minimal/app/auth.ts
+++ b/packages/template-typescript-minimal/app/auth.ts
@@ -1,0 +1,14 @@
+import {ShopperLogin, helpers} from 'commerce-sdk-isomorphic'
+import config from './commerce-api-config'
+
+const shopperLogin = new ShopperLogin(config)
+
+const getAccessToken = async () => {
+    const {access_token} = await helpers.loginGuestUser(
+        shopperLogin,
+        {redirectURI: `http://localhost:3000/callback`} // Callback URL must be configured in SLAS Admin
+    )
+    return access_token
+}
+
+export {getAccessToken}

--- a/packages/template-typescript-minimal/app/commerce-api-config.ts
+++ b/packages/template-typescript-minimal/app/commerce-api-config.ts
@@ -1,0 +1,10 @@
+export default {
+    proxy: `http://localhost:3000/mobify/proxy/api`,
+    parameters: {
+        clientId: 'c9c45bfd-0ed3-4aa2-9971-40f88962b836',
+        organizationId: 'f_ecom_zzrf_001',
+        shortCode: '8o7m175y',
+        siteId: 'RefArchGlobal',
+    },
+    throwOnBadResponse: true,
+}

--- a/packages/template-typescript-minimal/app/components/_app-config/index.tsx
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import {SCAPIProvider} from '../../provider'
+
+const AppConfig = ({children}) => {
+    return <SCAPIProvider>{children}</SCAPIProvider>
+}
+
+AppConfig.restore = (locals = {}) => {}
+
+AppConfig.freeze = () => undefined
+
+AppConfig.extraGetPropsArgs = (locals = {}) => {}
+
+export default AppConfig

--- a/packages/template-typescript-minimal/app/hooks/useProduct.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProduct.ts
@@ -1,0 +1,31 @@
+import useSWR from 'swr'
+import {ShopperProducts} from 'commerce-sdk-isomorphic'
+import config from '../commerce-api-config'
+import {getAccessToken} from '../auth'
+
+const sleep = (s) => new Promise((resolve) => setTimeout(resolve, s))
+
+const getProduct = async (productId: string) => {
+    const accessToken = await getAccessToken()
+
+    const api = new ShopperProducts({
+        ...config,
+        headers: {authorization: `Bearer ${accessToken}`},
+    })
+
+    await sleep(1)
+
+    const result = await api.getProduct({
+        parameters: {id: productId},
+    })
+
+    return result
+}
+
+const useProduct = ({productId}: {productId: string | undefined}) => {
+    const result = useSWR(productId, getProduct)
+
+    return result
+}
+
+export default useProduct

--- a/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
@@ -3,31 +3,27 @@ import {ShopperSearch} from 'commerce-sdk-isomorphic'
 import config from '../commerce-api-config'
 import {getAccessToken} from '../auth'
 
-// const authMiddleware = (useSWRNext) => {
-//     return async (key, fetcher, config) => {
-//         if (!tokens.access_token) {
-//             await getAccessToken()
-//         }
-//         const swr = useSWRNext(key, fetcher, config)
-//         return swr
-//     }
-// }
+const sleep = (s) => new Promise((resolve) => setTimeout(resolve, s))
 
-const useProductSearch = () => {
-    const result = useSWR('shirt', async () => {
-        const accessToken = await getAccessToken()
+const getProductSearch = async (searchTerm) => {
+    const accessToken = await getAccessToken()
 
-        const api = new ShopperSearch({
-            ...config,
-            headers: {authorization: `Bearer ${accessToken}`},
-        })
-
-        const result = await api.productSearch({
-            parameters: {q: 'shirt'},
-        })
-
-        return result
+    const api = new ShopperSearch({
+        ...config,
+        headers: {authorization: `Bearer ${accessToken}`},
     })
+
+    await sleep(1)
+
+    const result = await api.productSearch({
+        parameters: {q: searchTerm, limit: 20},
+    })
+
+    return result
+}
+
+const useProductSearch = ({searchTerm}) => {
+    const result = useSWR(searchTerm, getProductSearch)
 
     return result
 }

--- a/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
@@ -1,0 +1,35 @@
+import useSWR from 'swr'
+import {ShopperSearch} from 'commerce-sdk-isomorphic'
+import config from '../commerce-api-config'
+import {getAccessToken} from '../auth'
+
+// const authMiddleware = (useSWRNext) => {
+//     return async (key, fetcher, config) => {
+//         if (!tokens.access_token) {
+//             await getAccessToken()
+//         }
+//         const swr = useSWRNext(key, fetcher, config)
+//         return swr
+//     }
+// }
+
+const useProductSearch = () => {
+    const result = useSWR('shirt', async () => {
+        const accessToken = await getAccessToken()
+
+        const api = new ShopperSearch({
+            ...config,
+            headers: {authorization: `Bearer ${accessToken}`},
+        })
+
+        const result = await api.productSearch({
+            parameters: {q: 'shirt'},
+        })
+
+        return result
+    })
+
+    return result
+}
+
+export default useProductSearch

--- a/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProductSearch.ts
@@ -1,9 +1,11 @@
 import useSWR from 'swr'
 import {ShopperSearch} from 'commerce-sdk-isomorphic'
 import config from '../commerce-api-config'
+import {useServerEffect} from '../provider'
 import {getAccessToken} from '../auth'
 
-const sleep = (s) => new Promise((resolve) => setTimeout(resolve, s))
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const isServer = typeof window === 'undefined'
 
 const getProductSearch = async (searchTerm) => {
     const accessToken = await getAccessToken()
@@ -13,7 +15,7 @@ const getProductSearch = async (searchTerm) => {
         headers: {authorization: `Bearer ${accessToken}`},
     })
 
-    await sleep(1)
+    await sleep(2000)
 
     const result = await api.productSearch({
         parameters: {q: searchTerm, limit: 20},
@@ -22,10 +24,20 @@ const getProductSearch = async (searchTerm) => {
     return result
 }
 
-const useProductSearch = ({searchTerm}) => {
-    const result = useSWR(searchTerm, getProductSearch)
-
-    return result
+const useProductSearch = ({searchTerm}, source: []) => {
+    if (isServer) {
+        const {data, isLoading, error} = useServerEffect(
+            async () => {
+                const data = await getProductSearch(searchTerm)
+                return data
+            },
+            source,
+            searchTerm
+        )
+        return {data, error, isLoading}
+    }
+    const {data, error, isValidating} = useSWR(searchTerm, getProductSearch)
+    return {data, error, isLoading: isValidating}
 }
 
 export default useProductSearch

--- a/packages/template-typescript-minimal/app/hooks/useProducts.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProducts.ts
@@ -27,6 +27,18 @@ const useProducts = ({productIds}: {productIds: string[] | undefined}) => {
     const result = useSWR(key, getProducts)
     const {mutate} = useSWRConfig()
 
+    // Q: How do we do instant page reloading when PLP and PDP calls different APIs?
+
+    // This is where we make instant page loading happens
+    // when a call was made to /products/?ids=12328M,373829M,...
+    // 1. We cache the response under the cache key:
+    //    hash({productIds:[12328M,373829M]})
+    // 2. Annnnnnnnnnd, we also cache the individual product detail
+    //    hash({productId: 12328M})
+    //    hash({productId: 373829M})
+    //    This will populate the cache for individual useProduct(id) calls
+    //    and when user navigates to the PDP, the cache is already populated!
+
     if (productIds?.length && result.data) {
         productIds.forEach((productId) => {
             mutate(productId, () => {

--- a/packages/template-typescript-minimal/app/hooks/useProducts.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProducts.ts
@@ -1,4 +1,4 @@
-import useSWR from 'swr'
+import useSWR, {useSWRConfig} from 'swr'
 import {ShopperProducts} from 'commerce-sdk-isomorphic'
 import config from '../commerce-api-config'
 import {getAccessToken} from '../auth'
@@ -25,6 +25,16 @@ const getProducts = async (productIds: string) => {
 const useProducts = ({productIds}: {productIds: string[] | undefined}) => {
     const key = productIds?.join(',')
     const result = useSWR(key, getProducts)
+    const {mutate} = useSWRConfig()
+
+    if (productIds?.length && result.data) {
+        productIds.forEach((productId) => {
+            mutate(productId, () => {
+                const productData = result.data?.data.find((product) => product.id === productId)
+                return productData
+            })
+        })
+    }
 
     return result
 }

--- a/packages/template-typescript-minimal/app/hooks/useProducts.ts
+++ b/packages/template-typescript-minimal/app/hooks/useProducts.ts
@@ -1,0 +1,32 @@
+import useSWR from 'swr'
+import {ShopperProducts} from 'commerce-sdk-isomorphic'
+import config from '../commerce-api-config'
+import {getAccessToken} from '../auth'
+
+const sleep = (s) => new Promise((resolve) => setTimeout(resolve, s))
+
+const getProducts = async (productIds: string) => {
+    const accessToken = await getAccessToken()
+
+    const api = new ShopperProducts({
+        ...config,
+        headers: {authorization: `Bearer ${accessToken}`},
+    })
+
+    await sleep(1)
+
+    const result = await api.getProducts({
+        parameters: {ids: productIds},
+    })
+
+    return result
+}
+
+const useProducts = ({productIds}: {productIds: string[] | undefined}) => {
+    const key = productIds?.join(',')
+    const result = useSWR(key, getProducts)
+
+    return result
+}
+
+export default useProducts

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -4,55 +4,145 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React from 'react'
-import {Link} from 'react-router-dom'
+import React, {useEffect, useState} from 'react'
 
-import useProductSearch from '../hooks/useProductSearch'
-import useProducts from '../hooks/useProducts'
+import HelloTS from '../components/hello-typescript'
+import HelloJS from '../components/hello-javascript'
 
-const Home = () => {
-    const productSearch = useProductSearch({searchTerm: 'shirt'})
-    const productIds = productSearch?.data?.hits.map((hit) => hit.productId)
-    const productDetails = useProducts({productIds})
+interface Props {
+    value: number
+}
+
+const style = `
+body {
+    background: linear-gradient(-45deg, #e73c7e, #23a6d5, #ee7752);
+    background-size: 400% 400%;
+    animation: gradient 10s ease infinite;
+    height: 100vh;
+}
+@keyframes gradient {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+@keyframes fade {
+  0% { opacity: 0 }
+  100% { opacity: 1 }
+}
+.fade-in {
+    font-size: 18px;
+    opacity: 0;
+    animation: fade 1s ease-in-out;
+    animation-fill-mode: forwards;
+}
+.fade-in-0 { animation-delay: 0s}
+.fade-in-1 { animation-delay: 4s}
+.fade-in-2 { animation-delay: 8s}
+.fade-in-3 { animation-delay: 12s}
+.fade-in-4 { animation-delay: 16s}
+.fade-in-5 { animation-delay: 20s}
+body {
+    font-family: "Helvetica", sans-serif;
+    font-weight: 300;
+    color: rgba(255,255,255,0.8);
+    color: chartreuse;
+}
+.loading-screen {
+    mix-blend-mode: color-dodge;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+h1 {
+    font-size: 10em;
+    font-weight: 900;
+    letter-spacing: -0.05em;
+}
+.title {
+    text-align: right;
+}
+.divider {
+    mix-blend-mode: lighten;
+    width: 8px;
+    background-color: chartreuse;
+    height: 507px;
+    margin-left: 5em;
+    margin-right: 3em;
+}
+`
+
+const Home = ({value}: Props) => {
+    const [counter, setCounter] = useState(0)
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setCounter(counter + 1)
+        }, 1000)
+        return () => clearInterval(interval)
+    }, [counter, setCounter])
+
     return (
         <div>
-            {!productSearch?.data && productSearch?.isValidating && <h1>Loading...</h1>}
-            {productSearch?.data?.hits.map((hit) => {
-                const extraProductData = productDetails?.data?.data.find(
-                    (product) => product.id === hit.productId
-                )
-                return (
-                    <Link to={`/${hit.productId}`} key={hit.productId}>
-                        <div>
-                            <h1>Name: {hit.productName}</h1>
-                            <p>
-                                <b>The following data is from ShopperSearch API</b>
-                            </p>
-                            <p>Price: ${hit.price}</p>
-
-                            <p>
-                                <b>The following data is from ShopperProducts API</b>
-                            </p>
-
-                            {productDetails?.isValidating ? (
-                                <p>loading...</p>
-                            ) : (
-                                <div>
-                                    <p>Description: {extraProductData?.shortDescription}</p>
-                                    <p>Image groups</p>
-                                    <p>minOrderQuantity: {extraProductData?.minOrderQuantity}</p>
-                                </div>
-                            )}
-                        </div>
-                    </Link>
-                )
-            })}
+            <style dangerouslySetInnerHTML={{__html: style}} />
+            <div className="loading-screen">
+                <div className="panel title">
+                    <h1>
+                        Typescript
+                        <br />
+                        Support!
+                    </h1>
+                </div>
+                <div className="panel">
+                    <div className="divider"></div>
+                </div>
+                <div className="panel">
+                    <p style={{width: '300px'}} className="fade-in fade-in-0">
+                        <b>This page is written in Typescript</b>
+                        <br />
+                        <br />
+                        Server-side getProps works if this is a valid expression: &quot;5 times 7 is{' '}
+                        {value}
+                        &quot;
+                        <br />
+                        <br />
+                        Client-side JS works if this counter increments: {counter}
+                        <br />
+                        <br />
+                        <b>You can mix-and-match JS and TS</b>
+                        <br />
+                        <br />
+                        <HelloJS />
+                        &nbsp;
+                        <HelloTS message="it works!" />
+                    </p>
+                </div>
+            </div>
         </div>
     )
 }
 
 Home.getTemplateName = () => 'home'
 
-Home.getProps = async () => {}
+Home.getProps = async () => {
+    // Note: This is simply a mock function to demo deferred execution for fetching props (e.g.: Making a call to the server to fetch data)
+    const getData = (a: number, b: number) => {
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                resolve(a * b)
+            }, 50)
+        })
+    }
+    const value = await getData(5, 7)
+    return {value}
+}
 
 export default Home

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -4,145 +4,30 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React, {useEffect, useState} from 'react'
+import React from 'react'
 
-import HelloTS from '../components/hello-typescript'
-import HelloJS from '../components/hello-javascript'
+import useProductSearch from '../hooks/useProductSearch'
 
-interface Props {
-    value: number
-}
-
-const style = `
-body {
-    background: linear-gradient(-45deg, #e73c7e, #23a6d5, #ee7752);
-    background-size: 400% 400%;
-    animation: gradient 10s ease infinite;
-    height: 100vh;
-}
-@keyframes gradient {
-    0% {
-        background-position: 0% 50%;
-    }
-    50% {
-        background-position: 100% 50%;
-    }
-    100% {
-        background-position: 0% 50%;
-    }
-}
-@keyframes fade {
-  0% { opacity: 0 }
-  100% { opacity: 1 }
-}
-.fade-in {
-    font-size: 18px;
-    opacity: 0;
-    animation: fade 1s ease-in-out;
-    animation-fill-mode: forwards;
-}
-.fade-in-0 { animation-delay: 0s}
-.fade-in-1 { animation-delay: 4s}
-.fade-in-2 { animation-delay: 8s}
-.fade-in-3 { animation-delay: 12s}
-.fade-in-4 { animation-delay: 16s}
-.fade-in-5 { animation-delay: 20s}
-body {
-    font-family: "Helvetica", sans-serif;
-    font-weight: 300;
-    color: rgba(255,255,255,0.8);
-    color: chartreuse;
-}
-.loading-screen {
-    mix-blend-mode: color-dodge;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
-}
-h1 {
-    font-size: 10em;
-    font-weight: 900;
-    letter-spacing: -0.05em;
-}
-.title {
-    text-align: right;
-}
-.divider {
-    mix-blend-mode: lighten;
-    width: 8px;
-    background-color: chartreuse;
-    height: 507px;
-    margin-left: 5em;
-    margin-right: 3em;
-}
-`
-
-const Home = ({value}: Props) => {
-    const [counter, setCounter] = useState(0)
-
-    useEffect(() => {
-        const interval = setInterval(() => {
-            setCounter(counter + 1)
-        }, 1000)
-        return () => clearInterval(interval)
-    }, [counter, setCounter])
+const Home = () => {
+    const {data} = useProductSearch()
+    console.log('home')
 
     return (
         <div>
-            <style dangerouslySetInnerHTML={{__html: style}} />
-            <div className="loading-screen">
-                <div className="panel title">
-                    <h1>
-                        Typescript
-                        <br />
-                        Support!
-                    </h1>
-                </div>
-                <div className="panel">
-                    <div className="divider"></div>
-                </div>
-                <div className="panel">
-                    <p style={{width: '300px'}} className="fade-in fade-in-0">
-                        <b>This page is written in Typescript</b>
-                        <br />
-                        <br />
-                        Server-side getProps works if this is a valid expression: &quot;5 times 7 is{' '}
-                        {value}
-                        &quot;
-                        <br />
-                        <br />
-                        Client-side JS works if this counter increments: {counter}
-                        <br />
-                        <br />
-                        <b>You can mix-and-match JS and TS</b>
-                        <br />
-                        <br />
-                        <HelloJS />
-                        &nbsp;
-                        <HelloTS message="it works!" />
-                    </p>
-                </div>
-            </div>
+            {data?.hits.map((hit) => {
+                return (
+                    <div key={hit.productId}>
+                        <h1>{hit.productName}</h1>
+                        <p>${hit.price}</p>
+                    </div>
+                )
+            })}
         </div>
     )
 }
 
 Home.getTemplateName = () => 'home'
 
-Home.getProps = async () => {
-    // Note: This is simply a mock function to demo deferred execution for fetching props (e.g.: Making a call to the server to fetch data)
-    const getData = (a: number, b: number) => {
-        return new Promise((resolve) => {
-            setTimeout(() => {
-                resolve(a * b)
-            }, 50)
-        })
-    }
-    const value = await getData(5, 7)
-    return {value}
-}
+Home.getProps = async () => {}
 
 export default Home

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -5,43 +5,46 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React from 'react'
+import {Link} from 'react-router-dom'
 
 import useProductSearch from '../hooks/useProductSearch'
 import useProducts from '../hooks/useProducts'
 
 const Home = () => {
-    const {data: productSearchData, isValidating} = useProductSearch({searchTerm: 'shirt'})
-    const productIds = productSearchData?.hits.map((hit) => hit.productId)
-    const {data: products, isValidating: isLoadingProductDetail} = useProducts({productIds})
+    const productSearch = useProductSearch({searchTerm: 'shirt'})
+    const productIds = productSearch?.data?.hits.map((hit) => hit.productId)
+    const productDetails = useProducts({productIds})
     return (
         <div>
-            {!productSearchData && isValidating && <h1>Loading...</h1>}
-            {productSearchData?.hits.map((hit) => {
-                const extraProductData = products?.data.find(
+            {!productSearch?.data && productSearch?.isValidating && <h1>Loading...</h1>}
+            {productSearch?.data?.hits.map((hit) => {
+                const extraProductData = productDetails?.data?.data.find(
                     (product) => product.id === hit.productId
                 )
                 return (
-                    <div key={hit.productId}>
-                        <h1>Name: {hit.productName}</h1>
-                        <p>
-                            <b>The following data is from ShopperSearch API</b>
-                        </p>
-                        <p>Price: ${hit.price}</p>
+                    <Link to={`/${hit.productId}`} key={hit.productId}>
+                        <div>
+                            <h1>Name: {hit.productName}</h1>
+                            <p>
+                                <b>The following data is from ShopperSearch API</b>
+                            </p>
+                            <p>Price: ${hit.price}</p>
 
-                        <p>
-                            <b>The following data is from ShopperProducts API</b>
-                        </p>
+                            <p>
+                                <b>The following data is from ShopperProducts API</b>
+                            </p>
 
-                        {isLoadingProductDetail ? (
-                            <p>loading...</p>
-                        ) : (
-                            <div>
-                                <p>Description: {extraProductData?.shortDescription}</p>
-                                <p>Image groups</p>
-                                <p>minOrderQuantity: {extraProductData?.minOrderQuantity}</p>
-                            </div>
-                        )}
-                    </div>
+                            {productDetails?.isValidating ? (
+                                <p>loading...</p>
+                            ) : (
+                                <div>
+                                    <p>Description: {extraProductData?.shortDescription}</p>
+                                    <p>Image groups</p>
+                                    <p>minOrderQuantity: {extraProductData?.minOrderQuantity}</p>
+                                </div>
+                            )}
+                        </div>
+                    </Link>
                 )
             })}
         </div>

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -7,18 +7,40 @@
 import React from 'react'
 
 import useProductSearch from '../hooks/useProductSearch'
+import useProducts from '../hooks/useProducts'
 
 const Home = () => {
-    const {data} = useProductSearch()
-    console.log('home')
-
+    const {data: productSearchData, isValidating} = useProductSearch({searchTerm: 'shirt'})
+    const productIds = productSearchData?.hits.map((hit) => hit.productId)
+    const {data: products, isValidating: isLoadingProductDetail} = useProducts({productIds})
     return (
         <div>
-            {data?.hits.map((hit) => {
+            {!productSearchData && isValidating && <h1>Loading...</h1>}
+            {productSearchData?.hits.map((hit) => {
+                const extraProductData = products?.data.find(
+                    (product) => product.id === hit.productId
+                )
                 return (
                     <div key={hit.productId}>
-                        <h1>{hit.productName}</h1>
-                        <p>${hit.price}</p>
+                        <h1>Name: {hit.productName}</h1>
+                        <p>
+                            <b>The following data is from ShopperSearch API</b>
+                        </p>
+                        <p>Price: ${hit.price}</p>
+
+                        <p>
+                            <b>The following data is from ShopperProducts API</b>
+                        </p>
+
+                        {isLoadingProductDetail ? (
+                            <p>loading...</p>
+                        ) : (
+                            <div>
+                                <p>Description: {extraProductData?.shortDescription}</p>
+                                <p>Image groups</p>
+                                <p>minOrderQuantity: {extraProductData?.minOrderQuantity}</p>
+                            </div>
+                        )}
                     </div>
                 )
             })}

--- a/packages/template-typescript-minimal/app/pages/pdp.tsx
+++ b/packages/template-typescript-minimal/app/pages/pdp.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {useParams} from 'react-router-dom'
+
+import useProduct from '../hooks/useProduct'
+
+const PDP = () => {
+    const {productId} = useParams()
+    const {data} = useProduct({productId})
+
+    return (
+        <div>
+            {data ? (
+                <>
+                    <h1>{data.name}</h1>
+                    <p>{data.id}</p>
+                    <p>{data.shortDescription}</p>
+                </>
+            ) : (
+                <h1>Loading...</h1>
+            )}
+        </div>
+    )
+}
+
+PDP.getTemplateName = () => 'pdp'
+
+export default PDP

--- a/packages/template-typescript-minimal/app/pages/plp.tsx
+++ b/packages/template-typescript-minimal/app/pages/plp.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {Link} from 'react-router-dom'
+
+import useProductSearch from '../hooks/useProductSearch'
+import useProducts from '../hooks/useProducts'
+
+const PLP = () => {
+    // Q: How do we dealing with incomplete data, and the requests that depend on another request?
+    // A common issue we had was that on PLP, the product search data is incomplete
+    // the products are missing image / description that you have to make another call to
+    // the ShopperProducts API.
+
+    // A: In this example, we have two hook calls.
+    // 1. useProductSearch()
+    // 2. useProducts()
+    // The second call depends on the result of the first call.
+    // On the initial rendering, since useProductSearch's data is undefined
+    // useProducts will do nothing and wait for the result.
+
+    const productSearch = useProductSearch({searchTerm: 'shirt'})
+    const productIds = productSearch?.data?.hits.map((hit) => hit.productId)
+    const productDetails = useProducts({productIds})
+    return (
+        <div>
+            {!productSearch?.data && productSearch?.isValidating && <h1>Loading...</h1>}
+            {productSearch?.data?.hits.map((hit) => {
+                const extraProductData = productDetails?.data?.data.find(
+                    (product) => product.id === hit.productId
+                )
+                return (
+                    <Link to={`/${hit.productId}`} key={hit.productId}>
+                        <div>
+                            <h1>Name: {hit.productName}</h1>
+                            <p>
+                                <b>The following data is from ShopperSearch API</b>
+                            </p>
+                            <p>Price: ${hit.price}</p>
+
+                            <p>
+                                <b>The following data is from ShopperProducts API</b>
+                            </p>
+
+                            {productDetails?.isValidating ? (
+                                <p>loading...</p>
+                            ) : (
+                                <div>
+                                    <p>Description: {extraProductData?.shortDescription}</p>
+                                    <p>Image groups</p>
+                                    <p>minOrderQuantity: {extraProductData?.minOrderQuantity}</p>
+                                </div>
+                            )}
+                        </div>
+                    </Link>
+                )
+            })}
+        </div>
+    )
+}
+
+PLP.getTemplateName = () => 'plp'
+
+PLP.getProps = async () => {}
+
+export default PLP

--- a/packages/template-typescript-minimal/app/pages/plp.tsx
+++ b/packages/template-typescript-minimal/app/pages/plp.tsx
@@ -23,12 +23,13 @@ const PLP = () => {
     // On the initial rendering, since useProductSearch's data is undefined
     // useProducts will do nothing and wait for the result.
 
-    const productSearch = useProductSearch({searchTerm: 'shirt'})
+    const productSearch = useProductSearch({searchTerm: 'shirt'}, [])
     const productIds = productSearch?.data?.hits.map((hit) => hit.productId)
     const productDetails = useProducts({productIds})
+
     return (
         <div>
-            {!productSearch?.data && productSearch?.isValidating && <h1>Loading...</h1>}
+            {!productSearch?.data && productSearch?.isLoading && <h1>Loading...</h1>}
             {productSearch?.data?.hits.map((hit) => {
                 const extraProductData = productDetails?.data?.data.find(
                     (product) => product.id === hit.productId

--- a/packages/template-typescript-minimal/app/provider.tsx
+++ b/packages/template-typescript-minimal/app/provider.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import {
+    createServerEffectContext,
+    getAllContexts,
+} from 'pwa-kit-react-sdk/ssr/universal/server-effects'
+import useSWR, {SWRConfig} from 'swr'
+
+// NOTE: This is the important part of the API, here we get a context with a hook that will
+// use that context.
+const {ServerEffectProvider, useServerEffect} = createServerEffectContext('scapiHooks')
+
+const SCAPIContext = React.createContext()
+const initialValue = {name: 'scapiHooks', data: {}, requests: []}
+
+export const SCAPIProvider = (props) => {
+    const {scapiHooks} = getAllContexts()
+    const effectsValues =
+        typeof window === 'undefined'
+            ? scapiHooks || initialValue
+            : window.__PRELOADED_STATE__.scapiHooks
+
+    // TODO: How do we pass the cache key to the server effect context?
+    // we need to rename the unpredictable "uh_1-1" to something we know like "shirt"
+    // const SWRCache =
+    //     typeof window === 'undefined'
+    //         ? {}
+    //         : {['shirt']: window.__PRELOADED_STATE__.scapiHooks.data['uh_1-1']}
+
+    return (
+        <SCAPIContext.Provider value={{}}>
+            <ServerEffectProvider value={effectsValues}>
+                <SWRConfig value={{fallback: effectsValues.data}}>{props.children}</SWRConfig>
+            </ServerEffectProvider>
+        </SCAPIContext.Provider>
+    )
+}
+
+export {useServerEffect}

--- a/packages/template-typescript-minimal/app/routes.tsx
+++ b/packages/template-typescript-minimal/app/routes.tsx
@@ -7,13 +7,18 @@
 import loadable from '@loadable/component'
 
 const Home = loadable(() => import('./pages/home'))
+const PDP = loadable(() => import('./pages/pdp'))
 
 const routes = [
     {
         path: '/',
         exact: true,
-        component: Home
-    }
+        component: Home,
+    },
+    {
+        path: '/:productId',
+        component: PDP,
+    },
 ]
 
 export default routes

--- a/packages/template-typescript-minimal/app/routes.tsx
+++ b/packages/template-typescript-minimal/app/routes.tsx
@@ -8,12 +8,13 @@ import loadable from '@loadable/component'
 
 const Home = loadable(() => import('./pages/home'))
 const PDP = loadable(() => import('./pages/pdp'))
+const PLP = loadable(() => import('./pages/plp'))
 
 const routes = [
     {
         path: '/',
         exact: true,
-        component: Home,
+        component: PLP,
     },
     {
         path: '/:productId',

--- a/packages/template-typescript-minimal/package-lock.json
+++ b/packages/template-typescript-minimal/package-lock.json
@@ -24,6 +24,15 @@
 				"react-is": "^16.12.0"
 			}
 		},
+		"commerce-sdk-isomorphic": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-1.6.0.tgz",
+			"integrity": "sha512-iuSYNXo+ttV0bVmKHOy/sLB2kRABK9a69Gk1I5i77u/GYX/lhAxTTElj/o6ezqhk5H2SbI0Aw+sS7RVglHPY5A==",
+			"requires": {
+				"cross-fetch": "^3.1.5",
+				"nanoid": "^3.1.30"
+			}
+		},
 		"cross-env": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.1.tgz",
@@ -37,7 +46,6 @@
 			"version": "3.1.5",
 			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
 			"integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-			"dev": true,
 			"requires": {
 				"node-fetch": "2.6.7"
 			}
@@ -115,6 +123,11 @@
 				"tiny-warning": "^1.0.3"
 			}
 		},
+		"nanoid": {
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -125,7 +138,6 @@
 			"version": "2.6.7",
 			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
 			"integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-			"dev": true,
 			"requires": {
 				"whatwg-url": "^5.0.0"
 			}
@@ -289,6 +301,11 @@
 			"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 			"dev": true
 		},
+		"swr": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/swr/-/swr-1.3.0.tgz",
+			"integrity": "sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw=="
+		},
 		"tiny-invariant": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
@@ -304,8 +321,7 @@
 		"tr46": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
-			"dev": true
+			"integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
 		},
 		"value-equal": {
 			"version": "1.0.1",
@@ -316,14 +332,12 @@
 		"webidl-conversions": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
-			"dev": true
+			"integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
 		},
 		"whatwg-url": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
 			"integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-			"dev": true,
 			"requires": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -60,5 +60,9 @@
                 }
             ]
         }
+    },
+    "dependencies": {
+        "commerce-sdk-isomorphic": "^1.6.0",
+        "swr": "^1.3.0"
     }
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

This is a follow up spike for the recent discussions on Commerce API hook library.

This spike demonstrates the use of `swr` and using req/res cache as the global store, as oppose to an plain JS object type of global store (or Redux).

There were a few questions that this spike tries to answer:

1. Do we have enough flexibility using the req/res cache approach? One example is, on PLP, there is a common issue where we need to make two calls in sequential order to gather the data needed: `/productSearch?cid=xxx`+ `/products?ids=xxx,xxx,xxx` How do you reduce the data into the cache?

Answer: yes. 

```
const PLP = () => {
    const productSearch = useProductSearch({searchTerm: 'shirt'}, [])
    const productIds = productSearch?.data?.hits.map((hit) => hit.productId)
    
    // when productIds is undefined, this do nothing
    const productDetails = useProducts({productIds})
}
```

2. Can we achieve instant page load, e.g. from PLP navigate to PDP, and product data is available immediately? Especially when PLP and PDP uses 2 different endpoints (on PLP `/products?ids=xxx,xxx,xxx` v.s. on PDP `/product?id=xxx`)?

Answer: Yes. We can manually save data in the cache using `mutate`. See [here](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/654/files#diff-9f3e5b091f80e8220904b8759da0638f73486ddf363b3da80c6e5b9c1c6da8bcR30)

```
const useProducts = ({productIds}: {productIds: string[] | undefined}) => {
    const key = productIds?.join(',')
    const result = useSWR(key, getProducts)
    const {mutate} = useSWRConfig()

    if (productIds?.length && result.data) {
        productIds.forEach((productId) => {
            
            // THIS IS THE KEY PART
            // We manually save individual product data into the cache here
            mutate(productId, () => {
                const productData = result.data?.data.find((product) => product.id === productId)
                return productData
            })
        })
    }

    return result
}
```

**DEMO: https://scaffold-pwa-test-env.mobify-storefront.com/**

### Minor change required for `useServerEffect`

To be able to fetch data on server side and hydrate on client side, req/res cache relies on predictable cache keys. `useServerEffect` cache keys currently are not deterministic and looks like something like `uh_1-1` . We need the ability to pass in a custom cache key.

see [here](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/654/files#diff-2fe4818cd0ee7576df78117fe5aed3dbe9b8dfdf0428c080aa852720ed198359R30)