### PR TITLE
`bump-version` script: having a better default - @W-13789960@

### DIFF
--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -43,7 +43,7 @@ const main = (program) => {
         sh.exec(`node ${script1} ${targetVersion} ${opts.package}`)
 
         const script2 = path.join(__dirname, 'pwa-kit-deps-version.js')
-        const updateDepsBehaviour = /-dev\b/.test(targetVersion) ? 'sync' : 'latest'
+        const updateDepsBehaviour = opts.pwaKitDeps
         sh.exec(`node ${script2} ${updateDepsBehaviour} ${opts.package}`)
 
         // After updating the dependencies, let's update the package lock files
@@ -119,11 +119,20 @@ const updateDeps = (pkgJson) => {
 program.description('Bump the version of a package in our monorepo')
 program.arguments('<target-version>')
 
-program.option(
-    '-p, --package <package-name>',
-    'the package name or an alias to a group of packages',
-    'sdk'
-)
+program
+    .option(
+        '-p, --package <package-name>',
+        'the package name or an alias to a group of packages',
+        'sdk'
+    )
+    .addOption(
+        new program.Option(
+            '-d, --pwa-kit-deps <update-behavior>',
+            'for non-sdk packages, choose how to update their pwa-kit dependencies: either sync with repo or grab @latest from npm'
+        )
+            .choices(['sync', 'latest'])
+            .default('sync')
+    )
 
 program.parse(process.argv)
 main(program)


### PR DESCRIPTION
This PR extracts out the pwa-kit dependency update behaviour as an option (and having a better default for it too). This is the result of having gone through several PWA Kit releases recently.

## How to test the PR

First of all, try looking at the help message:

```bash
cd <monorepo-root>
npm run bump-version:retail-react-app -- -h
```

**Scenario 1: releasing retail-react-app together with the SDK** ← this is what we've been encountering lately
- `npm run bump-version:retail-react-app -- 1.1.0-preview.0`
- In this case, we'll want to  sync up the pwa-kit dependencies with what's in my local repo

So the only change is just the version number:

![GitHub Desktop 2023-07-20 at 15 53 48](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/847300/639cdbc2-3e66-4f1d-98a1-6c4aae757c82)

**Scenario 2: releasing retail-react-app on its own**
- `npm run bump-version:retail-react-app -- 1.1.0-preview.0 --pwa-kit-deps latest`
- Would need the pwa-kit dependencies downgraded to what's been published to npm `@latest`

![GitHub Desktop 2023-07-20 at 15 52 36](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/847300/14b94be3-2adc-4081-b3b6-0da80255b758)



