### PR TITLE
[example] Custom code splitting webpack config

### DIFF
--- a/packages/template-typescript-minimal/webpack.config.js
+++ b/packages/template-typescript-minimal/webpack.config.js
@@ -1,0 +1,24 @@
+const config = require('pwa-kit-dev/configs/webpack/config')
+
+// This is a demo to override splitChunks
+// to have more fine grain control over code splitting
+// config is an array and the first element is the client config
+// here we override the split chunks to split out the react/react-dom
+// packages from vendor.js
+config[0].optimization.splitChunks = {
+    cacheGroups: {
+        react: {
+            test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+            name: 'react',
+            chunks: 'all',
+            priority: 1,
+        },
+        vendor: {
+            test: /node_modules/,
+            name: 'vendor',
+            chunks: 'all',
+        },
+    },
+}
+
+module.exports = config


### PR DESCRIPTION
This is an example to show how to override webpack config to have fine grained code splitting setup.

This example splits react/react-dom packages from the vendor.js bundle, you could split any other dependencies following the same pattern.

### Before

<img width="1043" alt="Screen Shot 2022-09-16 at 12 28 44 PM" src="https://user-images.githubusercontent.com/10948652/190716778-41f6c589-077e-4653-bcfd-2a4f7fd00a54.png">


### After

<img width="1145" alt="Screen Shot 2022-09-16 at 12 28 33 PM" src="https://user-images.githubusercontent.com/10948652/190716751-d97cf8b0-89ec-4cb0-8744-7b91f1ef8f39.png">
