### PR TITLE
Release v2.1.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "publish": {
     "allowBranch": [
       "master"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "publish": {
     "allowBranch": [
       "master"

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "publish": {
     "allowBranch": [
       "master"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/packages/internal-lib-build/package-lock.json
+++ b/packages/internal-lib-build/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "internal-lib-build",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/internal-lib-build/package-lock.json
+++ b/packages/internal-lib-build/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "internal-lib-build",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/internal-lib-build/package-lock.json
+++ b/packages/internal-lib-build/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "internal-lib-build",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/internal-lib-build/package.json
+++ b/packages/internal-lib-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal-lib-build",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/packages/internal-lib-build/package.json
+++ b/packages/internal-lib-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal-lib-build",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/packages/internal-lib-build/package.json
+++ b/packages/internal-lib-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal-lib-build",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "engines": {
     "node": "^14.0.0",
     "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"

--- a/packages/pwa-kit-create-app/package-lock.json
+++ b/packages/pwa-kit-create-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-create-app",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-create-app/package-lock.json
+++ b/packages/pwa-kit-create-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-create-app",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-create-app/package-lock.json
+++ b/packages/pwa-kit-create-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-create-app",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-create-app/package.json
+++ b/packages/pwa-kit-create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-create-app",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "Salesforce's project generator tool",
   "author": "dev@mobify.com",
   "license": "See license in LICENSE",
@@ -40,7 +40,7 @@
     "tar": "^6.1.11"
   },
   "devDependencies": {
-    "internal-lib-build": "^2.1.0-alpha.0",
+    "internal-lib-build": "^2.1.0-alpha.1",
     "verdaccio": "^5.9.0"
   }
 }

--- a/packages/pwa-kit-create-app/package.json
+++ b/packages/pwa-kit-create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-create-app",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "description": "Salesforce's project generator tool",
   "author": "dev@mobify.com",
   "license": "See license in LICENSE",
@@ -40,7 +40,7 @@
     "tar": "^6.1.11"
   },
   "devDependencies": {
-    "internal-lib-build": "^2.1.0-dev",
+    "internal-lib-build": "^2.1.0-alpha.0",
     "verdaccio": "^5.9.0"
   }
 }

--- a/packages/pwa-kit-create-app/package.json
+++ b/packages/pwa-kit-create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-create-app",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "description": "Salesforce's project generator tool",
   "author": "dev@mobify.com",
   "license": "See license in LICENSE",
@@ -40,7 +40,7 @@
     "tar": "^6.1.11"
   },
   "devDependencies": {
-    "internal-lib-build": "^2.1.0-alpha.1",
+    "internal-lib-build": "^2.1.0",
     "verdaccio": "^5.9.0"
   }
 }

