### PR TITLE
Wrong import path for PD types

### DIFF
--- a/packages/template-retail-react-app/app/page-designer/index.js
+++ b/packages/template-retail-react-app/app/page-designer/index.js
@@ -5,6 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {Page, pageType} from '@salesforce/retail-react-app/app/page-designer/core'
+import {Page, pageType} from '@salesforce/commerce-sdk-react/components'
 
 export {Page, pageType}


### PR DESCRIPTION
This import references modules that are no longer there. Were moved to commerce-sdk-react

# Description

This index file isn't even used so probably can be removed instead of fixing this import.

# Types of Changes


- [X ] **Bug fix** (non-breaking change that fixes an issue)

# Changes

- Update path

# How to Test-Drive This PR

- n/a

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X ] There are no changes to UI
