### PR TITLE
[V3] Remove `cross-fetch` from `template-retail-react-app`

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.8.0-dev (Mar 03, 2023)
+- Remove `cross-fetch` dependency [#1160](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1160)
 - Make `mergeBasket` conditional more robust [#1048](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1048)
 
 ## v2.7.0 (Mar 03, 2023)

--- a/packages/template-retail-react-app/app/hooks/use-einstein.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {useMemo, useState} from 'react'
-import fetch from 'cross-fetch'
 import {getConfig} from 'pwa-kit-runtime/utils/ssr-config'
 import {useCommerceApi, useAccessToken, useUsid, useEncUserId} from 'commerce-sdk-react-preview'
 import {keysToCamel} from '../utils/utils'

--- a/packages/template-retail-react-app/app/hooks/use-einstein.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.test.js
@@ -13,6 +13,7 @@ import {
     mockBasket,
     mockRecommenderDetails
 } from './einstein-mock-data'
+import fetchMock from 'jest-fetch-mock'
 
 const einsteinApi = new EinsteinAPI({
     host: `http://localhost/test-path`,
@@ -21,7 +22,6 @@ const einsteinApi = new EinsteinAPI({
     cookieId: 'test-usid'
 })
 
-const fetchMock = require('jest-fetch-mock')
 const fetchOriginal = global.fetch
 
 beforeAll(() => {
@@ -35,9 +35,8 @@ afterAll(() => {
 
 describe('EinsteinAPI', () => {
     test('viewProduct sends expected api request', async () => {
-        
         await einsteinApi.sendViewProduct(mockProduct)
-        
+
         expect(fetch).toHaveBeenCalledWith(
             'http://localhost/test-path/v3/activities/test-site-id/viewProduct',
             {

--- a/packages/template-retail-react-app/app/hooks/use-einstein.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.test.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import fetch from 'cross-fetch'
 import {EinsteinAPI} from './use-einstein'
 import {
     mockAddToCartProduct,
@@ -15,13 +14,6 @@ import {
     mockRecommenderDetails
 } from './einstein-mock-data'
 
-jest.mock('cross-fetch', () => {
-    return {
-        __esModule: true,
-        default: jest.fn(() => ({json: jest.fn(), ok: true}))
-    }
-})
-
 const einsteinApi = new EinsteinAPI({
     host: `http://localhost/test-path`,
     einsteinId: 'test-id',
@@ -29,14 +21,23 @@ const einsteinApi = new EinsteinAPI({
     cookieId: 'test-usid'
 })
 
-beforeEach(() => {
-    jest.resetModules()
-    fetch.mockClear()
+const fetchMock = require('jest-fetch-mock')
+const fetchOriginal = global.fetch
+
+beforeAll(() => {
+    global.fetch = fetchMock
+    global.fetch.mockResponse(JSON.stringify({}))
+})
+
+afterAll(() => {
+    global.fetch = fetchOriginal
 })
 
 describe('EinsteinAPI', () => {
     test('viewProduct sends expected api request', async () => {
+        
         await einsteinApi.sendViewProduct(mockProduct)
+        
         expect(fetch).toHaveBeenCalledWith(
             'http://localhost/test-path/v3/activities/test-site-id/viewProduct',
             {

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -196,9 +196,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
@@ -208,9 +208,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.0.tgz",
-      "integrity": "sha512-TDD4UJzos3JJtM+tHX+w2Uc+KWj7GV+VKKFdMVd2Rx8sdA19hcc3P3AHFYd5LVOw+pYuSd5lICC3gm52B6Rwxw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.5.tgz",
+      "integrity": "sha512-FRqFlFKNazWYykft5zvzuEl1YyTDGsIRrjV9rvxvYkUC7W/ueBng1X68Xd6uRMzAaJ0xMKn08/wem5YS1lpX8w==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.25.1",
@@ -221,12 +221,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
+      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-string-parser": "^7.21.5",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
@@ -1155,9 +1155,9 @@
       }
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
-      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.8.tgz",
+      "integrity": "sha512-gxNky50AJL3AlkbjvTARiwAqei6/tNUxDZPSKd+3jqWVM3AmdVTTdpjHorR/an/M0VJqdsuq5oGcFH+rjtyujQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -1170,20 +1170,20 @@
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.1.3"
+        "stylis": "4.1.4"
       }
     },
     "node_modules/@emotion/cache": {
-      "version": "11.10.7",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
-      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.8.tgz",
+      "integrity": "sha512-5fyqGHi51LU95o7qQ/vD1jyvC4uCY5GcBT+UgP4LHdpO9jPDlXqhrRr9/wCKmfoAvh5G/F7aOh4MwQa+8uEqhA==",
       "dev": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.1.3"
+        "stylis": "4.1.4"
       }
     },
     "node_modules/@emotion/hash": {
@@ -1208,14 +1208,14 @@
       "dev": true
     },
     "node_modules/@emotion/react": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
-      "integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.8.tgz",
+      "integrity": "sha512-ZfGfiABtJ1P1OXqOBsW08EgCDp5fK6C5I8hUJauc/VcJBGSzqAirMnFslhFWnZJ/w5HxPI36XbvMV0l4KZHl+w==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.6",
-        "@emotion/cache": "^11.10.5",
+        "@emotion/babel-plugin": "^11.10.8",
+        "@emotion/cache": "^11.10.8",
         "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0",
@@ -1251,13 +1251,13 @@
       "dev": true
     },
     "node_modules/@emotion/styled": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.6.tgz",
-      "integrity": "sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
+      "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/babel-plugin": "^11.10.8",
         "@emotion/is-prop-valid": "^1.2.0",
         "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
@@ -1301,9 +1301,9 @@
       "dev": true
     },
     "node_modules/@formatjs/cli": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.0.4.tgz",
-      "integrity": "sha512-ivb+uUcYmHnffBkXM7OM4NDofxyfnVvW5G52p+M9Cg3DGMz3wVBm3TwW3SXgGGTft7CMWHeGQGXjxTOwBYKeEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.1.0.tgz",
+      "integrity": "sha512-A05diK7zr8LEw4KFrtJfDhIa5PNHHcdM4wSEsgLqU/KqzcT4Jf6RhgU6RExe7UBpvKKl51Q/j2JpPRlretDXcQ==",
       "dev": true,
       "bin": {
         "formatjs": "bin/formatjs"
@@ -1468,12 +1468,12 @@
       }
     },
     "node_modules/@lhci/cli": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.11.0.tgz",
-      "integrity": "sha512-5P0yvctSuriCPvQbos8VThk2DsPG/9LHzI+c6DD1hSAXTdiQJB3GDbz6BO6J/5fCEofA5OGOgyAhGWCTaN7SnA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.11.1.tgz",
+      "integrity": "sha512-NDq7Cd6cfINLuI88FSQt+hZ1RSRyOi4TFOO9MVip4BHtSm+BG83sYRGMllUoBt12N6F+5UQte58A9sJz65EI1g==",
       "dev": true,
       "dependencies": {
-        "@lhci/utils": "0.11.0",
+        "@lhci/utils": "0.11.1",
         "chrome-launcher": "^0.13.4",
         "compression": "^1.7.4",
         "debug": "^4.3.1",
@@ -1494,9 +1494,9 @@
       }
     },
     "node_modules/@lhci/utils": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.11.0.tgz",
-      "integrity": "sha512-kG1a6X83GemLyU9UbxpcdQIikiT4SWJabpyB73C5Iz+6SwjcQXBY8+2VpLhFKtkU9o+FZyc826Ikj7tRHnd2cQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.11.1.tgz",
+      "integrity": "sha512-ABUp+AFLRdfQ3+nTDinGxZAz4afBMjEoC1g9GlL5b9Faa9eC90fcmv4uS5V+jcQWFMYjbYpsajHIJfI6r6OIjA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.1",
@@ -1815,9 +1815,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.1.tgz",
-      "integrity": "sha512-vkPewLEG8ua0efo3SsVT0BcBtkq5RZX8oPhDAyKL+k/rdOYSQTEocfGEXSaBwIwsXeOGBUpfKqI+UmHvNqdWXg==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.5.tgz",
+      "integrity": "sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==",
       "dev": true,
       "funding": {
         "type": "github",
@@ -1825,12 +1825,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.1.tgz",
-      "integrity": "sha512-/crv1v+OeuGG6EOvaQmyeo9GCKtH4jbmuhZkvk9ulufRiHcTr/A9+YP9GevEAZzUTdzXMwenpTbyxBGvG2xXvw==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.5.tgz",
+      "integrity": "sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==",
       "dev": true,
       "dependencies": {
-        "@tanstack/query-core": "4.29.1",
+        "@tanstack/query-core": "4.29.5",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -1852,9 +1852,9 @@
       }
     },
     "node_modules/@tanstack/react-query-devtools": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.1.tgz",
-      "integrity": "sha512-lbtNGArplXLVmY8eEh8LFqZz61PJI38sASEcuKoSnEK8UgWvLCwY5vjlT8fzk10yQ4jhR3+PHKLDMXA5ifCTXw==",
+      "version": "4.29.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.6.tgz",
+      "integrity": "sha512-qpYI41a69MWmrllcGiSE1KlpmnwJY/w0yKMnmp6VXn7nVy0i5TMMAT4u8D48F1Ipv/BKIDI1lqxPAvB4MqryBg==",
       "dev": true,
       "dependencies": {
         "@tanstack/match-sorter-utils": "^8.7.0",
@@ -1866,7 +1866,7 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "4.29.1",
+        "@tanstack/react-query": "4.29.5",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -2127,9 +2127,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
-      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -2175,9 +2175,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
     "node_modules/@types/lodash.mergewith": {
@@ -2196,9 +2196,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.2.tgz",
+      "integrity": "sha512-GQW/JL/5Fz/0I8RpeBG9lKp0+aNcXEaVL71c0D2Q0QHDTFvlYKT7an0onCUXj85anv7b4/WesqdfchLc0jtsCg==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -2214,9 +2214,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.57",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.57.tgz",
-      "integrity": "sha512-e4msYpu5QDxzNrXDHunU/VPyv2M1XemGG/p7kfCjUiPtlLDCWLGQfgAMng6YyisWYxZ09mYdQlmMnyS0NfZdEg==",
+      "version": "17.0.58",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
+      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -2225,9 +2225,9 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.1.tgz",
+      "integrity": "sha512-8QZEV9+Kwy7tXFmjJrp3XUKQSs9LTnE0KnoUb0YCguWBiNW0Yfb2iBMYZ08WPg35IR6P3Z0s00B15SwZnO26+w==",
       "dev": true,
       "dependencies": {
         "@types/react": "*"
@@ -2427,6 +2427,19 @@
       "dev": true,
       "dependencies": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array-flatten": {
@@ -3184,9 +3197,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.0.tgz",
-      "integrity": "sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.1.tgz",
+      "integrity": "sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -3364,16 +3377,17 @@
       }
     },
     "node_modules/deep-equal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
-      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.1.tgz",
+      "integrity": "sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==",
       "dev": true,
       "dependencies": {
+        "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
-        "es-get-iterator": "^1.1.2",
-        "get-intrinsic": "^1.1.3",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.1",
+        "is-array-buffer": "^3.0.2",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -3381,7 +3395,7 @@
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
+        "regexp.prototype.flags": "^1.5.0",
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
@@ -5170,12 +5184,12 @@
       "dev": true
     },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "dev": true,
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/js-levenshtein": {
@@ -5244,9 +5258,9 @@
       }
     },
     "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-      "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -5360,9 +5374,9 @@
       "dev": true
     },
     "node_modules/lighthouse/node_modules/chrome-launcher": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
-      "integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+      "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -5495,9 +5509,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -5999,9 +6013,9 @@
       }
     },
     "node_modules/msw/node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -6060,9 +6074,9 @@
       }
     },
     "node_modules/msw/node_modules/yargs": {
-      "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -7185,14 +7199,14 @@
       "dev": true
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7694,15 +7708,15 @@
       "dev": true
     },
     "node_modules/stylis": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
-      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.4.tgz",
+      "integrity": "sha512-USf5pszRYwuE6hg9by0OkKChkQYEXfkeTtm0xKw+jqQhwyjCVLdYyMBK7R+n7dhzsblAWJnGxju4vxq5eH20GQ==",
       "dev": true
     },
     "node_modules/superjson": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.2.tgz",
-      "integrity": "sha512-ugvUo9/WmvWOjstornQhsN/sR9mnGtWGYeTxFuqLb4AiT4QdUavjGFRALCPKWWnAiUJ4HTpytj5e0t5HoMRkXg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.3.tgz",
+      "integrity": "sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==",
       "dev": true,
       "dependencies": {
         "copy-anything": "^3.0.2"
@@ -8146,9 +8160,9 @@
       }
     },
     "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true
     },
     "node_modules/which-typed-array": {
@@ -8406,9 +8420,9 @@
       }
     },
     "@babel/helper-string-parser": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
-      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
@@ -8487,18 +8501,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
-      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.5.tgz",
+      "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.0.tgz",
-      "integrity": "sha512-TDD4UJzos3JJtM+tHX+w2Uc+KWj7GV+VKKFdMVd2Rx8sdA19hcc3P3AHFYd5LVOw+pYuSd5lICC3gm52B6Rwxw==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.21.5.tgz",
+      "integrity": "sha512-FRqFlFKNazWYykft5zvzuEl1YyTDGsIRrjV9rvxvYkUC7W/ueBng1X68Xd6uRMzAaJ0xMKn08/wem5YS1lpX8w==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.25.1",
@@ -8506,12 +8520,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.4.tgz",
-      "integrity": "sha512-rU2oY501qDxE8Pyo7i/Orqma4ziCOrby0/9mvbDUGEfvZjb279Nk9k19e2fiCxHbRRpY2ZyrgW1eq22mvmOIzA==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.21.5.tgz",
+      "integrity": "sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-string-parser": "^7.21.5",
         "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
@@ -9204,9 +9218,9 @@
       "dev": true
     },
     "@emotion/babel-plugin": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.6.tgz",
-      "integrity": "sha512-p2dAqtVrkhSa7xz1u/m9eHYdLi+en8NowrmXeF/dKtJpU8lCWli8RUAati7NcSl0afsBott48pdnANuD0wh9QQ==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.10.8.tgz",
+      "integrity": "sha512-gxNky50AJL3AlkbjvTARiwAqei6/tNUxDZPSKd+3jqWVM3AmdVTTdpjHorR/an/M0VJqdsuq5oGcFH+rjtyujQ==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.16.7",
@@ -9219,20 +9233,20 @@
         "escape-string-regexp": "^4.0.0",
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
-        "stylis": "4.1.3"
+        "stylis": "4.1.4"
       }
     },
     "@emotion/cache": {
-      "version": "11.10.7",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.7.tgz",
-      "integrity": "sha512-VLl1/2D6LOjH57Y8Vem1RoZ9haWF4jesHDGiHtKozDQuBIkJm2gimVo0I02sWCuzZtVACeixTVB4jeE8qvCBoQ==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.10.8.tgz",
+      "integrity": "sha512-5fyqGHi51LU95o7qQ/vD1jyvC4uCY5GcBT+UgP4LHdpO9jPDlXqhrRr9/wCKmfoAvh5G/F7aOh4MwQa+8uEqhA==",
       "dev": true,
       "requires": {
         "@emotion/memoize": "^0.8.0",
         "@emotion/sheet": "^1.2.1",
         "@emotion/utils": "^1.2.0",
         "@emotion/weak-memoize": "^0.3.0",
-        "stylis": "4.1.3"
+        "stylis": "4.1.4"
       }
     },
     "@emotion/hash": {
@@ -9257,14 +9271,14 @@
       "dev": true
     },
     "@emotion/react": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.6.tgz",
-      "integrity": "sha512-6HT8jBmcSkfzO7mc+N1L9uwvOnlcGoix8Zn7srt+9ga0MjREo6lRpuVX0kzo6Jp6oTqDhREOFsygN6Ew4fEQbw==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.10.8.tgz",
+      "integrity": "sha512-ZfGfiABtJ1P1OXqOBsW08EgCDp5fK6C5I8hUJauc/VcJBGSzqAirMnFslhFWnZJ/w5HxPI36XbvMV0l4KZHl+w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.6",
-        "@emotion/cache": "^11.10.5",
+        "@emotion/babel-plugin": "^11.10.8",
+        "@emotion/cache": "^11.10.8",
         "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
         "@emotion/utils": "^1.2.0",
@@ -9292,13 +9306,13 @@
       "dev": true
     },
     "@emotion/styled": {
-      "version": "11.10.6",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.6.tgz",
-      "integrity": "sha512-OXtBzOmDSJo5Q0AFemHCfl+bUueT8BIcPSxu0EGTpGk6DmI5dnhSzQANm1e1ze0YZL7TDyAyy6s/b/zmGOS3Og==",
+      "version": "11.10.8",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.10.8.tgz",
+      "integrity": "sha512-gow0lF4Uw/QEdX2REMhI8v6wLOabPKJ+4HKNF0xdJ2DJdznN6fxaXpQOx6sNkyBhSUL558Rmcu1Lq/MYlVo4vw==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.18.3",
-        "@emotion/babel-plugin": "^11.10.6",
+        "@emotion/babel-plugin": "^11.10.8",
         "@emotion/is-prop-valid": "^1.2.0",
         "@emotion/serialize": "^1.1.1",
         "@emotion/use-insertion-effect-with-fallbacks": "^1.0.0",
@@ -9331,9 +9345,9 @@
       "dev": true
     },
     "@formatjs/cli": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.0.4.tgz",
-      "integrity": "sha512-ivb+uUcYmHnffBkXM7OM4NDofxyfnVvW5G52p+M9Cg3DGMz3wVBm3TwW3SXgGGTft7CMWHeGQGXjxTOwBYKeEA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/cli/-/cli-6.1.0.tgz",
+      "integrity": "sha512-A05diK7zr8LEw4KFrtJfDhIa5PNHHcdM4wSEsgLqU/KqzcT4Jf6RhgU6RExe7UBpvKKl51Q/j2JpPRlretDXcQ==",
       "dev": true,
       "requires": {}
     },
@@ -9470,12 +9484,12 @@
       }
     },
     "@lhci/cli": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.11.0.tgz",
