### PR TITLE
Use native fetch for einstein

### DIFF
--- a/packages/template-retail-react-app/app/hooks/use-einstein.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {useMemo, useState} from 'react'
-import fetch from 'cross-fetch'
 import {getConfig} from 'pwa-kit-runtime/utils/ssr-config'
 import {useCommerceApi, useAccessToken, useUsid, useEncUserId} from 'commerce-sdk-react-preview'
 import {keysToCamel} from '../utils/utils'

--- a/packages/template-retail-react-app/app/hooks/use-einstein.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.test.js
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import fetch from 'cross-fetch'
 import {EinsteinAPI} from './use-einstein'
 import {
     mockAddToCartProduct,
@@ -15,13 +14,6 @@ import {
     mockRecommenderDetails
 } from './einstein-mock-data'
 
-jest.mock('cross-fetch', () => {
-    return {
-        __esModule: true,
-        default: jest.fn(() => ({json: jest.fn(), ok: true}))
-    }
-})
-
 const einsteinApi = new EinsteinAPI({
     host: `http://localhost/test-path`,
     einsteinId: 'test-id',
@@ -31,10 +23,24 @@ const einsteinApi = new EinsteinAPI({
 
 beforeEach(() => {
     jest.resetModules()
-    fetch.mockClear()
 })
 
 describe('EinsteinAPI', () => {
+    let originalFetch
+
+    beforeEach(() => {
+        originalFetch = global.fetch
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: jest.fn(),
+                ok: true
+            })
+        )
+    })
+
+    afterEach(() => {
+        global.fetch = originalFetch
+    })
     test('viewProduct sends expected api request', async () => {
         await einsteinApi.sendViewProduct(mockProduct)
         expect(fetch).toHaveBeenCalledWith(


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
Since we only call Einstein on client side, there is no need to use cross-fetch for einstein. We can use native fetch 

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
