### PR TITLE
remove console warning

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/useCustomerType.ts
+++ b/packages/commerce-sdk-react/src/hooks/useCustomerType.ts
@@ -38,7 +38,6 @@ const useCustomerType = (): useCustomerType => {
     const isRegistered = customerType === 'registered'
 
     if (customerType !== null && customerType !== 'guest' && customerType !== 'registered') {
-        console.warn(`Unrecognized customer type found in storage: ${customerType}`)
         customerType = null
     }
 


### PR DESCRIPTION
There was a `console.warn` in useCustomerType hook and it is not useful and doesn't provide context/solution, it produces noise on server/testing logs.