### PR TITLE
sum all the price adjustments of a line item instead of first

### DIFF
--- a/packages/template-retail-react-app/app/components/item-variant/item-attributes.jsx
+++ b/packages/template-retail-react-app/app/components/item-variant/item-attributes.jsx
@@ -80,7 +80,10 @@ const ItemAttributes = ({includeQuantity, currency, ...props}) => {
                             <FormattedNumber
                                 style="currency"
                                 currency={currency || basket?.currency || activeCurrency}
-                                value={variant.priceAdjustments[0].price}
+                                value={variant.priceAdjustments.reduce(
+                                    (acc, adj) => acc + (adj.price ?? 0),
+                                    0
+                                )}
                             />
                         </Text>
                     </Text>


### PR DESCRIPTION

# Description

Fixes part of #1360: when multiple promotions (price adjustments) are applied to a line only the first one is used for the discounted value. This is confusing when there are multiple applied

# Types of Changes

- [X ] **Bug fix** (non-breaking change that fixes an issue)


# Changes

- sum all the price adjustment prices for the actual discount

# How to Test-Drive This PR

- See #1360 for the test products

## Accessibility Compliance


- [ X] There are no changes to UI

