### PR TITLE
Bump `ua-parser-js` in Runtime

### DIFF
--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -43,7 +43,7 @@
     "rimraf": "2.6.1",
     "semver": "^7.3.2",
     "set-cookie-parser": "^2.2.1",
-    "ua-parser-js": "^0.7.24",
+    "ua-parser-js": "^0.7.31",
     "whatwg-encoding": "^1.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
Our package.json references a vulnerable version of the mentioned package. Even though our lock file references the safe version we need to update our package.json to make sure scanning tools don't complain.