### PR TITLE
Catch any 404 page due to a missing translation file

### DIFF
--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -143,16 +143,17 @@ const App = (props) => {
         l10nConfig: site.l10n
     })
 
-    // Workaround for infinite loop if default site locale translation file is missing
-    const isDefaultTranslation = new RegExp(
-        `/static/translations/compiled/${site.l10n.defaultLocale}\\.json$`
-    ).test(location?.pathname)
+    const is404ForMissingTranslationFile = /\/static\/translations\/compiled\/[^.]+\.json$/.test(
+        location?.pathname
+    )
 
     // Fetch the translation message data using the target locale.
     const {data: messages} = useQuery({
         queryKey: ['app', 'translations', 'messages', targetLocale],
         queryFn: () => {
-            if (isDefaultTranslation) {
+            if (is404ForMissingTranslationFile) {
+                // Return early to prevent an infinite loop
+                // Otherwise, it'll continue to fetch the missing translation file again
                 return {}
             }
             return fetchTranslations(targetLocale)

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -143,6 +143,8 @@ const App = (props) => {
         l10nConfig: site.l10n
     })
 
+    // If the translation file exists, it'll be served directly from static folder (and won't reach this code here).
+    // However, if the file is missing, the App would render a 404 page.
     const is404ForMissingTranslationFile = /\/static\/translations\/compiled\/[^.]+\.json$/.test(
         location?.pathname
     )


### PR DESCRIPTION
Not just when fetching file for the site's default locale.

(And IMO it's simpler to explain what's going on, rather than needing to explain the difference between `site.l10n.defaultLocale` and `DEFAULT_LOCALE`)

Follow-up PR to #1324 

## How to test the changes

1. First of all, delete this translation file: `packages/template-retail-react-app/app/static/translations/compiled/en-GB.json`
2. Then run `npm start` to load the retail-react-app
3. Although the translation file is missing, the app would no longer get stuck and is now able to render the site (with the fallback of the inlined hardcoded strings).
4. Your browser's console would emit warnings about this missing translation file