### PR TITLE
Dev server: minimize the "Module not found" error during rebuilds

### DIFF
--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v2.3.0-dev (Aug 25, 2022)
+-   Minimize "Module not found" error during webpack rebuild, whenever a package dependency is being updated/built [#722](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/722)
+
 ## v2.2.0 (Aug 25, 2022)
 -   Added option to specify where/from the credentials can be saved/read [#647](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/647)
 

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -77,6 +77,9 @@ const baseConfig = (target) => {
     class Builder {
         constructor() {
             this.config = {
+                watchOptions: {
+                    aggregateTimeout: 1000
+                },
                 target,
                 mode,
                 ...(target === 'node'


### PR DESCRIPTION
When developing our hooks library (commerce-sdk-react) and testing in the test-commerce project, we were seeing _Module Not Found_ error pretty frequently. As a workaround, we had to restart our dev server. But doing so many times hurt our development flow.

![NeoVim Terminal 2022-09-16 at 11 33 18](https://user-images.githubusercontent.com/847300/190708010-5f9402fc-3fbb-493a-afa6-81fad14ea985.png)

I found webpack to be too eager to rebuild the app you're working on, whenever one of our sdk packages is being rebuilt. We needed a way to tell webpack to wait a bit before doing its rebuild. This PR adds a new watch option in the webpack config.

Ticket: [W-11767052](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000016bw5QYAQ/view)


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# How to Test-Drive This PR

First of all, run the dev server in the test-commerce project, and then run a build watch in our hooks library:

```bash
npm ci # at the root of monorepo, to rebuild all the packages
cd packages/test-commerce-sdk-react/
npm start
# Then open up a new terminal window/tab
cd packages/commerce-sdk-react
npm run build:watch
```

Then in your code editor:
1. Open up one of the files in the package `commerce-sdk-react`
2. Do a save (yes, no need to write additional code), and that should trigger the build-watch to rebuild the hooks library
3. Verify in your browser that the site is still working OK. 

Some variations to try:
- Do a save multiple times in a row ← to simulate developers who love to save their changes often
- If you see the Module Not Found error (it still happens occasionally), see if you do another save, would that fix things?


# Checklists

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
