### PR TITLE
Mock auth class

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/helper.test.tsx
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/helper.test.tsx
@@ -11,11 +11,16 @@ import {renderWithProviders} from '../../test-utils'
 
 const mockLoginGuestUser = jest.fn().mockResolvedValue('mockLoginGuestUser')
 
-jest.mock('../useAuth', () => {
-    return jest.fn(() => ({
-        ready: () => Promise.resolve({access_token: '123'}),
-        loginGuestUser: mockLoginGuestUser
-    }))
+jest.mock('../../auth', () => {
+    return class Auth {
+        ready() {
+            return Promise.resolve({access_token: '123'})
+        }
+
+        loginGuestUser() {
+            return mockLoginGuestUser()
+        }
+    }
 })
 
 const tests = [


### PR DESCRIPTION
In `/shopperlogin/helper.test.jsx`, the authentication module is incorrectly mocked and causing Auth class to still make requests. The PR attempts to mock the underlying Auth class to ensure no requests goes to network. 

Thanks @vmarta for finding the issue and suggested the fix.