### PR TITLE
Use default locale as target if none is specified

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.3.0-dev (Aug 25, 2022)
+- Ensure that a valid target locale is use if none is provided [#788](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/788)
 ## v2.2.0 (Aug 25, 2022)
 - Update zzrf-001 url [#694](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/694)
 - Optimize Server-side performance [#667](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/667)

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -51,9 +51,15 @@ import useMultiSite from '../../hooks/use-multi-site'
 
 const DEFAULT_NAV_DEPTH = 3
 const DEFAULT_ROOT_CATEGORY = 'root'
+const DEFAULT_LOCALE = 'en-US'
 
 const App = (props) => {
-    const {children, targetLocale, messages, categories: allCategories = {}} = props
+    const {
+        children,
+        targetLocale = DEFAULT_LOCALE,
+        messages = {},
+        categories: allCategories = {}
+    } = props
 
     const appOrigin = getAppOrigin()
 
@@ -157,7 +163,7 @@ const App = (props) => {
                 // NOTE: if you update this value, please also update the following npm scripts in `template-retail-react-app/package.json`:
                 // - "extract-default-translations"
                 // - "compile-translations:pseudo"
-                defaultLocale="en-US"
+                defaultLocale={DEFAULT_LOCALE}
             >
                 <CategoriesProvider categories={allCategories}>
                     <CurrencyProvider currency={currency}>


### PR DESCRIPTION
# Description

The `_app` component was written in a way that if you don't provide a target locale to be used in the intl provider, the provider will error out as the configuration is invalid. 

To be safe we should always use the default locale as the target is one isn't provided. NOTE: when I say default locale, I'm not talking about the default locale as defined in the projects site configuration, I'm talking about the locale in which the default messages are written in, you can think of this as the source locale. This value is guaranteed to work even if you don't provide messages to the provider since it's the same locale as the default messages.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Use default locale as target local if none is provided.

# How to Test-Drive This PR

- In the `_app` component comment out line 332 so we aren't returning a targetLocale from getProps
- Run the project `npm run start`
- The app should load as it normally would. Without this fix, the action of not returning a targetLocale value would cause the sight to error out.