### PR TITLE
fixes price display when a discounted price is 0

### DIFF
--- a/packages/template-retail-react-app/app/components/item-variant/item-price.jsx
+++ b/packages/template-retail-react-app/app/components/item-variant/item-price.jsx
@@ -50,7 +50,8 @@ const ItemPrice = ({currency, align = 'right', baseDirection = 'column', ...prop
     const {price, basePrice, priceAfterItemDiscount} = variant
     const isProductASet = variant?.type?.set
 
-    const displayPrice = priceAfterItemDiscount ? Math.min(price, priceAfterItemDiscount) : price
+    const displayPrice =
+        typeof priceAfterItemDiscount === 'number' ? Math.min(price, priceAfterItemDiscount) : price
 
     const hasDiscount = displayPrice !== price
 


### PR DESCRIPTION
# Description

This fixes part of #1360. When a price adjustment brings the product price to 0 the current display logic is broken as Boolean(0) === false. This is common in bonus products but other common price adjustment scenarios can also bring the price to that value.

# Types of Changes


- [ X] **Bug fix** (non-breaking change that fixes an issue)


# Changes

- Use min of price or priceAfterItemDiscount when priceAfterItemDiscount is a number

# How to Test-Drive This PR

- add a product with bonus product promotion attached. See that the price is correctly shown as 0 in the line item.

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X ] There are no changes to UI (existing UI elements are unchanged)
