### PR TITLE
[v3] Fix dev server not able to serve static files

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -366,6 +366,10 @@ const renderer =
                 },
                 plugins: [
                     ...config.plugins,
+                    // This must only appear on one config – this one is the only mandatory one.
+                    new CopyPlugin({
+                        patterns: [{from: 'app/static/', to: 'static/'}]
+                    }),
 
                     // Keep this on the slowest-to-build item - the server-side bundle.
                     new WebpackNotifierPlugin({
@@ -396,10 +400,6 @@ const ssr = (() => {
                     },
                     plugins: [
                         ...config.plugins,
-                        // This must only appear on one config – this one is the only mandatory one.
-                        new CopyPlugin({
-                            patterns: [{from: 'app/static/', to: 'static/'}]
-                        }),
                         analyzeBundle && getBundleAnalyzerPlugin(SSR)
                     ].filter(Boolean)
                 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

The dev server has a bug where it fails to serve static files. This PR aims to fix the issue.

The bug was introduced in https://github.com/SalesforceCommerceCloud/pwa-kit/commit/a402f66da2f130a817f76acaa127c3ae2da75041#diff-3c62fd04e584e6cbc2443d75ef447133665c8c21a1b34e0fa8b9d5a29cd88808 I don't exactly know why the CopyPlugin is moved to `ssr.js` webpack config, but that config is for production only.

This PR fixes the issue by ensuring the static files are copied into the build folder on both development and production environment.

verified change on production too https://scaffold-pwa-test-env.mobify-storefront.com/

# Changes

- Make sure the `CopyPlugin` for static files is included in dev webpack configs

# How to Test-Drive This PR

- npm start
- verify the hero image shows up like

<img width="1710" alt="Screenshot 2023-05-10 at 3 33 08 PM" src="https://github.com/SalesforceCommerceCloud/pwa-kit/assets/10948652/c216d3de-fab8-4abf-b456-857d66bcbd76">
