### PR TITLE
[commerce-sdk-react] Fix Shopper Baskets Test case

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
@@ -164,13 +164,19 @@ const addTaxesForBasketItemTestCase = [
 const nonEmptyResponseTestCases = Object.entries(testMap) as Array<
     [NonEmptyResponseMutations, Argument<Client[NonEmptyResponseMutations]>]
 >
-// Most test cases only apply to non-delete test cases, some (error handling) can include deleteBasket
-const allTestCases = [
-    ...nonEmptyResponseTestCases,
+
+// Endpoints returning void response on success
+const emptyResponseTestCases = [
     deleteTestCase,
     addPriceBooksToBasketTestCase,
     addTaxesForBasketTestCase,
     addTaxesForBasketItemTestCase
+]
+
+// Most test cases only apply to non-empty response test cases, some (error handling) can include deleteBasket
+const allTestCases = [
+    ...nonEmptyResponseTestCases,
+    ...emptyResponseTestCases
 ]
 
 describe('ShopperBaskets mutations', () => {
@@ -254,14 +260,8 @@ describe('ShopperBaskets mutations', () => {
             assertUpdateQuery(result.current.customerBaskets, oldCustomerBaskets)
         }
     )
-    test.each([
-        deleteTestCase,
-        addPriceBooksToBasketTestCase,
-        addTaxesForBasketTestCase,
-        addTaxesForBasketItemTestCase
-    ])('`%s` returns void on success', async () => {
+    test.each(emptyResponseTestCases)('`%s` returns void on success', async (mutationName, options) => {
         // Almost the standard 'returns data' test, just a different return type
-        const [mutationName, options] = deleteTestCase
         mockMutationEndpoints(basketsEndpoint, oldBasket)
         const {result, waitForValueToChange: wait} = renderHookWithProviders(() => {
             return useShopperBasketsMutation(mutationName)

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
@@ -174,10 +174,7 @@ const emptyResponseTestCases = [
 ]
 
 // Most test cases only apply to non-empty response test cases, some (error handling) can include deleteBasket
-const allTestCases = [
-    ...nonEmptyResponseTestCases,
-    ...emptyResponseTestCases
-]
+const allTestCases = [...nonEmptyResponseTestCases, ...emptyResponseTestCases]
 
 describe('ShopperBaskets mutations', () => {
     const storedCustomerIdKey = `${DEFAULT_TEST_CONFIG.siteId}_customer_id`
@@ -260,17 +257,20 @@ describe('ShopperBaskets mutations', () => {
             assertUpdateQuery(result.current.customerBaskets, oldCustomerBaskets)
         }
     )
-    test.each(emptyResponseTestCases)('`%s` returns void on success', async (mutationName, options) => {
-        // Almost the standard 'returns data' test, just a different return type
-        mockMutationEndpoints(basketsEndpoint, oldBasket)
-        const {result, waitForValueToChange: wait} = renderHookWithProviders(() => {
-            return useShopperBasketsMutation(mutationName)
-        })
-        expect(result.current.data).toBeUndefined()
-        act(() => result.current.mutate(options))
-        await waitAndExpectSuccess(wait, () => result.current)
-        expect(result.current.data).toBeUndefined()
-    })
+    test.each(emptyResponseTestCases)(
+        '`%s` returns void on success',
+        async (mutationName, options) => {
+            // Almost the standard 'returns data' test, just a different return type
+            mockMutationEndpoints(basketsEndpoint, oldBasket)
+            const {result, waitForValueToChange: wait} = renderHookWithProviders(() => {
+                return useShopperBasketsMutation(mutationName)
+            })
+            expect(result.current.data).toBeUndefined()
+            act(() => result.current.mutate(options))
+            await waitAndExpectSuccess(wait, () => result.current)
+            expect(result.current.data).toBeUndefined()
+        }
+    )
     test('`deleteBasket` removes the basket from the cache on success', async () => {
         // Almost the standard 'updates cache' test, but the cache changes are different
         const [mutationName, options] = deleteTestCase


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
