### PR TITLE
Fix multi-value query params being lost

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.8.0-dev (Mar 03, 2023)
+- Fix `multi-value` params being lost [#1150](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1150)
 ## v2.7.0 (Mar 03, 2023)
 ## v2.6.0 (Jan 25, 2023)
 


### PR DESCRIPTION
# Description

We are losing multi-value param values in the runtime because of `aws-serverless-express` as a result of the `req.originalUrl` not being fully preserved. For example a request for `hostname.com/path?param=1&param=2` will eventually be made available in the SDK and down into the PWA-Kit app with only the last param value `hostname.com/path?param=2`.    

Fortunately this issue doesn't happen to effect the `req.query` property. So as a temporary fix, we'll re-create the `location.search` value using the `req.query` paying special attention to the order of the params. 


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Patched the `location.search` property in the react rendering pipeline using the `req.params` which has the duplicate param values.

# How to Test-Drive This PR

- Goto [this](https://scaffold-pwa-test-env.mobify-storefront.com/global/en-GB/category/womens?limit=25&refine=c_refinementColor%3DBlue%7CGrey&refine=price%3D%28100..500%29&sort=best-matches&mobify_server_only=1) url
- If you see 3 filters applied to the product list, it's working
## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
