### PR TITLE
[V3] Remove unused peerDependency @chakra-ui/system

### DIFF
--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -76,9 +76,6 @@
     "react-intl": "^5.25.1",
     "react-router-dom": "^5.3.4"
   },
-  "peerDependencies": {
-    "@chakra-ui/system": "^2.5.6"
-  },
   "engines": {
     "node": "^16.11.0 || ^18.0.0",
     "npm": "^8.0.0 || ^9.0.0"


### PR DESCRIPTION
Based on the conversation [here](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1198#discussion_r1195655272), we should be able to remove the peerDependency `@chakra-ui/system` as it was a fix for Chakra V1, and we have now upgraded to Chakra v2.