### PR TITLE
Add suffix to ssr build files

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -358,7 +358,7 @@ const renderer =
                     // We want to split the build on local development to reduce memory usage.
                     // It is required to have a single entry point for the remote server.
                     // See pwa-kit-runtime/ssr/server/build-remote-server.js render method.
-                    filename: mode === development ? '[name].js' : 'server-renderer.js',
+                    filename: mode === development ? '[name]-server.js' : 'server-renderer.js',
                     libraryTarget: 'commonjs2'
                 },
                 plugins: [


### PR DESCRIPTION
This PR is a follow up for https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1155.

There is a bug where the client side js filenames have name collisions with ssr js filenames.

An example is the main.js file, this file is being compiled by both client side build and SSR build.

<img width="980" alt="Screenshot 2023-04-28 at 10 43 49 AM" src="https://user-images.githubusercontent.com/10948652/235219199-1597d7ba-a939-43b1-a129-fce1fbcab428.png">

The solution is to add a suffix to SSR build files to avoid naming collision.