### PR TITLE
Einstein handle variants

### DIFF
--- a/packages/template-retail-react-app/app/commerce-api/einstein.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.js
@@ -76,7 +76,7 @@ class EinsteinAPI {
             // https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-search?meta=type%3AProductSearchHit
             return {
                 id: product.productId,
-                sku: product.productId, //TODO: Should this be product.representedProduct.id instead?
+                sku: product.productId, //TODO: Should we switch this to product.representedProduct.id once we allow non-master products in search results?
                 altId: '',
                 altIdType: ''
             }
@@ -163,6 +163,7 @@ class EinsteinAPI {
         const body = {
             searchText,
             products,
+            showProducts: true, // Needed by Reports and Dashboards to differentiate searches with results vs no results
             ...args
         }
 
@@ -200,6 +201,7 @@ class EinsteinAPI {
                 id: category.id
             },
             products,
+            showProducts: true, // Needed by Reports and Dashboards to differentiate searches with results vs no results
             ...args
         }
 

--- a/packages/template-retail-react-app/app/commerce-api/einstein.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.test.js
@@ -75,7 +75,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"searchText":"tie","products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"searchText":"tie","products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"showProducts":true,"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -91,7 +91,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"category":{"id":"mens-accessories-ties"},"products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"category":{"id":"mens-accessories-ties"},"products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"showProducts":true,"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })

--- a/packages/template-retail-react-app/app/commerce-api/einstein.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/einstein.test.js
@@ -58,7 +58,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"product":{"id":"56736828M","sku":"","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"product":{"id":"56736828M","sku":"56736828M","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -75,7 +75,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"searchText":"tie","products":[{"id":"25752986M","sku":"","altId":"","altIdType":""},{"id":"25752235M","sku":"","altId":"","altIdType":""},{"id":"25752218M","sku":"","altId":"","altIdType":""},{"id":"25752981M","sku":"","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"searchText":"tie","products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -91,7 +91,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"category":{"id":"mens-accessories-ties"},"products":[{"id":"25752986M","sku":"","altId":"","altIdType":""},{"id":"25752235M","sku":"","altId":"","altIdType":""},{"id":"25752218M","sku":"","altId":"","altIdType":""},{"id":"25752981M","sku":"","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"category":{"id":"mens-accessories-ties"},"products":[{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},{"id":"25752235M","sku":"25752235M","altId":"","altIdType":""},{"id":"25752218M","sku":"25752218M","altId":"","altIdType":""},{"id":"25752981M","sku":"25752981M","altId":"","altIdType":""}],"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -109,7 +109,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"searchText":"tie","product":{"id":"25752986M","sku":"","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"searchText":"tie","product":{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -126,7 +126,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"category":{"id":"mens-accessories-ties"},"product":{"id":"25752986M","sku":"","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"category":{"id":"mens-accessories-ties"},"product":{"id":"25752986M","sku":"25752986M","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })
@@ -209,7 +209,7 @@ describe('EinsteinAPI', () => {
                     'x-cq-client-id': 'test-id'
                 },
                 body:
-                    '{"recommenderName":"testRecommender","__recoUUID":"883360544021M","product":{"id":"56736828M","sku":"","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
+                    '{"recommenderName":"testRecommender","__recoUUID":"883360544021M","product":{"id":"56736828M","sku":"56736828M","altId":"","altIdType":""},"cookieId":"test-usid","realm":"test","instanceType":"sbx"}'
             }
         )
     })

--- a/packages/template-retail-react-app/app/commerce-api/hooks/useBasket.js
+++ b/packages/template-retail-react-app/app/commerce-api/hooks/useBasket.js
@@ -123,13 +123,7 @@ export default function useBasket(opts = {}) {
                     throw new Error(response)
                 } else {
                     setBasket(response)
-                    const einsteinProduct = {
-                        id: item[0].productId,
-                        sku: '',
-                        price: item[0].price,
-                        quantity: item[0].quantity
-                    }
-                    einstein.sendAddToCart(einsteinProduct)
+                    einstein.sendAddToCart(item[0])
                 }
             },
 

--- a/packages/template-retail-react-app/app/commerce-api/mocks/einstein-mock-data.js
+++ b/packages/template-retail-react-app/app/commerce-api/mocks/einstein-mock-data.js
@@ -27,7 +27,7 @@ export const mockRecommendersResponse = {
     ]
 }
 
-export const mockAddToCartProduct = {id: '883360544021M', sku: '', price: 155, quantity: 1}
+export const mockAddToCartProduct = {productId: '883360544021M', sku: '', price: 155, quantity: 1}
 
 export const mockRecommenderDetails = {
     __recoUUID: '883360544021M',

--- a/packages/template-retail-react-app/app/components/recommended-products/index.jsx
+++ b/packages/template-retail-react-app/app/components/recommended-products/index.jsx
@@ -53,11 +53,6 @@ const RecommendedProducts = ({zone, recommender, products, title, shouldFetch, .
             return
         }
 
-        // Create the expected args object for products when given
-        const args = {
-            products: _products?.map(({id, sku}) => ({id: id, sku: sku}))
-        }
-
         // Check if the component should fetch results or not. This is useful
         // when you are still waiting on additional data, like `products`.
         if (typeof shouldFetch === 'function' && !shouldFetch()) {
@@ -67,11 +62,11 @@ const RecommendedProducts = ({zone, recommender, products, title, shouldFetch, .
         // Fetch either zone or recommender, but not both. If a zone and recommender
         // name are both provided, `zone` takes precendence.
         if (zone) {
-            getZoneRecommendations(zone, args)
+            getZoneRecommendations(zone, _products)
             return
         }
         if (recommender) {
-            getRecommendations(recommender, args)
+            getRecommendations(recommender, _products)
             return
         }
     }, [zone, recommender, _products, isInitialized])

--- a/packages/template-retail-react-app/app/components/recommended-products/index.jsx
+++ b/packages/template-retail-react-app/app/components/recommended-products/index.jsx
@@ -54,7 +54,9 @@ const RecommendedProducts = ({zone, recommender, products, title, shouldFetch, .
         }
 
         // Create the expected args object for products when given
-        const args = {products: _products?.map((id) => ({id}))}
+        const args = {
+            products: _products?.map(({id, sku}) => ({id: id, sku: sku}))
+        }
 
         // Check if the component should fetch results or not. This is useful
         // when you are still waiting on additional data, like `products`.

--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -201,7 +201,7 @@ export const AddToCartModal = () => {
                             />
                         }
                         recommender={'pdp-similar-items'}
-                        products={product && [product.id]}
+                        products={product && [{id: product.master.masterId, sku: product.id}]}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />

--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -201,7 +201,7 @@ export const AddToCartModal = () => {
                             />
                         }
                         recommender={'pdp-similar-items'}
-                        products={product && [{id: product.master.masterId, sku: product.id}]}
+                        products={product}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -265,7 +265,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                             />
                         }
                         recommender={'complete-the-set'}
-                        products={product && [{id: product.master.masterId, sku: product.id}]}
+                        products={product}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />
@@ -278,7 +278,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                             />
                         }
                         recommender={'pdp-similar-items'}
-                        products={product && [{id: product.master.masterId, sku: product.id}]}
+                        products={product}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -265,7 +265,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                             />
                         }
                         recommender={'complete-the-set'}
-                        products={product && [product.id]}
+                        products={product && [{id: product.master.masterId, sku: product.id}]}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />
@@ -278,7 +278,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                             />
                         }
                         recommender={'pdp-similar-items'}
-                        products={product && [product.id]}
+                        products={product && [{id: product.master.masterId, sku: product.id}]}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
                     />


### PR DESCRIPTION
This PR updates various Einstein activities (ie. viewProduct, viewReco, etc.) so that when variant products are involved, both the master product ID and the variant product ID are sent over (this aligns the PWA Kit with data sent by SFRA / SiteGenesis).

This PR also does some refactoring to make the Einstein API have more consistent parameters between the different methods. Before, some activities such as AddToCart handled destructuring outside of the API. Now AddToCart takes in an item and the destructuring happens inside the Einstein API.

The changes in this PR also fixes some odd behavior seen in Einstein recommendations. Our previous implementation which only sent the variant's id resulted in some recommendations associated with the master product not being returned.


# Description

The mapping between Einstein API products and SCAPI product variants looks like the following (where variant is some product of type variant or master):
Einstein - Variant
id = variant.master.masterId
sku = variant.id

The mapping between Einstein API items and cart items from SCAPI looks like the following:
Einstein - Item
id = item.productId
sku = '' (Blank because cart items always correspond with variants and a master product will never be a cart item)
price = item.price
quantity = item.quantity


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [X] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

# How to Test-Drive This PR

1. Start the app and do various activities (view PLP, PDP, click recommendations, checkout)
2. Check network tab for Einstein activities. Verify the data sent over includes both id and sku.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [X] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
