### PR TITLE
[Hybrid] PWA Kit should have a mechanism for replacing the access token when a SFRA login state is changed

### DIFF
--- a/packages/template-retail-react-app/app/commerce-api/auth.js
+++ b/packages/template-retail-react-app/app/commerce-api/auth.js
@@ -164,9 +164,7 @@ class Auth {
             })
             this._storage.delete(refreshTokenGuestStorageKey)
 
-            this._storageCopy.set(refreshTokenRegisteredStorageKey, token, {
-                expires: REFRESH_TOKEN_COOKIE_AGE
-            })
+            this._storageCopy.set(refreshTokenRegisteredStorageKey, token)
             this._storageCopy.delete(refreshTokenGuestStorageKey)
             return
         }
@@ -174,9 +172,7 @@ class Auth {
         this._storage.set(refreshTokenGuestStorageKey, token, {expires: REFRESH_TOKEN_COOKIE_AGE})
         this._storage.delete(refreshTokenRegisteredStorageKey)
 
-        this._storageCopy.set(refreshTokenGuestStorageKey, token, {
-            expires: REFRESH_TOKEN_COOKIE_AGE
-        })
+        this._storageCopy.set(refreshTokenGuestStorageKey, token)
         this._storageCopy.delete(refreshTokenRegisteredStorageKey)
     }
 

--- a/packages/template-retail-react-app/app/commerce-api/auth.js
+++ b/packages/template-retail-react-app/app/commerce-api/auth.js
@@ -9,7 +9,7 @@
 import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
 import {HTTPError} from 'pwa-kit-react-sdk/ssr/universal/errors'
 import {createCodeVerifier, generateCodeChallenge} from './pkce'
