### PR TITLE
Mobify v2.4.x remove Nock wild mode tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,6 @@ commands:
   runtests:
     description: 'Run tests'
     parameters:
-      enableIntegrationTests:
-          description: 'Enable expensive integration tests'
-          default: true
-          type: boolean
       cwd:
         description: 'The directory to execute the tests from'
         default: ${PWD}
@@ -82,11 +78,6 @@ commands:
             # End to end tests on nightly builds only
             if [[ $NIGHTLY ]]; then
               npm run test:e2e-ci
-            fi
-
-            # Only run expensive integration tests on these branches
-            if [[ (<< parameters.enableIntegrationTests >> == "true") && ( $MASTER || $DEVELOP || $RELEASE ) ]]; then
-              npm run test:integration
             fi
   smoketestscripts:
     description: 'Smoke test scripts'
@@ -120,8 +111,6 @@ jobs:
     steps:
       - checkout
       - setup
-      - runtests:
-          enableIntegrationTests: false
       - smoketestscripts
       - checkclean
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,9 +114,9 @@ commands:
               git diff --exit-code
 
 jobs:
-  testNode10:
+  testNode14:
     docker:
-      - image: circleci/node:10-stretch-browsers
+      - image: circleci/node:14-stretch-browsers
     steps:
       - checkout
       - setup
@@ -184,7 +184,7 @@ jobs:
 
   generatedSFCCProjectTest:
     docker:
-      - image: circleci/node:12-stretch-browsers
+      - image: circleci/node:14-stretch-browsers
     steps:
       - checkout
       - setup
@@ -223,7 +223,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - testNode10
+      - testNode14
       - testNode12
       - generatedSFCCProjectTest
   nightly-build:
@@ -236,7 +236,7 @@ workflows:
                 - develop
                 - v2-develop
     jobs:
