### PR TITLE
Change cc-nx-g expiry to 30 days

### DIFF
--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -156,7 +156,8 @@ class Auth {
     private shopperCustomersClient: ShopperCustomers<ApiClientConfigParams>
     private redirectURI: string
     private pendingToken: Promise<TokenResponse> | undefined
-    private REFRESH_TOKEN_EXPIRATION_DAYS = 90
+    private REFRESH_TOKEN_EXPIRATION_DAYS_REGISTERED = 90
+    private REFRESH_TOKEN_EXPIRATION_DAYS_GUEST = 30
     private stores: Record<StorageType, BaseStorage>
     private fetchedToken: string
     private OCAPISessionsURL: string
@@ -315,11 +316,15 @@ class Auth {
             ? 'refresh_token_guest_copy'
             : 'refresh_token_registered_copy'
 
+        const refreshTokenExpiry = isGuest
+            ? this.REFRESH_TOKEN_EXPIRATION_DAYS_GUEST
+            : this.REFRESH_TOKEN_EXPIRATION_DAYS_REGISTERED
+
         this.set(refreshTokenKey, res.refresh_token, {
-            expires: this.REFRESH_TOKEN_EXPIRATION_DAYS
+            expires: refreshTokenExpiry
         })
         this.set(refreshTokenCopyKey, res.refresh_token, {
-            expires: this.REFRESH_TOKEN_EXPIRATION_DAYS
+            expires: refreshTokenExpiry
         })
     }
 


### PR DESCRIPTION
According to our [documentation](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas.html?q=refresh%20token#access-tokens-and-refresh-tokens), logged in users refresh tokens (saved as cc-nx) are valid for 90 days in production. Meanwhile guest refresh tokens (saved as cc-nx-g) are valid for only 30 days in production.

PWA Kit currently sets both cc-nx-g and cc-nx cookies to live for 90 days.

This PR changes the expiry of cc-nx-g cookies to match the validity period of guest refresh tokens.

**NOTE: DO NOT MERGE UNTIL THE SAME CHANGE CAN BE MADE IN Plugin_SLAS** (see https://github.com/SalesforceCommerceCloud/plugin_slas/pull/153)

We want to make this change in both PWA and plugin_SLAS so that the expiry times remain consistent on hybrid sites.