--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-dev (May 16, 2022)
 
 -   Replace `Mobify` references/links with proper PWA Kit values. [#619](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/619)
 -   Add support for a custom build directory to `pwa-kit-dev build`. [#628](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/628)
--   By default, enable client-side hot module replacement [#630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/630)
+-   Introduce client-side hot module replacement. [#630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/630)
 
 ## v2.0.0 (May 16, 2022)
 

--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.1.0-alpha.0 (Jul 05, 2022)
+## v2.1.0 (Jul 05, 2022)
 
 -   Replace `Mobify` references/links with proper PWA Kit values. [#619](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/619)
 -   Add support for a custom build directory to `pwa-kit-dev build`. [#628](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/628)

--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v2.1.0-alpha.0 (Jul 05, 2022)
+## v2.1.0-alpha.0 (Jul 05, 2022)
 ## v2.1.0-dev (May 16, 2022)
 
 -   Replace `Mobify` references/links with proper PWA Kit values. [#619](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/619)

--- a/packages/pwa-kit-dev/package-lock.json
+++ b/packages/pwa-kit-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-dev",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-dev/package-lock.json
+++ b/packages/pwa-kit-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-dev",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-dev/package-lock.json
+++ b/packages/pwa-kit-dev/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-dev",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-dev/package.json
+++ b/packages/pwa-kit-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-dev",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "description": "Build tools for pwa-kit",
   "repository": {
     "type": "git",
@@ -91,7 +91,7 @@
     "morgan": "1.9.1",
     "open": "^8.4.0",
     "prettier": "^1.18.2",
-    "pwa-kit-runtime": "^2.1.0-dev",
+    "pwa-kit-runtime": "^2.1.0-alpha.0",
     "react-refresh": "^0.13.0",
     "replace-in-file": "^6.2.0",
     "request": "^2.88.0",
@@ -111,7 +111,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.0",
-    "internal-lib-build": "^2.1.0-dev",
+    "internal-lib-build": "^2.1.0-alpha.0",
     "nock": "^13.1.1",
     "superagent": "^6.1.0",
     "supertest": "^4.0.2"

--- a/packages/pwa-kit-dev/package.json
+++ b/packages/pwa-kit-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-dev",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "Build tools for pwa-kit",
   "repository": {
     "type": "git",
@@ -91,7 +91,7 @@
     "morgan": "1.9.1",
     "open": "^8.4.0",
     "prettier": "^1.18.2",
-    "pwa-kit-runtime": "^2.1.0-alpha.0",
+    "pwa-kit-runtime": "^2.1.0-alpha.1",
     "react-refresh": "^0.13.0",
     "replace-in-file": "^6.2.0",
     "request": "^2.88.0",
@@ -111,7 +111,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.0",
-    "internal-lib-build": "^2.1.0-alpha.0",
+    "internal-lib-build": "^2.1.0-alpha.1",
     "nock": "^13.1.1",
     "superagent": "^6.1.0",
     "supertest": "^4.0.2"

--- a/packages/pwa-kit-dev/package.json
+++ b/packages/pwa-kit-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-dev",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "description": "Build tools for pwa-kit",
   "repository": {
     "type": "git",
@@ -91,7 +91,7 @@
     "morgan": "1.9.1",
     "open": "^8.4.0",
     "prettier": "^1.18.2",
-    "pwa-kit-runtime": "^2.1.0-alpha.1",
+    "pwa-kit-runtime": "^2.1.0",
     "react-refresh": "^0.13.0",
     "replace-in-file": "^6.2.0",
     "request": "^2.88.0",
@@ -111,7 +111,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.0",
-    "internal-lib-build": "^2.1.0-alpha.1",
+    "internal-lib-build": "^2.1.0",
     "nock": "^13.1.1",
     "superagent": "^6.1.0",
     "supertest": "^4.0.2"

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -261,9 +261,7 @@ const enableReactRefresh = (config) => {
 
             new webpack.HotModuleReplacementPlugin(),
             new ReactRefreshWebpackPlugin({
-                overlay: {
-                    sockIntegration: 'whm'
-                }
+                overlay: false
             })
         ],
         output: {

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.1.0-alpha.0 (Jul 05, 2022)
+## v2.1.0 (Jul 05, 2022)
 -   Remove console logs from route component. [#651](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/651)
 
 ## v2.0.0 (May 16, 2022)

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-dev (May 16, 2022)
+-   Remove console logs from route component. [#651](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/651)
+
 ## v2.0.0 (May 16, 2022)
 -   Remove lodash and bluebird. [#534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/534)
 -   Support Multi-site implementation using dynamic config [#469](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/469)

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v2.1.0-alpha.0 (Jul 05, 2022)
+## v2.1.0-alpha.0 (Jul 05, 2022)
 ## v2.1.0-dev (May 16, 2022)
 ## v2.0.0 (May 16, 2022)
 -   Remove lodash and bluebird. [#534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/534)

--- a/packages/pwa-kit-react-sdk/package-lock.json
+++ b/packages/pwa-kit-react-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-react-sdk",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-react-sdk/package-lock.json
+++ b/packages/pwa-kit-react-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-react-sdk",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-react-sdk/package-lock.json
+++ b/packages/pwa-kit-react-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-react-sdk",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-react-sdk/package.json
+++ b/packages/pwa-kit-react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-react-sdk",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "A library that supports the isomorphic React rendering pipeline for Commerce Cloud Managed Runtime apps",
   "main": "dist/index.js",
   "engines": {
@@ -54,7 +54,7 @@
     "minimatch": "3.0.4",
     "mkdirp": "^1.0.4",
     "prop-types": "^15.6.0",
-    "pwa-kit-runtime": "^2.1.0-alpha.0",
+    "pwa-kit-runtime": "^2.1.0-alpha.1",
     "react-uid": "^2.2.0",
     "serialize-javascript": "^6.0.0",
     "svg-sprite-loader": "^6.0.11",
@@ -66,7 +66,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "1.15.2",
-    "internal-lib-build": "^2.1.0-alpha.0",
+    "internal-lib-build": "^2.1.0-alpha.1",
     "node-html-parser": "^3.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/pwa-kit-react-sdk/package.json
+++ b/packages/pwa-kit-react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-react-sdk",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "description": "A library that supports the isomorphic React rendering pipeline for Commerce Cloud Managed Runtime apps",
   "main": "dist/index.js",
   "engines": {
@@ -54,7 +54,7 @@
     "minimatch": "3.0.4",
     "mkdirp": "^1.0.4",
     "prop-types": "^15.6.0",
-    "pwa-kit-runtime": "^2.1.0-dev",
+    "pwa-kit-runtime": "^2.1.0-alpha.0",
     "react-uid": "^2.2.0",
     "serialize-javascript": "^6.0.0",
     "svg-sprite-loader": "^6.0.11",
@@ -66,7 +66,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "1.15.2",
-    "internal-lib-build": "^2.1.0-dev",
+    "internal-lib-build": "^2.1.0-alpha.0",
     "node-html-parser": "^3.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/pwa-kit-react-sdk/package.json
+++ b/packages/pwa-kit-react-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-react-sdk",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "description": "A library that supports the isomorphic React rendering pipeline for Commerce Cloud Managed Runtime apps",
   "main": "dist/index.js",
   "engines": {
@@ -54,7 +54,7 @@
     "minimatch": "3.0.4",
     "mkdirp": "^1.0.4",
     "prop-types": "^15.6.0",
-    "pwa-kit-runtime": "^2.1.0-alpha.1",
+    "pwa-kit-runtime": "^2.1.0",
     "react-uid": "^2.2.0",
     "serialize-javascript": "^6.0.0",
     "svg-sprite-loader": "^6.0.11",
@@ -66,7 +66,7 @@
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",
     "enzyme": "^3.8.0",
     "enzyme-adapter-react-16": "1.15.2",
-    "internal-lib-build": "^2.1.0-alpha.1",
+    "internal-lib-build": "^2.1.0",
     "node-html-parser": "^3.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v2.1.0-alpha.0 (Jul 05, 2022)
+## v2.1.0-alpha.0 (Jul 05, 2022)
 ## v2.1.0-dev (May 16, 2022)
 ## v2.0.0 (May 16, 2022)
 - Make the createApp API idiomatic for Express, fix service-worker loading. [#536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/536)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-alpha.0 (Jul 05, 2022)
-## v2.1.0-dev (May 16, 2022)
+
 ## v2.0.0 (May 16, 2022)
 - Make the createApp API idiomatic for Express, fix service-worker loading. [#536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/536)
 - Add environment specific configuration support via `getConfig`. [#447](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/447)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,3 @@
-## v2.1.0-alpha.0 (Jul 05, 2022)
-
 ## v2.0.0 (May 16, 2022)
 - Make the createApp API idiomatic for Express, fix service-worker loading. [#536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/536)
 - Add environment specific configuration support via `getConfig`. [#447](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/447)

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-runtime",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-runtime",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "pwa-kit-runtime",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-runtime",
-  "version": "2.1.0-alpha.0",
+  "version": "2.1.0-alpha.1",
   "description": "The PWAKit Runtime",
   "repository": {
     "type": "git",
@@ -55,7 +55,7 @@
     "@serverless/event-mocks": "^1.1.1",
     "aws-lambda-mock-context": "^3.2.1",
     "fs-extra": "^10.1.0",
-    "internal-lib-build": "^2.1.0-alpha.0",
+    "internal-lib-build": "^2.1.0-alpha.1",
     "nock": "^13.1.1",
     "node-fetch": "^2.6.7",
     "s3rver": "^3.1.0",
@@ -65,7 +65,7 @@
     "watch": "1.0.1"
   },
   "peerDependencies": {
-    "pwa-kit-dev": "^2.1.0-alpha.0"
+    "pwa-kit-dev": "^2.1.0-alpha.1"
   },
   "peerDependenciesMeta": {
     "pwa-kit-dev": {

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-runtime",
-  "version": "2.1.0-dev",
+  "version": "2.1.0-alpha.0",
   "description": "The PWAKit Runtime",
   "repository": {
     "type": "git",
@@ -55,7 +55,7 @@
     "@serverless/event-mocks": "^1.1.1",
     "aws-lambda-mock-context": "^3.2.1",
     "fs-extra": "^10.1.0",
-    "internal-lib-build": "^2.1.0-dev",
+    "internal-lib-build": "^2.1.0-alpha.0",
     "nock": "^13.1.1",
     "node-fetch": "^2.6.7",
     "s3rver": "^3.1.0",
@@ -65,7 +65,7 @@
     "watch": "1.0.1"
   },
   "peerDependencies": {
-    "pwa-kit-dev": "^2.1.0-dev"
+    "pwa-kit-dev": "^2.1.0-alpha.0"
   },
   "peerDependenciesMeta": {
     "pwa-kit-dev": {

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-kit-runtime",
-  "version": "2.1.0-alpha.1",
+  "version": "2.1.0",
   "description": "The PWAKit Runtime",
   "repository": {
     "type": "git",
@@ -55,7 +55,7 @@
     "@serverless/event-mocks": "^1.1.1",
     "aws-lambda-mock-context": "^3.2.1",
     "fs-extra": "^10.1.0",
-    "internal-lib-build": "^2.1.0-alpha.1",
+    "internal-lib-build": "^2.1.0",
     "nock": "^13.1.1",
     "node-fetch": "^2.6.7",
     "s3rver": "^3.1.0",
@@ -65,7 +65,7 @@
     "watch": "1.0.1"
   },
   "peerDependencies": {
-    "pwa-kit-dev": "^2.1.0-alpha.1"
+    "pwa-kit-dev": "^2.1.0"
   },
   "peerDependenciesMeta": {
     "pwa-kit-dev": {

--- a/packages/template-express-minimal/package-lock.json
+++ b/packages/template-express-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "template-express-minimal",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-express-minimal/package-lock.json
+++ b/packages/template-express-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "template-express-minimal",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-express-minimal/package-lock.json
+++ b/packages/template-express-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "template-express-minimal",
-	"version": "2.0.0-dev.8",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-express-minimal/package.json
+++ b/packages/template-express-minimal/package.json
@@ -1,11 +1,11 @@
 {
     "name": "template-express-minimal",
-    "version": "2.1.0-alpha.1",
+    "version": "2.1.0",
     "license": "See license in LICENSE",
     "private": true,
     "devDependencies": {
-        "pwa-kit-dev": "^2.1.0-alpha.1",
-        "pwa-kit-runtime": "^2.1.0-alpha.1",
+        "pwa-kit-dev": "^2.1.0",
+        "pwa-kit-runtime": "^2.1.0",
         "supertest": "^4.0.2"
     },
     "scripts": {

--- a/packages/template-express-minimal/package.json
+++ b/packages/template-express-minimal/package.json
@@ -1,11 +1,11 @@
 {
     "name": "template-express-minimal",
-    "version": "2.1.0-alpha.0",
+    "version": "2.1.0-alpha.1",
     "license": "See license in LICENSE",
     "private": true,
     "devDependencies": {
-        "pwa-kit-dev": "^2.1.0-alpha.0",
-        "pwa-kit-runtime": "^2.1.0-alpha.0",
+        "pwa-kit-dev": "^2.1.0-alpha.1",
+        "pwa-kit-runtime": "^2.1.0-alpha.1",
         "supertest": "^4.0.2"
     },
     "scripts": {

--- a/packages/template-express-minimal/package.json
+++ b/packages/template-express-minimal/package.json
@@ -1,11 +1,11 @@
 {
     "name": "template-express-minimal",
-    "version": "2.1.0-dev",
+    "version": "2.1.0-alpha.0",
     "license": "See license in LICENSE",
     "private": true,
     "devDependencies": {
-        "pwa-kit-dev": "^2.1.0-dev",
-        "pwa-kit-runtime": "^2.1.0-dev",
+        "pwa-kit-dev": "^2.1.0-alpha.0",
+        "pwa-kit-runtime": "^2.1.0-alpha.0",
         "supertest": "^4.0.2"
     },
     "scripts": {

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,5 +1,3 @@
-## v2.1.0-dev (May 16, 2022)
-
 ### Bug Fixes
 
 - Various instances of hard-coded text have been replaced with translatable messages (see [Translations](#translations)).

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "retail-react-app",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "retail-react-app",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "retail-react-app",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "retail-react-app",
-    "version": "2.1.0-alpha.1",
+    "version": "2.1.0",
     "license": "See license in LICENSE",
     "private": true,
     "engines": {
@@ -43,9 +43,9 @@
         "njwt": "^1.2.0",
         "node-fetch": "^2.6.7",
         "prop-types": "^15.6.0",
-        "pwa-kit-dev": "^2.1.0-alpha.1",
-        "pwa-kit-react-sdk": "^2.1.0-alpha.1",
-        "pwa-kit-runtime": "^2.1.0-alpha.1",
+        "pwa-kit-dev": "^2.1.0",
+        "pwa-kit-react-sdk": "^2.1.0",
+        "pwa-kit-runtime": "^2.1.0",
         "query-string": "^7.0.1",
         "raf": "^3.4.0",
         "randomstring": "^1.2.1",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "retail-react-app",
-    "version": "2.1.0-alpha.0",
+    "version": "2.1.0-alpha.1",
     "license": "See license in LICENSE",
     "private": true,
     "engines": {
@@ -43,9 +43,9 @@
         "njwt": "^1.2.0",
         "node-fetch": "^2.6.7",
         "prop-types": "^15.6.0",
-        "pwa-kit-dev": "^2.1.0-alpha.0",
-        "pwa-kit-react-sdk": "^2.1.0-alpha.0",
-        "pwa-kit-runtime": "^2.1.0-alpha.0",
+        "pwa-kit-dev": "^2.1.0-alpha.1",
+        "pwa-kit-react-sdk": "^2.1.0-alpha.1",
+        "pwa-kit-runtime": "^2.1.0-alpha.1",
         "query-string": "^7.0.1",
         "raf": "^3.4.0",
         "randomstring": "^1.2.1",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
     "name": "retail-react-app",
-    "version": "2.1.0-dev",
+    "version": "2.1.0-alpha.0",
     "license": "See license in LICENSE",
     "private": true,
     "engines": {
@@ -43,9 +43,9 @@
         "njwt": "^1.2.0",
         "node-fetch": "^2.6.7",
         "prop-types": "^15.6.0",
-        "pwa-kit-dev": "^2.1.0-dev",
-        "pwa-kit-react-sdk": "^2.1.0-dev",
-        "pwa-kit-runtime": "^2.1.0-dev",
+        "pwa-kit-dev": "^2.1.0-alpha.0",
+        "pwa-kit-react-sdk": "^2.1.0-alpha.0",
+        "pwa-kit-runtime": "^2.1.0-alpha.0",
         "query-string": "^7.0.1",
         "raf": "^3.4.0",
         "randomstring": "^1.2.1",

--- a/packages/template-typescript-minimal/package-lock.json
+++ b/packages/template-typescript-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "typescript-minimal",
-	"version": "2.1.0-alpha.1",
+	"version": "2.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-typescript-minimal/package-lock.json
+++ b/packages/template-typescript-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "typescript-minimal",
-	"version": "2.1.0-alpha.0",
+	"version": "2.1.0-alpha.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-typescript-minimal/package-lock.json
+++ b/packages/template-typescript-minimal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "typescript-minimal",
-	"version": "2.1.0-dev",
+	"version": "2.1.0-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-minimal",
-    "version": "2.1.0-alpha.0",
+    "version": "2.1.0-alpha.1",
     "engines": {
         "node": "^14.0.0",
         "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"
@@ -10,9 +10,9 @@
         "@loadable/component": "^5.15.0",
         "cross-env": "^5.2.0",
         "cross-fetch": "^3.1.5",
-        "pwa-kit-dev": "^2.1.0-alpha.0",
-        "pwa-kit-react-sdk": "^2.1.0-alpha.0",
-        "pwa-kit-runtime": "^2.1.0-alpha.0",
+        "pwa-kit-dev": "^2.1.0-alpha.1",
+        "pwa-kit-react-sdk": "^2.1.0-alpha.1",
+        "pwa-kit-runtime": "^2.1.0-alpha.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-minimal",
-    "version": "2.1.0-alpha.1",
+    "version": "2.1.0",
     "engines": {
         "node": "^14.0.0",
         "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"
@@ -10,9 +10,9 @@
         "@loadable/component": "^5.15.0",
         "cross-env": "^5.2.0",
         "cross-fetch": "^3.1.5",
-        "pwa-kit-dev": "^2.1.0-alpha.1",
-        "pwa-kit-react-sdk": "^2.1.0-alpha.1",
-        "pwa-kit-runtime": "^2.1.0-alpha.1",
+        "pwa-kit-dev": "^2.1.0",
+        "pwa-kit-react-sdk": "^2.1.0",
+        "pwa-kit-runtime": "^2.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -1,6 +1,6 @@
 {
     "name": "typescript-minimal",
-    "version": "2.1.0-dev",
+    "version": "2.1.0-alpha.0",
     "engines": {
         "node": "^14.0.0",
         "npm": "^6.14.4 || ^7.0.0 || ^8.0.0"
@@ -10,9 +10,9 @@
         "@loadable/component": "^5.15.0",
         "cross-env": "^5.2.0",
         "cross-fetch": "^3.1.5",
-        "pwa-kit-dev": "^2.1.0-dev",
-        "pwa-kit-react-sdk": "^2.1.0-dev",
-        "pwa-kit-runtime": "^2.1.0-dev",
+        "pwa-kit-dev": "^2.1.0-alpha.0",
+        "pwa-kit-react-sdk": "^2.1.0-alpha.0",
+        "pwa-kit-runtime": "^2.1.0-alpha.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",


### PR DESCRIPTION
# Changes

## pwa-kit-dev
-   Replace `Mobify` references/links with proper PWA Kit values. [#619](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/619)
-   Add support for a custom build directory to `pwa-kit-dev build`. [#628](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/628)
-   Introduce client-side hot module replacement. [#630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/630)

## pwa-kit-react-sdk
-   Remove console logs from route component. [#651](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/651)

