### PR TITLE
Mitigate local dev memory leaks

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -354,7 +354,11 @@ const renderer =
                 devtool: mode === development ? 'eval-source-map' : false,
                 output: {
                     path: buildDir,
-                    filename: 'server-renderer.js',
+
+                    // We want to split the build on local development to reduce memory usage.
+                    // It is required to have a single entry point for the remote server.
+                    // See pwa-kit-runtime/ssr/server/build-remote-server.js render method.
+                    filename: mode === development ? '[name].js' : 'server-renderer.js',
                     libraryTarget: 'commonjs2'
                 },
                 plugins: [


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

On Node 16, there is an memory leak issue when developers make multiple changes to a pwa kit project, will result in a javascript heap out of memory issue. Thanks @JCTucker for reporting the issue.

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
 1: 00007FF6E8E2158F v8::internal::CodeObjectRegistry::~CodeObjectRegistry+122159
 2: 00007FF6E8DAB356 DSA_meth_get_flags+64118
 3: 00007FF6E8DAC3D2 DSA_meth_get_flags+68338
 4: 00007FF6E96E3C84 v8::Isolate::ReportExternalAllocationLimitReached+116
 5: 00007FF6E96CE24D v8::SharedArrayBuffer::Externalize+781
 6: 00007FF6E957180C v8::internal::Heap::EphemeronKeyWriteBarrierFromCode+1468
 7: 00007FF6E956E924 v8::internal::Heap::CollectGarbage+4244
 8: 00007FF6E956C2A0 v8::internal::Heap::AllocateExternalBackingStore+2000
 9: 00007FF6E9590E26 v8::internal::Factory::NewFillerObject+214
10: 00007FF6E92C3475 v8::internal::DateCache::Weekday+1797
11: 00007FF6E9771961 v8::internal::SetupIsolateDelegate::SetupHeap+494417
12: 00007FF6E9747AEC v8::internal::SetupIsolateDelegate::SetupHeap+322780
13: 000002D73DB52285
error: Command failed: node C:\Users\jonathan.tucker\pwa-kit-starter-2.7\app\ssr.js
```

Using the Chrome devtools to take heap snapshots, we can see that the server webpack build `server-renderer.js` is being duplicated many times in the memory indicating there is a memory leak in the application. There are references (global and timers) hold on to the `server-renderer.js` string. Each copy is approximately 50MB. 

![Screenshot 2023-04-04 at 3 58 32 PM](https://user-images.githubusercontent.com/10948652/234961049-7d50e71a-1ab5-489e-bccc-61fde4bc3a7b.png)

After many trial and error attempts, the solution is to split the `server-renderer.js` build on local development to reduce the memory usage when webpack re-builds the application.

# Steps to reproduce

```sh
git clone https://github.com/SalesforceCommerceCloud/pwa-kit.git
cd pwa-kit
git checkout develop # before
git checkout v2-memory-leak-fix # after
npm ci

cd ./packages/template-retail-react-app
npm run start:inspect

# in a second terminal tab
# this script makes a change and triggers a webpack compile, every 2 seconds 
for n in {1..10000}; do echo "// $n" | tee -a app/constants.js; sleep 2; done;
```

Open Chrome Devtools and open the Memory tab, watch the memory heap size change in realtime.

![Screenshot 2023-04-27 at 11 52 04 AM](https://user-images.githubusercontent.com/10948652/234963507-3969f8b4-257d-4264-a01e-391ab41ca6b6.png)

# BEFORE & AFTER

While this change does not completely eliminate the memory leaks (nearly impossible to do given the complexity of the system), it significantly reduce the chance developers run into the issue since each re-build takes less space.

**BEFORE**

- 50~ saves to reach OOM error

**AFTER**

- 1000+ saves (still didn't hit OOM error) 🥳 


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)
