### PR TITLE
Explore how to clean up nock

### DIFF
--- a/packages/commerce-sdk-react/setup-jest.js
+++ b/packages/commerce-sdk-react/setup-jest.js
@@ -39,6 +39,9 @@ Object.defineProperty(window, 'localStorage', {
     value: localStorageMock
 })
 
-global.beforeEach(() => {
+global.afterEach(() => {
+    nock.cleanAll()
+})
+global.afterAll(() => {
     nock.restore()
 })


### PR DESCRIPTION
It's not clear from reading the Nock documentation which methods (and when to call them) we need to use to clean up after Nock. We have used `nock.restore` in our commerce hooks library. It turns out that it is a good idea to call `nock.cleanAll` too.

Resources:
- Our [own packages](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/f2f3403f9c0339998f5c6597975cd89dc7ce4208/packages/pwa-kit-dev/src/ssr/server/build-dev-server.test.js#L321) called `cleanAll`.
- This [article](https://codeburst.io/testing-mocking-http-requests-with-nock-480e3f164851) suggests calling both `cleanAll` and `restore`
- Nock's own [documentation](https://github.com/nock/nock)

## `nock.restore` vs `nock.cleanAll`

Both methods clean up different parts of nock, and they're both useful:
- `restore` is for restoring the original `http.request` and `http.ClientRequest` that got monkey-patched
- while `cleanAll` is to remove all mocks/interceptors.

For more details, please see the PR comments below.

# How to Test-Drive This PR

- Verify that CircleCI tests are passing
- Last time we ran the npm script `test:update-mocked-responses` but it's failing now (in both `develop` and this branch). It looks like some shopper promotions that we're querying are no longer available. ← I think we can ignore that for now.