### PR TITLE
Testing framework / patterns quality improvements

### DIFF
--- a/packages/commerce-sdk-react/jest.config.js
+++ b/packages/commerce-sdk-react/jest.config.js
@@ -19,10 +19,5 @@ module.exports = {
             statements: 0
         }
     },
-    collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],
-
-    // this reporter hides console.error when tests succeed
-    // this prevent expected errors from polluting jest logs
-    // https://github.com/rickhanlonii/jest-silent-reporter
-    reporters: [['jest-silent-reporter', {useDots: true, showPaths: true}]]
+    collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}']
 }

--- a/packages/commerce-sdk-react/setup-jest.js
+++ b/packages/commerce-sdk-react/setup-jest.js
@@ -32,6 +32,16 @@ Object.defineProperty(window, 'localStorage', {
     value: localStorageMock
 })
 
+global.beforeAll(() => {
+    // disable all real http requests
+    nock.disableNetConnect()
+    nock.emitter.on('no match', (req) => {
+        throw Error(
+            `\n\n\nYOUR TEST IS MAKING A REAL HTTP REQUEST. THIS IS A PROBLEM! PLEASE MOCK ALL HTTP CALLS\n\n\n `
+        )
+    })
+})
+
 global.afterEach(() => {
     nock.cleanAll()
 })

--- a/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.test.tsx
@@ -5,9 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React from 'react'
-import {render} from '@testing-library/react'
+import {render, waitFor} from '@testing-library/react'
 import Component from './index'
-import {PageContext} from '../Page'
+import {PageContext, Page} from '../Page'
+import {SAMPLE_PAGE} from '../Page/index.test'
 
 const SAMPLE_COMPONENT = {
     id: 'rfdvj4ojtltljw3',
@@ -42,22 +43,32 @@ test('Page throws if used outside of a Page component', () => {
     expect(() => render(<Component component={SAMPLE_COMPONENT} />)).toThrow()
 })
 
-test('Page renders correct component', () => {
+test('Page renders correct component', async () => {
     const component = <Component component={SAMPLE_COMPONENT} />
 
     const {container} = render(component, {
         // eslint-disable-next-line react/display-name
         wrapper: () => (
-            <PageContext.Provider value={{components: TEST_COMPONENTS}}>
-                {component}
-            </PageContext.Provider>
+            <Page
+                page={{
+                    ...SAMPLE_PAGE,
+                    regions: [...SAMPLE_PAGE.regions, SAMPLE_COMPONENT.regions[0]]
+                }}
+                components={TEST_COMPONENTS}
+            >
+                <PageContext.Provider value={{components: TEST_COMPONENTS}}>
+                    {component}
+                </PageContext.Provider>
+            </Page>
         )
     })
 
-    // Component are in document.
-    expect(container.querySelectorAll('.component')?.length).toEqual(1)
+    await waitFor(() => {
+        // Component are in document.
+        expect(container.querySelectorAll('.component')?.length).toEqual(3)
 
-    // Prodived components are in document. (Note: Sub-regions/components aren't rendered because that is
-    // the responsibility of the component definition.)
-    expect(container.querySelectorAll('.carousel')?.length).toEqual(1)
+        // Prodived components are in document. (Note: Sub-regions/components aren't rendered because that is
+        // the responsibility of the component definition.)
+        expect(container.querySelectorAll('.carousel')?.length).toEqual(2)
+    })
 })

--- a/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.test.tsx
@@ -38,6 +38,7 @@ const TEST_COMPONENTS = {
 }
 
 test('Page throws if used outside of a Page component', () => {
+    jest.spyOn(console, 'warn').mockImplementationOnce(jest.fn())
     expect(() => render(<Component component={SAMPLE_COMPONENT} />)).toThrow()
 })
 

--- a/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperience/Component/index.tsx
@@ -6,7 +6,7 @@
  */
 import React from 'react'
 import {Component as ComponentType} from '../types'
-import {usePageContext} from '../Page'
+import {usePageContext, Page, SAMPLE_PAGE} from '../Page'
 
 type ComponentProps = {
     component: ComponentType

--- a/packages/commerce-sdk-react/src/components/ShopperExperience/Page/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperience/Page/index.test.tsx
@@ -9,7 +9,7 @@ import {render} from '@testing-library/react'
 import Page from './index'
 import {Helmet} from 'react-helmet'
 
-const SAMPLE_PAGE = {
+export const SAMPLE_PAGE = {
     id: 'samplepage',
     typeId: 'storePage',
     aspectTypeId: 'pdpAspect',

--- a/packages/commerce-sdk-react/src/hooks/query.test.tsx
+++ b/packages/commerce-sdk-react/src/hooks/query.test.tsx
@@ -33,6 +33,7 @@ import {
 import {useOrder, usePaymentMethodsForOrder, useTaxesFromOrder} from './ShopperOrders/query'
 import {useProducts, useProduct, useCategories, useCategory} from './ShopperProducts/query'
 import {usePromotions, usePromotionsForCampaign} from './ShopperPromotions/query'
+import {waitFor} from '@testing-library/react'
 
 jest.mock('../auth/index.ts', () => {
     return jest.fn().mockImplementation(() => ({
@@ -238,6 +239,7 @@ test.each(QUERY_TESTS)('%j - 400 returns error', async ({hook, endpoint, notImpl
     if (notImplemented) {
         return
     }
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {})
     nock(DEFAULT_TEST_HOST)
         .get((uri) => endpoint.test(uri.split('?')[0]))
         .reply(400)
@@ -250,6 +252,10 @@ test.each(QUERY_TESTS)('%j - 400 returns error', async ({hook, endpoint, notImpl
 
     expect(result.current.isLoading).toBe(false)
     expect(result.current.error).toBeTruthy()
+    await waitFor(() => {
+        expect(error).toHaveBeenCalled()
+        error.mockReset()
+    })
 })
 
 test.each(QUERY_TESTS)('%j - throws error when not implemented', async ({hook, notImplemented}) => {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Digging into the questions we discussed re: testing (a big one being "how can we throw an error any time a test makes a real network request") I've realized that our default behavior of having error boundaries that show thrown Errors in the DOM (swallowing what happens in the console) is the reason we've not been able to make progress here.
I've added the following, but tests don't throw because the error boundary in commerce-sdk-react  catches this and displays it so that the throw doesn't cause a test failure.
```
    nock.emitter.on('no match', (req) => {
        throw Error(
            `\n\n\nYOUR TEST IS MAKING A REAL HTTP REQUEST. THIS IS A PROBLEM! PLEASE MOCK ALL HTTP CALLS\n\n\n `
        )
    })
```   
We should talk about the error boundary, I understand the purpose in template-retail-react-app but it's strange to swallow errors in the test scaffolding in `commerce-sdk-react` obviously it's a headless library, so the error shouldn't be swallowed in DOM in the library itself (or we'd have a big SSR problem on our hands).
I think the error boundary itself needs to be smart and probably needs to have an option to be disabled in "testing mode" via a provider that wraps all of our tests.
@kevinxh I've also found a fix for the noisy console issues  for the mutation error tests we can do

```
nock(DEFAULT_TEST_HOST).on('error', (err) => {
    // NOTE: nock does not throw console.errors but we want to assert against
    // console errors as well as swallow them to prevent noisy console test runs

    console.error(err)
})
...(other error handlers)
```
Which will cause each error to throw in the console. Right now, either the error boundary causes issues -- OR -- the tests are closing with the console.errors hanging, so they create the console noise.  A fix for this is to expect / await the errors and spyOn(console, 'error') which makes sure the tests don't close prior to the console.error logging

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
