### PR TITLE
Snyk dependency updates for V3

### DIFF
--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -10,9 +10,9 @@
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@loadable/babel-plugin": "^5.15.3",
-        "aws-sdk": "^2.1340.0",
+        "aws-sdk": "^2.1354.0",
         "aws-serverless-express": "3.4.0",
-        "cosmiconfig": "^8.0.0",
+        "cosmiconfig": "^8.1.3",
         "cross-env": "^5.2.1",
         "express": "^4.18.2",
         "header-case": "1.0.1",

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -31,9 +31,9 @@
   },
   "dependencies": {
     "@loadable/babel-plugin": "^5.15.3",
-    "aws-sdk": "^2.1340.0",
+    "aws-sdk": "^2.1354.0",
     "aws-serverless-express": "3.4.0",
-    "cosmiconfig": "^8.0.0",
+    "cosmiconfig": "^8.1.3",
     "cross-env": "^5.2.1",
     "express": "^4.18.2",
     "header-case": "1.0.1",


### PR DESCRIPTION
This PR applies the Snyk changes applied from #1169 onto our `v3` branch

The original Snyk PRs this PR is based off are:
https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1152
https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1151
https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1145
