### PR TITLE
[V3] Add `templateVersion` arg to `create-react-app`

### DIFF
--- a/packages/pwa-kit-create-app/CHANGELOG.md
+++ b/packages/pwa-kit-create-app/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v3.0.0-dev (May 11, 2023)
+
+-   Add `--templateVersion` argument to allow template version selection when generating a project using a template that is hosted on NPM. [#1229](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1229)
+-   Add extensible project generation support. [#1205](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1205)
+
 ## v2.7.1 (May 11, 2023)
 
 -   Moved the MRT reference app to the SDKs, so that we can verify eg. Node support [#966](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/966)

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -532,7 +532,7 @@ const processTemplate = (relFile, inputDir, outputDir, context) => {
  * @param {*} answers
  * @param {*} param2
  */
-const runGenerator = (context, {outputDir, templateVersion = DEFAULT_TEMPLATE_VERSION, verbose}) => {
+const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
     const {answers, preset} = context
     const {templateSource} = preset
     const {extend = false} = answers.project
@@ -639,7 +639,7 @@ const main = async (opts) => {
     // to "general" and "project" questions. It'll also be populated with details of the selected project,
     // like its `package.json` value.
     let context = INITIAL_CONTEXT
-    let {outputDir, verbose, preset, templateVersion = DEFAULT_TEMPLATE_VERSION} = opts
+    let {outputDir, verbose, preset, templateVersion} = opts
     const {prompt} = inquirer
     const OUTPUT_DIR_FLAG_ACTIVE = !!outputDir
     const presetId = preset || process.env.GENERATOR_PRESET
@@ -740,7 +740,8 @@ Examples:
         )
         .option(
             '--templateVersion <version>',
-            `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`
+            `The version of the template to be generated when it's source is NPM.`,
+            DEFAULT_TEMPLATE_VERSION
         )
         .option('--verbose', `Print additional logging information to the console.`, false)
 

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -531,7 +531,7 @@ const processTemplate = (relFile, inputDir, outputDir, context) => {
  * @param {*} answers
  * @param {*} param2
  */
-const runGenerator = (context, {outputDir, verbose}) => {
+const runGenerator = (context, {outputDir, templateVesion, verbose}) => {
     const {answers, preset} = context
     const {templateSource} = preset
     const {extend = false} = answers.project
@@ -549,7 +549,7 @@ const runGenerator = (context, {outputDir, verbose}) => {
     switch (type) {
         case TEMPLATE_SOURCE_NPM: {
             const tarFile = sh
-                .exec(`npm pack ${id}@latest --pack-destination="${tmp}"`, {
+                .exec(`npm pack ${id}@${templateVesion} --pack-destination="${tmp}"`, {
                     silent: true
                 })
                 .stdout.trim()
@@ -638,7 +638,7 @@ const main = async (opts) => {
     // to "general" and "project" questions. It'll also be populated with details of the selected project,
     // like its `package.json` value.
     let context = INITIAL_CONTEXT
-    let {outputDir, verbose, preset} = opts
+    let {outputDir, verbose, preset, templateVesion = 'latest'} = opts
     const {prompt} = inquirer
     const OUTPUT_DIR_FLAG_ACTIVE = !!outputDir
     const presetId = preset || process.env.GENERATOR_PRESET
@@ -685,7 +685,7 @@ const main = async (opts) => {
     // Inject the packageJSON into the context for extensibile projects.
     if (context.answers.project.extend) {
         const pkgJSON = JSON.parse(
-            sh.exec(`npm view ${selectedPreset.templateSource.id} --json`, {
+            sh.exec(`npm view ${selectedPreset.templateSource.id}@${templateVesion} --json`, {
                 silent: true
             }).stdout
         )
@@ -710,7 +710,7 @@ const main = async (opts) => {
     }
 
     // Generate the project.
-    runGenerator(context, {outputDir, verbose})
+    runGenerator(context, {outputDir, templateVesion, verbose})
 
     // Return the folder in which the project was generated in.
     return outputDir
@@ -736,6 +736,11 @@ Examples:
             `The name of a project preset to use (choices: ${PUBLIC_PRESET_NAMES.map(
                 (x) => `"${x}"`
             ).join(', ')})`
+        )
+        .option(
+            '--template-version',
+            `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`,
+            false
         )
         .option('--verbose', `Print additional logging information to the console.`, false)
 

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -739,8 +739,7 @@ Examples:
         )
         .option(
             '--templateVersion',
-            `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`,
-            false
+            `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`
         )
         .option('--verbose', `Print additional logging information to the console.`, false)
 

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -106,6 +106,7 @@ const INITIAL_CONTEXT = {
 }
 const TEMPLATE_SOURCE_NPM = 'npm'
 const TEMPLATE_SOURCE_BUNDLE = 'bundle'
+const DEFAULT_TEMPLATE_VERSION = 'latest'
 
 const EXTENSIBILITY_QUESTIONS = [
     {
@@ -531,7 +532,7 @@ const processTemplate = (relFile, inputDir, outputDir, context) => {
  * @param {*} answers
  * @param {*} param2
  */
-const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
+const runGenerator = (context, {outputDir, templateVersion = DEFAULT_TEMPLATE_VERSION, verbose}) => {
     const {answers, preset} = context
     const {templateSource} = preset
     const {extend = false} = answers.project
@@ -638,7 +639,7 @@ const main = async (opts) => {
     // to "general" and "project" questions. It'll also be populated with details of the selected project,
     // like its `package.json` value.
     let context = INITIAL_CONTEXT
-    let {outputDir, verbose, preset, templateVersion = 'latest'} = opts
+    let {outputDir, verbose, preset, templateVersion = DEFAULT_TEMPLATE_VERSION} = opts
     const {prompt} = inquirer
     const OUTPUT_DIR_FLAG_ACTIVE = !!outputDir
     const presetId = preset || process.env.GENERATOR_PRESET

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -738,7 +738,7 @@ Examples:
             ).join(', ')})`
         )
         .option(
-            '--templateVersion',
+            '--templateVersion <version>',
             `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`
         )
         .option('--verbose', `Print additional logging information to the console.`, false)

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -531,7 +531,7 @@ const processTemplate = (relFile, inputDir, outputDir, context) => {
  * @param {*} answers
  * @param {*} param2
  */
-const runGenerator = (context, {outputDir, templateVesion, verbose}) => {
+const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
     const {answers, preset} = context
     const {templateSource} = preset
     const {extend = false} = answers.project
@@ -549,7 +549,7 @@ const runGenerator = (context, {outputDir, templateVesion, verbose}) => {
     switch (type) {
         case TEMPLATE_SOURCE_NPM: {
             const tarFile = sh
-                .exec(`npm pack ${id}@${templateVesion} --pack-destination="${tmp}"`, {
+                .exec(`npm pack ${id}@${templateVersion} --pack-destination="${tmp}"`, {
                     silent: true
                 })
                 .stdout.trim()
@@ -638,7 +638,7 @@ const main = async (opts) => {
     // to "general" and "project" questions. It'll also be populated with details of the selected project,
     // like its `package.json` value.
     let context = INITIAL_CONTEXT
-    let {outputDir, verbose, preset, templateVesion = 'latest'} = opts
+    let {outputDir, verbose, preset, templateVersion = 'latest'} = opts
     const {prompt} = inquirer
     const OUTPUT_DIR_FLAG_ACTIVE = !!outputDir
     const presetId = preset || process.env.GENERATOR_PRESET
@@ -685,7 +685,7 @@ const main = async (opts) => {
     // Inject the packageJSON into the context for extensibile projects.
     if (context.answers.project.extend) {
         const pkgJSON = JSON.parse(
-            sh.exec(`npm view ${selectedPreset.templateSource.id}@${templateVesion} --json`, {
+            sh.exec(`npm view ${selectedPreset.templateSource.id}@${templateVersion} --json`, {
                 silent: true
             }).stdout
         )
@@ -710,7 +710,7 @@ const main = async (opts) => {
     }
 
     // Generate the project.
-    runGenerator(context, {outputDir, templateVesion, verbose})
+    runGenerator(context, {outputDir, templateVersion, verbose})
 
     // Return the folder in which the project was generated in.
     return outputDir
@@ -738,7 +738,7 @@ Examples:
             ).join(', ')})`
         )
         .option(
-            '--template-version',
+            '--templateVersion',
             `The version of the template to be generated. This defaults to 'latest'. NOTE: This option only applies to templates being downloaded from NPM.`,
             false
         )


### PR DESCRIPTION
# Description

Currently when generating a project that is independently versioned and lives on NPM (aka the retail-react-app), we by default download the latest version. This doesn't give use enough flexibility to download other versions of a given template when we want to. For example in the scenario where we release a "preview" version of our template, we wouldn't be able to generate it unless we tagged the preview version as "latest", which is obviously a bad thing to do. 

This this PR I've added a `--templateVersion` argument that will allow the cli to be invoked with a particular version number which will be used when downloading the template and it's information from NPM. 

If the version is not found on NPM, we passthrough the error thrown by the npm command for `view` as we use that command to get information about the package about to be downloaded. 

There is one slight caveat which is to use this argument, you must know that the underlying template that you are generating is on NPM and you must know a valid version that will be generated. 

In the future we'll most likely add a version picker that is displayed after making your PRESET selection.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Added `--templateVersion` argument to CLI

# How to Test-Drive This PR

```
// Clear your npx cache.
> rm -rf ~/.npm/_npx
// Generate a project using a bad version number (should exit with error)
> node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir generated-project --templateVersion 6.6.6
// Generate a project using a good version number (should exit with error)
> node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir generated-project --templateVersion 3.0.0-dev
```

## General

- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
