### PR TITLE
[V2] Internal lib build typescript dev dependency

### DIFF
--- a/packages/internal-lib-build/package-lock.json
+++ b/packages/internal-lib-build/package-lock.json
@@ -51,18 +51,26 @@
 				"regenerator-runtime": "^0.13.11",
 				"replace-in-file": "^6.3.5",
 				"rimraf": "2.7.1",
-				"shelljs": "^0.8.5",
-				"typescript": "4.8.3"
+				"shelljs": "^0.8.5"
 			},
 			"bin": {
 				"internal-lib-build": "bin/internal-lib-build.js"
 			},
 			"devDependencies": {
-				"npm-packlist": "^4.0.0"
+				"npm-packlist": "^4.0.0",
+				"typescript": "4.8.3"
 			},
 			"engines": {
 				"node": "^14.0.0 || ^16.0.0",
 				"npm": "^6.14.4 || ^7.0.0 || ^8.0.0"
+			},
+			"peerDependencies": {
+				"typescript": "4.8.3"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/packages/internal-lib-build/package.json
+++ b/packages/internal-lib-build/package.json
@@ -66,11 +66,19 @@
     "regenerator-runtime": "^0.13.11",
     "replace-in-file": "^6.3.5",
     "rimraf": "2.7.1",
-    "shelljs": "^0.8.5",
-    "typescript": "4.8.3"
+    "shelljs": "^0.8.5"
   },
   "devDependencies": {
-    "npm-packlist": "^4.0.0"
+    "npm-packlist": "^4.0.0",
+    "typescript": "4.8.3"
+  },
+  "peerDependencies": {
+    "typescript": "4.8.3"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "scripts": {
     "lint": "npm run lint:js",


### PR DESCRIPTION
Follow up to #1186 that moves the typescript dependency we added into a dev & peer dependency. This is done to mirror how the typescript dependency is set in v3.