### PR TITLE
`create-app` asks for your SLAS Client ID

### DIFF
--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -270,7 +270,7 @@ const retailReactAppPrompts = () => {
         },
         {
             name: 'clientId',
-            message: 'What is your SLAS API Client ID in Account Manager?',
+            message: 'What is your SLAS Client ID?',
             validate: validClientId
         },
         {


### PR DESCRIPTION
The current question in `pwa-kit-create-app`

> What is your SLAS API Client ID in Account Manager?

Is super confusing.

SLAS Client IDs have nothing to do with Account Manager.

This change makes it more clear.