### PR TITLE
Added session bridge call to login for phased launch

### DIFF
--- a/packages/template-retail-react-app/app/commerce-api/auth.js
+++ b/packages/template-retail-react-app/app/commerce-api/auth.js
@@ -190,6 +190,31 @@ class Auth {
     }
 
     /**
+     * Make a post request to the OCAPI /session endpoint to bridge the session.
+     *
+     * The HTTP response contains a set-cookie header which sets the dwsid session cookie.
+     * This cookie is used on SFRA, and it allows shoppers to navigate between SFRA and
+     * this PWA site seamlessly; this is often used to enable hybrid deployment.
+     *
+     * (Note: this method is client side only, b/c MRT doesn't support set-cookie header right now)
+     *
+     * @returns {Promise}
+     */
+    createOCAPISession() {
+        return fetch(
+            `${getAppOrigin()}/mobify/proxy/ocapi/s/${
+                this._config.parameters.siteId
+            }/dw/shop/v22_8/sessions`,
+            {
+                method: 'POST',
+                headers: {
+                    Authorization: this.authToken
+                }
+            }
+        )
+    }
+
+    /**
      * Authorizes the customer as a registered or guest user.
      * @param {CustomerCredentials} [credentials]
      * @returns {Promise}
@@ -210,15 +235,21 @@ class Auth {
             } else if (this.refreshToken) {
                 authorizationMethod = '_refreshAccessToken'
             }
-            return this[authorizationMethod](credentials).catch((error) => {
-                const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
-                if (retries === 0 && retryErrors.includes(error.message)) {
-                    retries = 1 // we only retry once
-                    this._clearAuth()
-                    return startLoginFlow()
-                }
-                throw error
-            })
+            return this[authorizationMethod](credentials)
+                .then((result) => {
+                    // Uncomment the following line for phased launch
+                    // this._onClient && this.createOCAPISession()
+                    return result
+                })
+                .catch((error) => {
+                    const retryErrors = [INVALID_TOKEN, EXPIRED_TOKEN]
+                    if (retries === 0 && retryErrors.includes(error.message)) {
+                        retries = 1 // we only retry once
+                        this._clearAuth()
+                        return startLoginFlow()
+                    }
+                    throw error
+                })
         }
 
         this._pendingLogin = startLoginFlow().finally(() => {


### PR DESCRIPTION
In phased launch environments, the PWA needs a way to update the plugin_SLAS / SFRA login state.

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes
- Added `createOCAPISession()` function to `commerce-api/auth.js` in `template-retail-react-app`
- The call to the function is intentionally commented out. It needs to be executed for phased launch deployments only.
