### PR TITLE
Feature: Extract einstein RefArch-specific values to constant

### DIFF
--- a/packages/template-retail-react-app/app/constants.js
+++ b/packages/template-retail-react-app/app/constants.js
@@ -90,3 +90,15 @@ export const TOAST_MESSAGE_REMOVED_FROM_WISHLIST = defineMessage({
     id: 'global.info.removed_from_wishlist',
     defaultMessage: 'Item removed from wishlist'
 })
+
+// Einstein recommender constants used in <RecommendedProducts/>
+export const EINSTEIN_RECOMMENDERS = {
+    ADD_TO_CART_MODAL: 'pdp-similar-items',
+    CART_RECENTLY_VIEWED: 'viewed-recently-einstein',
+    CART_MAY_ALSO_LIKE: 'product-to-product-einstein',
+    PDP_COMPLETE_SET: 'complete-the-set',
+    PDP_MIGHT_ALSO_LIKE: 'pdp-similar-items',
+    PDP_RECENTLY_VIEWED: 'viewed-recently-einstein',
+    EMPTY_SEARCH_RESULTS_TOP_SELLERS: 'home-top-revenue-for-category',
+    EMPTY_SEARCH_RESULTS_MOST_VIEWED: 'products-in-all-categories'
+}

--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -30,6 +30,7 @@ import RecommendedProducts from '../components/recommended-products'
 import {LockIcon} from '../components/icons'
 import {findImageGroupBy} from '../utils/image-groups-utils'
 import {getDisplayVariationValues} from '../utils/product-utils'
