### PR TITLE
Improve some flaky PDP tests

### DIFF
--- a/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.test.js
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.test.js
@@ -97,6 +97,6 @@ test('the View Options button', async () => {
             expect(modal).toBeVisible()
         },
         // Seems like rendering the modal takes a bit more time
-        {timeout: 10000}
+        {timeout: 5000}
     )
 }, 30000)

--- a/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.test.js
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.test.js
@@ -97,6 +97,6 @@ test('the View Options button', async () => {
             expect(modal).toBeVisible()
         },
         // Seems like rendering the modal takes a bit more time
-        {timeout: 5000}
+        {timeout: 10000}
     )
 }, 30000)

--- a/packages/template-retail-react-app/app/pages/product-detail/index.test.js
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.test.js
@@ -118,7 +118,7 @@ describe('product set', () => {
                 expect(within(modal).getByText(/items added to cart/i)).toBeInTheDocument()
             },
             // Seems like rendering the modal takes a bit more time
-            {timeout: 5000}
+            {timeout: 10000}
         )
     }, 30000)
 

--- a/packages/template-retail-react-app/app/pages/product-detail/index.test.js
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.test.js
@@ -109,7 +109,7 @@ describe('product set', () => {
             expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
         })
 
-        const buttons = await screen.findAllByRole('button', {name: /add set to cart/i})
+        const buttons = await screen.findAllByText(/add set to cart/i)
         fireEvent.click(buttons[0])
 
         await waitFor(
@@ -129,7 +129,7 @@ describe('product set', () => {
             expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
         })
 
-        const buttons = await screen.findAllByRole('button', {name: /add set to cart/i})
+        const buttons = await screen.findAllByText(/add set to cart/i)
         fireEvent.click(buttons[0])
 
         await waitFor(() => {

--- a/packages/template-retail-react-app/app/pages/product-detail/index.test.js
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.test.js
@@ -105,9 +105,12 @@ describe('product set', () => {
         const initialBasket = {basketId: 'valid_id'}
         renderWithProviders(<MockedComponent />, {wrapperProps: {initialBasket}})
 
-        await waitFor(() => {
-            expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
-        })
+        await waitFor(
+            () => {
+                expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
+            },
+            {timeout: 5000}
+        )
 
         const buttons = await screen.findAllByText(/add set to cart/i)
         fireEvent.click(buttons[0])
@@ -125,9 +128,12 @@ describe('product set', () => {
     test('add the set to cart with error messages', async () => {
         renderWithProviders(<MockedComponent />)
 
-        await waitFor(() => {
-            expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
-        })
+        await waitFor(
+            () => {
+                expect(screen.getAllByText('Winter Look')[0]).toBeInTheDocument()
+            },
+            {timeout: 5000}
+        )
 
         const buttons = await screen.findAllByText(/add set to cart/i)
         fireEvent.click(buttons[0])


### PR DESCRIPTION
Following up on our recent conversation, I've tweaked the PDP tests such that:
- Waiting _longer_ for the added-to-cart modal. 
  - The previous timeout was sometimes not long enough, since on CI the average wait time was close to the timeout → I've roughly measured it here in #1080 
- Using a more performant query (byRole vs byText)