-      "integrity": "sha512-5P0yvctSuriCPvQbos8VThk2DsPG/9LHzI+c6DD1hSAXTdiQJB3GDbz6BO6J/5fCEofA5OGOgyAhGWCTaN7SnA==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.11.1.tgz",
+      "integrity": "sha512-NDq7Cd6cfINLuI88FSQt+hZ1RSRyOi4TFOO9MVip4BHtSm+BG83sYRGMllUoBt12N6F+5UQte58A9sJz65EI1g==",
       "dev": true,
       "requires": {
-        "@lhci/utils": "0.11.0",
+        "@lhci/utils": "0.11.1",
         "chrome-launcher": "^0.13.4",
         "compression": "^1.7.4",
         "debug": "^4.3.1",
@@ -9493,9 +9507,9 @@
       }
     },
     "@lhci/utils": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.11.0.tgz",
-      "integrity": "sha512-kG1a6X83GemLyU9UbxpcdQIikiT4SWJabpyB73C5Iz+6SwjcQXBY8+2VpLhFKtkU9o+FZyc826Ikj7tRHnd2cQ==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@lhci/utils/-/utils-0.11.1.tgz",
+      "integrity": "sha512-ABUp+AFLRdfQ3+nTDinGxZAz4afBMjEoC1g9GlL5b9Faa9eC90fcmv4uS5V+jcQWFMYjbYpsajHIJfI6r6OIjA==",
       "dev": true,
       "requires": {
         "debug": "^4.3.1",
@@ -9760,25 +9774,25 @@
       }
     },
     "@tanstack/query-core": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.1.tgz",
