### PR TITLE
Grab `pwa-kit` package versions for projects using template extensibility

### DIFF
--- a/packages/pwa-kit-dev/src/utils/script-utils.test.js
+++ b/packages/pwa-kit-dev/src/utils/script-utils.test.js
@@ -141,24 +141,6 @@ describe('scriptUtils', () => {
         })
     })
 
-    describe('findPackageVersionInTree', () => {
-        test('should return the package version if found', () => {
-            const tree = {
-                version: '0.0.1',
-                name: 'test',
-                dependencies: {
-                    '@salesforce/retail-react-app': {
-                        version: '1.0.0',
-                        dependencies: {'@salesforce/pwa-kit-react-sdk': {version: '3.0.0'}}
-                    }
-                }
-            }
-            expect(
-                scriptUtils.findPackageVersionInTree(tree, '@salesforce/pwa-kit-react-sdk')
-            ).toBe('3.0.0')
-        })
-    })
-
     describe('getPackageVersion', () => {
         test('should return the package version if found', () => {
             execSync.mockReturnValueOnce(
@@ -168,7 +150,16 @@ describe('scriptUtils', () => {
                     dependencies: {
                         '@salesforce/retail-react-app': {
                             version: '1.0.0',
-                            dependencies: {'@salesforce/pwa-kit-react-sdk': {version: '3.0.0'}}
+                            dependencies: {
+                                'some-other-library': {
+                                    version: '2.0.0',
+                                    dependencies: {
+                                        '@salesforce/pwa-kit-react-sdk': {
+                                            version: '3.0.0'
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 })

--- a/packages/pwa-kit-dev/src/utils/script-utils.ts
+++ b/packages/pwa-kit-dev/src/utils/script-utils.ts
@@ -119,11 +119,9 @@ export const findPackageVersionInTree = (tree: any, pkgName: string): string | n
     }
 
     for (const key in tree) {
-        for (const innerKey in tree[key]) {
-            if (tree[key][innerKey].dependencies) {
-                const result = findPackageVersionInTree(tree[key][innerKey].dependencies, pkgName)
-                if (result) return result
-            }
+        if (tree[key].dependencies) {
+            const result = findPackageVersionInTree(tree[key].dependencies, pkgName)
+            if (result) return result
         }
     }
 
@@ -134,7 +132,7 @@ export const getPackageVersion = (pkgName: string) => {
     try {
         const output = execSync(`npm ls ${pkgName} --json`, {encoding: 'utf-8'})
         const parsedOutput = JSON.parse(output)
-        return findPackageVersionInTree(parsedOutput, pkgName)
+        return findPackageVersionInTree(parsedOutput.dependencies, pkgName)
     } catch (err) {
         return null
     }

--- a/packages/pwa-kit-dev/src/utils/script-utils.ts
+++ b/packages/pwa-kit-dev/src/utils/script-utils.ts
@@ -327,6 +327,17 @@ export const createBundle = async ({
                 let cc_overrides: string[] = []
                 const packageVersions: {[key: string]: string} = {}
 
+                // Use 'npm ls' to find package versions
+                for (const dep of pwaKitDeps) {
+                    const version = getPackageVersion(dep)
+                    if (version) {
+                        packageVersions[dep] = version
+                    } else {
+                        packageVersions[dep] = 'unknown'
+                        console.warn(`Unable to find package version for ${dep}`)
+                    }
+                }
+
                 if (ccExtensibility.extends) {
                     const overrides_files = await walkDir(
                         ccExtensibility.overridesDir,
@@ -335,16 +346,6 @@ export const createBundle = async ({
                     cc_overrides = Array.from(overrides_files).filter((item) =>
                         existsSync(path.join(extendsTemplate, item))
                     )
-
-                    // If the project is using template extensbility, we must use 'npm ls' to find the versions of pwa-kit packages
-                    for (const dep of pwaKitDeps) {
-                        const version = getPackageVersion(dep)
-                        if (version) {
-                            packageVersions[dep] = version
-                        } else {
-                            console.warn(`Unable to find package version for ${dep}`)
-                        }
-                    }
                 }
                 bundle_metadata = {
                     dependencies: {...packageVersions, ...dependencies, ...devDependencies},


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
In a generated project, there are zero direct dependencies in `package.json` and only `@salesforce/retail-react-app` as a devDependency. Thus, for projects using template extensibility, we have to introspect the nested dependencies to identify the versions of `pwa-kit` packages that are being used, specifically `@salesforce/pwa-kit-dev`, `@salesforce/pwa-kit-runtime`, and `@salesforce/pwa-kit-react-sdk`

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- In `script-utils.ts`, if a customer is using template extensibility, use `ccExtensibility.extends` to identify the base template that they are extending
- Introspect that package's `package.json` through `node_modules` to identify the versions of `pwa-kit` packages and send as part of the bundle to Cloud

# How to Test-Drive This PR

- Checkout this branch
- From a generated project using template extensibility, push a bundle to MRT
- Verify in the **Bundle Metadata** section of the bundle detail page that both the version of the template and `pwa-kit` packages are there
<img width="1696" alt="Screenshot 2023-08-11 at 12 34 11 PM" src="https://github.com/SalesforceCommerceCloud/pwa-kit/assets/84923642/ce1d7643-0778-4e44-9803-92d0568e0f3f">

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
