### PR TITLE
Allow query hook parameters to be `null`.

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperBaskets']
 
 /**
  * Gets a basket.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Baskets `getBasket` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-baskets?meta=getBasket| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperbaskets.shopperbaskets-1.html#getbasket | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useBasket = (
-    apiOptions: Argument<Client['getBasket']>,
+    apiOptions: NullableParameters<Argument<Client['getBasket']>>,
     queryOptions: ApiQueryOptions<Client['getBasket']> = {}
 ): UseQueryResult<DataType<Client['getBasket']>> => {
     type Options = Argument<Client['getBasket']>
@@ -30,15 +32,16 @@ export const useBasket = (
     const methodName = 'getBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -46,13 +49,15 @@ export const useBasket = (
 }
 /**
  * Gets applicable payment methods for an existing basket considering the open payment amount only.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Baskets `getPaymentMethodsForBasket` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-baskets?meta=getPaymentMethodsForBasket| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperbaskets.shopperbaskets-1.html#getpaymentmethodsforbasket | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePaymentMethodsForBasket = (
-    apiOptions: Argument<Client['getPaymentMethodsForBasket']>,
+    apiOptions: NullableParameters<Argument<Client['getPaymentMethodsForBasket']>>,
     queryOptions: ApiQueryOptions<Client['getPaymentMethodsForBasket']> = {}
 ): UseQueryResult<DataType<Client['getPaymentMethodsForBasket']>> => {
     type Options = Argument<Client['getPaymentMethodsForBasket']>
@@ -61,15 +66,16 @@ export const usePaymentMethodsForBasket = (
     const methodName = 'getPaymentMethodsForBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -77,13 +83,15 @@ export const usePaymentMethodsForBasket = (
 }
 /**
  * Gets applicable price books for an existing basket.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Baskets `getPriceBooksForBasket` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-baskets?meta=getPriceBooksForBasket| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperbaskets.shopperbaskets-1.html#getpricebooksforbasket | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePriceBooksForBasket = (
-    apiOptions: Argument<Client['getPriceBooksForBasket']>,
+    apiOptions: NullableParameters<Argument<Client['getPriceBooksForBasket']>>,
     queryOptions: ApiQueryOptions<Client['getPriceBooksForBasket']> = {}
 ): UseQueryResult<DataType<Client['getPriceBooksForBasket']>> => {
     type Options = Argument<Client['getPriceBooksForBasket']>
@@ -92,15 +100,16 @@ export const usePriceBooksForBasket = (
     const methodName = 'getPriceBooksForBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -108,13 +117,15 @@ export const usePriceBooksForBasket = (
 }
 /**
  * Gets the applicable shipping methods for a certain shipment of a basket.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Baskets `getShippingMethodsForShipment` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-baskets?meta=getShippingMethodsForShipment| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperbaskets.shopperbaskets-1.html#getshippingmethodsforshipment | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useShippingMethodsForShipment = (
-    apiOptions: Argument<Client['getShippingMethodsForShipment']>,
+    apiOptions: NullableParameters<Argument<Client['getShippingMethodsForShipment']>>,
     queryOptions: ApiQueryOptions<Client['getShippingMethodsForShipment']> = {}
 ): UseQueryResult<DataType<Client['getShippingMethodsForShipment']>> => {
     type Options = Argument<Client['getShippingMethodsForShipment']>
@@ -123,15 +134,16 @@ export const useShippingMethodsForShipment = (
     const methodName = 'getShippingMethodsForShipment'
     const requiredParameters = ['organizationId', 'basketId', 'shipmentId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -139,13 +151,15 @@ export const useShippingMethodsForShipment = (
 }
 /**
  * This method gives you the external taxation data set by the PUT taxes API. This endpoint can be called only if external taxation mode was used for basket creation. See POST /baskets for more information.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Baskets `getTaxesFromBasket` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-baskets?meta=getTaxesFromBasket| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperbaskets.shopperbaskets-1.html#gettaxesfrombasket | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useTaxesFromBasket = (
-    apiOptions: Argument<Client['getTaxesFromBasket']>,
+    apiOptions: NullableParameters<Argument<Client['getTaxesFromBasket']>>,
     queryOptions: ApiQueryOptions<Client['getTaxesFromBasket']> = {}
 ): UseQueryResult<DataType<Client['getTaxesFromBasket']>> => {
     type Options = Argument<Client['getTaxesFromBasket']>
@@ -154,15 +168,16 @@ export const useTaxesFromBasket = (
     const methodName = 'getTaxesFromBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
@@ -10,40 +10,46 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperBaskets<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    getBasket: ['/organizations/', string, '/baskets/', string, Params<'getBasket'>]
+    getBasket: [
+        '/organizations/',
+        string | undefined,
+        '/baskets/',
+        string | undefined,
+        Params<'getBasket'>
+    ]
     getPaymentMethodsForBasket: [
         '/organizations/',
-        string,
+        string | undefined,
         '/baskets/',
-        string,
+        string | undefined,
         '/payment-methods',
         Params<'getPaymentMethodsForBasket'>
     ]
     getPriceBooksForBasket: [
         '/organizations/',
-        string,
+        string | undefined,
         '/baskets/',
-        string,
+        string | undefined,
         '/price-books',
         Params<'getPriceBooksForBasket'>
     ]
     getShippingMethodsForShipment: [
         '/organizations/',
-        string,
+        string | undefined,
         '/baskets/',
-        string,
+        string | undefined,
         '/shipments/',
-        string,
+        string | undefined,
         '/shipping-methods',
         Params<'getShippingMethodsForShipment'>
     ]
     getTaxesFromBasket: [
         '/organizations/',
-        string,
+        string | undefined,
         '/baskets/',
-        string,
+        string | undefined,
         '/taxes',
         Params<'getTaxesFromBasket'>
     ]

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperContexts']
 
 /**
  * Gets the shopper's context based on the shopperJWT. ******** This API is currently a work in progress, and not available to use yet. ********
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Contexts `getShopperContext` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-contexts?meta=getShopperContext| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercontexts.shoppercontexts-1.html#getshoppercontext | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useShopperContext = (
-    apiOptions: Argument<Client['getShopperContext']>,
+    apiOptions: NullableParameters<Argument<Client['getShopperContext']>>,
     queryOptions: ApiQueryOptions<Client['getShopperContext']> = {}
 ): UseQueryResult<DataType<Client['getShopperContext']>> => {
     type Options = Argument<Client['getShopperContext']>
@@ -30,15 +32,16 @@ export const useShopperContext = (
     const methodName = 'getShopperContext'
     const requiredParameters = ['organizationId', 'usid'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
@@ -10,13 +10,13 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperContexts<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
     getShopperContext: [
         '/organizations/',
-        string,
+        string | undefined,
         '/shopper-context/',
-        string,
+        string | undefined,
         Params<'getShopperContext'>
     ]
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
@@ -5,10 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperCustomers']
@@ -16,13 +16,15 @@ type Client = ApiClients['shopperCustomers']
 // TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
 // /**
 //  * Gets the new external profile for a customer.This endpoint is in closed beta, available to select few customers. Please get in touch with your Account Team if you'd like to participate in the beta program
+//  * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+//  * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
 //  * @returns A TanStack Query query hook with data from the Shopper Customers `getExternalProfile` endpoint.
 //  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getExternalProfile| Salesforce Developer Center} for more information about the API endpoint.
 //  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getexternalprofile | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
 //  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
 //  */
 // export const useExternalProfile = (
