### PR TITLE
Fix invalid hook call

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,9 @@ commands:
           name: 'Install Dependencies'
           command: |
 
-            # Add Chrome to apt sources
-            wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
-            sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
-
             # Install system dependencies
             sudo apt-get update
-            sudo apt-get install python-dev python-pip google-chrome-stable time
+            sudo apt-get install python-dev python-pip time
             sudo pip install -U pip setuptools
             sudo pip install awscli==1.18.85 datadog==0.40.1
             sudo npm install -g npm@6.14.4

--- a/packages/template-retail-react-app/app/components/_app-config/index.test.js
+++ b/packages/template-retail-react-app/app/components/_app-config/index.test.js
@@ -4,16 +4,31 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-// import React from 'react'
-// import {render} from '@testing-library/react'
+import React from 'react'
+import {render} from '@testing-library/react'
 import AppConfig from './index.jsx'
 
+import {CorrelationIdProvider} from 'pwa-kit-react-sdk/ssr/universal/contexts'
+import {uuidv4} from 'pwa-kit-react-sdk/utils/uuidv4.client'
+import { StaticRouter } from 'react-router-dom'
+
+import mockConfig from '../../../config/mocks/default'
+
 describe('AppConfig', () => {
-    // TODO: revisit this test
-    // test('renders', () => {
-    //     const {container} = render(<AppConfig locals={{}} />)
-    //     expect(container).toBeDefined()
-    // })
+    test('renders', () => {
+        const locals = {
+            appConfig: mockConfig.app
+        }
+
+        const {container} = render(
+            <StaticRouter>
+                <CorrelationIdProvider correlationId={() => uuidv4()}>
+                    <AppConfig locals={locals} />
+                </CorrelationIdProvider>
+            </StaticRouter>
+        )
+        expect(container).toBeDefined()
+    })
 
     test('AppConfig static methods behave as expected', () => {
         const mockAPI = {}

--- a/packages/template-retail-react-app/app/components/_app-config/index.test.js
+++ b/packages/template-retail-react-app/app/components/_app-config/index.test.js
@@ -10,7 +10,7 @@ import AppConfig from './index.jsx'
 
 import {CorrelationIdProvider} from 'pwa-kit-react-sdk/ssr/universal/contexts'
 import {uuidv4} from 'pwa-kit-react-sdk/utils/uuidv4.client'
-import { StaticRouter } from 'react-router-dom'
+import {StaticRouter} from 'react-router-dom'
 
 import mockConfig from '../../../config/mocks/default'
 

--- a/packages/template-retail-react-app/jest.config.js
+++ b/packages/template-retail-react-app/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     ...base,
     moduleNameMapper: {
         ...base.moduleNameMapper,
+        '^react$': '<rootDir>/node_modules/react/index.js',
         '^react-router-dom(.*)$': '<rootDir>/node_modules/react-router-dom/index.js'
     },
     setupFilesAfterEnv: [path.join(__dirname, 'jest-setup.js')],


### PR DESCRIPTION
[There is a bug in `Jest.resetModules`](https://github.com/facebook/jest/issues/8987) that seems to reinstantiate React whenever this function is called. This led to bizarre `Invalid Hook call` errors when a test tries to render a component that imports a provider from an external library.

In our scenario, the AppConfig is now wrapped by several providers from the pwa-kit-react-sdk: CorrelationIdProvider, CommerceAPIProvider, and QueryClientProvider via the withReactQuery HOC. Each of these providers are throwing `invalid hook call` errors on the first hook they call.

To get around the error, this PR updates the template-retail-react-app's jest config to always use the same instance of React.

This PR also makes a few more changes to the app config test to provide values required by the new providers.
