### PR TITLE
@T-10402494@ Fix url to localization readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ npm run push -- -m "Message to help you recognize this bundle"
 
 ## 🌍 Localization
 
-See the [Localization README.md](./packages/template-retail-react-app/app/translations/README.md) for important setup instructions for localization.
+See the [Localization README.md](./packages/template-retail-react-app/translations/README.md) for important setup instructions for localization.
 
 ## ⚠️ License Information
 


### PR DESCRIPTION
The top-level readme's link to the localization readme is incorrect and leads to a 404.

This change fixes this link