-//     apiOptions: Argument<Client['getExternalProfile']>,
+//     apiOptions: NullableParameters<Argument<Client['getExternalProfile']>>,
 //     queryOptions: ApiQueryOptions<Client['getExternalProfile']> = {}
 // ): UseQueryResult<DataType<Client['getExternalProfile']>> => {
 //     type Options = Argument<Client['getExternalProfile']>
@@ -36,15 +38,16 @@ type Client = ApiClients['shopperCustomers']
 //         'siteId'
 //     ] as const
 
-//     // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-//     // to generate the correct query key.
-//     const netOptions = mergeOptions(client, apiOptions)
+//     // Parameters can be set in `apiOptions` or `client.clientConfig`;
+//     // we must merge them in order to generate the correct query key.
+//     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
 //     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+//     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
 //     const method = async (options: Options) => await client[methodName](options)
 
 //     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
 //     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-//     return useQuery<Options, Data>(netOptions, queryOptions, {
+//     return useQuery<Client, Options, Data>(netOptions, queryOptions, {
 //         method,
 //         queryKey,
 //         requiredParameters
@@ -52,13 +55,15 @@ type Client = ApiClients['shopperCustomers']
 // }
 /**
  * Gets a customer with all existing addresses and payment instruments associated with the requested customer.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomer` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomer| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomer | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomer = (
-    apiOptions: Argument<Client['getCustomer']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomer']>>,
     queryOptions: ApiQueryOptions<Client['getCustomer']> = {}
 ): UseQueryResult<DataType<Client['getCustomer']>> => {
     type Options = Argument<Client['getCustomer']>
@@ -67,15 +72,16 @@ export const useCustomer = (
     const methodName = 'getCustomer'
     const requiredParameters = ['organizationId', 'customerId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -83,13 +89,15 @@ export const useCustomer = (
 }
 /**
  * Retrieves a customer's address by address name.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerAddress` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerAddress| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomeraddress | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerAddress = (
-    apiOptions: Argument<Client['getCustomerAddress']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerAddress']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerAddress']> = {}
 ): UseQueryResult<DataType<Client['getCustomerAddress']>> => {
     type Options = Argument<Client['getCustomerAddress']>
@@ -98,15 +106,16 @@ export const useCustomerAddress = (
     const methodName = 'getCustomerAddress'
     const requiredParameters = ['organizationId', 'customerId', 'addressName', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -114,13 +123,15 @@ export const useCustomerAddress = (
 }
 /**
  * Gets the baskets of a customer.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerBaskets` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerBaskets| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerbaskets | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerBaskets = (
-    apiOptions: Argument<Client['getCustomerBaskets']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerBaskets']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerBaskets']> = {}
 ): UseQueryResult<DataType<Client['getCustomerBaskets']>> => {
     type Options = Argument<Client['getCustomerBaskets']>
@@ -129,15 +140,16 @@ export const useCustomerBaskets = (
     const methodName = 'getCustomerBaskets'
     const requiredParameters = ['organizationId', 'customerId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -145,13 +157,15 @@ export const useCustomerBaskets = (
 }
 /**
  * Returns a pageable list of all customer's orders. The default page size is 10.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerOrders` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerOrders| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerorders | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerOrders = (
-    apiOptions: Argument<Client['getCustomerOrders']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerOrders']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerOrders']> = {}
 ): UseQueryResult<DataType<Client['getCustomerOrders']>> => {
     type Options = Argument<Client['getCustomerOrders']>
@@ -160,15 +174,16 @@ export const useCustomerOrders = (
     const methodName = 'getCustomerOrders'
     const requiredParameters = ['organizationId', 'customerId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -176,13 +191,15 @@ export const useCustomerOrders = (
 }
 /**
  * Retrieves a customer's payment instrument by its ID.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerPaymentInstrument` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerPaymentInstrument| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerpaymentinstrument | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerPaymentInstrument = (
-    apiOptions: Argument<Client['getCustomerPaymentInstrument']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerPaymentInstrument']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerPaymentInstrument']> = {}
 ): UseQueryResult<DataType<Client['getCustomerPaymentInstrument']>> => {
     type Options = Argument<Client['getCustomerPaymentInstrument']>
@@ -196,15 +213,16 @@ export const useCustomerPaymentInstrument = (
         'siteId'
     ] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -212,13 +230,15 @@ export const useCustomerPaymentInstrument = (
 }
 /**
  * Returns all customer product lists.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerProductLists` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerProductLists| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerproductlists | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerProductLists = (
-    apiOptions: Argument<Client['getCustomerProductLists']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerProductLists']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerProductLists']> = {}
 ): UseQueryResult<DataType<Client['getCustomerProductLists']>> => {
     type Options = Argument<Client['getCustomerProductLists']>
@@ -227,15 +247,16 @@ export const useCustomerProductLists = (
     const methodName = 'getCustomerProductLists'
     const requiredParameters = ['organizationId', 'customerId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -243,13 +264,15 @@ export const useCustomerProductLists = (
 }
 /**
  * Returns a customer product list of the given customer and the items in the list.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerProductList` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerProductList| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerproductlist | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerProductList = (
-    apiOptions: Argument<Client['getCustomerProductList']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerProductList']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerProductList']> = {}
 ): UseQueryResult<DataType<Client['getCustomerProductList']>> => {
     type Options = Argument<Client['getCustomerProductList']>
@@ -258,15 +281,16 @@ export const useCustomerProductList = (
     const methodName = 'getCustomerProductList'
     const requiredParameters = ['organizationId', 'customerId', 'listId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -274,13 +298,15 @@ export const useCustomerProductList = (
 }
 /**
  * Returns an item of a customer product list and the actual product details like image, availability and price.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getCustomerProductListItem` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getCustomerProductListItem| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getcustomerproductlistitem | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCustomerProductListItem = (
-    apiOptions: Argument<Client['getCustomerProductListItem']>,
+    apiOptions: NullableParameters<Argument<Client['getCustomerProductListItem']>>,
     queryOptions: ApiQueryOptions<Client['getCustomerProductListItem']> = {}
 ): UseQueryResult<DataType<Client['getCustomerProductListItem']>> => {
     type Options = Argument<Client['getCustomerProductListItem']>
@@ -295,15 +321,16 @@ export const useCustomerProductListItem = (
         'siteId'
     ] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -311,13 +338,15 @@ export const useCustomerProductListItem = (
 }
 /**
  * Retrieves all public product lists as defined by the given search term (for example, email OR first name and last name).
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getPublicProductListsBySearchTerm` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getPublicProductListsBySearchTerm| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getpublicproductlistsbysearchterm | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePublicProductListsBySearchTerm = (
-    apiOptions: Argument<Client['getPublicProductListsBySearchTerm']>,
+    apiOptions: NullableParameters<Argument<Client['getPublicProductListsBySearchTerm']>>,
     queryOptions: ApiQueryOptions<Client['getPublicProductListsBySearchTerm']> = {}
 ): UseQueryResult<DataType<Client['getPublicProductListsBySearchTerm']>> => {
     type Options = Argument<Client['getPublicProductListsBySearchTerm']>
@@ -326,15 +355,16 @@ export const usePublicProductListsBySearchTerm = (
     const methodName = 'getPublicProductListsBySearchTerm'
     const requiredParameters = ['organizationId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -342,13 +372,15 @@ export const usePublicProductListsBySearchTerm = (
 }
 /**
  * Retrieves a public product list by ID and the items under that product list.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getPublicProductList` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getPublicProductList| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getpublicproductlist | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePublicProductList = (
-    apiOptions: Argument<Client['getPublicProductList']>,
+    apiOptions: NullableParameters<Argument<Client['getPublicProductList']>>,
     queryOptions: ApiQueryOptions<Client['getPublicProductList']> = {}
 ): UseQueryResult<DataType<Client['getPublicProductList']>> => {
     type Options = Argument<Client['getPublicProductList']>
@@ -357,15 +389,16 @@ export const usePublicProductList = (
     const methodName = 'getPublicProductList'
     const requiredParameters = ['organizationId', 'listId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -373,13 +406,15 @@ export const usePublicProductList = (
 }
 /**
  * Retrieves an item from a public product list and the actual product details like product, image, availability and price.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Customers `getProductListItem` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-customers?meta=getProductListItem| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppercustomers.shoppercustomers-1.html#getproductlistitem | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useProductListItem = (
-    apiOptions: Argument<Client['getProductListItem']>,
+    apiOptions: NullableParameters<Argument<Client['getProductListItem']>>,
     queryOptions: ApiQueryOptions<Client['getProductListItem']> = {}
 ): UseQueryResult<DataType<Client['getProductListItem']>> => {
     type Options = Argument<Client['getProductListItem']>
@@ -388,15 +423,16 @@ export const useProductListItem = (
     const methodName = 'getProductListItem'
     const requiredParameters = ['organizationId', 'listId', 'itemId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
@@ -10,97 +10,103 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperCustomers<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
     getExternalProfile: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/external-profile',
         Params<'getExternalProfile'>
     ]
-    getCustomer: ['/organizations/', string, '/customers/', string, Params<'getCustomer'>]
+    getCustomer: [
+        '/organizations/',
+        string | undefined,
+        '/customers/',
+        string | undefined,
+        Params<'getCustomer'>
+    ]
     getCustomerAddress: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/addresses/',
-        string,
+        string | undefined,
         Params<'getCustomerAddress'>
     ]
     getCustomerBaskets: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/baskets',
         Params<'getCustomerBaskets'>
     ]
     getCustomerOrders: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/orders',
         Params<'getCustomerOrders'>
     ]
     getCustomerPaymentInstrument: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/payment-instruments/',
-        string,
+        string | undefined,
         Params<'getCustomerPaymentInstrument'>
     ]
     getCustomerProductLists: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/product-lists',
         Params<'getCustomerProductLists'>
     ]
     getCustomerProductList: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/product-lists/',
-        string,
+        string | undefined,
         Params<'getCustomerProductList'>
     ]
     getCustomerProductListItem: [
         '/organizations/',
-        string,
+        string | undefined,
         '/customers/',
-        string,
+        string | undefined,
         '/product-lists/',
-        string,
+        string | undefined,
         '/items/',
-        string,
+        string | undefined,
         Params<'getCustomerProductListItem'>
     ]
     getPublicProductListsBySearchTerm: [
         '/organizations/',
-        string,
+        string | undefined,
         '/product-lists',
         Params<'getPublicProductListsBySearchTerm'>
     ]
     getPublicProductList: [
         '/organizations/',
-        string,
+        string | undefined,
         '/product-lists/',
-        string,
+        string | undefined,
         Params<'getPublicProductList'>
     ]
     getProductListItem: [
         '/organizations/',
-        string,
+        string | undefined,
         '/product-lists/',
-        string,
+        string | undefined,
         '/items/',
-        string,
+        string | undefined,
         Params<'getProductListItem'>
     ]
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
@@ -5,10 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperExperience']
@@ -19,13 +19,15 @@ type Client = ApiClients['shopperExperience']
 Either `categoryId` or `productId` must be given in addition to `aspectTypeId`. Because only a single page-to-product and page-to-category assignment per aspect type can be authored today, the returned results contains one element at most.
 
 **Important**: Because this resource uses the GET method, you must not pass sensitive data (payment card information, for example) and must not perform any transactional processes within the server-side scripts that are run for the page and components.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Experience `getPages` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-experience?meta=getPages| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperexperience.shopperexperience-1.html#getpages | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePages = (
-    apiOptions: Argument<Client['getPages']>,
+    apiOptions: NullableParameters<Argument<Client['getPages']>>,
     queryOptions: ApiQueryOptions<Client['getPages']> = {}
 ): UseQueryResult<DataType<Client['getPages']>> => {
     type Options = Argument<Client['getPages']>
@@ -34,15 +36,16 @@ export const usePages = (
     const methodName = 'getPages'
     const requiredParameters = ['organizationId', 'aspectTypeId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -52,13 +55,15 @@ export const usePages = (
  * Get a Page Designer page based on a single page ID. The results will apply the visibility rules for the page's components, such as personalization or scheduled visibility.
 
 **Important**: Because this resource uses the GET method, you must not pass sensitive data (payment card information, for example) and must not perform any transactional processes within the server-side scripts that are run for the page and components.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Experience `getPage` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-experience?meta=getPage| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperexperience.shopperexperience-1.html#getpage | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePage = (
-    apiOptions: Argument<Client['getPage']>,
+    apiOptions: NullableParameters<Argument<Client['getPage']>>,
     queryOptions: ApiQueryOptions<Client['getPage']> = {}
 ): UseQueryResult<DataType<Client['getPage']>> => {
     type Options = Argument<Client['getPage']>
@@ -67,15 +72,16 @@ export const usePage = (
     const methodName = 'getPage'
     const requiredParameters = ['organizationId', 'pageId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
@@ -10,10 +10,16 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperExperience<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    getPages: ['/organizations/', string, '/pages', Params<'getPages'>]
-    getPage: ['/organizations/', string, '/pages/', string, Params<'getPage'>]
+    getPages: ['/organizations/', string | undefined, '/pages', Params<'getPages'>]
+    getPage: [
+        '/organizations/',
+        string | undefined,
+        '/pages/',
+        string | undefined,
+        Params<'getPage'>
+    ]
 }
 
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperGiftCertificates']
 
 /**
  * Action to retrieve an existing gift certificate.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Gift Certificates `getGiftCertificate` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-gift-certificates?meta=getGiftCertificate| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppergiftcertificates.shoppergiftcertificates-1.html#getgiftcertificate | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useGiftCertificate = (
-    apiOptions: Argument<Client['getGiftCertificate']>,
+    apiOptions: NullableParameters<Argument<Client['getGiftCertificate']>>,
     queryOptions: ApiQueryOptions<Client['getGiftCertificate']> = {}
 ): UseQueryResult<DataType<Client['getGiftCertificate']>> => {
     type Options = Argument<Client['getGiftCertificate']>
@@ -30,15 +32,16 @@ export const useGiftCertificate = (
     const methodName = 'getGiftCertificate'
     const requiredParameters = ['organizationId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(
+    return useQuery<Client, Options, Data>(
         netOptions,
         {
             // !!! This is a violation of our design goal of minimal logic in the indivudal endpoint

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
@@ -10,11 +10,11 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperGiftCertificates<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
     getGiftCertificate: [
         '/organizations/',
-        string,
+        string | undefined,
         '/gift-certificate',
         Params<'getGiftCertificate'>
     ]

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperLogin']
 
 /**
  * Get credential quality statistics for a user.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Login `retrieveCredQualityUserInfo` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-login?meta=retrieveCredQualityUserInfo| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperlogin.shopperlogin-1.html#retrievecredqualityuserinfo | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCredQualityUserInfo = (
-    apiOptions: Argument<Client['retrieveCredQualityUserInfo']>,
+    apiOptions: NullableParameters<Argument<Client['retrieveCredQualityUserInfo']>>,
     queryOptions: ApiQueryOptions<Client['retrieveCredQualityUserInfo']> = {}
 ): UseQueryResult<DataType<Client['retrieveCredQualityUserInfo']>> => {
     type Options = Argument<Client['retrieveCredQualityUserInfo']>
@@ -30,15 +32,16 @@ export const useCredQualityUserInfo = (
     const methodName = 'retrieveCredQualityUserInfo'
     const requiredParameters = ['organizationId', 'username'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -46,13 +49,15 @@ export const useCredQualityUserInfo = (
 }
 /**
  * Returns a JSON listing of claims about the currently authenticated user.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Login `getUserInfo` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-login?meta=getUserInfo| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperlogin.shopperlogin-1.html#getuserinfo | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useUserInfo = (
-    apiOptions: Argument<Client['getUserInfo']>,
+    apiOptions: NullableParameters<Argument<Client['getUserInfo']>>,
     queryOptions: ApiQueryOptions<Client['getUserInfo']> = {}
 ): UseQueryResult<DataType<Client['getUserInfo']>> => {
     type Options = Argument<Client['getUserInfo']>
@@ -61,15 +66,16 @@ export const useUserInfo = (
     const methodName = 'getUserInfo'
     const requiredParameters = ['organizationId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -77,13 +83,15 @@ export const useUserInfo = (
 }
 /**
  * Returns a JSON listing of the OpenID/OAuth endpoints, supported scopes and claims, public keys used to sign the tokens, and other details.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Login `getWellknownOpenidConfiguration` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-login?meta=getWellknownOpenidConfiguration| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperlogin.shopperlogin-1.html#getwellknownopenidconfiguration | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useWellknownOpenidConfiguration = (
-    apiOptions: Argument<Client['getWellknownOpenidConfiguration']>,
+    apiOptions: NullableParameters<Argument<Client['getWellknownOpenidConfiguration']>>,
     queryOptions: ApiQueryOptions<Client['getWellknownOpenidConfiguration']> = {}
 ): UseQueryResult<DataType<Client['getWellknownOpenidConfiguration']>> => {
     type Options = Argument<Client['getWellknownOpenidConfiguration']>
@@ -92,15 +100,16 @@ export const useWellknownOpenidConfiguration = (
     const methodName = 'getWellknownOpenidConfiguration'
     const requiredParameters = ['organizationId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -108,13 +117,15 @@ export const useWellknownOpenidConfiguration = (
 }
 /**
  * Returns a JSON Web Key Set (JWKS) containing the current, past, and future public keys. The key set enables clients to validate the Shopper JSON Web Token (JWT) issued by SLAS.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Login `getJwksUri` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-login?meta=getJwksUri| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperlogin.shopperlogin-1.html#getjwksuri | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useJwksUri = (
-    apiOptions: Argument<Client['getJwksUri']>,
+    apiOptions: NullableParameters<Argument<Client['getJwksUri']>>,
     queryOptions: ApiQueryOptions<Client['getJwksUri']> = {}
 ): UseQueryResult<DataType<Client['getJwksUri']>> => {
     type Options = Argument<Client['getJwksUri']>
@@ -123,15 +134,16 @@ export const useJwksUri = (
     const methodName = 'getJwksUri'
     const requiredParameters = ['organizationId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
@@ -10,22 +10,22 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperLogin<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
     retrieveCredQualityUserInfo: [
         '/organizations/',
-        string,
+        string | undefined,
         '/cred-qual/user',
         Params<'retrieveCredQualityUserInfo'>
     ]
-    getUserInfo: ['/organizations/', string, '/oauth2/userinfo', Params<'getUserInfo'>]
+    getUserInfo: ['/organizations/', string | undefined, '/oauth2/userinfo', Params<'getUserInfo'>]
     getWellknownOpenidConfiguration: [
         '/organizations/',
-        string,
+        string | undefined,
         '/oauth2/.well-known/openid-configuration',
         Params<'getWellknownOpenidConfiguration'>
     ]
-    getJwksUri: ['/organizations/', string, '/oauth2/jwks', Params<'getJwksUri'>]
+    getJwksUri: ['/organizations/', string | undefined, '/oauth2/jwks', Params<'getJwksUri'>]
 }
 
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperOrders']
 
 /**
  * Gets information for an order.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Orders `getOrder` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-orders?meta=getOrder| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperorders.shopperorders-1.html#getorder | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useOrder = (
-    apiOptions: Argument<Client['getOrder']>,
+    apiOptions: NullableParameters<Argument<Client['getOrder']>>,
     queryOptions: ApiQueryOptions<Client['getOrder']> = {}
 ): UseQueryResult<DataType<Client['getOrder']>> => {
     type Options = Argument<Client['getOrder']>
@@ -30,15 +32,16 @@ export const useOrder = (
     const methodName = 'getOrder'
     const requiredParameters = ['organizationId', 'orderNo', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -46,13 +49,15 @@ export const useOrder = (
 }
 /**
  * Gets the applicable payment methods for an existing order considering the open payment amount only.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Orders `getPaymentMethodsForOrder` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-orders?meta=getPaymentMethodsForOrder| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperorders.shopperorders-1.html#getpaymentmethodsfororder | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePaymentMethodsForOrder = (
-    apiOptions: Argument<Client['getPaymentMethodsForOrder']>,
+    apiOptions: NullableParameters<Argument<Client['getPaymentMethodsForOrder']>>,
     queryOptions: ApiQueryOptions<Client['getPaymentMethodsForOrder']> = {}
 ): UseQueryResult<DataType<Client['getPaymentMethodsForOrder']>> => {
     type Options = Argument<Client['getPaymentMethodsForOrder']>
@@ -61,15 +66,16 @@ export const usePaymentMethodsForOrder = (
     const methodName = 'getPaymentMethodsForOrder'
     const requiredParameters = ['organizationId', 'orderNo', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -79,13 +85,15 @@ export const usePaymentMethodsForOrder = (
  * This method gives you the external taxation data of the order transferred from the basket during 
 order creation. This endpoint can be called only if external taxation was used. See POST /baskets 
 for more information.         
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Orders `getTaxesFromOrder` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-orders?meta=getTaxesFromOrder| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperorders.shopperorders-1.html#gettaxesfromorder | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useTaxesFromOrder = (
-    apiOptions: Argument<Client['getTaxesFromOrder']>,
+    apiOptions: NullableParameters<Argument<Client['getTaxesFromOrder']>>,
     queryOptions: ApiQueryOptions<Client['getTaxesFromOrder']> = {}
 ): UseQueryResult<DataType<Client['getTaxesFromOrder']>> => {
     type Options = Argument<Client['getTaxesFromOrder']>
@@ -94,15 +102,16 @@ export const useTaxesFromOrder = (
     const methodName = 'getTaxesFromOrder'
     const requiredParameters = ['organizationId', 'orderNo', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
@@ -10,22 +10,28 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperOrders<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    getOrder: ['/organizations/', string, '/orders/', string, Params<'getOrder'>]
+    getOrder: [
+        '/organizations/',
+        string | undefined,
+        '/orders/',
+        string | undefined,
+        Params<'getOrder'>
+    ]
     getPaymentMethodsForOrder: [
         '/organizations/',
-        string,
+        string | undefined,
         '/orders/',
-        string,
+        string | undefined,
         '/payment-methods',
         Params<'getPaymentMethodsForOrder'>
     ]
     getTaxesFromOrder: [
         '/organizations/',
-        string,
+        string | undefined,
         '/orders/',
-        string,
+        string | undefined,
         '/taxes',
         Params<'getTaxesFromOrder'>
     ]

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperProducts']
 
 /**
  * Allows access to multiple products by a single request. Only products that are online and assigned to a site catalog are returned. The maximum number of productIDs that can be requested are 24. Along with product details, the availability, product options, images, price, promotions, and variations for the valid products will be included, as appropriate.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Products `getProducts` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-products?meta=getProducts| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperproducts.shopperproducts-1.html#getproducts | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useProducts = (
-    apiOptions: Argument<Client['getProducts']>,
+    apiOptions: NullableParameters<Argument<Client['getProducts']>>,
     queryOptions: ApiQueryOptions<Client['getProducts']> = {}
 ): UseQueryResult<DataType<Client['getProducts']>> => {
     type Options = Argument<Client['getProducts']>
@@ -30,15 +32,16 @@ export const useProducts = (
     const methodName = 'getProducts'
     const requiredParameters = ['organizationId', 'ids', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -46,13 +49,15 @@ export const useProducts = (
 }
 /**
  * Allows access to product details for a single product ID. Only products that are online and assigned to a site catalog are returned. Along with product details, the availability, images, price, bundled_products, set_products, recommedations, product options, variations, and promotions for the products will be included, as appropriate.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Products `getProduct` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-products?meta=getProduct| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperproducts.shopperproducts-1.html#getproduct | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useProduct = (
-    apiOptions: Argument<Client['getProduct']>,
+    apiOptions: NullableParameters<Argument<Client['getProduct']>>,
     queryOptions: ApiQueryOptions<Client['getProduct']> = {}
 ): UseQueryResult<DataType<Client['getProduct']>> => {
     type Options = Argument<Client['getProduct']>
@@ -61,15 +66,16 @@ export const useProduct = (
     const methodName = 'getProduct'
     const requiredParameters = ['organizationId', 'id', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -77,13 +83,15 @@ export const useProduct = (
 }
 /**
  * When you use the URL template, the server returns multiple categories (a result object of category documents). You can use this template as a convenient way of obtaining multiple categories in a single request, instead of issuing separate requests for each category. You can specify up to 50 multiple IDs. You must enclose the list of IDs in parentheses. If a category identifier contains parenthesis or the separator sign, you must URL encode the character. The server only returns online categories.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Products `getCategories` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-products?meta=getCategories| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperproducts.shopperproducts-1.html#getcategories | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCategories = (
-    apiOptions: Argument<Client['getCategories']>,
+    apiOptions: NullableParameters<Argument<Client['getCategories']>>,
     queryOptions: ApiQueryOptions<Client['getCategories']> = {}
 ): UseQueryResult<DataType<Client['getCategories']>> => {
     type Options = Argument<Client['getCategories']>
@@ -92,15 +100,16 @@ export const useCategories = (
     const methodName = 'getCategories'
     const requiredParameters = ['organizationId', 'ids', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -110,13 +119,15 @@ export const useCategories = (
  * When you use the URL template below, the server returns a category identified by its ID; by default, the server
 also returns the first level of subcategories, but you can specify another level by setting the levels
 parameter. The server only returns online categories.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Products `getCategory` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-products?meta=getCategory| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperproducts.shopperproducts-1.html#getcategory | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useCategory = (
-    apiOptions: Argument<Client['getCategory']>,
+    apiOptions: NullableParameters<Argument<Client['getCategory']>>,
     queryOptions: ApiQueryOptions<Client['getCategory']> = {}
 ): UseQueryResult<DataType<Client['getCategory']>> => {
     type Options = Argument<Client['getCategory']>
@@ -125,15 +136,16 @@ export const useCategory = (
     const methodName = 'getCategory'
     const requiredParameters = ['organizationId', 'id', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
@@ -10,12 +10,24 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperProducts<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    getProducts: ['/organizations/', string, '/products', Params<'getProducts'>]
-    getProduct: ['/organizations/', string, '/products/', string, Params<'getProduct'>]
-    getCategories: ['/organizations/', string, '/categories', Params<'getCategories'>]
-    getCategory: ['/organizations/', string, '/categories/', string, Params<'getCategory'>]
+    getProducts: ['/organizations/', string | undefined, '/products', Params<'getProducts'>]
+    getProduct: [
+        '/organizations/',
+        string | undefined,
+        '/products/',
+        string | undefined,
+        Params<'getProduct'>
+    ]
+    getCategories: ['/organizations/', string | undefined, '/categories', Params<'getCategories'>]
+    getCategory: [
+        '/organizations/',
+        string | undefined,
+        '/categories/',
+        string | undefined,
+        Params<'getCategory'>
+    ]
 }
 
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
@@ -5,23 +5,25 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperPromotions']
 
 /**
  * Returns an array of enabled promotions for a list of specified IDs. In the request URL, you can specify up to 50 IDs. If you specify an ID that contains either parentheses or the separator characters, you must URL encode these characters. Each request returns only enabled promotions as the server does not consider promotion qualifiers or schedules.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Promotions `getPromotions` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-promotions?meta=getPromotions| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperpromotions.shopperpromotions-1.html#getpromotions | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePromotions = (
-    apiOptions: Argument<Client['getPromotions']>,
+    apiOptions: NullableParameters<Argument<Client['getPromotions']>>,
     queryOptions: ApiQueryOptions<Client['getPromotions']> = {}
 ): UseQueryResult<DataType<Client['getPromotions']>> => {
     type Options = Argument<Client['getPromotions']>
@@ -30,15 +32,16 @@ export const usePromotions = (
     const methodName = 'getPromotions'
     const requiredParameters = ['organizationId', 'siteId', 'ids'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -50,13 +53,15 @@ criteria. In the request URL, you must provide a campaign_id parameter, and you 
 range by providing start_date and end_date parameters. Both parameters are required to specify a date range, as 
 omitting one causes the server to return a MissingParameterException fault. Each request returns only enabled
 promotions, since the server does not consider promotion qualifiers or schedules.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Promotions `getPromotionsForCampaign` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-promotions?meta=getPromotionsForCampaign| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperpromotions.shopperpromotions-1.html#getpromotionsforcampaign | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const usePromotionsForCampaign = (
-    apiOptions: Argument<Client['getPromotionsForCampaign']>,
+    apiOptions: NullableParameters<Argument<Client['getPromotionsForCampaign']>>,
     queryOptions: ApiQueryOptions<Client['getPromotionsForCampaign']> = {}
 ): UseQueryResult<DataType<Client['getPromotionsForCampaign']>> => {
     type Options = Argument<Client['getPromotionsForCampaign']>
@@ -65,15 +70,16 @@ export const usePromotionsForCampaign = (
     const methodName = 'getPromotionsForCampaign'
     const requiredParameters = ['organizationId', 'campaignId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
@@ -10,14 +10,14 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperPromotions<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    getPromotions: ['/organizations/', string, '/promotions', Params<'getPromotions'>]
+    getPromotions: ['/organizations/', string | undefined, '/promotions', Params<'getPromotions'>]
     getPromotionsForCampaign: [
         '/organizations/',
-        string,
+        string | undefined,
         '/promotions/campaigns/',
-        string,
+        string | undefined,
         Params<'getPromotionsForCampaign'>
     ]
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
@@ -5,10 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {UseQueryResult} from '@tanstack/react-query'
-import {ApiClients, ApiQueryOptions, Argument, DataType} from '../types'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperSearch']
@@ -16,13 +16,15 @@ type Client = ApiClients['shopperSearch']
 /**
  * Provides keyword and refinement search functionality for products. Only returns the product ID, link, and name in
 the product search hit. The search result contains only products that are online and assigned to site catalog.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Search `productSearch` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-search?meta=productSearch| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppersearch.shoppersearch-1.html#productsearch | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useProductSearch = (
-    apiOptions: Argument<Client['productSearch']>,
+    apiOptions: NullableParameters<Argument<Client['productSearch']>>,
     queryOptions: ApiQueryOptions<Client['productSearch']> = {}
 ): UseQueryResult<DataType<Client['productSearch']>> => {
     type Options = Argument<Client['productSearch']>
@@ -31,15 +33,16 @@ export const useProductSearch = (
     const methodName = 'productSearch'
     const requiredParameters = ['organizationId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -47,13 +50,15 @@ export const useProductSearch = (
 }
 /**
  * Provides keyword search functionality for products, categories, and brands suggestions. Returns suggested products, suggested categories, and suggested brands for the given search phrase.
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
  * @returns A TanStack Query query hook with data from the Shopper Search `getSearchSuggestions` endpoint.
  * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-search?meta=getSearchSuggestions| Salesforce Developer Center} for more information about the API endpoint.
  * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shoppersearch.shoppersearch-1.html#getsearchsuggestions | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
  * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
  */
 export const useSearchSuggestions = (
-    apiOptions: Argument<Client['getSearchSuggestions']>,
+    apiOptions: NullableParameters<Argument<Client['getSearchSuggestions']>>,
     queryOptions: ApiQueryOptions<Client['getSearchSuggestions']> = {}
 ): UseQueryResult<DataType<Client['getSearchSuggestions']>> => {
     type Options = Argument<Client['getSearchSuggestions']>
@@ -62,15 +67,16 @@ export const useSearchSuggestions = (
     const methodName = 'getSearchSuggestions'
     const requiredParameters = ['organizationId', 'siteId', 'q'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`, we must merge them in order
-    // to generate the correct query key.
-    const netOptions = mergeOptions(client, apiOptions)
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
@@ -10,12 +10,17 @@ import {pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperSearch<{shortCode: string}>
-type Params<T extends keyof QueryKeys> = NonNullable<Argument<Client[T]>['parameters']>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
 export type QueryKeys = {
-    productSearch: ['/organizations/', string, '/product-search', Params<'productSearch'>]
+    productSearch: [
+        '/organizations/',
+        string | undefined,
+        '/product-search',
+        Params<'productSearch'>
+    ]
     getSearchSuggestions: [
         '/organizations/',
-        string,
+        string | undefined,
         '/search-suggestions',
         Params<'getSearchSuggestions'>
     ]

--- a/packages/commerce-sdk-react/src/hooks/types.ts
+++ b/packages/commerce-sdk-react/src/hooks/types.ts
@@ -54,6 +54,17 @@ export type ExcludeTail<T extends readonly unknown[]> = T extends readonly [...i
         : Readonly<Head>
     : T // If it's a plain array, rather than a tuple, then removing the last element has no effect
 
+/** Adds `null` as an allowed value to all properties. */
+type AllowNull<T> = {[K in keyof T]: T[K] | null}
+
+/** Gets the keys of `T` which allow `null` as a possible value. */
+type NullKeys<T> = {[K in keyof T]-?: null extends T[K] ? K : never}[keyof T]
+
+/** Removes `null` values and marks those properties as optional. */
+export type NullToOptional<T> = Omit<T, NullKeys<T>> & {
+    [K in keyof T]?: NonNullable<T[K]>
+}
+
 // --- API CLIENTS --- //
 export type ApiParameter = string | number | boolean | string[] | number[]
 
@@ -131,7 +142,7 @@ export type MergedOptions<Client extends ApiClient, Options extends ApiOptions> 
 
 /** Query key interface used by API query hooks. */
 export type ApiQueryKey<Params extends Record<string, unknown> = Record<string, unknown>> =
-    readonly [...path: string[], parameters: Params]
+    readonly [...path: (string | undefined)[], parameters: Params]
 
 /** Query options for endpoint hooks. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,6 +152,17 @@ export type ApiQueryOptions<Method extends ApiMethod<any, unknown>> = Prettify<
         'queryFn' | 'queryKey'
     >
 >
+
+/** Adds `null` as an allowed value to all parameters. */
+export type NullableParameters<T extends {parameters?: object}> = {
+    // This `extends` check allows us to more easily preserve required/optional parameters
+    [K in keyof T]: K extends 'parameters' ? AllowNull<T[K]> : T[K]
+}
+
+/** Remove `null` and `undefined` values from all parameters. */
+export type OmitNullableParameters<T extends {parameters: object}> = Omit<T, 'parameters'> & {
+    parameters: NullToOptional<T['parameters']>
+}
 
 // --- CACHE HELPERS --- //
 

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -99,18 +99,6 @@ export const matchParameters = (
     return matchParametersStrict(search)
 }
 
-/** Creates a query predicate that matches against common API config parameters. */
-export const matchesApiConfig = (parameters: Record<string, ApiParameter | undefined>) =>
-    matchParameters(parameters, [
-        // NOTE: `shortCode` and `version` are omitted, as query keys are constructed from endpoint
-        // paths, but the two paarameters are only used to construct the base URI.
-        'clientId',
-        'currency', // TODO: maybe?
-        'locale', // TODO: maybe?
-        'organizationId',
-        'siteId'
-    ])
-
 /** Creates a query predicate that returns true if all of the given predicates return true. */
 export const and =
     <Args extends unknown[]>(...funcs: Array<(...args: Args) => boolean>) =>

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -5,7 +5,15 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {Query, QueryClient} from '@tanstack/react-query'
-import {ApiClient, ApiOptions, ApiParameter, CacheUpdate, MergedOptions} from './types'
+import {
+    ApiClient,
+    ApiOptions,
+    ApiParameter,
+    CacheUpdate,
+    MergedOptions,
+    NullToOptional,
+    OmitNullableParameters
+} from './types'
 
 /** Applies the set of cache updates to the query client. */
 export const updateCache = (queryClient: QueryClient, cacheUpdates: CacheUpdate, data: unknown) => {
@@ -38,17 +46,17 @@ export const isObject = (obj: unknown): obj is Record<string, unknown> =>
 
 /** Determines whether a value has all of the given keys. */
 export const hasAllKeys = <T>(object: T, keys: ReadonlyArray<keyof T>): boolean =>
-    keys.every((key) => object[key] !== undefined)
+    keys.every((key) => object[key] !== undefined && object[key] !== null)
 
 /** Creates a query predicate that determines whether a query key starts with the given path segments. */
 export const pathStartsWith =
-    (search: readonly string[]) =>
+    (search: readonly (string | undefined)[]) =>
     ({queryKey}: Query): boolean =>
         queryKey.length >= search.length && search.every((lookup, idx) => queryKey[idx] === lookup)
 
 /** Creates a query predicate that determines whether a query key fully matches the given path segments. */
 export const matchesPath =
-    (search: readonly string[]) =>
+    (search: readonly (string | undefined)[]) =>
     ({queryKey}: Query): boolean =>
         // ApiQueryKey = [...path, parameters]
         queryKey.length === 1 + search.length &&
@@ -122,7 +130,8 @@ export const mergeOptions = <Client extends ApiClient, Options extends ApiOption
             : ({} as {body: never})),
         parameters: {
             ...client.clientConfig.parameters,
-            ...options.parameters
+            // If we pass a blank override, don't actually override it.
+            ...(options.parameters ? omitNullable(options.parameters) : {})
         },
         headers: {
             ...client.clientConfig.parameters,
@@ -137,11 +146,35 @@ export const pick = <T extends object, K extends keyof T>(
     obj: T,
     keys: readonly K[]
 ): Pick<T, K> => {
-    const picked = {} as Pick<T, K> // Assertion is not true, yet, but we make it so!
+    // Assertion is not true, yet, but we make it so!
+    const picked = {} as Pick<T, K>
     keys.forEach((key) => {
         if (key in obj) {
+            // Skip assigning optional/missing parameters
             picked[key] = obj[key]
         }
     })
     return picked
 }
+
+/** Removes keys with `null` or `undefined` values from the given object. */
+export const omitNullable = <T extends object>(obj: T): NullToOptional<T> => {
+    // Assertion is not true, yet, but we make it so!
+    const stripped = {} as NullToOptional<T>
+    // Assertion because `Object.entries` is limited :\
+    const entries = Object.entries(obj) as Array<[keyof T, T[keyof T]]>
+    for (const [key, value] of entries) {
+        if (value !== null && value !== undefined) stripped[key] = value
+    }
+    return stripped
+}
+
+/** Removes keys with `null` or `undefined` values from the `parameters` of the given object. */
+export const omitNullableParameters = <T extends {parameters: object}>(
+    obj: T
+): OmitNullableParameters<T> => ({
+    ...obj,
+    // Without the explicit generic parameter, the generic is inferred as `object`,
+    // the connection to `T` is lost, and TypeScript complains.
+    parameters: omitNullable<T['parameters']>(obj.parameters)
+})


### PR DESCRIPTION
When the app is initializing, some values (e.g. `customerId`) can be unset. React doesn't allow conditionally calling hooks. Therefore, we must support an explicit "unset" value for parameters. As it is not otherwise used by the Commerce API or isomorphic SDK, `null` is a natural choice for the fallback value.

<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Use a hook. Pass `null` as a value. Observe that TypeScript does not complain, and the hook is not executed.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
