### PR TITLE
Footer: fix hydration error with the locale dropdown

### DIFF
--- a/packages/template-retail-react-app/app/components/footer/index.jsx
+++ b/packages/template-retail-react-app/app/components/footer/index.jsx
@@ -12,7 +12,7 @@ import {
     Divider,
     SimpleGrid,
     useMultiStyleConfig,
-    Select,
+    Select as ChakraSelect,
     Heading,
     Input,
     InputGroup,
@@ -29,6 +29,7 @@ import {HideOnDesktop, HideOnMobile} from '../responsive'
 import {getPathWithLocale} from '../../utils/url'
 import LocaleText from '../locale-text'
 import useMultiSite from '../../hooks/use-multi-site'
+import styled from '@emotion/styled'
 
 const [StylesProvider, useStyles] = createStylesContext('Footer')
 const Footer = ({...otherProps}) => {
@@ -39,6 +40,15 @@ const Footer = ({...otherProps}) => {
     const {l10n} = site
     const supportedLocaleIds = l10n?.supportedLocales.map((locale) => locale.id)
     const showLocaleSelector = supportedLocaleIds?.length > 1
+
+    // NOTE: this is a workaround to fix hydration error, by making sure that the `option.selected` property is set.
+    // For some reason, adding some styles prop (to the option element) prevented `selected` from being set.
+    // So now we add the styling to the parent element instead.
+    const Select = styled(ChakraSelect)({
+        // Targeting the child element
+        option: styles.localeDropdownOption
+    })
+
     return (
         <Box as="footer" {...styles.container} {...otherProps}>
             <Box {...styles.content}>
@@ -130,7 +140,7 @@ const Footer = ({...otherProps}) => {
                                 {...otherProps}
                             >
                                 <Select
-                                    value={locale}
+                                    defaultValue={locale}
                                     onChange={({target}) => {
                                         setLocale(target.value)
 
@@ -144,14 +154,8 @@ const Footer = ({...otherProps}) => {
                                     variant="filled"
                                     {...styles.localeDropdown}
                                 >
-                                    {/* NOTE: this needs to be a native <option> (and not <chakra.option>)
-                                        It's a workaround to fix hydration error, by making sure that the `selected` property is set */}
                                     {supportedLocaleIds.map((locale) => (
-                                        <option
-                                            key={locale}
-                                            value={locale}
-                                            style={{color: 'black'}}
-                                        >
+                                        <option key={locale} value={locale}>
                                             <LocaleText shortCode={locale} />
                                         </option>
                                     ))}

--- a/packages/template-retail-react-app/app/components/footer/index.jsx
+++ b/packages/template-retail-react-app/app/components/footer/index.jsx
@@ -145,13 +145,13 @@ const Footer = ({...otherProps}) => {
                                     {...styles.localeDropdown}
                                 >
                                     {supportedLocaleIds.map((locale) => (
-                                        <LocaleText
-                                            as="option"
-                                            value={locale}
-                                            shortCode={locale}
+                                        <option
                                             key={locale}
-                                            {...styles.localeDropdownOption}
-                                        />
+                                            value={locale}
+                                            style={{color: 'black'}}
+                                        >
+                                            <LocaleText shortCode={locale} />
+                                        </option>
                                     ))}
                                 </Select>
                             </FormControl>

--- a/packages/template-retail-react-app/app/components/footer/index.jsx
+++ b/packages/template-retail-react-app/app/components/footer/index.jsx
@@ -144,6 +144,8 @@ const Footer = ({...otherProps}) => {
                                     variant="filled"
                                     {...styles.localeDropdown}
                                 >
+                                    {/* NOTE: this needs to be a native <option> (and not <chakra.option>)
+                                        It's a workaround to fix hydration error, by making sure that the `selected` property is set */}
                                     {supportedLocaleIds.map((locale) => (
                                         <option
                                             key={locale}

--- a/packages/template-retail-react-app/app/components/locale-selector/index.jsx
+++ b/packages/template-retail-react-app/app/components/locale-selector/index.jsx
@@ -15,6 +15,7 @@ import {
     AccordionItem,
     AccordionPanel,
     Box,
+    Text,
 
     // Hooks
     useStyleConfig
@@ -66,7 +67,9 @@ const LocaleSelector = ({selectedLocale = '', locales = [], onSelect = () => {},
                                 )}
                                 {/* Display flag icon if one exists */}
                                 {flags[selectedLocale]}
-                                <LocaleText {...styles.selectedText} shortCode={selectedLocale} />
+                                <Text {...styles.selectedText}>
+                                    <LocaleText shortCode={selectedLocale} />
+                                </Text>
                             </AccordionButton>
                             <AccordionPanel>
                                 <Accordion allowToggle={true} {...styles.accordion}>
@@ -80,10 +83,9 @@ const LocaleSelector = ({selectedLocale = '', locales = [], onSelect = () => {},
                                                 {flags[locale]}
 
                                                 {/* Locale name */}
-                                                <LocaleText
-                                                    {...styles.optionText}
-                                                    shortCode={locale}
-                                                />
+                                                <Text {...styles.optionText}>
+                                                    <LocaleText shortCode={locale} />
+                                                </Text>
 
                                                 {/* Selection indicator */}
                                                 {selectedLocale === locale && (

--- a/packages/template-retail-react-app/app/components/locale-text/index.jsx
+++ b/packages/template-retail-react-app/app/components/locale-text/index.jsx
@@ -8,21 +8,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {defineMessages, useIntl} from 'react-intl'
-import {chakra, Text} from '@chakra-ui/react'
 
-const LocaleText = ({shortCode, as, ...otherProps}) => {
+const LocaleText = ({shortCode}) => {
     const intl = useIntl()
-    const Wrapper = as ? chakra(as) : Text
     const message = LOCALE_MESSAGES[shortCode]
 
     if (!message) {
         console.error(
             `No locale message found for "${shortCode}". Please update the list accordingly.`
         )
-        return <Wrapper {...otherProps}>Unknown {shortCode}</Wrapper>
+        return <>Unknown {shortCode}</>
     }
 
-    return <Wrapper {...otherProps}>{intl.formatMessage(message)}</Wrapper>
+    return <>{intl.formatMessage(message)}</>
 }
 
 LocaleText.displayName = 'LocaleText'
@@ -31,11 +29,7 @@ LocaleText.propTypes = {
     /**
      * The locale shortcode that you would like the localized text for.
      */
-    shortCode: PropTypes.string.isRequired,
-    /**
-     * The element type to render this component as, defaults to a Text component.
-     */
-    as: PropTypes.string
+    shortCode: PropTypes.string.isRequired
 }
 
 export default LocaleText

--- a/packages/template-retail-react-app/app/components/locale-text/index.test.js
+++ b/packages/template-retail-react-app/app/components/locale-text/index.test.js
@@ -9,29 +9,28 @@ import LocaleText from './index'
 import {renderWithProviders} from '../../utils/test-utils'
 
 test('Renders LocaleText', () => {
-    renderWithProviders(<LocaleText shortCode="en-GB" />)
-    const text = document.querySelector('.chakra-text')
-
-    expect(text).toBeInTheDocument()
-})
-
-test('Renders LocaleText with as type', () => {
-    renderWithProviders(<LocaleText className="test-class" shortCode="en-GB" as="option" />)
-
-    const text = document.querySelector('option.test-class')
-
-    expect(text).toBeInTheDocument()
+    renderWithProviders(
+        <div>
+            <LocaleText shortCode="en-GB" />
+        </div>
+    )
+    const el = document.querySelector('div')
+    expect(el.textContent).toBe('English (United Kingdom)')
 })
 
 test('Warns on missing shortCode message definition', () => {
     jest.spyOn(console, 'error')
 
-    renderWithProviders(<LocaleText shortCode="fa-KE" />)
+    renderWithProviders(
+        <div>
+            <LocaleText shortCode="fa-KE" />
+        </div>
+    )
 
-    const text = document.querySelector('.chakra-text')
+    const el = document.querySelector('div')
 
     expect(console.error.mock.calls[0][0]).toContain(
         `No locale message found for "fa-KE". Please update the list accordingly.`
     )
-    expect(text).toBeInTheDocument()
+    expect(el.textContent).toBe('Unknown fa-KE')
 })

--- a/packages/template-retail-react-app/app/theme/components/project/footer.js
+++ b/packages/template-retail-react-app/app/theme/components/project/footer.js
@@ -62,6 +62,9 @@ export default {
                 background: 'whiteAlpha.500'
             }
         },
+        localeDropdownOption: {
+            color: 'black'
+        },
         bottomHalf: {
             maxWidth: {base: '34.5rem', lg: '100%'}
         },

--- a/packages/template-retail-react-app/app/theme/components/project/footer.js
+++ b/packages/template-retail-react-app/app/theme/components/project/footer.js
@@ -62,9 +62,6 @@ export default {
                 background: 'whiteAlpha.500'
             }
         },
-        localeDropdownOption: {
-            color: 'black'
-        },
         bottomHalf: {
             maxWidth: {base: '34.5rem', lg: '100%'}
         },


### PR DESCRIPTION
It looks like there's a bug with chakra-enhanced `<option>` where the `selected` property is no longer set. That's why there's a mismatch between the client and server rendered html.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
