### PR TITLE
Replace ExtendsCircularImportsPlugin with OverridesResolverPlugin

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -21,7 +21,7 @@ import SpeedMeasurePlugin from 'speed-measure-webpack-plugin'
 
 import {sdkReplacementPlugin, makeRegExp} from './plugins'
 import {CLIENT, SERVER, CLIENT_OPTIONAL, SSR, REQUEST_PROCESSOR} from './config-names'
-import ExtendsCircularImportsPlugin from './overrides-plugin'
+import OverridesResolverPlugin from './overrides-plugin'
 
 const projectDir = process.cwd()
 const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
@@ -159,7 +159,7 @@ const baseConfig = (target) => {
                     ...(EXT_EXTENDS && EXT_OVERRIDES_DIR
                         ? {
                               plugins: [
-                                  new ExtendsCircularImportsPlugin({
+                                  new OverridesResolverPlugin({
                                       extends: [EXT_EXTENDS],
                                       overridesDir: EXT_OVERRIDES_DIR,
                                       projectDir: process.cwd()
@@ -195,10 +195,10 @@ const baseConfig = (target) => {
                             ? Object.assign(
                                   // NOTE: when an array of `extends` dirs are accepted, don't coerce here
                                   ...[EXT_EXTENDS].map((extendTarget) => ({
-                                      [extendTarget]: [
-                                          path.resolve(projectDir, EXT_OVERRIDES_DIR_NO_SLASH),
-                                          path.resolve(projectDir, `node_modules/${extendTarget}`)
-                                      ]
+                                      [extendTarget]: path.resolve(
+                                          projectDir,
+                                          `node_modules/${extendTarget}`
+                                      )
                                   }))
                               )
                             : {}),

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -453,7 +453,7 @@ const renderer =
                         patterns: [
                             {
                                 from: `${
-                                    EXT_OVERRIDES_DIR ? EXT_OVERRIDES_DIR + '/' : ''
+                                    EXT_OVERRIDES_DIR ? EXT_OVERRIDES_DIR_NO_SLASH + '/' : ''
                                 }app/static`,
                                 to: 'static/',
                                 noErrorOnMissing: true
@@ -489,7 +489,7 @@ const ssr = (() => {
                             patterns: [
                                 {
                                     from: `${
-                                        EXT_OVERRIDES_DIR ? EXT_OVERRIDES_DIR + '/' : ''
+                                        EXT_OVERRIDES_DIR ? EXT_OVERRIDES_DIR_NO_SLASH + '/' : ''
                                     }app/static`,
                                     to: 'static/'
                                 }

--- a/packages/pwa-kit-dev/src/configs/webpack/overrides-plugin.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/overrides-plugin.js
@@ -5,15 +5,16 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import path from 'path'
-import {makeRegExp} from './plugins'
+import glob from 'glob'
 
 /**
- * @class ExtendsCircularImportsPlugin
+ * @class OverridesResolverPlugin
  *
- *  This plugin adds "guardrails" to the "Overrides" behavior of the Template Extensibility feature,
- *  preventing the dynamic aliases in webpack/config.js from allowing a file to attempt to import itself
+ *  This plugin provides the "Overrides" behavior of the Template Extensibility feature,
+ *  allowing third party implementations that depend on an npm module for the base implementation
+ *  and then overriding only specific files
  */
-class ExtendsCircularImportsPlugin {
+class OverridesResolverPlugin {
     /**
      *
      * @param options
@@ -26,51 +27,108 @@ class ExtendsCircularImportsPlugin {
         this.extends = options.extends || []
         this.projectDir = options.projectDir
         this._allSearchDirs = [this.projectDir + this.overridesDir, ...this.extends]
+        this.pkg = require(path.resolve(this.projectDir, 'package.json'))
+        this.extendsHashMap = new Map()
+
+        const OVERRIDES_EXTENSIONS = '.+(js|jsx|ts|tsx|svg|jpg|jpeg)'
+        const globPattern = `${this.pkg?.ccExtensibility?.overridesDir?.replace(
+            /^\//,
+            ''
+        )}/**/*${OVERRIDES_EXTENSIONS}`
+        const overridesFsRead = glob.sync(globPattern)
+
+        const overrideReplace = this.pkg?.ccExtensibility?.overridesDir + '/'
+
+        overridesFsRead.forEach((item) => {
+            const end = item.substring(item.lastIndexOf('/index'))
+            const [l, ...rest] = item.split(/(index|\.)/)
+            this.extendsHashMap.set(
+                l.replace(/\/$/, '')?.replace(overrideReplace.replace(/\//, ''), ''),
+                [end, rest]
+            )
+        })
+    }
+
+    /**
+     *
+     * @param requestPath
+     * @param dirs
+     */
+    findFileFromMap(requestPath, dirs) {
+        const fileExt = path.extname(requestPath)
+        for (const dir of dirs) {
+            let base = path.join(dir, requestPath)
+            if (fileExt) {
+                const noExtPath = requestPath.replace(fileExt, '')
+                if (this.extendsHashMap.has(noExtPath)) {
+                    return base
+                }
+            } else {
+                if (this.extendsHashMap.has(requestPath)) {
+                    const end = this.extendsHashMap.get(requestPath)[1]
+                    const isRequestingIndex = end[0] === 'index'
+                    let result = base?.replace(/$\//, '') + end.join('')
+                    if (isRequestingIndex) {
+                        result = path.join(base, this.extendsHashMap.get(requestPath)[1].join(''))
+                    }
+                    return result
+                }
+            }
+        }
     }
 
     toOverrideRelative(path) {
         const override = this.findOverride(path)
-        return path?.substring(override?.length + 1)
+        return path.substring(override.length + 1)
     }
 
     findOverride(path) {
         return this._allSearchDirs.find((override) => {
-            return path?.indexOf(override) === 0
+            return path.indexOf(override) === 0
         })
     }
 
+    isFromExtends(request, path) {
+        // in npm namespaces like `@salesforce/<pkg>` we need to ignore the first slash
+        const basePkgIndex = request?.startsWith('@') ? 1 : 0
+        return (
+            this.extends.includes(request?.split('/')?.[basePkgIndex]) &&
+            // this is very important, to avoid circular imports, check that the
+            // `issuer` (requesting context) isn't the overrides directory
+            !path.match(this.projectDir + this.overridesDir)
+        )
+    }
+
     apply(resolver) {
-        const extendsRegex = makeRegExp(`(${this.extends?.join('|')})`)
-        resolver
-            .getHook('before-resolve')
-            .tapAsync('BeforeAliasPlugin', (request, requestContext, callback) => {
-                const splitPath = request?.request?.split(extendsRegex)
-                if (
-                    splitPath?.length > 2 &&
-                    request.path?.includes(this.projectDir + this.overridesDir) &&
-                    request.context.issuer.includes(splitPath?.[2]) &&
-                    request.request.includes(splitPath?.[2])
-                ) {
-                    const target = resolver.ensureHook('resolved')
-                    var relativeOverride = this.toOverrideRelative(request.context.issuer)
-                    requestContext.path = path.resolve(
-                        this.projectDir,
-                        'node_modules',
-                        splitPath?.[1],
-                        relativeOverride
+        resolver.getHook('resolve').tapAsync(
+            'FeatureResolverPlugin',
+            function (requestContext, resolveContext, callback) {
+                let targetFile
+                let overrideRelative
+                if (this.isFromExtends(requestContext.request, requestContext.path)) {
+                    overrideRelative = this.toOverrideRelative(requestContext.request)?.replace(
+                        /$\//,
+                        ''
                     )
-                    return resolver.doResolve(
+                    targetFile = this.findFileFromMap(overrideRelative, this._allSearchDirs)
+                }
+
+                if (targetFile) {
+                    const target = resolver.ensureHook('resolved')
+                    requestContext.path = targetFile
+                    resolver.doResolve(
                         target,
                         requestContext,
-                        `BeforeAliasPlugin found base override file`,
-                        requestContext,
+                        `${this.constructor.name} found base override file`,
+                        resolveContext,
                         callback
                     )
                 } else {
                     return callback()
                 }
-            })
+            }.bind(this)
+        )
     }
 }
 
-export default ExtendsCircularImportsPlugin
+export default OverridesResolverPlugin


### PR DESCRIPTION
This PR reverts the ExtendsCircularImportsPlugin back to an earlier version when it was known as the OverridesResolverPlugin.

# Description

The ExtendsCircularImportsPlugin is a guardrail we've introduced to the webpack build process to prevent files from self-referencing. However, we discovered an edge case where it would also block file imports from the template if another file has the same name in the extension app.

For example, in `pwa-kit-overrides/app/components/_app`, make an attempt to override some of the constants we are reading from `retail-react-app/app/constants`

```
import {
    THEME_COLOR,
    HOME_HREF,
    CAT_MENU_DEFAULT_NAV_SSR_DEPTH,
    CAT_MENU_DEFAULT_ROOT_CATEGORY,
    DEFAULT_LOCALE
} from 'retail-react-app/app/constants'
import {
    DEFAULT_SITE_TITLE
} from '../../constants'
```
After creating a constants file in `pwa-kit-overrides/app`, you will begin to see attempts to import the original template-retail-react-app constants file (in the template-retail-react-app) fail with the following errors:
```
  WARNING in ../template-retail-react-app/app/pages/product-list/partials/refinements.jsx 35:135-156
  export 'FILTER_ACCORDION_SATE' (imported as 'FILTER_ACCORDION_SATE') was not found in 'retail-react-app/app/constants' (possible exports: DEFAULT_SITE_TITLE)
   @ ../template-retail-react-app/app/pages/product-list/index.jsx 31:0-87 481:38-49 557:112-123
   @ ./node_modules/retail-react-app/app/routes.jsx
   @ ./pwa-kit-overrides/app/routes.jsx 22:0-64 159:3-10
   @ ../pwa-kit-react-sdk/dist/ssr/universal/components/route-component/index.js 14:38-61
   @ ../pwa-kit-react-sdk/dist/ssr/browser/main.js 14:22-72
   @ ./pwa-kit-overrides/app/main.jsx 7:0-82 10:22-27 10:31-52
```
To fix, we are reverting back to an earlier version of our override plugin that utilized scanning the files of the extension app.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# How to Test-Drive This PR

- See description

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
