### PR TITLE
Remove test.only

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/mutation.test.ts
@@ -363,7 +363,7 @@ describe('ShopperCustomers mutations', () => {
             await waitForValueToChange(() => result.current.query)
             assertUpdateQuery(result.current.query, data)
         })
-        test.only('`deleteCustomerProductListItem` updates cache on success', async () => {
+        test('`deleteCustomerProductListItem` updates cache on success', async () => {
             const data = oldProductListItem
             const list = baseProductList
             const listResult = baseListResult


### PR DESCRIPTION
A `test.only` is accidentally merged into `v3`, this PR removes it! Thanks @bendvc for catching it!