### PR TITLE
`internal-lib-build`: detect test files in both js(x) and ts(x) extensions

### DIFF
--- a/packages/internal-lib-build/configs/jest/jest.config.js
+++ b/packages/internal-lib-build/configs/jest/jest.config.js
@@ -28,7 +28,6 @@ module.exports = {
         '/node_modules/',
         '/vendor/'
     ],
-    testRegex: '\\.?(test|spec)\\.jsx?$',
     testEnvironment: 'jest-environment-jsdom-global',
     testEnvironmentOptions: {
         resources: 'usable'


### PR DESCRIPTION


# Description

When I was working on #682 , I realized that after using the jest config found in `internal-test-lib`, no tests were being found. Then finally I found out why that was happening: the config file was setting an option such that it searches for only javascript files.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
