### PR TITLE
Do not use a proxy to call Einstein

### DIFF
--- a/packages/pwa-kit-create-app/assets/pwa/default.js
+++ b/packages/pwa-kit-create-app/assets/pwa/default.js
@@ -36,7 +36,7 @@ module.exports = {
         },
         // Einstein api config
         einsteinAPI: {
-            proxyPath: \`/mobify/proxy/${einsteinApi.proxyPath}\`,
+            host: 'https://api.cquotient.com',
             einsteinId: '${einsteinApi.einsteinId}',
             siteId: '${einsteinApi.siteId}'
         }
@@ -70,10 +70,6 @@ module.exports = {
             {
                 host: '${new URL(commerceApi.instanceUrl).hostname}',
                 path: 'ocapi'
-            },
-            {
-                host: 'api.cquotient.com',
-                path: 'einstein'
             }
         ]
     }

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -190,7 +190,6 @@ const runGenerator = (answers, {outputDir, verbose}) => {
         siteId: answers['commerce-api'].siteId
     }
     const einsteinApi = {
-        proxyPath: 'einstein',
         einsteinId: answers['einstein-api'].einsteinId,
         siteId: answers['einstein-api'].siteId || answers['commerce-api'].siteId
     }

--- a/packages/pwa-kit-react-sdk/setup-jest.js
+++ b/packages/pwa-kit-react-sdk/setup-jest.js
@@ -40,10 +40,6 @@ jest.mock('pwa-kit-runtime/utils/ssr-config', () => {
                     {
                         host: 'zzrf-001.dx.commercecloud.salesforce.com',
                         path: 'ocapi'
-                    },
-                    {
-                        host: 'api.cquotient.com',
-                        path: 'einstein'
                     }
                 ]
             }

--- a/packages/template-retail-react-app/app/commerce-api/einstein.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import fetch from 'cross-fetch'
-import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
 import {keysToCamel} from './utils'
 
 class EinsteinAPI {

--- a/packages/template-retail-react-app/app/commerce-api/einstein.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.js
@@ -47,8 +47,7 @@ class EinsteinAPI {
 
     async einsteinFetch(endpoint, method, body) {
         const config = this.config
-        const {proxyPath, einsteinId} = config
-        const host = `${getAppOrigin()}${proxyPath}`
+        const {host, einsteinId} = config
 
         const headers = {
             'Content-Type': 'application/json',

--- a/packages/template-retail-react-app/app/commerce-api/einstein.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.test.js
@@ -28,7 +28,7 @@ const getProductsSpy = jest.fn()
 const config = {
     _config: {
         einsteinConfig: {
-            proxyPath: `/test-path`,
+            host: `http://localhost/test-path`,
             einsteinId: 'test-id',
             siteId: 'test-site-id'
         }

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -41,6 +41,7 @@ const {handler} = runtime.createHandler(options, (app) => {
                 directives: {
                     'img-src': ["'self'", '*.commercecloud.salesforce.com', 'data:'],
                     'script-src': ["'self'", "'unsafe-eval'", 'storage.googleapis.com'],
+                    'connect-src': ["'self'", 'api.cquotient.com'],
 
                     // Do not upgrade insecure requests for local development
                     'upgrade-insecure-requests': isRemote() ? [] : null

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -29,7 +29,7 @@ module.exports = {
             }
         },
         einsteinAPI: {
-            proxyPath: `/mobify/proxy/einstein`,
+            host: 'https://api.cquotient.com',
             einsteinId: '1ea06c6e-c936-4324-bcf0-fada93f83bb1',
             // This differs from the siteId in commerceAPIConfig for testing purposes
             siteId: 'aaij-MobileFirst'
@@ -56,10 +56,6 @@ module.exports = {
             {
                 host: 'zzrf-001.dx.commercecloud.salesforce.com',
                 path: 'ocapi'
-            },
-            {
-                host: 'api.cquotient.com',
-                path: 'einstein'
             }
         ]
     }

--- a/packages/template-retail-react-app/config/mocks/default.js
+++ b/packages/template-retail-react-app/config/mocks/default.js
@@ -75,7 +75,7 @@ module.exports = {
             }
         },
         einsteinAPI: {
-            proxyPath: `/mobify/proxy/einstein`,
+            host: 'https://api.cquotient.com',
             einsteinId: '1ea06c6e-c936-4324-bcf0-fada93f83bb1',
             // This differs from the siteId in commerceAPIConfig for testing purposes
             siteId: 'aaij-MobileFirst'
@@ -110,10 +110,6 @@ module.exports = {
             {
                 host: 'zzrf-001.sandbox.us03.dx.commercecloud.salesforce.com',
                 path: 'ocapi'
-            },
-            {
-                host: 'api.cquotient.com',
-                path: 'einstein'
             }
         ]
     }

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -57,10 +57,6 @@
                 {
                     "host": "zzrf-001.dx.commercecloud.salesforce.com",
                     "path": "ocapi"
-                },
-                {
-                    "host": "api.cquotient.com",
-                    "path": "einstein"
                 }
             ]
         }

--- a/packages/test-commerce-sdk-react/package.json
+++ b/packages/test-commerce-sdk-react/package.json
@@ -58,10 +58,6 @@
         {
           "host": "zzrf-001.dx.commercecloud.salesforce.com",
           "path": "ocapi"
-        },
-        {
-          "host": "api.cquotient.com",
-          "path": "einstein"
         }
       ]
     }


### PR DESCRIPTION
Currently the Retail React App uses a proxy to communicate with Einstein API (/mobify/proxy/einstein).

This results in all Einstein Activity data going through a Cloudfront proxy. This causes all activity data to have a ClientUserAgent of `Amazon Cloudfront`

To ensure Einstein is able to track correct information, this PR removes the proxy so requests are sent directly to Einstein from the React app.

Communicating to Einstein directly resulted in a CSP error in the browser at first so this PR includes a change to allow `api.cquotient.com` (the production Einstein endpoint) through.


Testing this change:
1. Start the app with this change
2. Navigate to a PDP or PLP. This will trigger an Einstein event (viewCategory or viewProduct)
3. Check your network tab and verify the request is not blocked by CSP

Note:
`api.cquotient.com` may be blocked by ad blockers. When testing this change, you may have to disable my own adblocker.


Considerations:
I replace the proxyPath property in the Einstein config with a host property, so we may need to update some docs to match.
Also, the new host property requires that a protocol be included (ie. https://)