-      "integrity": "sha512-vkPewLEG8ua0efo3SsVT0BcBtkq5RZX8oPhDAyKL+k/rdOYSQTEocfGEXSaBwIwsXeOGBUpfKqI+UmHvNqdWXg==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.5.tgz",
+      "integrity": "sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==",
       "dev": true
     },
     "@tanstack/react-query": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.1.tgz",
-      "integrity": "sha512-/crv1v+OeuGG6EOvaQmyeo9GCKtH4jbmuhZkvk9ulufRiHcTr/A9+YP9GevEAZzUTdzXMwenpTbyxBGvG2xXvw==",
+      "version": "4.29.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.5.tgz",
+      "integrity": "sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==",
       "dev": true,
       "requires": {
-        "@tanstack/query-core": "4.29.1",
+        "@tanstack/query-core": "4.29.5",
         "use-sync-external-store": "^1.2.0"
       }
     },
     "@tanstack/react-query-devtools": {
-      "version": "4.29.1",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.1.tgz",
-      "integrity": "sha512-lbtNGArplXLVmY8eEh8LFqZz61PJI38sASEcuKoSnEK8UgWvLCwY5vjlT8fzk10yQ4jhR3+PHKLDMXA5ifCTXw==",
+      "version": "4.29.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-4.29.6.tgz",
+      "integrity": "sha512-qpYI41a69MWmrllcGiSE1KlpmnwJY/w0yKMnmp6VXn7nVy0i5TMMAT4u8D48F1Ipv/BKIDI1lqxPAvB4MqryBg==",
       "dev": true,
       "requires": {
         "@tanstack/match-sorter-utils": "^8.7.0",
@@ -9993,9 +10007,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
-      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
+      "version": "29.5.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.1.tgz",
+      "integrity": "sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",
@@ -10034,9 +10048,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.192",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.192.tgz",
-      "integrity": "sha512-km+Vyn3BYm5ytMO13k9KTp27O75rbQ0NFw+U//g+PX7VZyjCioXaRFisqSIJRECljcTv73G3i6BpglNGHgUQ5A==",
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
       "dev": true
     },
     "@types/lodash.mergewith": {
@@ -10055,9 +10069,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.2.tgz",
+      "integrity": "sha512-GQW/JL/5Fz/0I8RpeBG9lKp0+aNcXEaVL71c0D2Q0QHDTFvlYKT7an0onCUXj85anv7b4/WesqdfchLc0jtsCg==",
       "dev": true
     },
     "@types/parse-json": {
@@ -10073,9 +10087,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.57",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.57.tgz",
-      "integrity": "sha512-e4msYpu5QDxzNrXDHunU/VPyv2M1XemGG/p7kfCjUiPtlLDCWLGQfgAMng6YyisWYxZ09mYdQlmMnyS0NfZdEg==",
+      "version": "17.0.58",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.58.tgz",
+      "integrity": "sha512-c1GzVY97P0fGxwGxhYq989j4XwlcHQoto6wQISOC2v6wm3h0PORRWJFHlkRjfGsiG3y1609WdQ+J+tKxvrEd6A==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -10084,9 +10098,9 @@
       }
     },
     "@types/react-dom": {
-      "version": "18.0.11",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz",
-      "integrity": "sha512-O38bPbI2CWtgw/OoQoY+BRelw7uysmXbWvw3nLWO21H1HSh+GOlqPuXshJfjmpNlKiiSDG9cc1JZAaMmVdcTlw==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.1.tgz",
+      "integrity": "sha512-8QZEV9+Kwy7tXFmjJrp3XUKQSs9LTnE0KnoUb0YCguWBiNW0Yfb2iBMYZ08WPg35IR6P3Z0s00B15SwZnO26+w==",
       "dev": true,
       "requires": {
         "@types/react": "*"
@@ -10256,6 +10270,16 @@
       "dev": true,
       "requires": {
         "deep-equal": "^2.0.5"
+      }
+    },
+    "array-buffer-byte-length": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
+      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "is-array-buffer": "^3.0.1"
       }
     },
     "array-flatten": {
@@ -10831,9 +10855,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.0.tgz",
-      "integrity": "sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==",
+      "version": "3.30.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.30.1.tgz",
+      "integrity": "sha512-nXBEVpmUnNRhz83cHd9JRQC52cTMcuXAmR56+9dSMpRdpeA4I1PX6yjmhd71Eyc/wXNsdBdUDIj1QTIeZpU5Tg==",
       "dev": true
     },
     "cosmiconfig": {
@@ -10967,16 +10991,17 @@
       "dev": true
     },
     "deep-equal": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.0.tgz",
