### PR TITLE
Explore having react-query config be on user land

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
@@ -12,20 +12,6 @@ import {FetchStrategy} from '../fetch-strategy'
 
 const STATE_KEY = '__reactQuery'
 
-// This is where we want to set the default query client configuration that are
-// safe for execution on the server and client. If there are any other config
-// option defaults that need to be set in the future, they should be set here.
-const SAFE_QUERY_CLIENT_CONFIG = {
-    defaultOptions: {
-        queries: {
-            retry: false
-        },
-        mutations: {
-            retry: false
-        }
-    }
-}
-
 /**
  * A HoC for adding React Query support to your application.
  *
@@ -40,7 +26,7 @@ export const withReactQuery = (Wrapped, options = {}) => {
     const isServerSide = typeof window === 'undefined'
     /* istanbul ignore next */
     const wrappedComponentName = Wrapped.displayName || Wrapped.name
-    const queryClientConfig = options.queryClientConfig || SAFE_QUERY_CLIENT_CONFIG
+    const queryClientConfig = options.queryClientConfig
 
     /**
      * @private

--- a/packages/template-typescript-minimal/app/components/_app-config/index.js
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.js
@@ -9,11 +9,14 @@ import {withReactQuery} from 'pwa-kit-react-sdk/ssr/universal/components/with-re
 import AppConfig from 'pwa-kit-react-sdk/ssr/universal/components/_app-config'
 
 // Recommended settings for PWA-Kit usages.
+// NOTE: they will be applied on both server and client side.
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false
+                retry: false,
+                staleTime: 2 * 1000,
+                retryOnMount: false
             },
             mutations: {
                 retry: false

--- a/packages/template-typescript-minimal/app/components/_app-config/index.js
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.js
@@ -8,6 +8,8 @@ import {withLegacyGetProps} from 'pwa-kit-react-sdk/ssr/universal/components/wit
 import {withReactQuery} from 'pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import AppConfig from 'pwa-kit-react-sdk/ssr/universal/components/_app-config'
 
+const isServerSide = typeof window === 'undefined'
+
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 const options = {
@@ -16,7 +18,7 @@ const options = {
             queries: {
                 retry: false,
                 staleTime: 2 * 1000,
-                retryOnMount: false
+                ...(isServerSide ? {retryOnMount: false} : {})
             },
             mutations: {
                 retry: false

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -73,17 +73,15 @@ AppConfig.restore = () => {}
 AppConfig.extraGetPropsArgs = () => {}
 AppConfig.freeze = () => {}
 
-const isServerSide = typeof window === 'undefined'
 // Recommended settings for PWA-Kit usages.
+// NOTE: they will be applied on both server and client side.
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
                 retry: false,
-                // Avoid double requests during hydration
-                staleTime: 5 * 1000,
-                // So that the final value for the `isLoading` state is correct, whenever a query has an error in SSR.
-                ...(isServerSide ? {retryOnMount: false} : {})
+                staleTime: 2 * 1000,
+                retryOnMount: false
             },
             mutations: {
                 retry: false

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -73,12 +73,17 @@ AppConfig.restore = () => {}
 AppConfig.extraGetPropsArgs = () => {}
 AppConfig.freeze = () => {}
 
-// Recommended settings for PWA-Kit usage.
+const isServerSide = typeof window === 'undefined'
+// Recommended settings for PWA-Kit usages.
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false
+                retry: false,
+                // Avoid double requests during hydration
+                staleTime: 5 * 1000,
+                // So that the final value for the `isLoading` state is correct, whenever a query has an error in SSR.
+                ...(isServerSide ? {retryOnMount: false} : {})
             },
             mutations: {
                 retry: false

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -73,6 +73,8 @@ AppConfig.restore = () => {}
 AppConfig.extraGetPropsArgs = () => {}
 AppConfig.freeze = () => {}
 
+const isServerSide = typeof window === 'undefined'
+
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 const options = {
@@ -81,7 +83,7 @@ const options = {
             queries: {
                 retry: false,
                 staleTime: 2 * 1000,
-                retryOnMount: false
+                ...(isServerSide ? {retryOnMount: false} : {})
             },
             mutations: {
                 retry: false


### PR DESCRIPTION
Based on our previous conversation: what if we have all of the react-query configurations live in the user land? 

# Changes

- Removed the default options from pwa-kit idk
- Have all default options now be in the template
- Show what resolving tickets [1](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000172lUtYAI/view), [2](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000017x6qOYAQ/view) looks like in this new setup

# How to Test-Drive This PR

See PR #767 for the instruction.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
