### PR TITLE
Bugfix: image gallery thumbnails not working without DIS

### DIFF
--- a/packages/template-retail-react-app/app/components/image-gallery/index.jsx
+++ b/packages/template-retail-react-app/app/components/image-gallery/index.jsx
@@ -138,7 +138,7 @@ const ImageGallery = ({imageGroups = [], selectedVariationAttributes = {}, size}
                             borderWidth={`${selected ? '1px' : 0}`}
                         >
                             <AspectRatio ratio={1}>
-                                <Img alt={image.alt} src={image.disBaseLink} />
+                                <Img alt={image.alt} src={image.disBaseLink || image.link} />
                             </AspectRatio>
                         </ListItem>
                     )


### PR DESCRIPTION

# Description

When dynamic imaging isn't available need to look at `.link` attribute. This was done in most places already but was missing in the thumbnails of the image gallery. 

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- adds fix to image gallery component thumbnails

# How to Test-Drive This PR

- use a catalog with external images instead of internal (this will make DIS unavailable for those products)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
