### PR TITLE
@W-12627135 - Fix ARIA for ListMenuTrigger Component 

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Accessibility Improvements
 
 <!-- Order by Pull Request ID! -->
+- Ensure the ListMenuTrigger component applies ARIA attributes to the correct element for the trigger icon [#1600](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1600)
 - Ensure form fields and icons have accessible labels [#1526](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1526)
 - Ensure active user interface components have sufficient contrast [#1534](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1534)
 - Fix outline on keyboard focus [#1536](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1536/files)

--- a/packages/template-retail-react-app/app/components/list-menu/index.jsx
+++ b/packages/template-retail-react-app/app/components/list-menu/index.jsx
@@ -69,21 +69,21 @@ const ListMenuTrigger = ({item, name, isOpen, onOpen, onClose, hasItems}) => {
                 {name}
             </Link>
 
-            <Link
-                as={RouteLink}
-                to={'#'}
-                onMouseOver={onOpen}
-                onKeyDown={(e) => {
-                    keyMap[e.key]?.(e)
-                }}
-                {...baseStyle.listMenuTriggerLinkIcon}
-            >
-                <PopoverTrigger>
+            <PopoverTrigger>
+                <Link
+                    as={RouteLink}
+                    to={'#'}
+                    onMouseOver={onOpen}
+                    onKeyDown={(e) => {
+                        keyMap[e.key]?.(e)
+                    }}
+                    {...baseStyle.listMenuTriggerLinkIcon}
+                >
                     <Fade in={hasItems}>
                         <ChevronIconTrigger {...baseStyle.selectedButtonIcon} />
                     </Fade>
-                </PopoverTrigger>
-            </Link>
+                </Link>
+            </PopoverTrigger>
         </Box>
     )
 }


### PR DESCRIPTION
# Description

This PR fixes [@W-12627135](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001MFgEpYAL/view) where the ARIA roles, states and properties were places on the wrong element in the menu and could potentially confuse screen readers.

The fix here was to simply wrap the Link component with the popover trigger and not next it inside of the Link. This results in similar markup, but now the link has all the correct ARIA attributes that it should.

#### This image was provided by the auditors, highlighting the ARIA props being on the wrong element:
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/eca9ec98-231d-4e26-989c-58bc6e37fab9)

#### This image is the markup after this PR changes, showing that now the ARIA props are correctly situated on the link tag:
<img width="1682" alt="Screenshot 2023-12-05 at 2 02 56 PM" src="https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/e4804488-b080-438e-90de-2aae1dce8c51">

NOTE: There have been some changes to the components that have resulted in some differences in the markup (e.g. you can see this additional fade div) those changes have no bearings on this solution.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Change what components are encompassed by the popover trigger.

# How to Test-Drive This PR

- Check out and preview this code.
- Use html inspector to inspect the "down-chevron" icon next to "New Arrivals" in the main navigation.
- Ensure that the markup looks like the image provided above where the ARIA attributes "haspopup", "expanded", "controls", etc are on the anchor tag and not the div within it.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
