### PR TITLE
Fix `getConfig` referencing config from incorrect location

### DIFF
--- a/packages/pwa-kit-dev/bin/pwa-kit-dev.js
+++ b/packages/pwa-kit-dev/bin/pwa-kit-dev.js
@@ -294,6 +294,10 @@ const main = async () => {
 
                 const credentials = await scriptUtils.readCredentials(credentialsFile)
 
+                if (!fse.pathExistsSync(buildDirectory)) {
+                    throw new Error(`Supplied "buildDirectory" does not exist!`)
+                }
+
                 const mobify = getConfig({buildDirectory}) || {}
 
                 if (!projectSlug) {

--- a/packages/pwa-kit-dev/bin/pwa-kit-dev.js
+++ b/packages/pwa-kit-dev/bin/pwa-kit-dev.js
@@ -249,7 +249,7 @@ const main = async () => {
         .addOption(
             new program.Option(
                 '-b, --buildDirectory <buildDirectory>',
-                'a custom project directory where your build is located'
+                'a custom project build directory that you want to push'
             ).default(p.join(process.cwd(), 'build'), './build')
         )
         .addOption(
@@ -285,12 +285,16 @@ const main = async () => {
                 credentialsFile
             }) => {
                 // Set the deployment target env var, this is required to ensure we
-                // get the correct configuration object.
-                process.env.DEPLOY_TARGET = target
+                // get the correct configuration object. Do not assign the variable it if
+                // the target value is `undefined` as it will serialied as a "undefined"
+                // string value.
+                if (target) {
+                    process.env.DEPLOY_TARGET = target
+                }
 
                 const credentials = await scriptUtils.readCredentials(credentialsFile)
 
-                const mobify = getConfig() || {}
+                const mobify = getConfig({buildDirectory}) || {}
 
                 if (!projectSlug) {
                     projectSlug = await getProjectName()

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.8.0-dev (Mar 03, 2023)
+- Add optional parameter to override configuration folder used in `getConfig` [#1049](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1049)
 ## v2.7.0 (Mar 03, 2023)
 - Support Node 16 [#965](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/965)
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-config.client.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.client.test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-env jest */
+/* eslint max-nested-callbacks:0 */
+
+import {getConfig} from './ssr-config.client'
+
+let windowSpy
+
+beforeEach(() => {
+    windowSpy = jest.spyOn(window, 'window', 'get')
+})
+
+afterEach(() => {
+    windowSpy.mockRestore()
+})
+
+describe('Client getConfig', () => {
+    test('returns window.__CONFIG__ value', () => {
+        windowSpy.mockImplementation(() => ({
+            __CONFIG__: {}
+        }))
+
+        expect(getConfig()).toEqual({})
+    })
+})

--- a/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
@@ -9,7 +9,6 @@
 const SUPPORTED_FILE_TYPES = ['js', 'yml', 'yaml', 'json']
 
 const IS_REMOTE = Object.prototype.hasOwnProperty.call(process.env, 'AWS_LAMBDA_FUNCTION_NAME')
-const CONFIG_SEARCH_DIRECTORY = IS_REMOTE ? 'build' : ''
 
 /**
  * Returns the express app configuration file in object form. The file will be resolved in the
@@ -38,13 +37,14 @@ const CONFIG_SEARCH_DIRECTORY = IS_REMOTE ? 'build' : ''
 /* istanbul ignore next */
 export const getConfig = (opts = {}) => {
     const {buildDirectory} = opts
+    const configDirBase = IS_REMOTE ? 'build' : ''
     let targetName = process?.env?.DEPLOY_TARGET || ''
 
     const targetSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/${targetName}.${ext}`)
     const localeSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/local.${ext}`)
     const defaultSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/default.${ext}`)
 
-    const searchFrom = buildDirectory || process.cwd() + '/' + CONFIG_SEARCH_DIRECTORY
+    const searchFrom = buildDirectory || process.cwd() + '/' + configDirBase
 
     // Combined search places.
     const searchPlaces = [

--- a/packages/pwa-kit-runtime/src/utils/ssr-config.server.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.server.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/* eslint-env jest */
+/* eslint max-nested-callbacks:0 */
+
+import {getConfig} from './ssr-config.server'
+
+describe('Server "getConfig"', () => {
+    const env = process.env
+
+    beforeEach(() => {
+        jest.resetModules()
+        process.env = {...env}
+    })
+
+    afterEach(() => {
+        process.env = env
+    })
+
+    test('throws when no config files are found running remotely', () => {
+        expect(getConfig).toThrow()
+    })
+
+    test('throws when no config files are found running locally', () => {
+        process.env.AWS_LAMBDA_FUNCTION_NAME = ''
+        expect(getConfig).toThrow()
+    })
+})

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -7,6 +7,7 @@
 const sites = require('./sites.js')
 
 module.exports = {
+    location: 'template project folder',
     app: {
         url: {
             site: 'path',

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -7,7 +7,6 @@
 const sites = require('./sites.js')
 
 module.exports = {
-    location: 'template project folder',
     app: {
         url: {
             site: 'path',


### PR DESCRIPTION
# Description

This PR fixes #986. As described in the issue, the `getConfig` function is using the config defined in the projects source folder when pushing a bundle. Although this isn't major issue as the `push` command in a given project will build the project before pushing. But if you are to use the `pwa-kit-dev` cli directly outside of running in an npm script for a project that is already built, then you'll have issues. 

The change involves passing an option argument to `getConfig` to override where the config should be loaded from. I also fixed a couple other bugs in the code that I came across. I've left comments in the PR about those.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Fix `target` environment variable being "undefined"
- Allow `getConfig` to be passed a `buildDirectory` path which will override the `searchFrom` value used in cosmifconfig
- Fix push option description to be more clear

# How to Test-Drive This PR

- (step1)