-      "integrity": "sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.1.tgz",
+      "integrity": "sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==",
       "dev": true,
       "requires": {
+        "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
-        "es-get-iterator": "^1.1.2",
-        "get-intrinsic": "^1.1.3",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.1",
+        "is-array-buffer": "^3.0.2",
         "is-date-object": "^1.0.5",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
@@ -10984,7 +11009,7 @@
         "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.4.3",
+        "regexp.prototype.flags": "^1.5.0",
         "side-channel": "^1.0.4",
         "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
@@ -12349,9 +12374,9 @@
       "dev": true
     },
     "js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
       "dev": true
     },
     "js-levenshtein": {
@@ -12407,9 +12432,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-          "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+          "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12480,9 +12505,9 @@
       },
       "dependencies": {
         "chrome-launcher": {
-          "version": "0.15.1",
-          "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.1.tgz",
-          "integrity": "sha512-UugC8u59/w2AyX5sHLZUHoxBAiSiunUhZa3zZwMH6zPVis0C3dDKiRWyUGIo14tTbZHGVviWxv3PQWZ7taZ4fg==",
+          "version": "0.15.2",
+          "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
+          "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -12582,9 +12607,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -12989,9 +13014,9 @@
           }
         },
         "rxjs": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-          "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+          "version": "7.8.1",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+          "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
           "dev": true,
           "requires": {
             "tslib": "^2.1.0"
@@ -13035,9 +13060,9 @@
           "dev": true
         },
         "yargs": {
-          "version": "17.7.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
             "cliui": "^8.0.1",
@@ -13872,14 +13897,14 @@
       "dev": true
     },
     "regexp.prototype.flags": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
