### PR TITLE
issue 738 - adding back OCAPI session bridge for phased rollouts

### DIFF
--- a/packages/template-retail-react-app/app/commerce-api/auth.js
+++ b/packages/template-retail-react-app/app/commerce-api/auth.js
@@ -190,6 +190,31 @@ class Auth {
     }
 
     /**
+     * Make a post request to the OCAPI /session endpoint to bridge the session.
+     *
+     * The HTTP response contains a set-cookie header which sets the dwsid session cookie.
+     * This cookie is used on SFRA, and it allows shoppers to navigate between SFRA and
+     * this PWA site seamlessly; this is often used to enable hybrid deployment.
+     *
+     * (Note: this method is client side only, b/c MRT doesn't support set-cookie header right now)
+     *
+     * @returns {Promise}
+     */
+    createOCAPISession() {
+        return fetch(
+            `${getAppOrigin()}/mobify/proxy/ocapi/s/${
+                this._config.parameters.siteId
+            }/dw/shop/v21_3/sessions`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: this.authToken
+                }
+            }
+        )
+    }
+
+    /**
      * Authorizes the customer as a registered or guest user.
      * @param {CustomerCredentials} [credentials]
      * @returns {Promise}
@@ -210,15 +235,21 @@ class Auth {
             } else if (this.refreshToken) {
                 authorizationMethod = '_refreshAccessToken'
             }
-            return this[authorizationMethod](credentials).catch((error) => {
-                const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
-                if (retries === 0 && retryErrors.includes(error.message)) {
-                    retries = 1 // we only retry once
-                    this._clearAuth()
-                    return startLoginFlow()
-                }
-                throw error
-            })
+            return this[authorizationMethod](credentials)
+                .catch((error) => {
+                    const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
+                    if (retries === 0 && retryErrors.includes(error.message)) {
+                        retries = 1 // we only retry once
+                        this._clearAuth()
+                        return startLoginFlow()
+                    }
+                    throw error
+                })
+                .then((result) => {
+                    // Uncomment the following line for phased launch
+                    // this._onClient && this.createOCAPISession()
+                    return result
+                })
         }
 
         this._pendingLogin = startLoginFlow().finally(() => {


### PR DESCRIPTION
see issue #738 

# Description

### Steps To Reproduce

1. start out on pwa, add products to guest cart
2. cart page redirects to SFRA cart page, session is successfully restored from PWA refresh token
3. on SFRA login page, click "login" -> returns to PWA for login
4. login via PWA
5. return to SFRA cart page. notice that the previous guest `dwsid` is still set and `onSession` is never triggered on SFRA, resulting in a cleared guest cart. Customer is not logged in via SFRA.

### Expected result

Returning to SFRA after logging in via PWA should maintain session state and cart

**Current State**:
Notice that returning to SFRA the second time never calls `onSession` so the `dwsid` is never set from the logged in refresh token. The old `dwsid` from the initial session is used, resulting in an empty cart. There's no way to login via SFRA.

https://user-images.githubusercontent.com/375787/192851283-ddea313f-ecfc-4451-b984-f3f862a460b1.mov

**Updated State**

https://user-images.githubusercontent.com/375787/192851325-e499d233-b54b-44e5-8e73-11e5d274d4c9.mov

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- restoring previous code/ session bridge that was removed #684, required for phased rollouts. Left session bridge commented out. If this is the desired approach, we should add this line to the [phased rollout documentation](https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/phased-headless-rollouts.html)

# How to Test-Drive This PR

1. start out on pwa, add products to guest cart
2. cart page redirects to SFRA cart page, session is successfully restored from PWA refresh token
3. on SFRA login page, click "login" -> returns to PWA for login
4. login via PWA
5. return to SFRA cart page. notice you are correctly logged in and cart is restored.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