+import {EINSTEIN_RECOMMENDERS} from '../constants'
 
 /**
  * This is the context for managing the AddToCartModal.
@@ -229,7 +230,7 @@ export const AddToCartModal = () => {
                                     id="add_to_cart_modal.recommended_products.title.might_also_like"
                                 />
                             }
-                            recommender={'pdp-similar-items'}
+                            recommender={EINSTEIN_RECOMMENDERS.ADD_TO_CART_MODAL}
                             products={[product]}
                             mx={{base: -4, md: -8, lg: 0}}
                             shouldFetch={() => product?.id}

--- a/packages/template-retail-react-app/app/pages/cart/index.jsx
+++ b/packages/template-retail-react-app/app/pages/cart/index.jsx
@@ -33,6 +33,7 @@ import useBasket from '../../commerce-api/hooks/useBasket'
 // Constants
 import {
     API_ERROR_MESSAGE,
+    EINSTEIN_RECOMMENDERS,
     TOAST_ACTION_VIEW_WISHLIST,
     TOAST_MESSAGE_ADDED_TO_WISHLIST
 } from '../../constants'
@@ -302,7 +303,7 @@ const Cart = () => {
                                         id="cart.recommended_products.title.recently_viewed"
                                     />
                                 }
-                                recommender={'viewed-recently-einstein'}
+                                recommender={EINSTEIN_RECOMMENDERS.CART_RECENTLY_VIEWED}
                                 mx={{base: -4, sm: -6, lg: 0}}
                             />
 
@@ -313,7 +314,7 @@ const Cart = () => {
                                         id="cart.recommended_products.title.may_also_like"
                                     />
                                 }
-                                recommender={'product-to-product-einstein'}
+                                recommender={EINSTEIN_RECOMMENDERS.CART_MAY_ALSO_LIKE}
                                 products={basket?.productItems}
                                 shouldFetch={() =>
                                     basket?.basketId && basket.productItems?.length > 0

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -31,6 +31,7 @@ import {HTTPNotFound} from 'pwa-kit-react-sdk/ssr/universal/errors'
 // constant
 import {
     API_ERROR_MESSAGE,
+    EINSTEIN_RECOMMENDERS,
     MAX_CACHE_AGE,
     TOAST_ACTION_VIEW_WISHLIST,
     TOAST_MESSAGE_ADDED_TO_WISHLIST
@@ -294,7 +295,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                                     id="product_detail.recommended_products.title.complete_set"
                                 />
                             }
-                            recommender={'complete-the-set'}
+                            recommender={EINSTEIN_RECOMMENDERS.PDP_COMPLETE_SET}
                             products={[product]}
                             mx={{base: -4, md: -8, lg: 0}}
                             shouldFetch={() => product?.id}
@@ -307,7 +308,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                                 id="product_detail.recommended_products.title.might_also_like"
                             />
                         }
-                        recommender={'pdp-similar-items'}
+                        recommender={EINSTEIN_RECOMMENDERS.PDP_MIGHT_ALSO_LIKE}
                         products={[product]}
                         mx={{base: -4, md: -8, lg: 0}}
                         shouldFetch={() => product?.id}
@@ -320,7 +321,7 @@ const ProductDetail = ({category, product, isLoading}) => {
                                 id="product_detail.recommended_products.title.recently_viewed"
                             />
                         }
-                        recommender={'viewed-recently-einstein'}
+                        recommender={EINSTEIN_RECOMMENDERS.PDP_RECENTLY_VIEWED}
                         mx={{base: -4, md: -8, lg: 0}}
                     />
                 </Stack>

--- a/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
@@ -12,7 +12,7 @@ import {Link as RouteLink} from 'react-router-dom'
 import {defineMessage, FormattedMessage, useIntl} from 'react-intl'
 import {SearchIcon} from '../../../components/icons'
 import RecommendedProducts from '../../../components/recommended-products'
-import {EINSTEIN_RECOMMENDERS} from "../../../constants";
+import {EINSTEIN_RECOMMENDERS} from '../../../constants'
 
 const contactUsMessage = defineMessage({
     id: 'empty_search_results.link.contact_us',
@@ -103,7 +103,6 @@ const EmptySearchResults = ({searchQuery, category}) => {
                             recommender={EINSTEIN_RECOMMENDERS.EMPTY_SEARCH_RESULTS_MOST_VIEWED}
                             mx={{base: -4, md: -8, lg: 0}}
                         />
-
                     </Stack>
                 </Fragment>
             )}

--- a/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
@@ -12,6 +12,7 @@ import {Link as RouteLink} from 'react-router-dom'
 import {defineMessage, FormattedMessage, useIntl} from 'react-intl'
 import {SearchIcon} from '../../../components/icons'
 import RecommendedProducts from '../../../components/recommended-products'
+import {EINSTEIN_RECOMMENDERS} from "../../../constants";
 
 const contactUsMessage = defineMessage({
     id: 'empty_search_results.link.contact_us',
@@ -88,7 +89,7 @@ const EmptySearchResults = ({searchQuery, category}) => {
                                     id="empty_search_results.recommended_products.title.top_sellers"
                                 />
                             }
-                            recommender={'home-top-revenue-for-category'}
+                            recommender={EINSTEIN_RECOMMENDERS.EMPTY_SEARCH_RESULTS_TOP_SELLERS}
                             mx={{base: -4, md: -8, lg: 0}}
                         />
 
@@ -99,7 +100,7 @@ const EmptySearchResults = ({searchQuery, category}) => {
                                     id="empty_search_results.recommended_products.title.most_viewed"
                                 />
                             }
-                            recommender={'products-in-all-categories'}
+                            recommender={EINSTEIN_RECOMMENDERS.EMPTY_SEARCH_RESULTS_MOST_VIEWED}
                             mx={{base: -4, md: -8, lg: 0}}
                         />
 

--- a/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/empty-results.jsx
@@ -103,16 +103,6 @@ const EmptySearchResults = ({searchQuery, category}) => {
                             mx={{base: -4, md: -8, lg: 0}}
                         />
 
-                        <RecommendedProducts
-                            title={
-                                <FormattedMessage
-                                    defaultMessage="Most Viewed"
-                                    id="empty_search_results.recommended_products.title.most_viewed"
-                                />
-                            }
-                            recommender={'products-in-all-categories'}
-                            mx={{base: -4, md: -8, lg: 0}}
-                        />
                     </Stack>
                 </Fragment>
             )}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

The recommender values used in pwa-kit are highly specific to the Einstein realm `aaij-MobileFirst` (i.e. RefArch demo). Implementations will almost always want to change this. This extracts the individual values into a new constant map by location and use case.

This makes it easier to change and diff with future updates rather than making a change to individual components.

Additionally this improves extensibility as this file is easier to extend in extensible templated projects. 

Also removes a duplicate recommender on the no results page.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **New feature** (non-breaking change that adds functionality)

# Changes

- extracts recommender string values to a new constant
- removes duplicate recommended on no results page

# How to Test-Drive This PR

- No results page should have only 1 most viewed recommender: i.e. see the duplicate today on https://pwa-kit.mobify-storefront.com/global/en-GB/search?q=testing

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

