### PR TITLE
[V3][Hooks Integration 🪝] Replace last of the `getProps`

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/route-component/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/route-component/index.js
@@ -56,10 +56,11 @@ const withErrorHandling = (Wrapped) => {
  */
 export const routeComponent = (Wrapped, isPage, locals) => {
     const AppConfig = getAppConfig()
-    const extraArgs = AppConfig.extraGetPropsArgs(locals)
 
     const hocs = AppConfig.getHOCsInUse()
     const getPropsEnabled = hocs.indexOf(withLegacyGetProps) >= 0
+
+    const extraArgs = getPropsEnabled ? AppConfig.extraGetPropsArgs(locals) : {}
 
     /* istanbul ignore next */
     const wrappedComponentName = Wrapped.displayName || Wrapped.name

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -18,7 +18,6 @@ import {getConfig} from 'pwa-kit-runtime/utils/ssr-config'
 import {createUrlTemplate} from '../../utils/url'
 
 import {CommerceApiProvider} from 'commerce-sdk-react-preview'
-import {withLegacyGetProps} from 'pwa-kit-react-sdk/ssr/universal/components/with-legacy-get-props'
 import {withReactQuery} from 'pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from 'pwa-kit-react-sdk/ssr/universal/hooks'
 import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
@@ -86,14 +85,6 @@ AppConfig.restore = (locals = {}) => {
 
 AppConfig.freeze = () => undefined
 
-AppConfig.extraGetPropsArgs = (locals = {}) => {
-    return {
-        buildUrl: locals.buildUrl,
-        site: locals.site,
-        locale: locals.locale
-    }
-}
-
 AppConfig.propTypes = {
     children: PropTypes.node,
     locals: PropTypes.object
@@ -119,4 +110,4 @@ const options = {
     }
 }
 
-export default withReactQuery(withLegacyGetProps(AppConfig), options)
+export default withReactQuery(AppConfig, options)

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -137,7 +137,7 @@ const App = (props) => {
     const {data: messages} = useQuery({
         queryKey: ['app', 'translationas', 'messages', targetLocale],
         queryFn: () => fetchTranslations(targetLocale),
-        enabled: typeof window === 'undefined'
+        enabled: isServer
     })
 
     // Used to conditionally render header/footer for checkout page

--- a/packages/template-retail-react-app/app/components/_app/index.test.js
+++ b/packages/template-retail-react-app/app/components/_app/index.test.js
@@ -65,19 +65,6 @@ describe('App', () => {
         expect(screen.getByText('Any children here')).toBeInTheDocument()
     })
 
-    test('shouldGetProps returns true only server-side', () => {
-        windowSpy.mockImplementation(() => undefined)
-
-        expect(App.shouldGetProps()).toBe(true)
-
-        windowSpy.mockImplementation(() => ({
-            location: {
-                origin: 'http://localhost:3000/'
-            }
-        }))
-        expect(App.shouldGetProps()).toBe(false)
-    })
-
     test('The localized hreflang links exist in the html head', () => {
         useMultiSite.mockImplementation(() => resultUseMultiSite)
         renderWithProviders(

--- a/packages/template-retail-react-app/app/pages/page-not-found/index.jsx
+++ b/packages/template-retail-react-app/app/pages/page-not-found/index.jsx
@@ -9,6 +9,7 @@ import React from 'react'
 import {Box, Heading, Flex, Button, Stack, Text} from '@chakra-ui/react'
 import {Helmet} from 'react-helmet'
 import {useIntl} from 'react-intl'
+import {useServerContext} from 'pwa-kit-react-sdk/ssr/universal/hooks'
 import {SearchIcon} from '../../components/icons'
 import {useHistory} from 'react-router-dom'
 import Link from '../../components/link'
@@ -16,6 +17,12 @@ import Link from '../../components/link'
 const PageNotFound = () => {
     const intl = useIntl()
     const history = useHistory()
+    const {res} = useServerContext()
+
+    if (res) {
+        res.status(404)
+    }
+
     return (
         <Box
             layerStyle="page"
@@ -78,12 +85,6 @@ const PageNotFound = () => {
             </Flex>
         </Box>
     )
-}
-
-PageNotFound.getProps = async ({res}) => {
-    if (res) {
-        res.status(404)
-    }
 }
 
 export default PageNotFound

--- a/packages/template-retail-react-app/app/utils/test-utils.js
+++ b/packages/template-retail-react-app/app/utils/test-utils.js
@@ -16,7 +16,6 @@ import {AddToCartModalProvider} from '../hooks/use-add-to-cart-modal'
 import {ServerContext} from 'pwa-kit-react-sdk/ssr/universal/contexts'
 import {IntlProvider} from 'react-intl'
 import {CommerceApiProvider} from 'commerce-sdk-react-preview'
-import {withLegacyGetProps} from 'pwa-kit-react-sdk/ssr/universal/components/with-legacy-get-props'
 import {withReactQuery} from 'pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import fallbackMessages from '../translations/compiled/en-GB.json'
 import mockConfig from '../../config/mocks/default'
@@ -170,7 +169,7 @@ TestProviders.propTypes = {
  * @param {object} options
  */
 export const renderWithProviders = (children, options) => {
-    const TestProvidersWithDataAPI = withReactQuery(withLegacyGetProps(TestProviders), {
+    const TestProvidersWithDataAPI = withReactQuery(TestProviders, {
         queryClientConfig: {
             defaultOptions: {
                 queries: {


### PR DESCRIPTION
# Description

There were a few places left in the `retail-react-template` where we were still using `getProps`. A) in the `pge-not-found` page and B) in the `_app` component. In this PR I'm replacing those uses of `getProps `with their non-getProps `react-query` equivalent.

_NOTE: Because we use ssrPrepass to get hooks working server-side there was an issue where during prepass the messages aren't available, leading to warnings in the console for missing translations. To work around this I updated the custom error handler to only warn if there are messages defined/loaded and the individual message isn't found._

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Replace _app getProps with useQuery implementation.
- Replace page-not-found getProps with useServerContext
- Remove use of the `withLegacyGetProps` HOC
- Remove any unused tests.
- Fix bug in SDK where it was required that you have an `extraGetPropsArgs` implementation even when you aren't using getProps.
- Remove `getProps` HOC from test render function.

# How to Test-Drive This PR

- Load dev server and set basic features of localization, changing the local, seeing the text change on various pages etc.
- Goto a url where there is no route defined to see that you get a 404 response when the page not found page renders.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
