### PR TITLE
@W-12627152@ Change radio refinements to buttons

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Accessibility improvements
 
-- Change radio refinements from radio inputs to styled buttons [#1605](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1605)
+- Change radio refinements (for example, filtering by Price) from radio inputs to styled buttons [#1605](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1605)
 
 ## v2.2.0-dev (Nov 3, 2023)
 

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,3 +1,9 @@
+## There's gonna be a merge conflict cuz we're mid release
+
+### Accessibility improvements
+
+- Change radio refinements from radio inputs to styled buttons [#1605](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1605)
+
 ## v2.2.0-dev (Nov 3, 2023)
 
 ### Accessibility Improvements

--- a/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
@@ -25,7 +25,7 @@ const RadioRefinement = ({filter, value, toggleFilter, selectedFilters}) => {
                 // these workarounds to prevent it from receiving focus.
                 inputProps={{'aria-hidden': true, tabIndex: -1}}
                 onClick={() => buttonRef.current?.click()}
-            ></Radio>
+            />
             <Text
                 ref={buttonRef}
                 ml={2}

--- a/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
@@ -1,66 +1,74 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2023, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import React from 'react'
-import {
-    Box,
-    Text,
-    Radio,
-    RadioGroup,
-    Stack
-} from '@salesforce/retail-react-app/app/components/shared/ui'
+import React, {useRef} from 'react'
+import {Box, Text, Radio, Stack} from '@salesforce/retail-react-app/app/components/shared/ui'
 import PropTypes from 'prop-types'
+
+const RadioRefinement = ({filter, value, toggleFilter, selectedFilters}) => {
+    const buttonRef = useRef()
+    // Because choosing a refinement is equivalent to a form submission, the best semantic choice
+    // for the refinement is a button or a link, rather than a radio input. The radio element here
+    // is purely for visual purposes, and should probably be replaced with a simple icon.
+    return (
+        <Box>
+            <Radio
+                display="inline-flex"
+                height={{base: '44px', lg: '24px'}}
+                isChecked={selectedFilters.includes(value.value)}
+                // Ideally, this "icon" would be part of the button, but doing so with a radio input
+                // triggers `onClick` twice. The radio must be separate, and therefore we must add
+                // these workarounds to prevent it from receiving focus.
+                inputProps={{'aria-hidden': true, tabIndex: -1}}
+                onClick={() => buttonRef.current?.click()}
+            ></Radio>
+            <Text
+                ref={buttonRef}
+                ml={2}
+                as="button"
+                fontSize="sm"
+                onClick={() => toggleFilter(value, filter.attributeId, false, false)}
+            >
+                {value.label}
+            </Text>
+        </Box>
+    )
+}
+
+RadioRefinement.propTypes = {
+    filter: PropTypes.object,
+    value: PropTypes.object,
+    toggleFilter: PropTypes.func,
+    selectedFilters: PropTypes.arrayOf(PropTypes.object)
+}
 
 const RadioRefinements = ({filter, toggleFilter, selectedFilters}) => {
     return (
-        <Box>
-            <RadioGroup
-                // The following `false` fallback is required to avoid the radio group
-                // from switching to "uncontrolled mode" when `selectedFilters` is empty.
-                value={selectedFilters[0] ?? false}
-            >
-                <Stack spacing={1}>
-                    {filter.values
-                        .filter((refinementValue) => refinementValue.hitCount > 0)
-                        .map((value) => {
-                            return (
-                                <Box key={value.value}>
-                                    <Radio
-                                        display="flex"
-                                        alignItems="center"
-                                        height={{base: '44px', lg: '24px'}}
-                                        value={value.value}
-                                        onChange={() =>
-                                            toggleFilter(
-                                                value,
-                                                filter.attributeId,
-                                                selectedFilters.includes(value.value),
-                                                false
-                                            )
-                                        }
-                                        fontSize="sm"
-                                    >
-                                        <Text marginLeft={-1} fontSize="sm">
-                                            {value.label}
-                                        </Text>
-                                    </Radio>
-                                </Box>
-                            )
-                        })}
-                </Stack>
-            </RadioGroup>
-        </Box>
+        <Stack spacing={1}>
+            {filter.values.map(
+                (value) =>
+                    value.hitCount > 0 && (
+                        <RadioRefinement
+                            key={value.value}
+                            value={value}
+                            filter={filter}
+                            toggleFilter={toggleFilter}
+                            selectedFilters={selectedFilters}
+                        />
+                    )
+            )}
+        </Stack>
     )
 }
 
 RadioRefinements.propTypes = {
     filter: PropTypes.object,
     toggleFilter: PropTypes.func,
-    selectedFilters: PropTypes.array
+    selectedFilters: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default RadioRefinements

--- a/packages/template-retail-react-app/app/pages/product-list/partials/refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/refinements.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2023, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -25,7 +25,8 @@ import LinkRefinements from '@salesforce/retail-react-app/app/pages/product-list
 import {isServer} from '@salesforce/retail-react-app/app/utils/utils'
 import {FILTER_ACCORDION_SATE} from '@salesforce/retail-react-app/app/constants'
 
-const componentMap = {
+/** Map of refinement attribute IDs to the components used to display values as filter options. */
+export const componentMap = {
     cgid: LinkRefinements,
     c_refinementColor: ColorRefinements,
     c_size: SizeRefinements,


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

When viewing the PLP (e.g. [Womens Clothing](https://pwa-kit.mobify-storefront.com/global/en-GB/category/womens-clothing)), clicking a refinement updates the page with filtered results. The individual options are mostly implemented as buttons, which makes sense, because buttons are explicit "do something" elements. One exception to this is the _radio_ refinement, (e.g. the Price filter). Those are implemented as radio inputs. This doesn't make sense, semantically, because radio inputs are "specify a choice" form elements, and the "do something" is supposed to be controlled by a separate element (the submit button, in a typical form).

This PR changes the radio refinements from radio inputs to buttons, to bring them into alignment with the rest of the refinements. It preserves the radio button as a (hopefully) purely visual indicator. Ideally, this would be done with an icon component, instead of a radio input, but I don't know of any way to do that with what we currently have (Chakra). Instead, I use an actual radio input and attempt to disable all interactivity.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Start dev server
- View a category ([Womens Clothing](http://localhost:3000/global/en-GB/category/womens-clothing))
- Click the text of any price filter. Observe it gets filtered by that price.
- Click the text of any other price filter. Observe that the old filter is removed, and a new one is applied.
- Click the text of the active price filter. Observe that there is now no filter applied.
- Repeat the steps above, but instead click the radio buttons. Make the same observations.
- After clicking on a radio button, hit `Tab`. Hit `Shift+Tab`. Observe that only the text is focused, the radio buttons are skipped.
- Activate VoiceOver. Navigate the price filters. Observe that only the buttons are interactive; the radio inputs cannot receive focus.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
