### PR TITLE
W-14337923: Fix a11y color contrasts

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v2.2.0-dev (Nov 3, 2023)
+- (A11y) Ensure active user interface components have sufficient contrast [#1534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1534)
+
 ## v2.1.0 (Nov 3, 2023)
 
 - Support Storefront Preview 

--- a/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
@@ -50,7 +50,7 @@ const ColorRefinements = ({filter, toggleFilter, selectedFilters}) => {
                                     <Center
                                         {...styles.swatchButton}
                                         marginRight={0}
-                                        border={'1px solid black'}
+                                        border="1px solid black"
                                     >
                                         <Box
                                             marginRight={0}

--- a/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
@@ -50,10 +50,7 @@ const ColorRefinements = ({filter, toggleFilter, selectedFilters}) => {
                                     <Center
                                         {...styles.swatchButton}
                                         marginRight={0}
-                                        border={
-                                            value.label.toLowerCase() === 'white' &&
-                                            '1px solid black'
-                                        }
+                                        border={'1px solid black'}
                                     >
                                         <Box
                                             marginRight={0}

--- a/packages/template-retail-react-app/app/theme/components/base/checkbox.js
+++ b/packages/template-retail-react-app/app/theme/components/base/checkbox.js
@@ -12,7 +12,7 @@ export default {
         },
         control: {
             marginTop: '2px',
-            borderColor: 'gray.600',
+            borderColor: 'gray.500',
             _checked: {
                 backgroundColor: 'blue.600',
                 borderColor: 'blue.600',

--- a/packages/template-retail-react-app/app/theme/components/base/checkbox.js
+++ b/packages/template-retail-react-app/app/theme/components/base/checkbox.js
@@ -12,6 +12,7 @@ export default {
         },
         control: {
             marginTop: '2px',
+            borderColor: 'gray.600',
             _checked: {
                 backgroundColor: 'blue.600',
                 borderColor: 'blue.600',

--- a/packages/template-retail-react-app/app/theme/components/base/input.js
+++ b/packages/template-retail-react-app/app/theme/components/base/input.js
@@ -30,7 +30,7 @@ export default {
             // we use filled variant for
             // search input
             field: {
-                borderColor: 'gray.500',
+                borderColor: 'gray.600',
                 backgroundColor: 'gray.100',
                 _focus: {
                     backgroundColor: 'white'

--- a/packages/template-retail-react-app/app/theme/components/base/input.js
+++ b/packages/template-retail-react-app/app/theme/components/base/input.js
@@ -21,11 +21,17 @@ export default {
         }
     },
     variants: {
+        outline: {
+            field: {
+                borderColor: 'gray.500'
+            }
+        },
         filled: {
             // we use filled variant for
             // search input
             field: {
-                backgroundColor: 'gray.50',
+                borderColor: 'gray.500',
+                backgroundColor: 'gray.100',
                 _focus: {
                     backgroundColor: 'white'
                 },

--- a/packages/template-retail-react-app/app/theme/foundations/shadows.js
+++ b/packages/template-retail-react-app/app/theme/foundations/shadows.js
@@ -5,5 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export default {
-    top: '0px -1px 3px rgba(0, 0, 0, 0.1), 0px -1px 2px rgba(0, 0, 0, 0.06)'
+    top: '0px -1px 3px rgba(0, 0, 0, 0.1), 0px -1px 2px rgba(0, 0, 0, 0.06)',
+    outline: '0 0 0 3px var(--chakra-colors-blue-500)'
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
This PR fixes a11y color contrasts recommended in W-14337923

Major issues: 
- The contrast ratio of focus state color/background color not being satisfy the 3:1. 
Current focus state color of component is using chakra default variable: shadows.outline. See [here](https://github.com/chakra-ui/chakra-ui/blob/073bbcd21a9caa830d71b61d6302f47aaa5c154d/packages/components/theme/src/foundations/shadows.ts#L9).
e.g:
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/f872154b-56b1-4cc6-8924-e0796212878d)

     -  Solution: override the value in theme.shadows.outline in pwa-kit will fix all of this a11y issue. See [here](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1534/files#diff-a335e174fdbf285ddafc7841f6b541eeb1a64cded2fd9ea8cc8a8e590c6589c3R9). This will fix 9 childrend issues 
     - ![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/fa34e091-3648-4536-abaf-4f65cfa32b7f)

- Search input background color against adjacent color.
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/e21ec8cc-3374-4c48-a178-8a24fe4ab3ff)
    -  Solution: Add border that has a minimum of 3:1 contrast against both the white page background and the inner gray (off white) background of the input field. 
    


- One of the color filter in color refinement has insufficient contrast:  
- ![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/381f8f74-c644-42fd-9772-c88aeab47e8a)
    - Solution: Add a border that has a contrast ratio of 3:1 or greater with the surrounding colors for all colors
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/5400365c-6f0e-401e-97b4-dfc32c53611e)


- The gray outline for the 'This is a gift' checkbox has insufficient color contrast against adjacent colors
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/900ea37c-85b3-489d-9b85-0f8d33f691d9)

   - Solution: change the checkbox border to a darker shade of grey to create higher contrast. Here we use gray.500
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/82efb940-b0dd-48df-a249-62ebaf2d0ec3)


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Check out code
- Run Retail App
- Confirm all the a11y issues in are resolved

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
