### PR TITLE
Hooks cleanup and named version of `execute`

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -334,9 +334,11 @@ the body are the following properties if specified:
 /**
  * A hook for performing actions with the Shopper Baskets API.
  */
-export function useShopperBasketsAction<Action extends ShopperBasketsActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperBasketsAction<Action extends `${ShopperBasketsActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -353,5 +355,9 @@ export function useShopperBasketsAction<Action extends ShopperBasketsActions>(
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -34,9 +34,11 @@ export enum ShopperContextsActions {
 /**
  * A hook for performing actions with the Shopper Contexts API.
  */
-export function useShopperContextsAction<Action extends ShopperContextsActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperContextsAction<Action extends `${ShopperContextsActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -53,5 +55,9 @@ export function useShopperContextsAction<Action extends ShopperContextsActions>(
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -223,9 +223,11 @@ The value of this property must be valid for the type of custom attribute define
 /**
  * A hook for performing actions with the Shopper Customers API.
  */
-export function useShopperCustomersAction<Action extends ShopperCustomersActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperCustomersAction<Action extends `${ShopperCustomersActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -242,5 +244,9 @@ export function useShopperCustomersAction<Action extends ShopperCustomersActions
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperDiscoverySearch/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDiscoverySearch/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -22,9 +22,11 @@ export enum ShopperDiscoverySearchActions {
 /**
  * A hook for performing actions with the Shopper Discovery Search API.
  */
-export function useShopperDiscoverySearchAction<Action extends ShopperDiscoverySearchActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperDiscoverySearchAction<Action extends `${ShopperDiscoverySearchActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -41,5 +43,9 @@ export function useShopperDiscoverySearchAction<Action extends ShopperDiscoveryS
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -22,9 +22,11 @@ export enum ShopperGiftCertificatesActions {
 /**
  * A hook for performing actions with the Shopper Gift Certificates API.
  */
-export function useShopperGiftCertificatesAction<Action extends ShopperGiftCertificatesActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperGiftCertificatesAction<Action extends `${ShopperGiftCertificatesActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -41,5 +43,9 @@ export function useShopperGiftCertificatesAction<Action extends ShopperGiftCerti
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/action.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/action.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ActionResponse, ApiClients, Argument, DataType} from '../types'
+import {ApiClients, Argument, DataType, ScapiActionResponse} from '../types'
 import {useAsyncExecute} from '../useAsync'
 import useCommerceApi from '../useCommerceApi'
 
@@ -70,9 +70,11 @@ export enum ShopperLoginActions {
 /**
  * A hook for performing actions with the Shopper Login API.
  */
-export function useShopperLoginAction<Action extends ShopperLoginActions>(
+// TODO: Why does prettier not like "extends `${Actions}`"?
+// eslint-disable-next-line prettier/prettier
+export function useShopperLoginAction<Action extends `${ShopperLoginActions}`>(
     action: Action
-): ActionResponse<Argument<Client[Action]>, DataType<Client[Action]>> {
+): ScapiActionResponse<Argument<Client[Action]>, DataType<Client[Action]>, Action> {
     type Arg = Argument<Client[Action]>
     type Data = DataType<Client[Action]>
     // Directly calling `client[action](arg)` doesn't work, because the methods don't fully
@@ -89,5 +91,9 @@ export function useShopperLoginAction<Action extends ShopperLoginActions>(
     const method = client[action]
     assertMethod(method)
 
-    return useAsyncExecute((arg: Arg) => method.call(client, arg))
+    const hook = useAsyncExecute((arg: Arg) => method.call(client, arg))
+    // TypeScript loses information when using a computed property name - it assumes `string`, but
+    // we know it's `Action`. This type assertion just restores that lost information.
+    const namedAction = {[action]: hook.execute} as Record<Action, typeof hook.execute>
+    return {...hook, ...namedAction}
 }

--- a/packages/commerce-sdk-react/src/hooks/types.ts
+++ b/packages/commerce-sdk-react/src/hooks/types.ts
@@ -44,10 +44,14 @@ export type QueryResponse<T> = {isLoading: boolean; error?: Error; data?: T}
  * Object returned by an "action" hook.
  */
 export type ActionResponse<Args extends unknown[], Data> = QueryResponse<Data> & {
-    execute: (args: Args) => void
+    execute: (...args: Args) => void
 }
 
-export type DependencyList = readonly unknown[]
+/**
+ * Object returned by a SCAPI "action" hook.
+ */
+export type ScapiActionResponse<Arg, Data, Name extends string> = ActionResponse<[Arg], Data> &
+    Record<Name, ActionResponse<[Arg], Data>['execute']>
 
 /**
  * The first argument of a function.

--- a/packages/commerce-sdk-react/src/hooks/types.ts
+++ b/packages/commerce-sdk-react/src/hooks/types.ts
@@ -35,53 +35,31 @@ export interface ApiClients {
     shopperSearch: ShopperSearch<ApiClientConfigParams>
 }
 
-// These are the common params for all query hooks
-// it allows user to override configs for specific query
-export interface QueryParams {
-    siteId?: string
-    locale?: string
-    currency?: string
-    organizationId?: string
-    shortCode?: string
-}
+/**
+ * Object returned by a "query" hook.
+ */
+export type QueryResponse<T> = {isLoading: boolean; error?: Error; data?: T}
 
-export type QueryResponse<T> =
-    | {
-          isLoading: boolean
-          error?: undefined
-          data?: undefined
-      }
-    | {
-          isLoading: true
-          error?: Error
-          data?: T
-      }
-    | {
-          isLoading: false
-          error: Error
-          data?: undefined
-      }
-    | {
-          isLoading: false
-          error?: undefined
-          data: T
-      }
-
-// TODO: Include action name as a key in addition to "execute"?
-export type ActionResponse<A, R> = QueryResponse<R> & {
-    execute: (arg: A) => void
+/**
+ * Object returned by an "action" hook.
+ */
+export type ActionResponse<Args extends unknown[], Data> = QueryResponse<Data> & {
+    execute: (args: Args) => void
 }
 
 export type DependencyList = readonly unknown[]
 
-export type Argument<T extends (arg: any) => unknown> = T extends (arg: infer R) => any ? R : never
+/**
+ * The first argument of a function.
+ */
+export type Argument<T extends (arg: any) => unknown> = Parameters<T>[0]
 
-export interface SdkMethod<A, R> {
-    (arg: A): Promise<R>
-    // Specifying `Response` separately is important so that `R` is just the data type
-    (arg: A, flag?: boolean): Promise<Response | R>
-}
-
-export type DataType<T extends (...args: any[]) => Promise<any>> = T extends SdkMethod<any, infer R>
+/**
+ * The data type returned by a commerce-sdk-isomorphic method when the raw response
+ * flag is not set.
+ */
+export type DataType<T extends (arg: any) => Promise<unknown>> = T extends (
+    arg: any
+) => Promise<Response | infer R>
     ? R
     : never

--- a/packages/commerce-sdk-react/src/hooks/useAsync.ts
+++ b/packages/commerce-sdk-react/src/hooks/useAsync.ts
@@ -24,14 +24,16 @@ export const useAsync = <T>(fn: () => Promise<T>, deps?: unknown[]): QueryRespon
     return result
 }
 
-export const useAsyncExecute = <A, R>(fn: (arg: A) => Promise<R>) => {
+export const useAsyncExecute = <Args extends unknown[], Ret>(
+    fn: (...args: Args) => Promise<Ret>
+) => {
     // This is a stub implementation to validate the types.
     // The real implementation will be more React-y.
-    const result: ActionResponse<A, R> = {
+    const result: ActionResponse<Args, Ret> = {
         isLoading: false,
-        execute(arg: A) {
+        execute(...args: Args) {
             result.isLoading = true
-            fn(arg)
+            fn(...args)
                 .then((data) => {
                     result.isLoading = false
                     result.data = data

--- a/packages/commerce-sdk-react/src/hooks/useAsync.ts
+++ b/packages/commerce-sdk-react/src/hooks/useAsync.ts
@@ -25,7 +25,9 @@ export const useAsync = <T>(fn: () => Promise<T>, deps?: unknown[]): QueryRespon
     return result
 }
 
-export const useAsyncCallback = <Args extends unknown[], Ret>(fn: (...args: Args) => Promise<Ret>) => {
+export const useAsyncCallback = <Args extends unknown[], Ret>(
+    fn: (...args: Args) => Promise<Ret>
+) => {
     const [isLoading, setIsLoading] = useState(false)
     const [data, setData] = useState<Ret | undefined>(undefined)
     const [error, setError] = useState<Error | undefined>(undefined)


### PR DESCRIPTION
Follow-up to #674 with some action items from the walkthrough last week. Namely, simplified a few types and figured out a way to add the action name as an alias for `execute`.

Example:
```ts
// No more of this!
const { execute: createBasket } = useShopperBasketsAction(ShopperBasketsActions.CreateBasket)
// Yay, marginally fewer keystrokes!
const { createBasket } = useShopperBasketsAction(ShopperBasketsActions.CreateBasket)
// This is still possible, though, for generic use
const { execute } = useShopperBasketsAction(variableAction)
```

This PR also steals some thunder from #677 to (hopefully) minimize merge conflicts. Thanks, Kev!
# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
