### PR TITLE
Parallelize lighthouse ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
     env:
       # The "default" npm is the one that ships with a given version of node.
       # For more: https://nodejs.org/en/download/releases/
-      IS_MRT_NODE: ${{ matrix.node == 16 && matrix.npm == 8 }}
       IS_DEFAULT_NPM: ${{ matrix.node == 16 && matrix.npm == 8 || matrix.node == 18 && matrix.npm == 9 }}
       IS_LATEST_NPM: ${{ matrix.node == 16 && matrix.npm == 8 }}
     steps:
@@ -63,12 +62,6 @@ jobs:
 
       - name: Run unit tests
         uses: "./.github/actions/unit_tests"
-
-      - name: Run Lighthouse CI on the PWA
-        # lighthouse ci doesn't work on node 18 at this time 
-        # https://github.com/GoogleChrome/lighthouse-ci/issues/862
-        if: env.IS_MRT_NODE == 'true'
-        uses: "./.github/actions/lighthouse_ci"
 
       - name: Smoke test scripts
         if: env.IS_DEFAULT_NPM == 'true'
@@ -303,3 +296,27 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: packages/pwa-kit-create-app/local-npm-repo/verdaccio.log
+  lighthouse:
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [16]
+    runs-on: ubuntu-latest
+    env:
+      IS_TEMPLATE_FROM_RETAIL_REACT_APP: ${{ matrix.template == 'test-project' || matrix.template == 'retail-react-app-demo' }}
+      PROJECT_DIR: generated-${{ matrix.template }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+
+      - name: Setup Ubuntu Machine
+        uses: "./.github/actions/setup_ubuntu"
+
+      - name: Run Lighthouse CI on the PWA
+        uses: "./.github/actions/lighthouse_ci"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -302,9 +302,6 @@ jobs:
       matrix:
         node: [16]
     runs-on: ubuntu-latest
-    env:
-      IS_TEMPLATE_FROM_RETAIL_REACT_APP: ${{ matrix.template == 'test-project' || matrix.template == 'retail-react-app-demo' }}
-      PROJECT_DIR: generated-${{ matrix.template }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -300,7 +300,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16]
+        node: [16] # Should match node version supported by MRT.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     env:
       # The "default" npm is the one that ships with a given version of node.
       # For more: https://nodejs.org/en/download/releases/
-      IS_DEFAULT_NPM: ${{ matrix.node == 16 && matrix.npm == 8 || matrix.node == 18 && matrix.npm == 9 }}
+      IS_DEFAULT_NPM: ${{ (matrix.node == 16 && matrix.npm == 8) || (matrix.node == 18 && matrix.npm == 9) }}
       IS_LATEST_NPM: ${{ matrix.node == 16 && matrix.npm == 8 }}
     steps:
       - name: Checkout


### PR DESCRIPTION
While fixing failing lighthouse CI test in this [PR](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1124), I noticed that the lighthouse test takes 7+ minutes and runs in the node 16 / npm 8 job. This is a bottleneck and this PR attempts to parallelize the lighthouse run to reduce overall CI time.

<img width="798" alt="Screenshot 2023-04-12 at 10 30 51 AM" src="https://user-images.githubusercontent.com/10948652/231537613-65c17e60-684b-4954-9c46-b8cd68753fe8.png">


<img width="273" alt="Screenshot 2023-04-11 at 2 56 59 PM" src="https://user-images.githubusercontent.com/10948652/231297273-756377c1-e74b-41cc-a7d6-e914dfcbc279.png">

