### PR TITLE
A11y: add aria-label for checkout header's back-to-cart link - @W-14338154@

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout/partials/checkout-header.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/checkout-header.jsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React from 'react'
-import {FormattedMessage} from 'react-intl'
+import {FormattedMessage, useIntl} from 'react-intl'
 import {
     Badge,
     Box,
@@ -19,6 +19,7 @@ import {HOME_HREF} from '@salesforce/retail-react-app/app/constants'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
 const CheckoutHeader = () => {
+    const intl = useIntl()
     const {
         derivedData: {totalItems}
     } = useCurrentBasket()
@@ -45,6 +46,13 @@ const CheckoutHeader = () => {
                                 <Badge variant="notification">{totalItems}</Badge>
                             </Center>
                         }
+                        aria-label={intl.formatMessage(
+                            {
+                                id: 'checkout_header.link.assistive_msg.cart',
+                                defaultMessage: 'Back to cart, number of items: {numItems}'
+                            },
+                            {numItems: totalItems}
+                        )}
                     >
                         <FormattedMessage
                             defaultMessage="Back to cart"

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -767,6 +767,16 @@
       "value": "Salesforce or its affiliates. All rights reserved. This is a demo store only. Orders made WILL NOT be processed."
     }
   ],
+  "checkout_header.link.assistive_msg.cart": [
+    {
+      "type": 0,
+      "value": "Back to cart, number of items: "
+    },
+    {
+      "type": 1,
+      "value": "numItems"
+    }
+  ],
   "checkout_header.link.cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -767,6 +767,16 @@
       "value": "Salesforce or its affiliates. All rights reserved. This is a demo store only. Orders made WILL NOT be processed."
     }
   ],
+  "checkout_header.link.assistive_msg.cart": [
+    {
+      "type": 0,
+      "value": "Back to cart, number of items: "
+    },
+    {
+      "type": 1,
+      "value": "numItems"
+    }
+  ],
   "checkout_header.link.cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1551,6 +1551,24 @@
       "value": "]"
     }
   ],
+  "checkout_header.link.assistive_msg.cart": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓȧȧƈķ ŧǿǿ ƈȧȧřŧ, ƞŭŭḿƀḗḗř ǿǿƒ īŧḗḗḿş: "
+    },
+    {
+      "type": 1,
+      "value": "numItems"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "checkout_header.link.cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -295,6 +295,9 @@
   "checkout_footer.message.copyright": {
     "defaultMessage": "Salesforce or its affiliates. All rights reserved. This is a demo store only. Orders made WILL NOT be processed."
   },
+  "checkout_header.link.assistive_msg.cart": {
+    "defaultMessage": "Back to cart, number of items: {numItems}"
+  },
   "checkout_header.link.cart": {
     "defaultMessage": "Back to cart"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -295,6 +295,9 @@
   "checkout_footer.message.copyright": {
     "defaultMessage": "Salesforce or its affiliates. All rights reserved. This is a demo store only. Orders made WILL NOT be processed."
   },
+  "checkout_header.link.assistive_msg.cart": {
+    "defaultMessage": "Back to cart, number of items: {numItems}"
+  },
   "checkout_header.link.cart": {
     "defaultMessage": "Back to cart"
   },


### PR DESCRIPTION
Adding to this recently-merged PR #1526 , this PR adds a similar aria-label for the the Back To Cart link for the checkout header. It was done already in the main header, but not yet for the checkout's. Now the label also describes how many items are in the cart.

Here's a video to show VoiceOver in action:
1. AFTER: Initially showing the change in localhost → "Back to cart, number of items: 1"
2. BEFORE: Then switching tab to what's live on https://pwa-kit.mobify-storefront.com/ for comparison → only "Back to cart"


https://github.com/SalesforceCommerceCloud/pwa-kit/assets/847300/411495fd-cd1d-4dd0-a16a-ce269f6b94f7
