### PR TITLE
Enable Testing of TypeScript and TypeScript w/ JSX Syntax

### DIFF
--- a/packages/internal-lib-build/configs/jest/jest.config.js
+++ b/packages/internal-lib-build/configs/jest/jest.config.js
@@ -17,7 +17,7 @@ module.exports = {
     cacheDirectory: './node_modules/.cache',
     clearMocks: true,
     collectCoverage: true,
-    moduleFileExtensions: ['js', 'jsx', 'json'],
+    moduleFileExtensions: ['js', 'jsx', 'json', 'ts', 'tsx'],
     moduleNameMapper: {
         '^.+\\.svg$': path.join(__dirname, '__mocks__', 'emptyStringMock.js')
     },


### PR DESCRIPTION
# Description

Currently the jest config in the `internal-lib-build` folder doesn't allow ts or tsx modules to be loaded. So if you were to import a ts/tsx file into the `react-rendering.js` file in the `pwa-kit-react-sdk` for example and run the tests for that library you would get an error similar to below.

```
    Cannot find module './test' from 'src/ssr/server/react-rendering.js'

    Require stack:
      src/ssr/server/react-rendering.js
      src/ssr/server/react-rendering.test.js


    However, Jest was able to find:
        './test.ts'

    You might want to include a file extension in your import, or update your 'moduleFileExtensions', which is currently ['js', 'jsx', 'json'].
```

This PR updated the allowable module file extensions to include `.ts` and `.tsx` to be in alignment with the build tools that allow these types of modules.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Update jest module extension types

# How to Test-Drive This PR

- Create a new file called `test.ts` that exports a named test function ```export const test = () => { console.log("this is a test") }``` in this folder `/pwa-kit/packages/pwa-kit-react-sdk/src/ssr/server/`
- Import that names export into `react-rendering.js` like this `import {test} from './test`
- Run the tests and they should pass. The same scenario should fail on the `develop` branch.

