### PR TITLE
[MRT Reference App] @W-13153758 Enable cache for /cache endpoint

### DIFF
--- a/packages/template-mrt-reference-app/app/ssr.js
+++ b/packages/template-mrt-reference-app/app/ssr.js
@@ -133,7 +133,8 @@ const jsonFromRequest = (req) => {
         body: req.body,
         headers: redactAndSortObjectKeys(req.headers),
         ip: req.ip,
-        env: filterAndSortObjectKeys(process.env, ENVS_TO_EXPOSE)
+        env: filterAndSortObjectKeys(process.env, ENVS_TO_EXPOSE),
+        timestamp: new Date().toISOString()
     }
 }
 
@@ -165,6 +166,14 @@ const tlsVersionTest = async (_, res) => {
         .catch(() => false)
     res.header('Content-Type', 'application/json')
     res.send(JSON.stringify({'tls1.1': response11, 'tls1.2': response12}, null, 4))
+}
+
+/**
+ * Express handler that enables the cache and returns a JSON response with diagnostic values.
+ */
+const cacheTest = async (req, res) => {
+    res.set('Cache-Control', 's-maxage=60')
+    res.json(jsonFromRequest(req))
 }
 
 /**
@@ -222,6 +231,7 @@ const {handler, app, server} = runtime.createHandler(options, (app) => {
     // Configure routes
     app.all('/exception', exception)
     app.get('/tls', tlsVersionTest)
+    app.get('/cache', cacheTest)
 
     // Add a /auth/logout path that will always send a 401 (to allow clearing
     // of browser credentials)

--- a/packages/template-mrt-reference-app/app/ssr.test.js
+++ b/packages/template-mrt-reference-app/app/ssr.test.js
@@ -32,11 +32,16 @@ describe('server', () => {
     test.each([
         ['/', 200, 'application/json; charset=utf-8'],
         ['/tls', 200, 'application/json; charset=utf-8'],
-        ['/exception', 500, 'text/html; charset=utf-8']
+        ['/exception', 500, 'text/html; charset=utf-8'],
+        ['/cache', 200, 'application/json; charset=utf-8']
     ])('Path %p should render correctly', (path, expectedStatus, expectedContentType) => {
         return request(app)
             .get(path)
             .expect(expectedStatus)
             .expect('Content-Type', expectedContentType)
+    })
+
+    test('Path "/cache" has Cache-Control set', () => {
+        return request(app).get('/cache').expect('Cache-Control', 's-maxage=60')
     })
 })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

(NOTE: this PR replays @hajinsuha1 changes from #1219 where CI checks were stuck due being an external contributor and GH PR checks not running? 🤔 )

#1219 
#1236 

Updates `template-mrt-reference-app/ssr.js` to enable caching when sending a get request to the `/cache` endpoint. This will allow us to write smoke tests for the CloudFrontDistrbution's cache behaviour
https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001Qmt1DYAR/view

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- set response header to `Cache-Control: s-maxage=60` when the endpoint is `/cache`

# How to Test-Drive This PR

- Clone this repo and run `npm ci`
- Start the mrt-reference-app: `cd packages/template-mrt-reference-app && npm start`
- navigate to http://localhost:3000/cache and verify 
  - timestamp is in the response body
  - `"cache-control": "s-maxage=60"` in the response headers
- navigate to any other URL e.g., http://localhost:3000 and verify 
  - timestamp is in the response body
  - `"cache-control": "no-cache"` in the response headers