-      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+      "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "functions-have-names": "^1.2.2"
+        "define-properties": "^1.2.0",
+        "functions-have-names": "^1.2.3"
       }
     },
     "remove-accents": {
@@ -14281,15 +14306,15 @@
       }
     },
     "stylis": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.3.tgz",
-      "integrity": "sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.1.4.tgz",
+      "integrity": "sha512-USf5pszRYwuE6hg9by0OkKChkQYEXfkeTtm0xKw+jqQhwyjCVLdYyMBK7R+n7dhzsblAWJnGxju4vxq5eH20GQ==",
       "dev": true
     },
     "superjson": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.2.tgz",
-      "integrity": "sha512-ugvUo9/WmvWOjstornQhsN/sR9mnGtWGYeTxFuqLb4AiT4QdUavjGFRALCPKWWnAiUJ4HTpytj5e0t5HoMRkXg==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-1.12.3.tgz",
+      "integrity": "sha512-0j+U70KUtP8+roVPbwfqkyQI7lBt7ETnuA7KXbTDX3mCKiD/4fXs2ldKSMdt0MCfpTwiMxo20yFU3vu6ewETpQ==",
       "dev": true,
       "requires": {
         "copy-anything": "^3.0.2"
@@ -14641,9 +14666,9 @@
       }
     },
     "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true
     },
     "which-typed-array": {

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -51,7 +51,6 @@
     "card-validator": "^8.1.1",
     "commerce-sdk-react-preview": "^2.8.0-dev",
     "cross-env": "^5.2.1",
-    "cross-fetch": "^3.1.5",
     "focus-visible": "^5.2.0",
     "framer-motion": "^3.10.6",
     "full-icu": "^1.5.0",


### PR DESCRIPTION
# Description

We recently removed the `commerce-api` client code from the template, leaving behind the einstein implementation. Because einstein is only ever used on the client we don't need to use `cross-fetch`, so we are removing it in this PR.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Remove `cross-fetch` from useEinstein hook
- Fix tests to mock global fetch.
- Remove dep in package.json and re-lock

# How to Test-Drive This PR

- Run tests, they should pass.
- Preview the template and navigate from page to page, you should see fetch logs for `viewCategory` `viewProduct` etc. This means things are still working.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
