### PR TITLE
Change all ARIA labels to translatable messages

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Other Features
 
 - Implement gift option for basket [#1546](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1546)
+- Added option to specify `isLoginPage` function to the `withRegistration` component. The default behavior is "all pages ending in `/login`". [#1572](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1572)
 
 ### Bug Fixes
 

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.2.0-dev (Nov 3, 2023)
+
 - Replace max-age with s-maxage to only cache shared caches [#1564](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1564)
 
 ### Accessibility Improvements
@@ -12,6 +13,7 @@
 - Make security code tooltip receive keyboard focus [#1551](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1551)
 - Improve accessibility of quantity picker [#1552](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1552)
 - Improve keyboard accessibility of product scroller [#1559](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1559)
+- Improve keyboard accessibility of account menu and nav bar [#1572](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1572)
 
 ### Other Features
 

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -257,18 +257,13 @@ const App = (props) => {
     }
 
     const onAccountClick = () => {
-        // Link to account page for registered customer, open auth modal otherwise
-        if (isRegistered) {
-            const path = buildUrl('/account')
-            history.push(path)
-        } else {
-            // if they already are at the login page, do not show login modal
-            if (new RegExp(`^/login$`).test(location.pathname)) return
-            authModal.onOpen()
-        }
+        // Link to account page if registered; Header component will show auth modal for guest users
+        const path = buildUrl('/account')
+        history.push(path)
     }
 
     const onWishlistClick = () => {
+        // Link to wishlist page if registered; Header component will show auth modal for guest users
         const path = buildUrl('/account/wishlist')
         history.push(path)
     }

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -18,7 +18,6 @@ import {
     useAccessToken,
     useCategory,
     useCommerceApi,
-    useCustomerType,
     useCustomerBaskets,
     useShopperBasketsMutation
 } from '@salesforce/commerce-sdk-react'
@@ -123,7 +122,6 @@ const App = (props) => {
     const history = useHistory()
     const location = useLocation()
     const authModal = useAuthModal()
-    const {isRegistered} = useCustomerType()
     const {site, locale, buildUrl} = useMultiSite()
 
     const [isOnline, setIsOnline] = useState(true)

--- a/packages/template-retail-react-app/app/components/field/index.jsx
+++ b/packages/template-retail-react-app/app/components/field/index.jsx
@@ -19,6 +19,7 @@ import {
     Checkbox
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import {VisibilityIcon, VisibilityOffIcon} from '@salesforce/retail-react-app/app/components/icons'
+import {useIntl} from 'react-intl'
 
 const Field = ({
     name,
@@ -35,8 +36,18 @@ const Field = ({
     helpText,
     children
 }) => {
+    const intl = useIntl()
     const [hidePassword, setHidePassword] = useState(true)
     const PasswordIcon = hidePassword ? VisibilityIcon : VisibilityOffIcon
+    const passwordIconLabel = hidePassword
+        ? intl.formatMessage({
+              id: 'field.password.assistive_msg.show_password',
+              defaultMessage: 'Show password'
+          })
+        : intl.formatMessage({
+              id: 'field.password.assistive_msg.hide_password',
+              defaultMessage: 'Hide password'
+          })
     const inputType =
         type === 'password' && hidePassword ? 'password' : type === 'password' ? 'text' : type
     return (
@@ -51,8 +62,7 @@ const Field = ({
 
                 return (
                     <FormControl id={name} isInvalid={error}>
-                        {!['checkbox', 'radio'].includes(type) &&
-                            type !== 'hidden' &&
+                        {!['checkbox', 'radio', 'hidden'].includes(type) &&
                             (formLabel || <FormLabel>{label}</FormLabel>)}
 
                         <InputGroup>
@@ -83,7 +93,7 @@ const Field = ({
                                 <InputRightElement>
                                     <IconButton
                                         variant="ghosted"
-                                        aria-label="Show password"
+                                        aria-label={passwordIconLabel}
                                         icon={<PasswordIcon color="gray.500" boxSize={6} />}
                                         onClick={() => setHidePassword(!hidePassword)}
                                     />
@@ -120,7 +130,7 @@ const Field = ({
                             {children}
                         </InputGroup>
 
-                        {error && !type !== 'hidden' && (
+                        {error && type !== 'hidden' && (
                             <FormErrorMessage color="red.600">{error.message}</FormErrorMessage>
                         )}
 

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -184,7 +184,6 @@ const Header = ({
                                     {...getAccountMenuButtonProps()}
                                     onMouseOver={onAccountMenuOpen}
                                     onMouseLeave={handleIconsMouseLeave}
-                                    onClick={(e) => console.log('click', e.target)}
                                 />
                             </PopoverTrigger>
 

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -174,7 +174,10 @@ const Header = ({
                         >
                             <PopoverTrigger>
                                 <ChevronDownIcon
-                                    aria-label="My account trigger"
+                                    aria-label={intl.formatMessage({
+                                        id: 'header.button.assistive_msg.my_account_menu',
+                                        defaultMessage: 'Open account menu'
+                                    })}
                                     onMouseLeave={handleIconsMouseLeave}
                                     onKeyDown={(e) => {
                                         keyMap[e.key]?.(e)

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -107,6 +107,7 @@ const Header = ({
 
     const accountMenuKeyDownMap = {
         Escape: () => onAccountMenuClose(),
+        ' ': () => onAccountMenuOpen(),
         Enter: () => onAccountMenuOpen()
     }
 

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -49,8 +49,6 @@ import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation
 import LoadingSpinner from '@salesforce/retail-react-app/app/components/loading-spinner'
 import {isHydrated, noop} from '@salesforce/retail-react-app/app/utils/utils'
 
-const ENTER_KEY = 'Enter'
-
 const IconButtonWithRegistration = withRegistration(IconButton)
 /**
  * The header is the main source for accessing
@@ -154,18 +152,15 @@ const Header = ({
                             {...styles.search}
                         />
                     </Box>
-                    <AccountIcon
-                        {...styles.accountIcon}
-                        tabIndex={0}
-                        onMouseOver={isDesktop ? onOpen : noop}
-                        onKeyDown={(e) => {
-                            e.key === ENTER_KEY ? onMyAccountClick() : noop
-                        }}
-                        onClick={onMyAccountClick}
+                    <IconButtonWithRegistration
+                        icon={<AccountIcon {...styles.accountIcon} />}
                         aria-label={intl.formatMessage({
                             id: 'header.button.assistive_msg.my_account',
                             defaultMessage: 'My account'
                         })}
+                        variant="unstyled"
+                        onClick={onMyAccountClick}
+                        onMouseOver={isDesktop ? onOpen : noop}
                     />
 
                     {isRegistered && isHydrated() && (

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -85,6 +85,8 @@ const Header = ({
     const logout = useAuthHelper(AuthHelpers.Logout)
     const navigate = useNavigation()
     const {
+        getButtonProps: getAccountMenuButtonProps,
+        getDisclosureProps: getAccountMenuDisclosureProps,
         isOpen: isAccountMenuOpen,
         onClose: onAccountMenuClose,
         onOpen: onAccountMenuOpen
@@ -103,12 +105,6 @@ const Header = ({
         await logout.mutateAsync()
         navigate('/login')
         setShowLoading(false)
-    }
-
-    const accountMenuKeyDownMap = {
-        Escape: () => onAccountMenuClose(),
-        ' ': () => onAccountMenuOpen(),
-        Enter: () => onAccountMenuOpen()
     }
 
     const handleIconsMouseLeave = () => {
@@ -178,18 +174,17 @@ const Header = ({
                             onOpen={onAccountMenuOpen}
                         >
                             <PopoverTrigger>
-                                <ChevronDownIcon
+                                <IconButton
                                     aria-label={intl.formatMessage({
                                         id: 'header.button.assistive_msg.my_account_menu',
                                         defaultMessage: 'Open account menu'
                                     })}
-                                    onMouseLeave={handleIconsMouseLeave}
-                                    onKeyDown={(e) => {
-                                        accountMenuKeyDownMap[e.key]?.(e)
-                                    }}
-                                    {...styles.arrowDown}
+                                    icon={<ChevronDownIcon {...styles.arrowDown} />}
+                                    variant="unstyled"
+                                    {...getAccountMenuButtonProps()}
                                     onMouseOver={onAccountMenuOpen}
-                                    tabIndex={0}
+                                    onMouseLeave={handleIconsMouseLeave}
+                                    onClick={(e) => console.log('click', e.target)}
                                 />
                             </PopoverTrigger>
 
@@ -202,6 +197,7 @@ const Header = ({
                                 onMouseOver={() => {
                                     hasEnterPopoverContent.current = true
                                 }}
+                                {...getAccountMenuDisclosureProps()}
                             >
                                 <PopoverArrow />
                                 <PopoverHeader>

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -84,7 +84,11 @@ const Header = ({
     const {isRegistered} = useCustomerType()
     const logout = useAuthHelper(AuthHelpers.Logout)
     const navigate = useNavigation()
-    const {isOpen, onClose, onOpen} = useDisclosure()
+    const {
+        isOpen: isAccountMenuOpen,
+        onClose: onAccountMenuClose,
+        onOpen: onAccountMenuOpen
+    } = useDisclosure()
     const [isDesktop] = useMediaQuery('(min-width: 992px)')
 
     const [showLoading, setShowLoading] = useState(false)
@@ -101,15 +105,15 @@ const Header = ({
         setShowLoading(false)
     }
 
-    const keyMap = {
-        Escape: () => onClose(),
-        Enter: () => onOpen()
+    const accountMenuKeyDownMap = {
+        Escape: () => onAccountMenuClose(),
+        Enter: () => onAccountMenuOpen()
     }
 
     const handleIconsMouseLeave = () => {
         // don't close the menu if users enter the popover content
         setTimeout(() => {
-            if (!hasEnterPopoverContent.current) onClose()
+            if (!hasEnterPopoverContent.current) onAccountMenuClose()
         }, 100)
     }
 
@@ -160,17 +164,17 @@ const Header = ({
                         })}
                         variant="unstyled"
                         onClick={onMyAccountClick}
-                        onMouseOver={isDesktop ? onOpen : noop}
+                        onMouseOver={isDesktop ? onAccountMenuOpen : noop}
                     />
 
                     {isRegistered && isHydrated() && (
                         <Popover
                             isLazy
                             arrowSize={15}
-                            isOpen={isOpen}
+                            isOpen={isAccountMenuOpen}
                             placement="bottom-end"
-                            onClose={onClose}
-                            onOpen={onOpen}
+                            onClose={onAccountMenuClose}
+                            onOpen={onAccountMenuOpen}
                         >
                             <PopoverTrigger>
                                 <ChevronDownIcon
@@ -180,10 +184,10 @@ const Header = ({
                                     })}
                                     onMouseLeave={handleIconsMouseLeave}
                                     onKeyDown={(e) => {
-                                        keyMap[e.key]?.(e)
+                                        accountMenuKeyDownMap[e.key]?.(e)
                                     }}
                                     {...styles.arrowDown}
-                                    onMouseOver={onOpen}
+                                    onMouseOver={onAccountMenuOpen}
                                     tabIndex={0}
                                 />
                             </PopoverTrigger>
@@ -192,7 +196,7 @@ const Header = ({
                                 {...styles.popoverContent}
                                 onMouseLeave={() => {
                                     hasEnterPopoverContent.current = false
-                                    onClose()
+                                    onAccountMenuClose()
                                 }}
                                 onMouseOver={() => {
                                     hasEnterPopoverContent.current = true

--- a/packages/template-retail-react-app/app/components/header/index.test.js
+++ b/packages/template-retail-react-app/app/components/header/index.test.js
@@ -62,11 +62,11 @@ test('renders Header', async () => {
     renderWithProviders(<Header />)
 
     await waitFor(() => {
-        const menu = document.querySelector('button[aria-label="Menu"]')
-        const logo = document.querySelector('button[aria-label="Logo"]')
-        const account = document.querySelector('svg[aria-label="My account"]')
-        const cart = document.querySelector('button[aria-label="My cart, number of items: 0"]')
-        const wishlist = document.querySelector('button[aria-label="Wishlist"]')
+        const menu = screen.getByLabelText('Menu')
+        const logo = screen.getByLabelText('Logo')
+        const account = screen.getByLabelText('My account')
+        const cart = screen.getByLabelText('My cart, number of items: 0')
+        const wishlist = screen.getByLabelText('Wishlist')
         const searchInput = document.querySelector('input[type="search"]')
         expect(menu).toBeInTheDocument()
         expect(logo).toBeInTheDocument()
@@ -91,10 +91,10 @@ test('renders Header with event handlers', async () => {
         />
     )
     await waitFor(() => {
-        const menu = document.querySelector('button[aria-label="Menu"]')
-        const logo = document.querySelector('button[aria-label="Logo"]')
-        const account = document.querySelector('svg[aria-label="My account"]')
-        const cart = document.querySelector('button[aria-label="My cart, number of items: 0"]')
+        const menu = screen.getByLabelText('Menu')
+        const logo = screen.getByLabelText('Logo')
+        const account = screen.getByLabelText('My account')
+        const cart = screen.getByLabelText('My cart, number of items: 0')
         expect(menu).toBeInTheDocument()
         fireEvent.click(menu)
         expect(onMenuClick).toHaveBeenCalledTimes(1)
@@ -124,7 +124,7 @@ test.each(testBaskets)(
         renderWithProviders(<Header />)
 
         await waitFor(() => {
-            const cart = document.querySelector('button[aria-label="My cart, number of items: 0"]')
+            const cart = screen.getByLabelText('My cart, number of items: 0')
             const badge = document.querySelector(
                 'button[aria-label="My cart, number of items: 0"] .chakra-badge'
             )
@@ -141,9 +141,7 @@ test('renders cart badge when basket is loaded', async () => {
 
     await waitFor(() => {
         // Look for badge.
-        const badge = document.querySelector(
-            'button[aria-label="My cart, number of items: 2"] .chakra-badge'
-        )
+        const badge = screen.getByLabelText('My cart, number of items: 2')
         expect(badge).toBeInTheDocument()
     })
 })
@@ -156,10 +154,10 @@ test('route to account page when an authenticated users click on account icon', 
 
     await waitFor(() => {
         // Look for account icon
-        const accountTrigger = document.querySelector('svg[aria-label="My account trigger"]')
+        const accountTrigger = screen.getByLabelText('Open account menu')
         expect(accountTrigger).toBeInTheDocument()
     })
-    const accountIcon = document.querySelector('svg[aria-label="My account"]')
+    const accountIcon = screen.getByLabelText('My account')
     fireEvent.click(accountIcon)
     await waitFor(() => {
         expect(history.push).toHaveBeenCalledWith(createPathWithDefaults('/account'))
@@ -181,7 +179,7 @@ test('route to wishlist page when an authenticated users click on wishlist icon'
 
     await waitFor(() => {
         // Look for account icon
-        const accountTrigger = document.querySelector('svg[aria-label="My account trigger"]')
+        const accountTrigger = screen.getByLabelText('Open account menu')
         expect(accountTrigger).toBeInTheDocument()
     })
     const wishlistIcon = screen.getByRole('button', {name: /wishlist/i})
@@ -207,10 +205,10 @@ test('shows dropdown menu when an authenticated users hover on the account icon'
 
     await waitFor(() => {
         // Look for account icon
-        const accountTrigger = document.querySelector('svg[aria-label="My account trigger"]')
+        const accountTrigger = screen.getByLabelText('Open account menu')
         expect(accountTrigger).toBeInTheDocument()
     })
-    const accountIcon = document.querySelector('svg[aria-label="My account"]')
+    const accountIcon = screen.getByLabelText('My account')
     fireEvent.click(accountIcon)
     await waitFor(() => {
         expect(history.push).toHaveBeenCalledWith(createPathWithDefaults('/account'))

--- a/packages/template-retail-react-app/app/components/list-menu/index.jsx
+++ b/packages/template-retail-react-app/app/components/list-menu/index.jsx
@@ -225,6 +225,7 @@ const ListMenu = ({root, maxColumns = MAXIMUM_NUMBER_COLUMNS}) => {
     const theme = useTheme()
     const {baseStyle} = theme.components.ListMenu
     const [ariaBusy, setAriaBusy] = useState(true)
+    const intl = useIntl()
 
     useEffect(() => {
         setAriaBusy(false)
@@ -233,7 +234,10 @@ const ListMenu = ({root, maxColumns = MAXIMUM_NUMBER_COLUMNS}) => {
     return (
         <nav
             id="list-menu"
-            aria-label="main"
+            aria-label={intl.formatMessage({
+                id: 'list_menu.nav.assistive_msg',
+                defaultMessage: 'Main navigation'
+            })}
             aria-live="polite"
             aria-busy={ariaBusy}
             aria-atomic="true"

--- a/packages/template-retail-react-app/app/components/list-menu/index.test.js
+++ b/packages/template-retail-react-app/app/components/list-menu/index.test.js
@@ -19,7 +19,7 @@ describe('ListMenu', () => {
         const categoryTrigger = screen.getByText(/Mens/i)
         await user.hover(categoryTrigger)
         expect(categoryTrigger).toBeInTheDocument()
-        expect(screen.getByRole('navigation', {name: 'main'})).toBeInTheDocument()
+        expect(screen.getByRole('navigation', {name: 'Main navigation'})).toBeInTheDocument()
         const suit = screen.getByText(/suits/i)
         expect(suit).toBeInTheDocument()
     })

--- a/packages/template-retail-react-app/app/components/pagination/index.jsx
+++ b/packages/template-retail-react-app/app/components/pagination/index.jsx
@@ -53,7 +53,10 @@ const Pagination = (props) => {
                 // as intended, the workaround is to use the current url when its disabled.
                 href={prev || currentURL}
                 to={prev || currentURL}
-                aria-label="Previous Page"
+                aria-label={intl.formatMessage({
+                    id: 'pagination.link.prev.assistive_msg',
+                    defaultMessage: 'Previous Page'
+                })}
                 isDisabled={!prev}
                 variant="link"
             >
@@ -102,7 +105,10 @@ const Pagination = (props) => {
                 // as intended, the workaround is to use the current url when its disabled.
                 href={next || currentURL}
                 to={next || currentURL}
-                aria-label="Next Page"
+                aria-label={intl.formatMessage({
+                    id: 'pagination.link.next.assistive_msg',
+                    defaultMessage: 'Next Page'
+                })}
                 isDisabled={!next}
                 variant="link"
             >

--- a/packages/template-retail-react-app/app/components/promo-popover/index.jsx
+++ b/packages/template-retail-react-app/app/components/promo-popover/index.jsx
@@ -16,7 +16,6 @@ import {
     PopoverContent,
     PopoverHeader,
     PopoverTrigger,
-    Portal,
     Text
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import {InfoIcon} from '@salesforce/retail-react-app/app/components/icons'

--- a/packages/template-retail-react-app/app/components/with-registration/index.jsx
+++ b/packages/template-retail-react-app/app/components/with-registration/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2023, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -13,20 +13,31 @@ import {useLocation} from 'react-router-dom'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 
-const withRegistration = (Component) => {
+/**
+ * Higher-order component that modifies the given component's `onClick` to show the login form if
+ * the user is not logged in.
+ * @param {React.Component} component Component to wrap.
+ * @param {(location: Location, locale: string) => boolean} [options.isLoginPage] Function that
+ * determines whether the current page is the "login" page, to avoid showing a duplicate modal.
+ * Defaults to all paths ending with "/login".
+ * @returns {React.Component} wrapped component
+ */
+const withRegistration = (
+    Component,
+    {isLoginPage = (loc) => loc.pathname.endsWith('/login')} = {}
+) => {
     const WrappedComponent = ({onClick = noop, ...passThroughProps}) => {
         const {data: customer} = useCurrentCustomer()
         const authModal = useAuthModal()
+        const showToast = useToast()
         const location = useLocation()
         const {formatMessage, locale} = useIntl()
-        const isLoginPage = new RegExp(`^/${locale}/login$`).test(location.pathname)
-        const showToast = useToast()
 
         const handleClick = (e) => {
             e.preventDefault()
             if (!customer.isRegistered) {
                 // Do not show auth modal if users is already on the login page
-                if (isLoginPage) {
+                if (isLoginPage(location, locale)) {
                     showToast({
                         title: formatMessage({
                             defaultMessage: 'Please sign in to continue!',

--- a/packages/template-retail-react-app/app/hooks/use-auth-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-auth-modal.js
@@ -278,7 +278,12 @@ export const AuthModal = ({
         >
             <ModalOverlay />
             <ModalContent>
-                <ModalCloseButton />
+                <ModalCloseButton
+                    aria-label={formatMessage({
+                        id: 'auth_modal.button.close.assistive_msg',
+                        defaultMessage: 'Close login form'
+                    })}
+                />
                 <ModalBody pb={8} bg="white" paddingBottom={14} marginTop={14}>
                     {!form.formState.isSubmitSuccessful && currentView === LOGIN_VIEW && (
                         <LoginForm

--- a/packages/template-retail-react-app/app/page-designer/layouts/carousel/index.jsx
+++ b/packages/template-retail-react-app/app/page-designer/layouts/carousel/index.jsx
@@ -18,7 +18,7 @@ import {
 import {Component, regionPropType} from '@salesforce/commerce-sdk-react/components'
 import {ChevronLeftIcon, ChevronRightIcon} from '@salesforce/retail-react-app/app/components/icons'
 import {useEffect} from 'react'
-import {useIntl} from '@salesforce/retail-react-app/node_modules/react-intl/index'
+import {useIntl} from 'react-intl'
 
 /**
  * Display child components in a carousel slider manner. Configurations include the number of

--- a/packages/template-retail-react-app/app/page-designer/layouts/carousel/index.jsx
+++ b/packages/template-retail-react-app/app/page-designer/layouts/carousel/index.jsx
@@ -18,6 +18,7 @@ import {
 import {Component, regionPropType} from '@salesforce/commerce-sdk-react/components'
 import {ChevronLeftIcon, ChevronRightIcon} from '@salesforce/retail-react-app/app/components/icons'
 import {useEffect} from 'react'
+import {useIntl} from '@salesforce/retail-react-app/node_modules/react-intl/index'
 
 /**
  * Display child components in a carousel slider manner. Configurations include the number of
@@ -37,6 +38,7 @@ import {useEffect} from 'react'
  * @returns {React.ReactElement} - Carousel component.
  */
 export const Carousel = (props = {}) => {
+    const intl = useIntl()
     const scrollRef = useRef()
     const breakpoint = useBreakpoint()
     const [hasOverflow, setHasOverflow] = useState(false)
@@ -172,11 +174,14 @@ export const Carousel = (props = {}) => {
                     {/* boxShadow requires !important --> https://github.com/chakra-ui/chakra-ui/issues/3553 */}
                     <IconButton
                         data-testid="carousel-nav-left"
-                        aria-label="Scroll carousel left"
+                        aria-label={intl.formatMessage({
+                            id: 'carousel.button.scroll_left.assistive_msg',
+                            defaultMessage: 'Scroll carousel left'
+                        })}
                         icon={<ChevronLeftIcon color="black" />}
                         borderRadius="full"
                         colorScheme="whiteAlpha"
-                        boxShadow={'0 3px 10px rgb(0 0 0 / 20%) !important'}
+                        boxShadow="0 3px 10px rgb(0 0 0 / 20%) !important"
                         onClick={() => scroll(-1)}
                     />
                 </Box>
@@ -191,11 +196,14 @@ export const Carousel = (props = {}) => {
                     {/* boxShadow requires !important --> https://github.com/chakra-ui/chakra-ui/issues/3553 */}
                     <IconButton
                         data-testid="carousel-nav-right"
-                        aria-label="Scroll carousel right"
+                        aria-label={intl.formatMessage({
+                            id: 'carousel.button.scroll_right.assistive_msg',
+                            defaultMessage: 'Scroll carousel right'
+                        })}
                         icon={<ChevronRightIcon color="black" />}
                         borderRadius="full"
                         colorScheme="whiteAlpha"
-                        boxShadow={'0 3px 10px rgb(0 0 0 / 20%) !important'}
+                        boxShadow="0 3px 10px rgb(0 0 0 / 20%) !important"
                         onClick={() => scroll(1)}
                     />
                 </Box>

--- a/packages/template-retail-react-app/app/pages/cart/partials/cart-secondary-button-group.jsx
+++ b/packages/template-retail-react-app/app/pages/cart/partials/cart-secondary-button-group.jsx
@@ -7,7 +7,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {
-    Box,
     Button,
     ButtonGroup,
     Checkbox,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -413,6 +413,18 @@
       "value": "Password Reset"
     }
   ],
+  "carousel.button.scroll_left.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Scroll carousel left"
+    }
+  ],
+  "carousel.button.scroll_right.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Scroll carousel right"
+    }
+  ],
   "cart.info.removed_from_cart": [
     {
       "type": 0,
@@ -1163,6 +1175,18 @@
       "value": "Top Sellers"
     }
   ],
+  "field.password.assistive_msg.hide_password": [
+    {
+      "type": 0,
+      "value": "Hide password"
+    }
+  ],
+  "field.password.assistive_msg.show_password": [
+    {
+      "type": 0,
+      "value": "Show password"
+    }
+  ],
   "footer.column.account": [
     {
       "type": 0,
@@ -1339,6 +1363,12 @@
       "value": " added to wishlist"
     }
   ],
+  "global.info.already_in_wishlist": [
+    {
+      "type": 0,
+      "value": "Item is already in wishlist"
+    }
+  ],
   "global.info.removed_from_wishlist": [
     {
       "type": 0,
@@ -1367,6 +1397,12 @@
     {
       "type": 0,
       "value": "My account"
+    }
+  ],
+  "header.button.assistive_msg.my_account_menu": [
+    {
+      "type": 0,
+      "value": "Open account menu"
     }
   ],
   "header.button.assistive_msg.my_cart_with_num_items": [
@@ -1605,6 +1641,12 @@
     {
       "type": 0,
       "value": "Please select all your options above"
+    }
+  ],
+  "list_menu.nav.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Main navigation"
     }
   ],
   "locale_text.message.ar-SA": [
@@ -2117,10 +2159,22 @@
       "value": "Next"
     }
   ],
+  "pagination.link.next.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Next Page"
+    }
+  ],
   "pagination.link.prev": [
     {
       "type": 0,
       "value": "Prev"
+    }
+  ],
+  "pagination.link.prev.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Previous Page"
     }
   ],
   "password_card.info.password_updated": [
@@ -2327,7 +2381,7 @@
       "value": " to wishlist"
     }
   ],
-  "product_tile.assistive_msg.remove_from wishlist": [
+  "product_tile.assistive_msg.remove_from_wishlist": [
     {
       "type": 0,
       "value": "Remove "

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -355,6 +355,12 @@
       "value": "You Might Also Like"
     }
   ],
+  "auth_modal.button.close.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Close login form"
+    }
+  ],
   "auth_modal.description.now_signed_in": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -413,6 +413,18 @@
       "value": "Password Reset"
     }
   ],
+  "carousel.button.scroll_left.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Scroll carousel left"
+    }
+  ],
+  "carousel.button.scroll_right.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Scroll carousel right"
+    }
+  ],
   "cart.info.removed_from_cart": [
     {
       "type": 0,
@@ -1163,6 +1175,18 @@
       "value": "Top Sellers"
     }
   ],
+  "field.password.assistive_msg.hide_password": [
+    {
+      "type": 0,
+      "value": "Hide password"
+    }
+  ],
+  "field.password.assistive_msg.show_password": [
+    {
+      "type": 0,
+      "value": "Show password"
+    }
+  ],
   "footer.column.account": [
     {
       "type": 0,
@@ -1373,6 +1397,12 @@
     {
       "type": 0,
       "value": "My account"
+    }
+  ],
+  "header.button.assistive_msg.my_account_menu": [
+    {
+      "type": 0,
+      "value": "Open account menu"
     }
   ],
   "header.button.assistive_msg.my_cart_with_num_items": [
@@ -1611,6 +1641,12 @@
     {
       "type": 0,
       "value": "Please select all your options above"
+    }
+  ],
+  "list_menu.nav.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Main navigation"
     }
   ],
   "locale_text.message.ar-SA": [
@@ -2123,10 +2159,22 @@
       "value": "Next"
     }
   ],
+  "pagination.link.next.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Next Page"
+    }
+  ],
   "pagination.link.prev": [
     {
       "type": 0,
       "value": "Prev"
+    }
+  ],
+  "pagination.link.prev.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Previous Page"
     }
   ],
   "password_card.info.password_updated": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -355,6 +355,12 @@
       "value": "You Might Also Like"
     }
   ],
+  "auth_modal.button.close.assistive_msg": [
+    {
+      "type": 0,
+      "value": "Close login form"
+    }
+  ],
   "auth_modal.description.now_signed_in": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -845,6 +845,34 @@
       "value": "]"
     }
   ],
+  "carousel.button.scroll_left.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şƈřǿǿŀŀ ƈȧȧřǿǿŭŭşḗḗŀ ŀḗḗƒŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "carousel.button.scroll_right.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şƈřǿǿŀŀ ƈȧȧřǿǿŭŭşḗḗŀ řīɠħŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "cart.info.removed_from_cart": [
     {
       "type": 0,
@@ -2411,6 +2439,34 @@
       "value": "]"
     }
   ],
+  "field.password.assistive_msg.hide_password": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ħīḓḗḗ ƥȧȧşşẇǿǿřḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "field.password.assistive_msg.show_password": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şħǿǿẇ ƥȧȧşşẇǿǿřḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "footer.column.account": [
     {
       "type": 0,
@@ -2857,6 +2913,20 @@
     {
       "type": 0,
       "value": "Ḿẏ ȧȧƈƈǿǿŭŭƞŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "header.button.assistive_msg.my_account_menu": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ǿƥḗḗƞ ȧȧƈƈǿǿŭŭƞŧ ḿḗḗƞŭŭ"
     },
     {
       "type": 0,
@@ -3391,6 +3461,20 @@
     {
       "type": 0,
       "value": "Ƥŀḗḗȧȧşḗḗ şḗḗŀḗḗƈŧ ȧȧŀŀ ẏǿǿŭŭř ǿǿƥŧīǿǿƞş ȧȧƀǿǿṽḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "list_menu.nav.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḿȧȧīƞ ƞȧȧṽīɠȧȧŧīǿǿƞ"
     },
     {
       "type": 0,
@@ -4531,6 +4615,20 @@
       "value": "]"
     }
   ],
+  "pagination.link.next.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƞḗḗẋŧ Ƥȧȧɠḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "pagination.link.prev": [
     {
       "type": 0,
@@ -4539,6 +4637,20 @@
     {
       "type": 0,
       "value": "Ƥřḗḗṽ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "pagination.link.prev.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƥřḗḗṽīǿǿŭŭş Ƥȧȧɠḗḗ"
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -739,6 +739,20 @@
       "value": "]"
     }
   ],
+  "auth_modal.button.close.assistive_msg": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈŀǿǿşḗḗ ŀǿǿɠīƞ ƒǿǿřḿ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "auth_modal.description.now_signed_in": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -162,6 +162,12 @@
   "auth_modal.password_reset_success.title.password_reset": {
     "defaultMessage": "Password Reset"
   },
+  "carousel.button.scroll_left.assistive_msg": {
+    "defaultMessage": "Scroll carousel left"
+  },
+  "carousel.button.scroll_right.assistive_msg": {
+    "defaultMessage": "Scroll carousel right"
+  },
   "cart.info.removed_from_cart": {
     "defaultMessage": "Item removed from cart"
   },
@@ -471,6 +477,12 @@
   "empty_search_results.recommended_products.title.top_sellers": {
     "defaultMessage": "Top Sellers"
   },
+  "field.password.assistive_msg.hide_password": {
+    "defaultMessage": "Hide password"
+  },
+  "field.password.assistive_msg.show_password": {
+    "defaultMessage": "Show password"
+  },
   "footer.column.account": {
     "defaultMessage": "Account"
   },
@@ -543,6 +555,9 @@
   "global.info.added_to_wishlist": {
     "defaultMessage": "{quantity} {quantity, plural, one {item} other {items}} added to wishlist"
   },
+  "global.info.already_in_wishlist": {
+    "defaultMessage": "Item is already in wishlist"
+  },
   "global.info.removed_from_wishlist": {
     "defaultMessage": "Item removed from wishlist"
   },
@@ -557,6 +572,9 @@
   },
   "header.button.assistive_msg.my_account": {
     "defaultMessage": "My account"
+  },
+  "header.button.assistive_msg.my_account_menu": {
+    "defaultMessage": "Open account menu"
   },
   "header.button.assistive_msg.my_cart_with_num_items": {
     "defaultMessage": "My cart, number of items: {numItems}"
@@ -670,6 +688,9 @@
   },
   "lCPCxk": {
     "defaultMessage": "Please select all your options above"
+  },
+  "list_menu.nav.assistive_msg": {
+    "defaultMessage": "Main navigation"
   },
   "locale_text.message.ar-SA": {
     "defaultMessage": "Arabic (Saudi Arabia)"
@@ -906,8 +927,14 @@
   "pagination.link.next": {
     "defaultMessage": "Next"
   },
+  "pagination.link.next.assistive_msg": {
+    "defaultMessage": "Next Page"
+  },
   "pagination.link.prev": {
     "defaultMessage": "Prev"
+  },
+  "pagination.link.prev.assistive_msg": {
+    "defaultMessage": "Previous Page"
   },
   "password_card.info.password_updated": {
     "defaultMessage": "Password updated"
@@ -1005,7 +1032,7 @@
   "product_tile.assistive_msg.add_to_wishlist": {
     "defaultMessage": "Add {product} to wishlist"
   },
-  "product_tile.assistive_msg.remove_from wishlist": {
+  "product_tile.assistive_msg.remove_from_wishlist": {
     "defaultMessage": "Remove {product} from wishlist"
   },
   "product_tile.label.starting_at_price": {

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -144,6 +144,9 @@
   "add_to_cart_modal.recommended_products.title.might_also_like": {
     "defaultMessage": "You Might Also Like"
   },
+  "auth_modal.button.close.assistive_msg": {
+    "defaultMessage": "Close login form"
+  },
   "auth_modal.description.now_signed_in": {
     "defaultMessage": "You're now signed in."
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -162,6 +162,12 @@
   "auth_modal.password_reset_success.title.password_reset": {
     "defaultMessage": "Password Reset"
   },
+  "carousel.button.scroll_left.assistive_msg": {
+    "defaultMessage": "Scroll carousel left"
+  },
+  "carousel.button.scroll_right.assistive_msg": {
+    "defaultMessage": "Scroll carousel right"
+  },
   "cart.info.removed_from_cart": {
     "defaultMessage": "Item removed from cart"
   },
@@ -471,6 +477,12 @@
   "empty_search_results.recommended_products.title.top_sellers": {
     "defaultMessage": "Top Sellers"
   },
+  "field.password.assistive_msg.hide_password": {
+    "defaultMessage": "Hide password"
+  },
+  "field.password.assistive_msg.show_password": {
+    "defaultMessage": "Show password"
+  },
   "footer.column.account": {
     "defaultMessage": "Account"
   },
@@ -560,6 +572,9 @@
   },
   "header.button.assistive_msg.my_account": {
     "defaultMessage": "My account"
+  },
+  "header.button.assistive_msg.my_account_menu": {
+    "defaultMessage": "Open account menu"
   },
   "header.button.assistive_msg.my_cart_with_num_items": {
     "defaultMessage": "My cart, number of items: {numItems}"
@@ -673,6 +688,9 @@
   },
   "lCPCxk": {
     "defaultMessage": "Please select all your options above"
+  },
+  "list_menu.nav.assistive_msg": {
+    "defaultMessage": "Main navigation"
   },
   "locale_text.message.ar-SA": {
     "defaultMessage": "Arabic (Saudi Arabia)"
@@ -909,8 +927,14 @@
   "pagination.link.next": {
     "defaultMessage": "Next"
   },
+  "pagination.link.next.assistive_msg": {
+    "defaultMessage": "Next Page"
+  },
   "pagination.link.prev": {
     "defaultMessage": "Prev"
+  },
+  "pagination.link.prev.assistive_msg": {
+    "defaultMessage": "Previous Page"
   },
   "password_card.info.password_updated": {
     "defaultMessage": "Password updated"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -144,6 +144,9 @@
   "add_to_cart_modal.recommended_products.title.might_also_like": {
     "defaultMessage": "You Might Also Like"
   },
+  "auth_modal.button.close.assistive_msg": {
+    "defaultMessage": "Close login form"
+  },
   "auth_modal.description.now_signed_in": {
     "defaultMessage": "You're now signed in."
   },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Noticed when reviewing #1570 that the ARIA labels were hard-coded strings, rather than translatable messages. Did a quick search in the project to find all the other instances of that. Spotted a few small issues along the way, so I fixed those as well.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Listed in commit history

# How to Test-Drive This PR

To test that the messages are now translatable:
- Update relevant translations in translation files
- Start dev server
- Observe that your changes are reflected on the page

To test other changes
- Start dev server
- Click "My account" button as guest. Should open login modal.
- Click "My account" button as registered user. Should go to account.
- Hitting space/enter on "My account" button should have the same result as clicking.
- Hitting space/enter on account menu icon should open the menu.
- Turn on VoiceOver
- View login screen.
- Tab over the 👁️‍🗨️ icon. Should say "show password".
- Click 👁️‍🗨️ icon. Should show password and now say "hide password".
- Tab focus on "My account" button. It should now say "My account, button"
  - It should probably be a link, rather than a button, but that's harder to change without breaking customers
- Tab focus on account dropdown icon. It should now say "Open account menu"

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