-import {isTokenValid, createGetTokenBody, hasSFRAAuthStateChanged} from './utils'
+import {isTokenExpired, createGetTokenBody, hasSFRAAuthStateChanged} from './utils'
 import {
     usidStorageKey,
     cidStorageKey,
@@ -142,7 +142,7 @@ class Auth {
 
     get isTokenValid() {
         return (
-            isTokenValid(this.authToken) &&
+            !isTokenExpired(this.authToken) &&
             !hasSFRAAuthStateChanged(this._storage, this._storageCopy)
         )
     }

--- a/packages/template-retail-react-app/app/commerce-api/constants.js
+++ b/packages/template-retail-react-app/app/commerce-api/constants.js
@@ -1,0 +1,11 @@
+export const usidStorageKey = 'usid'
+export const cidStorageKey = 'cid'
+export const encUserIdStorageKey = 'enc-user-id'
+export const tokenStorageKey = 'token'
+export const refreshTokenRegisteredStorageKey = 'cc-nx'
+export const refreshTokenGuestStorageKey = 'cc-nx-g'
+export const oidStorageKey = 'oid'
+export const dwSessionIdKey = 'dwsid'
+export const REFRESH_TOKEN_COOKIE_AGE = 90 // 90 days. This value matches SLAS cartridge.
+export const EXPIRED_TOKEN = 'EXPIRED_TOKEN'
+export const INVALID_TOKEN = 'invalid refresh_token'

--- a/packages/template-retail-react-app/app/commerce-api/constants.js
+++ b/packages/template-retail-react-app/app/commerce-api/constants.js
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 export const usidStorageKey = 'usid'
 export const cidStorageKey = 'cid'
 export const encUserIdStorageKey = 'enc-user-id'

--- a/packages/template-retail-react-app/app/commerce-api/index.js
+++ b/packages/template-retail-react-app/app/commerce-api/index.js
@@ -10,7 +10,7 @@ import * as sdk from 'commerce-sdk-isomorphic'
 import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
 import ShopperBaskets from './shopper-baskets'
 import OcapiShopperOrders from './ocapi-shopper-orders'
-import {getTenantId, isError, isTokenValid} from './utils'
+import {getTenantId, isError} from './utils'
 import Auth from './auth'
 import EinsteinAPI from './einstein'
 

--- a/packages/template-retail-react-app/app/commerce-api/index.js
+++ b/packages/template-retail-react-app/app/commerce-api/index.js
@@ -199,7 +199,7 @@ class CommerceAPI {
         // If the token is invalid (missing, past/nearing expiration), we issue
         //  a login call, which will attempt to refresh the token or get a new
         //  guest token. Once login is complete, we can proceed.
-        if (!isTokenValid(this.auth.authToken)) {
+        if (!this.auth.isTokenValid) {
             // NOTE: Login will update `this.auth.authToken` with a fresh token
             await this.auth.login()
         }

--- a/packages/template-retail-react-app/app/commerce-api/index.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/index.test.js
@@ -232,7 +232,7 @@ describe('CommerceAPI', () => {
     })
     test('Use same customer if token is valid', async () => {
         const Utils = require('./utils')
-        jest.spyOn(Utils, 'isTokenValid').mockReturnValue(true)
+        jest.spyOn(Utils, 'isTokenExpired').mockReturnValue(false)
         const _CommerceAPI = require('./index').default
         const api = new _CommerceAPI(apiConfig)
 

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -292,8 +292,8 @@ export function hasSFRAAuthStateChanged(storage, storageCopy) {
         (storageCopy.get(refreshTokenGuestStorageKey) && refreshTokenGuestStorageKey) ||
         (storageCopy.get(refreshTokenRegisteredStorageKey) && refreshTokenRegisteredStorageKey)
 
-    if(refreshTokenKey !== refreshTokenCopyKey) {
-        return true;
+    if (refreshTokenKey !== refreshTokenCopyKey) {
+        return true
     }
 
     return storage.get(refreshTokenKey) !== storageCopy.get(refreshTokenCopyKey)

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -277,9 +277,9 @@ export const noop = () => {}
  * WARNING: This function is relevant to be used in Hybrid deployments only.
  * Compares the refresh_token keys for guest(cc-nx-g) and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit
  * to determine if the login state of the shopper on SFRA site has changed.
- * @param {*} storage Cookie storage on PWA Kit in hybrid deployment.
- * @param {*} storageCopy Local storage holding the copy of the refresh_token in hybrid deployment.
- * @returns true if the keys do not match (login state changed), false otherwise.
+ * @param {Storage} storage Cookie storage on PWA Kit in hybrid deployment.
+ * @param {LocalStorage} storageCopy Local storage holding the copy of the refresh_token in hybrid deployment.
+ * @returns {boolean} true if the keys do not match (login state changed), false otherwise.
  */
 export function hasSFRAAuthStateChanged(storage, storageCopy) {
     let refreshTokenKey =

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -7,6 +7,7 @@
 import jwtDecode from 'jwt-decode'
 import {getAppOrigin} from 'pwa-kit-react-sdk/utils/url'
 import {HTTPError} from 'pwa-kit-react-sdk/ssr/universal/errors'
+import {refreshTokenGuestStorageKey, refreshTokenRegisteredStorageKey} from './constants'
 import fetch from 'cross-fetch'
 
 /**
@@ -271,3 +272,24 @@ export const convertSnakeCaseToSentenceCase = (text) => {
  * Usually used as default for event handlers.
  */
 export const noop = () => {}
+
+
+/**
+ * WARNING: This function is relevant to be used in Hybrid deployments only.
+ * Compares the refresh_token keys for guest(cc-nx-g) and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit
+ * to determine if the login state of the shopper on SFRA site has changed.
+ * @param {*} storage Cookie storage on PWA Kit in hybrid deployment.
+ * @param {*} storageCopy Local storage holding the copy of the refresh_token in hybrid deployment.
+ * @returns true if the keys do not match (login state changed), false otherwise.
+ */
+export function hasSFRAAuthStateChanged(storage, storageCopy) {
+    let refreshTokenKey =
+        (storage.get(refreshTokenGuestStorageKey) && refreshTokenGuestStorageKey) ||
+        (storage.get(refreshTokenRegisteredStorageKey) && refreshTokenRegisteredStorageKey)
+
+    let refreshTokenCopyKey =
+        (storageCopy.get(refreshTokenGuestStorageKey) && refreshTokenGuestStorageKey) ||
+        (storageCopy.get(refreshTokenRegisteredStorageKey) && refreshTokenRegisteredStorageKey)
+
+    return refreshTokenKey !== refreshTokenCopyKey
+}

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -17,18 +17,18 @@ import fetch from 'cross-fetch'
  * @param {string} token - The JWT bearer token to be inspected
  * @returns {boolean}
  */
-export function isTokenValid(token) {
+export function isTokenExpired(token) {
     if (!token) {
-        return false
+        return true
     }
     const {exp, iat} = jwtDecode(token.replace('Bearer ', ''))
     const validTimeSeconds = exp - iat - 60
     const tokenAgeSeconds = Date.now() / 1000 - iat
     if (validTimeSeconds > tokenAgeSeconds) {
-        return true
+        return false
     }
 
-    return false
+    return true
 }
 
 // Returns fomrulated body for SopperLogin getToken endpoint

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -275,7 +275,7 @@ export const noop = () => {}
 
 /**
  * WARNING: This function is relevant to be used in Hybrid deployments only.
- * Compares the refresh_token keys for guest(cc-nx-g) and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit
+ * Compares the refresh_token keys for guest('cc-nx-g') and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit
  * to determine if the login state of the shopper on SFRA site has changed.
  * @param {Storage} storage Cookie storage on PWA Kit in hybrid deployment.
  * @param {LocalStorage} storageCopy Local storage holding the copy of the refresh_token in hybrid deployment.

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -273,7 +273,6 @@ export const convertSnakeCaseToSentenceCase = (text) => {
  */
 export const noop = () => {}
 
-
 /**
  * WARNING: This function is relevant to be used in Hybrid deployments only.
  * Compares the refresh_token keys for guest(cc-nx-g) and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit

--- a/packages/template-retail-react-app/app/commerce-api/utils.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.js
@@ -276,7 +276,9 @@ export const noop = () => {}
 /**
  * WARNING: This function is relevant to be used in Hybrid deployments only.
  * Compares the refresh_token keys for guest('cc-nx-g') and registered('cc-nx') login from the cookie received from SFRA with the copy stored in localstorage on PWA Kit
- * to determine if the login state of the shopper on SFRA site has changed.
+ * to determine if the login state of the shopper on SFRA site has changed. If the keys are different we return true considering the login state did change. If the keys are same,
+ * we compare the values of the refresh_token to cover an edge case where the login state might have changed multiple times on SFRA and the eventual refresh_token key might be same
+ * as that on PWA Kit which would incorrectly show both keys to be the same even though the sessions are different.
  * @param {Storage} storage Cookie storage on PWA Kit in hybrid deployment.
  * @param {LocalStorage} storageCopy Local storage holding the copy of the refresh_token in hybrid deployment.
  * @returns {boolean} true if the keys do not match (login state changed), false otherwise.
@@ -290,5 +292,9 @@ export function hasSFRAAuthStateChanged(storage, storageCopy) {
         (storageCopy.get(refreshTokenGuestStorageKey) && refreshTokenGuestStorageKey) ||
         (storageCopy.get(refreshTokenRegisteredStorageKey) && refreshTokenRegisteredStorageKey)
 
-    return refreshTokenKey !== refreshTokenCopyKey
+    if(refreshTokenKey !== refreshTokenCopyKey) {
+        return true;
+    }
+
+    return storage.get(refreshTokenKey) !== storageCopy.get(refreshTokenCopyKey)
 }

--- a/packages/template-retail-react-app/app/commerce-api/utils.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.test.js
@@ -7,7 +7,7 @@
 import jwt from 'njwt'
 import {
     camelCaseKeysToUnderscore,
-    isTokenValid,
+    isTokenExpired,
     keysToCamel,
     convertSnakeCaseToSentenceCase,
     handleAsyncError,
@@ -27,20 +27,20 @@ jest.mock('./utils', () => {
     }
 })
 
-describe('isTokenValid', () => {
-    test('returns false when no token given', () => {
-        expect(isTokenValid()).toBe(false)
+describe('isTokenExpired', () => {
+    test('returns true when no token given', () => {
+        expect(isTokenExpired()).toBe(true)
     })
 
-    test('returns true for valid token', () => {
+    test('returns false for valid token', () => {
         const token = createJwt(600)
         const bearerToken = `Bearer ${token}`
-        expect(isTokenValid(token)).toBe(true)
-        expect(isTokenValid(bearerToken)).toBe(true)
+        expect(isTokenExpired(token)).toBe(false)
+        expect(isTokenExpired(bearerToken)).toBe(false)
     })
 
-    test('returns false if token expires within 60 econds', () => {
-        expect(isTokenValid(createJwt(59))).toBe(false)
+    test('returns true if token expires within 60 econds', () => {
+        expect(isTokenExpired(createJwt(59))).toBe(true)
     })
 })
 

--- a/packages/template-retail-react-app/app/commerce-api/utils.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.test.js
@@ -256,13 +256,22 @@ describe('hasSFRAAuthStateChanged', () => {
 
         expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(true)
     })
-    test('returns false when refresh_token keys are the same', () => {
+    test('returns false when refresh_token keys and values are the same', () => {
+        const storage = new Map()
+        const storageCopy = new Map()
+
+        storage.set('cc-nx', 'testRefreshToken1')
+        storageCopy.set('cc-nx', 'testRefreshToken1')
+
+        expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(false)
+    })
+    test('returns true when refresh_token keys are same but values are the different', () => {
         const storage = new Map()
         const storageCopy = new Map()
 
         storage.set('cc-nx-g', 'testRefreshToken1')
         storageCopy.set('cc-nx-g', 'testRefreshToken2')
 
-        expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(false)
+        expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(true)
     })
 })

--- a/packages/template-retail-react-app/app/commerce-api/utils.test.js
+++ b/packages/template-retail-react-app/app/commerce-api/utils.test.js
@@ -10,7 +10,8 @@ import {
     isTokenValid,
     keysToCamel,
     convertSnakeCaseToSentenceCase,
-    handleAsyncError
+    handleAsyncError,
+    hasSFRAAuthStateChanged
 } from './utils'
 
 const createJwt = (secondsToExp) => {
@@ -242,5 +243,26 @@ describe('handleAsyncError', () => {
     test('works even if func is not async', async () => {
         const func = jest.fn().mockReturnValue(1)
         expect(await handleAsyncError(func)()).toBe(1)
+    })
+})
+
+describe('hasSFRAAuthStateChanged', () => {
+    test('returns true when refresh_token keys are different', () => {
+        const storage = new Map()
+        const storageCopy = new Map()
+
+        storage.set('cc-nx-g', 'testRefreshToken1')
+        storageCopy.set('cc-nx', 'testRefreshToken2')
+
+        expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(true)
+    })
+    test('returns false when refresh_token keys are the same', () => {
+        const storage = new Map()
+        const storageCopy = new Map()
+
+        storage.set('cc-nx-g', 'testRefreshToken1')
+        storageCopy.set('cc-nx-g', 'testRefreshToken2')
+
+        expect(hasSFRAAuthStateChanged(storage, storageCopy)).toBe(false)
     })
 })

--- a/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
@@ -139,10 +139,13 @@ test('Allows customer to sign in to their account', async () => {
     user.click(screen.getByText(/sign in/i))
 
     // wait for successful toast to appear
-    await waitFor(() => {
-        expect(screen.getByText(/Welcome Tester/i)).toBeInTheDocument()
-        expect(screen.getByText(/you're now signed in/i)).toBeInTheDocument()
-    }, {timeout: 20000})
+    await waitFor(
+        () => {
+            expect(screen.getByText(/Welcome Tester/i)).toBeInTheDocument()
+            expect(screen.getByText(/you're now signed in/i)).toBeInTheDocument()
+        },
+        {timeout: 20000}
+    )
 })
 
 test('Renders error when given incorrect log in credentials', async () => {
@@ -235,7 +238,10 @@ test('Allows customer to create an account', async () => {
     user.paste(withinForm.getAllByLabelText(/password/i)[0], 'Password!1')
     user.click(withinForm.getByText(/create account/i))
 
-    await waitFor(() => {
-        expect(screen.getAllByText(/customer@test.com/i).length).toEqual(1)
-    }, {timeout: 20000})
+    await waitFor(
+        () => {
+            expect(screen.getAllByText(/customer@test.com/i).length).toEqual(1)
+        },
+        {timeout: 20000}
+    )
 })

--- a/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
@@ -38,7 +38,8 @@ const mockLogin = jest.fn()
 jest.mock('../commerce-api/auth', () => {
     return jest.fn().mockImplementation(() => {
         return {
-            login: mockLogin
+            login: mockLogin,
+            isTokenValid: true
         }
     })
 })
@@ -141,7 +142,7 @@ test('Allows customer to sign in to their account', async () => {
     await waitFor(() => {
         expect(screen.getByText(/Welcome Tester/i)).toBeInTheDocument()
         expect(screen.getByText(/you're now signed in/i)).toBeInTheDocument()
-    })
+    }, {timeout: 20000})
 })
 
 test('Renders error when given incorrect log in credentials', async () => {
@@ -235,6 +236,6 @@ test('Allows customer to create an account', async () => {
     user.click(withinForm.getByText(/create account/i))
 
     await waitFor(() => {
-        expect(screen.getAllByText(/welcome tester/i).length).toEqual(2)
-    })
+        expect(screen.getAllByText(/customer@test.com/i).length).toEqual(1)
+    }, {timeout: 20000})
 })

--- a/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
@@ -47,7 +47,7 @@ jest.mock('../commerce-api/utils', () => {
     const originalModule = jest.requireActual('../commerce-api/utils')
     return {
         ...originalModule,
-        isTokenValid: jest.fn().mockReturnValue(true),
+        isTokenExpired: jest.fn().mockReturnValue(false),
         hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',

--- a/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
@@ -48,6 +48,7 @@ jest.mock('../commerce-api/utils', () => {
     return {
         ...originalModule,
         isTokenValid: jest.fn().mockReturnValue(true),
+        hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',
             code: 'test',

--- a/packages/template-retail-react-app/app/pages/checkout/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/index.test.js
@@ -38,7 +38,7 @@ jest.mock('../../commerce-api/utils', () => {
     const originalModule = jest.requireActual('../../commerce-api/utils')
     return {
         ...originalModule,
-        isTokenValid: jest.fn().mockReturnValue(true),
+        isTokenExpired: jest.fn().mockReturnValue(false),
         hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',

--- a/packages/template-retail-react-app/app/pages/checkout/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/index.test.js
@@ -39,6 +39,7 @@ jest.mock('../../commerce-api/utils', () => {
     return {
         ...originalModule,
         isTokenValid: jest.fn().mockReturnValue(true),
+        hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',
             code: 'test',

--- a/packages/template-retail-react-app/app/pages/login/index.test.js
+++ b/packages/template-retail-react-app/app/pages/login/index.test.js
@@ -43,7 +43,7 @@ jest.mock('../../commerce-api/utils', () => {
     const originalModule = jest.requireActual('../../commerce-api/utils')
     return {
         ...originalModule,
-        isTokenValid: jest.fn().mockReturnValue(true),
+        isTokenExpired: jest.fn().mockReturnValue(false),
         hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',

--- a/packages/template-retail-react-app/app/pages/login/index.test.js
+++ b/packages/template-retail-react-app/app/pages/login/index.test.js
@@ -44,6 +44,7 @@ jest.mock('../../commerce-api/utils', () => {
     return {
         ...originalModule,
         isTokenValid: jest.fn().mockReturnValue(true),
+        hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',
             code: 'test',

--- a/packages/template-retail-react-app/app/pages/registration/index.test.jsx
+++ b/packages/template-retail-react-app/app/pages/registration/index.test.jsx
@@ -48,6 +48,7 @@ jest.mock('../../commerce-api/utils', () => {
     return {
         ...originalModule,
         isTokenValid: jest.fn().mockReturnValue(true),
+        hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',
             code: 'test',

--- a/packages/template-retail-react-app/app/pages/registration/index.test.jsx
+++ b/packages/template-retail-react-app/app/pages/registration/index.test.jsx
@@ -47,7 +47,7 @@ jest.mock('../../commerce-api/utils', () => {
     const originalModule = jest.requireActual('../../commerce-api/utils')
     return {
         ...originalModule,
-        isTokenValid: jest.fn().mockReturnValue(true),
+        isTokenExpired: jest.fn().mockReturnValue(false),
         hasSFRAAuthStateChanged: jest.fn().mockReturnValue(false),
         createGetTokenBody: jest.fn().mockReturnValue({
             grantType: 'test',

--- a/packages/template-retail-react-app/jest-setup.js
+++ b/packages/template-retail-react-app/jest-setup.js
@@ -84,12 +84,12 @@ jest.mock('pwa-kit-runtime/utils/ssr-config', () => {
     }
 })
 
-// Mock isTokenValid globally
+// Mock isTokenExpired globally
 jest.mock('./app/commerce-api/utils', () => {
     const originalModule = jest.requireActual('./app/commerce-api/utils')
     return {
         ...originalModule,
-        isTokenValid: jest.fn().mockReturnValue(true)
+        isTokenExpired: jest.fn().mockReturnValue(false)
     }
 })
 


### PR DESCRIPTION
On login, PWA Kit stores several properties such as the access token and refresh token. Once an access token is present, PWA Kit will continue to use the same access token until it expires, where it will then use the refresh token to acquire a new access token.

In hybrid sites, SFRA logins are handled by plugin_SLAS. However, plugin_SLAS only has the ability to modify the refresh token on login. Since it is unable to modify/revoke the access token directly, situations can occur where a user with a PWA Kit access token navigates to SFRA, logs in via SFRA, then goes back to PWA Kit where their login status would remain unchanged since the access token from before the SFRA login will continue to be in use.

For PWA Kit to know whether plugin_SLAS has changed a user's login state, PWA needs to know when the refresh token changes.

# Description

- All PWA Kit login scenarios (guest, registered, and refresh token) should store the refresh token in a 2nd property in addition to cc-nx-g / cc-nx
- On every request to SCAPI, before we check for the existence of an access token, run a check comparing the value of the refresh token stored in cc-nx-g / cc-nx with the 2nd copy. If the values are equal, continue to use the access token. If the values are different, throw out (or revoke) the existing access token and trigger a new login using the refresh token stored in cc-nx-g / cc-nx

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Implemented `hasSFRAAuthStateChanged(...)` to compare `refresh_token` keys between SFRA and PWA
- Moved constants from `commerce-api/auth.js` to `commerce-api/constants.js` for shared usage
- updated `auth.js` with a getter function for `isTokenValid` to combine token validation and sfra login state changed checks
- Updated if conditions to use `this.auth.isTokenValid` from `auth.js` instead of using the util function `isTokenValid(...)`

# How to Test-Drive This PR


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
