### PR TITLE
Remove Console Logs

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -649,7 +649,6 @@ describe('The Node SSR Environment', () => {
             mocks: () => {
                 const AppConfig = getAppConfig()
                 jest.spyOn(AppConfig.prototype, 'render').mockImplementation(() => {
-                    console.log('Throwing an error!!')
                     throw new Error()
                 })
             },
@@ -699,7 +698,6 @@ describe('The Node SSR Environment', () => {
                 const app = RemoteServerFactory._createApp(opts())
                 app.get('/*', render)
                 if (mocks) {
-                    console.log('Doing the mocking')
                     mocks()
                 }
                 return request(app)


### PR DESCRIPTION
When merging [PR](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/724) we left in a couple console logs. This PR removes them.