### PR TITLE
export icon helper function so it can be used to create custom icons in overrides

### DIFF
--- a/packages/template-retail-react-app/app/components/icons/index.jsx
+++ b/packages/template-retail-react-app/app/components/icons/index.jsx
@@ -84,7 +84,7 @@ VisaSymbol.viewBox = VisaSymbol.viewBox || '0 0 38 22'
  * @param {string} name - the filename of the imported svg (does not include extension)
  */
 /* istanbul ignore next */
-const icon = (name, passProps) => {
+export const icon = (name, passProps) => {
     const displayName = name
         .toLowerCase()
         .replace(/(?:^|[\s-/])\w/g, (match) => match.toUpperCase())


### PR DESCRIPTION
Very simple change to export the icon helper function in the retail-react-app's icons component so that it can be used in overrides to generate Chakra Icons for custom .svgs (i.e. - ones that aren't already in the base list of icon .svg filenames).

Example usage:

import {icon} from '@salesforce/retail-react-app/app/components/icons'

import '../../assets/svg/flexible-clock.svg'

export const FlexibleClockIcon = icon('flexible-clock')

export * from '@salesforce/retail-react-app/app/components/icons'