### PR TITLE
@W-13889216: Setting cookies samesite conditionally

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v1.1.0-dev (TTBD)
+- Setting cookies config `samesite` conditionally when the code is loaded in/outside of an iframe [#1403](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1403)
 
 ## v1.0.1 (Jul 26, 2023)
 

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v1.1.0-dev (TTBD)
-- Setting cookies config `samesite` conditionally when the code is loaded in/outside of an iframe [#1403](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1403)
+- Support storefront preview [#1403](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1403)
 
 ## v1.0.1 (Jul 26, 2023)
 

--- a/packages/commerce-sdk-react/src/auth/storage.ts
+++ b/packages/commerce-sdk-react/src/auth/storage.ts
@@ -50,7 +50,7 @@ export class CookieStorage extends BaseStorage {
     set(key: string, value: string, options?: Cookies.CookieAttributes) {
         const suffixedKey = this.getSuffixedKey(key)
         const isInIframe = window.location !== window.parent.location
-        const isLocalHost = window.location.protocol === 'http:'
+        const isLocalHost = window.location.hostname === 'localhost'
         Cookies.set(suffixedKey, value, {
             // Deployed sites will always be HTTPS, but the local dev server is served over HTTP.
             // Ideally, this would be `secure: true`, because Chrome and Firefox both treat
@@ -61,6 +61,7 @@ export class CookieStorage extends BaseStorage {
             // setting sameSite to none lose that restriction to
             // make sure that cookies can be read/sent when code is loaded in an iframe
             // outside of iframe, we want to keep that restriction to avoid security risk
+            // https://web.dev/samesite-cookie-recipes/
             sameSite: !isLocalHost && isInIframe ? 'none' : 'strict',
             ...options
         })

--- a/packages/commerce-sdk-react/src/auth/storage.ts
+++ b/packages/commerce-sdk-react/src/auth/storage.ts
@@ -44,16 +44,24 @@ export class CookieStorage extends BaseStorage {
         super(options)
 
         if (typeof document === 'undefined') {
-            throw new Error('CookieStorage is not avaliable on the current environment.')
+            throw new Error('CookieStorage is not available on the current environment.')
         }
     }
     set(key: string, value: string, options?: Cookies.CookieAttributes) {
         const suffixedKey = this.getSuffixedKey(key)
+        const isInIframe = window.location !== window.parent.location
+        const isLocalHost = window.location.protocol === 'http:'
         Cookies.set(suffixedKey, value, {
             // Deployed sites will always be HTTPS, but the local dev server is served over HTTP.
             // Ideally, this would be `secure: true`, because Chrome and Firefox both treat
             // localhost as a Secure context. But Safari doesn't, so here we are.
             secure: !onClient() || window.location.protocol === 'https:',
+            // By default, Chromes does not allow cookies to be sent/read
+            // when the code is loaded in iframe (e.g storefront preview case)
+            // setting sameSite to none lose that restriction to
+            // make sure that cookies can be read/sent when code is loaded in an iframe
+            // outside of iframe, we want to keep that restriction to avoid security risk
+            sameSite: !isLocalHost && isInIframe ? 'none' : 'strict',
             ...options
         })
     }

--- a/packages/commerce-sdk-react/src/auth/storage.ts
+++ b/packages/commerce-sdk-react/src/auth/storage.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import Cookies from 'js-cookie'
-import {onClient} from '../utils'
+import {getCookieSameSiteAttribute, onClient} from '../utils'
 import {IFRAME_HOST_ALLOW_LIST} from '../constant'
 
 export type StorageType = 'cookie' | 'local' | 'memory'
@@ -50,11 +50,7 @@ export class CookieStorage extends BaseStorage {
     }
     set(key: string, value: string, options?: Cookies.CookieAttributes) {
         const suffixedKey = this.getSuffixedKey(key)
-        const parentUrl = document.location?.ancestorOrigins?.[0] || document.referrer
-        const parentHostName = parentUrl ? new URL(parentUrl).hostname : ''
-        const isInAllowList = IFRAME_HOST_ALLOW_LIST.includes(parentHostName)
-
-        const isLocalHost = window.location.hostname === 'localhost'
+        
         Cookies.set(suffixedKey, value, {
             // Deployed sites will always be HTTPS, but the local dev server is served over HTTP.
             // Ideally, this would be `secure: true`, because Chrome and Firefox both treat
@@ -66,7 +62,7 @@ export class CookieStorage extends BaseStorage {
             // make sure that cookies can be read/sent when code is loaded in an iframe of a certain allow host list.
             // Outside of iframe, we want to keep most browser default value (Chrome or Firefox uses Lax)
             // https://web.dev/samesite-cookie-recipes/
-            sameSite: !isLocalHost && isInAllowList ? 'none' : 'Lax',
+            sameSite: getCookieSameSiteAttribute(),
             ...options
         })
     }

--- a/packages/commerce-sdk-react/src/auth/storage.ts
+++ b/packages/commerce-sdk-react/src/auth/storage.ts
@@ -6,7 +6,7 @@
  */
 import Cookies from 'js-cookie'
 import {onClient} from '../utils'
-import {IFRAME_HOST_ALLOW_LIST} from "../constant";
+import {IFRAME_HOST_ALLOW_LIST} from '../constant'
 
 export type StorageType = 'cookie' | 'local' | 'memory'
 
@@ -34,7 +34,6 @@ export abstract class BaseStorage {
     abstract delete(key: string): void
 }
 
-
 /**
  * A normalized implementation for Cookie store. It implements the BaseStorage interface
  * which allows developers to easily switch between Cookie, LocalStorage, Memory store
@@ -51,7 +50,8 @@ export class CookieStorage extends BaseStorage {
     }
     set(key: string, value: string, options?: Cookies.CookieAttributes) {
         const suffixedKey = this.getSuffixedKey(key)
-        const parentHostName = new URL(document.location?.ancestorOrigins?.[0] || document.referrer)?.hostname
+        const parentUrl = document.location?.ancestorOrigins?.[0] || document.referrer
+        const parentHostName = parentUrl ? new URL(parentUrl).hostname : ''
         const isInAllowList = IFRAME_HOST_ALLOW_LIST.includes(parentHostName)
 
         const isLocalHost = window.location.hostname === 'localhost'

--- a/packages/commerce-sdk-react/src/constant.ts
+++ b/packages/commerce-sdk-react/src/constant.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * This list contain domains that can host code in iframe
+ */
+export const IFRAME_HOST_ALLOW_LIST = [
+    'runtime.commercecloud.com',
+    'runtime-admin-preview.mobify-storefront.com'
+]

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -5,7 +5,21 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {IFRAME_HOST_ALLOW_LIST} from "./constant";
+
 /**
  * Utility to determine if you are on the browser (client) or not.
  */
 export const onClient = (): boolean => typeof window !== 'undefined'
+
+export const getCookieSameSiteAttribute = () => {
+    // document.location?.ancestorOrigins?.[0] will provide the parent host url, but it only works for Chrome and Safari.
+    // Firefox does not have this field. document.referrer is common use for parent url, but it could be less reliable.
+    // It is best to use it a fallback option for Firefox
+    const parentUrl = document.location?.ancestorOrigins?.[0] || document.referrer
+    const parentHostName = parentUrl ? new URL(parentUrl).hostname : ''
+    const isParentSiteTrusted = IFRAME_HOST_ALLOW_LIST.includes(parentHostName)
+    const isLocalHost = window.location.hostname === 'localhost'
+
+    return !isLocalHost && isParentSiteTrusted ? 'none' : 'Lax'
+}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
This PR fixes the auth loop call happening on MRT environment for Storefront preview that is loaded cross-site/cross-domain. 
The reason of the issue is because cookies is not allowed to be sent/read when an app is loaded in an iframe. This is a default Chrome behavior. 

To address this issue, we want to make sure to lose this restriction when the storefront is in an iframe by configuring `sameSite` option for Cookies. Otherwise, it should keep that restriction. 


MRT
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/a3d3f919-6bf9-48fb-a788-5a0ff91f3ac7)

Localhost:
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/4fe3ed95-ffb6-482e-9d22-08934d6ce278)


<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Pull the code
Cookies Samesite should be strict on local development either inside or outside of an iframe
    - Run storefront localhost and check cookies config to make sure samesite is strict since it is not loaded in the iframe
    - Start Runtime Admin, go to this page: http://localhost:4000/salesforce-systems/scaffold-pwa/alex/preview. Observe that the cookies rules are still strict since it is localhost

On MRT environment
- A fix is deployed to this target: https://runtime-admin-alex-env.mobify-storefront.com/salesforce-systems/scaffold-pwa/alex/preview. Check cookies config to see sameSite is set to `none` with secure is `true`. The loop issue has been resolved due to that

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