-      - testNode10:
+      - testNode14:
           context: nightly-build
       - testNode12:
           context: nightly-build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ up the front-end of the Mobify platform. These include:
 ## Requirements
 
 ```
-Node ^10.17.0 or ^12.x
+Node ^14
 npm ^5.7.1 or ^6.11.3
 ```
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,7 +3,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.4.11",
+  "version": "2.4.12",
   "publish": {
     "allowBranch": [
       "master"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-platform-sdks",
-  "version": "2.4.10",
+  "version": "2.4.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobify-platform-sdks",
   "version": "2.4.11",
   "engines": {
-    "node": "^10.17.0 || ^12.0.0",
+    "node": "^10.17.0 || ^12.0.0 || ^14.0.0",
     "npm": ">=5.7.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobify-platform-sdks",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "engines": {
     "node": "^10.17.0 || ^12.0.0 || ^14.0.0",
     "npm": ">=5.7.1"

--- a/packages/commerce-integrations/CHANGELOG.md
+++ b/packages/commerce-integrations/CHANGELOG.md
@@ -1,3 +1,4 @@
+## v2.4.12 (Nov 02, 2022)
 ## v2.4.11 (Apr 29, 2022)
 ## v2.4.10 (Feb 24, 2022)
 - Security package updates

--- a/packages/commerce-integrations/package-lock.json
+++ b/packages/commerce-integrations/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mobify/commerce-integrations",
-	"version": "2.4.11",
+	"version": "2.4.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/commerce-integrations/package.json
+++ b/packages/commerce-integrations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobify/commerce-integrations",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "A customizable API abstraction layer for ecommerce backends.",
   "publishConfig": {
     "access": "public"

--- a/packages/commerce-integrations/package.json
+++ b/packages/commerce-integrations/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "npm run lint:js -- --fix",
     "lint:js": "eslint \"**/*.{js,jsx}\"",
     "test": "jest",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "format": "prettier --write \"**/*.{js,jsx}\""
   },
   "repository": {

--- a/packages/commerce-integrations/src/utils/test-utils.js
+++ b/packages/commerce-integrations/src/utils/test-utils.js
@@ -12,8 +12,9 @@ import nock from 'nock'
  *
  * @private
  */
-export const isIntegrationTest = process.env.TEST_TYPE === 'integration'
-nock.back.setMode(isIntegrationTest ? 'wild' : 'record')
+// 2022.11.03 - We've decided to only run the tests in record mode
+// since mobify v2.x is no longer being actively maintained
+nock.back.setMode('record')
 nock.back.fixtures = `${__dirname}/../../cassettes`
 
 /**

--- a/packages/create-app/package-lock.json
+++ b/packages/create-app/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@mobify/create-app",
-	"version": "2.4.11",
+	"version": "2.4.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mobify/create-app",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "Mobify's project generator tool",
   "author": "dev@mobify.com",
   "license": "See license in LICENSE",

--- a/packages/progressive-web-sdk/CHANGELOG.md
+++ b/packages/progressive-web-sdk/CHANGELOG.md
@@ -1,3 +1,4 @@
+## v2.4.12 (Nov 02, 2022)
 ## v2.4.11 (Apr 29, 2022)
 - Security package updates
 ## v2.4.10 (Feb 24, 2022)

--- a/packages/progressive-web-sdk/CHANGELOG.md
+++ b/packages/progressive-web-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.4.12 (Nov 02, 2022)
+- Add Node 14 support
 ## v2.4.11 (Apr 29, 2022)
 - Security package updates
 ## v2.4.10 (Feb 24, 2022)

--- a/packages/progressive-web-sdk/package-lock.json
+++ b/packages/progressive-web-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "progressive-web-sdk",
-	"version": "2.4.11",
+	"version": "2.4.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/progressive-web-sdk/package.json
+++ b/packages/progressive-web-sdk/package.json
@@ -34,7 +34,6 @@
     "lint:js": "eslint \"**/*.{js,jsx}\"",
     "lint:sass": "sass-lint -c node_modules/mobify-code-style/css/.sass-lint.yml 'src/**/*.scss' -v",
     "test": "cross-env NODE_ENV=test jest --runInBand --coverage",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "test:watch": "npm test -- --watch",
     "test:inspect": "node --inspect-brk jest --runInBand",
     "version": "node ./scripts/version.js",

--- a/packages/progressive-web-sdk/package.json
+++ b/packages/progressive-web-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progressive-web-sdk",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "description": "A set of libraries and components which make up the SDK for Progressive Web",
   "main": "dist/index.js",
   "bin": {

--- a/packages/progressive-web-sdk/package.json
+++ b/packages/progressive-web-sdk/package.json
@@ -10,7 +10,7 @@
     "sdk-create-hash-manifest": "bin/create-hash-manifest.js"
   },
   "engines": {
-    "node": "^10.17.0 || ^12.0.0"
+    "node": "^10.17.0 || ^12.0.0 || ^14.0.0"
   },
   "files": [
     "bin",

--- a/packages/pwa/package-lock.json
+++ b/packages/pwa/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "scaffold-pwa",
-	"version": "2.4.11",
+	"version": "2.4.12",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scaffold-pwa",
-  "version": "2.4.11",
+  "version": "2.4.12",
   "siteName": "NPSP Web",
   "siteUrl": "https://www.example.com/",
   "projectSlug": "scaffold-pwa",
@@ -43,7 +43,7 @@
     }
   },
   "dependencies": {
-    "@mobify/commerce-integrations": "^2.4.11",
+    "@mobify/commerce-integrations": "^2.4.12",
     "bluebird": "^3.5.1",
     "core-js": "2.4.0",
     "es6-object-assign": "^1.1.0",
@@ -129,7 +129,7 @@
     "nodemon": "1.18.10",
     "postcss-loader": "3.0.0",
     "prettier": "1.18.2",
-    "progressive-web-sdk": "^2.4.11",
+    "progressive-web-sdk": "^2.4.12",
     "raf": "^3.4.0",
     "raw-loader": "0.5.1",
     "react-loadable": "^5.5.0",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -163,7 +163,6 @@
     "test": "jest",
     "test:e2e": "nightwatch --suiteRetries 2 --config tests/e2e/nightwatch.conf.js tests/e2e/workflows/home-plp-pdp.js",
     "test:e2e-ci": "node ./scripts/run-e2e.js",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "test:max-file-size": "bundlesize",
     "format": "prettier --write \"**/*.{js,jsx}\""
   },


### PR DESCRIPTION
Removing the integration tests in Mobify v2.4.x branch since this version is no longer actively maintained. Run the tests in record mode only.