### PR TITLE
Mobify v2.4.x remove integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,10 +56,6 @@ commands:
   runtests:
     description: 'Run tests'
     parameters:
-      enableIntegrationTests:
-          description: 'Enable expensive integration tests'
-          default: true
-          type: boolean
       cwd:
         description: 'The directory to execute the tests from'
         default: ${PWD}
@@ -82,11 +78,6 @@ commands:
             # End to end tests on nightly builds only
             if [[ $NIGHTLY ]]; then
               npm run test:e2e-ci
-            fi
-
-            # Only run expensive integration tests on these branches
-            if [[ (<< parameters.enableIntegrationTests >> == "true") && ( $MASTER || $DEVELOP || $RELEASE ) ]]; then
-              npm run test:integration
             fi
   smoketestscripts:
     description: 'Smoke test scripts'
@@ -120,8 +111,7 @@ jobs:
     steps:
       - checkout
       - setup
-      - runtests:
-          enableIntegrationTests: false
+      - runtests
       - smoketestscripts
       - checkclean
       - store_test_results:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lerna": "lerna",
     "pretest": "npm run lint",
     "test": "lerna run --stream --concurrency=1 test",
-    "test:integration": "lerna run --stream --concurrency=1 test:integration",
     "test:e2e-ci": "lerna run --stream --concurrency=1 test:e2e-ci",
     "test:max-file-size": "lerna run --stream test:max-file-size",
     "lint": "lerna run --parallel --stream lint -- --silent",

--- a/packages/commerce-integrations/package.json
+++ b/packages/commerce-integrations/package.json
@@ -13,7 +13,6 @@
     "lint:fix": "npm run lint:js -- --fix",
     "lint:js": "eslint \"**/*.{js,jsx}\"",
     "test": "jest",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "format": "prettier --write \"**/*.{js,jsx}\""
   },
   "repository": {

--- a/packages/commerce-integrations/src/utils/test-utils.js
+++ b/packages/commerce-integrations/src/utils/test-utils.js
@@ -12,8 +12,9 @@ import nock from 'nock'
  *
  * @private
  */
-export const isIntegrationTest = process.env.TEST_TYPE === 'integration'
-nock.back.setMode(isIntegrationTest ? 'wild' : 'record')
+// 2022.11.03 - We've decided to only run the tests in lockdown mode
+// since mobify v2.x is no longer being actively maintained
+nock.back.setMode('lockdown')
 nock.back.fixtures = `${__dirname}/../../cassettes`
 
 /**

--- a/packages/progressive-web-sdk/package.json
+++ b/packages/progressive-web-sdk/package.json
@@ -34,7 +34,6 @@
     "lint:js": "eslint \"**/*.{js,jsx}\"",
     "lint:sass": "sass-lint -c node_modules/mobify-code-style/css/.sass-lint.yml 'src/**/*.scss' -v",
     "test": "cross-env NODE_ENV=test jest --runInBand --coverage",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "test:watch": "npm test -- --watch",
     "test:inspect": "node --inspect-brk jest --runInBand",
     "version": "node ./scripts/version.js",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -163,7 +163,6 @@
     "test": "jest",
     "test:e2e": "nightwatch --suiteRetries 2 --config tests/e2e/nightwatch.conf.js tests/e2e/workflows/home-plp-pdp.js",
     "test:e2e-ci": "node ./scripts/run-e2e.js",
-    "test:integration": "cross-env TEST_TYPE=integration npm run test",
     "test:max-file-size": "bundlesize",
     "format": "prettier --write \"**/*.{js,jsx}\""
   },


### PR DESCRIPTION
Removing the integration tests in Mobify v2.4.x branch since this version is no longer actively maintained. Run the tests in lockdown mode only.