### PR TITLE
Fix broken CI – confusing path to package.json in the 'dist' directory!

### DIFF
--- a/packages/pwa-kit-dev/src/utils/script-utils.ts
+++ b/packages/pwa-kit-dev/src/utils/script-utils.ts
@@ -45,7 +45,7 @@ interface Bundle {
 }
 
 export const getPkgJSON = async () => {
-    return readJson(path.join(__dirname, '..', '..', 'package.json'))
+    return readJson(path.join(__dirname, '..', 'package.json'))
 }
 
 export class CloudAPIClient {

--- a/packages/pwa-kit-dev/src/utils/script-utils.ts
+++ b/packages/pwa-kit-dev/src/utils/script-utils.ts
@@ -44,8 +44,41 @@ interface Bundle {
     ssr_shared: string[]
 }
 
-export const getPkgJSON = async () => {
-    return readJson(path.join(__dirname, '..', 'package.json'))
+interface Pkg {
+    name: string
+    version: string
+}
+
+/**
+ * Get the package info for pwa-kit-dev.
+ */
+export const getPkgJSON = async (): Promise<Pkg> => {
+    const candidates = [
+        path.join(__dirname, '..', 'package.json'),
+        path.join(__dirname, '..', '..', 'package.json')
+    ]
+    for (const candidate of candidates) {
+        try {
+            const data = await readJson(candidate)
+            return data as Pkg
+        } catch {
+            // Keep looking
+        }
+    }
+    return {name: 'pwa-kit-dev', version: 'unknown'}
+}
+
+/**
+ * Get the package info for the current project.
+ */
+export const getProjectPkg = async (): Promise<Pkg> => {
+    const p = path.join(process.cwd(), 'package.json')
+    try {
+        const data = await readJson(p)
+        return data as Pkg
+    } catch {
+        throw new Error(`Could not read project package at "${p}"`)
+    }
 }
 
 export class CloudAPIClient {


### PR DESCRIPTION
@adamraya Put together steps to reproduce. The following should fail on develop and succeed on this branch:

```
GENERATOR_PRESET=test-project node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir ~/generated-test-project

cd ~/generated-test-project

npm run push -- -s scaffold-pwa --message "test generated-test-project build" --target test-env-2
```