### PR TITLE
Copy static folders for ssr webpack build

### DIFF
--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -320,6 +320,18 @@ const withChunking = (config) => {
     }
 }
 
+const staticFolderCopyPlugin = new CopyPlugin({
+    patterns: [
+        {
+            from: path
+                .resolve(`${EXT_OVERRIDES_DIR ? EXT_OVERRIDES_DIR_NO_SLASH + '/' : ''}app/static`)
+                .replace(/\\/g, '/'),
+            to: `static/`,
+            noErrorOnMissing: true
+        }
+    ]
+})
+
 const ruleForBabelLoader = (babelPlugins) => {
     return {
         id: 'babel-loader',
@@ -391,6 +403,7 @@ const enableReactRefresh = (config) => {
         }
     }
 }
+
 const client =
     entryPointExists(['app', 'main']) &&
     baseConfig('web')
@@ -466,26 +479,7 @@ const renderer =
                 },
                 plugins: [
                     ...config.plugins,
-
-                    // This must only appear on one config – this one is the only mandatory one.
-                    new CopyPlugin({
-                        patterns: [
-                            {
-                                from: path
-                                    .resolve(
-                                        `${
-                                            EXT_OVERRIDES_DIR
-                                                ? EXT_OVERRIDES_DIR_NO_SLASH + '/'
-                                                : ''
-                                        }app/static`
-                                    )
-                                    .replace(/\\/g, '/'),
-                                to: `static/`,
-                                noErrorOnMissing: true
-                            }
-                        ]
-                    }),
-
+                    staticFolderCopyPlugin,
                     // Keep this on the slowest-to-build item - the server-side bundle.
                     new WebpackNotifierPlugin({
                         title: `PWA Kit Project: ${pkg.name}`,
@@ -516,6 +510,7 @@ const ssr = (() => {
                     },
                     plugins: [
                         ...config.plugins,
+                        staticFolderCopyPlugin,
                         analyzeBundle && getBundleAnalyzerPlugin(SSR)
                     ].filter(Boolean)
                 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

@hajinsuha1  recently found an issue that when building the `template-mrt-reference-app`, static folder isn't being copied over in the build. This is because that the static folder copying is only enabled for the `renderer`, but the mrt reference app doesn't have/need a renderer! [The entry point](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa-kit-dev/src/configs/webpack/config.js#L455) requires the project to have installed the `pwa-kit-react-sdk`, but this isn't the case for the mrt reference app.

The PR fixes the issue by adding the copy plugin for the `ssr.js` build, so if there is a bff only project like mrt reference app, the static files are still copied over.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- add CopyPlugin to the ssr.js webpack config

# How to Test-Drive This PR

- `cd packages/template-mrt-reference-app`
- `npm run build`
- verify the static folder is copied into the `/build` folder, including favicon and the example.txt

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
