### PR TITLE
Show selected refinements even for no results.

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Add local development support for node 20 [#1612](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1612)
   - Support for node 20 is not yet available on Managed Runtime
+- Display selected refinements on PLP, even if the selected refinement has no hits [#1622](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1622)
 
 ## v2.2.0 (Nov 8, 2023)
 

--- a/packages/template-retail-react-app/app/pages/product-list/partials/checkbox-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/checkbox-refinements.jsx
@@ -18,26 +18,27 @@ const CheckboxRefinements = ({filter, toggleFilter, selectedFilters}) => {
     const {formatMessage} = useIntl()
     return (
         <Stack spacing={1}>
-            {filter.values
-                ?.filter((refinementValue) => refinementValue.hitCount > 0)
-                .map((value) => {
-                    const isChecked = selectedFilters.includes(value.value)
+            {filter.values?.map((value) => {
+                const isChecked = selectedFilters.includes(value.value)
+                // Don't display refinements with no results, unless we got there by selecting too
+                // many refinements
+                if (value.hitCount === 0 && !isChecked) return
 
-                    return (
-                        <Box key={value.value}>
-                            <Checkbox
-                                isChecked={isChecked}
-                                onChange={() => toggleFilter(value, filter.attributeId, isChecked)}
-                                aria-label={formatMessage(
-                                    isChecked ? REMOVE_FILTER : ADD_FILTER,
-                                    value
-                                )}
-                            >
-                                {value.label}
-                            </Checkbox>
-                        </Box>
-                    )
-                })}
+                return (
+                    <Box key={value.value}>
+                        <Checkbox
+                            isChecked={isChecked}
+                            onChange={() => toggleFilter(value, filter.attributeId, isChecked)}
+                            aria-label={formatMessage(
+                                isChecked ? REMOVE_FILTER : ADD_FILTER,
+                                value
+                            )}
+                        >
+                            {value.label}
+                        </Checkbox>
+                    </Box>
+                )
+            })}
         </Stack>
     )
 }

--- a/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/color-refinements.jsx
@@ -32,73 +32,75 @@ const ColorRefinements = ({filter, toggleFilter, selectedFilters}) => {
 
     return (
         <SimpleGrid columns={2} spacing={2} mt={1}>
-            {filter.values
-                .filter((refinementValue) => refinementValue.hitCount > 0)
-                .map((value, idx) => {
-                    const isSelected = selectedFilters.includes(value.value)
+            {filter.values.map((value, idx) => {
+                const isSelected = selectedFilters.includes(value.value)
 
-                    return (
-                        <Box key={idx}>
-                            <HStack
-                                onClick={() => toggleFilter(value, filter.attributeId, isSelected)}
-                                spacing={1}
-                                cursor="pointer"
+                // Don't display refinements with no results, unless we got there by selecting too
+                // many refinements
+                if (value.hitCount === 0 && !isSelected) return
+
+                return (
+                    <Box key={idx}>
+                        <HStack
+                            onClick={() => toggleFilter(value, filter.attributeId, isSelected)}
+                            spacing={1}
+                            cursor="pointer"
+                        >
+                            <Button
+                                {...styles.swatch}
+                                color={isSelected ? 'black' : 'gray.200'}
+                                border={isSelected ? '1px' : '0'}
+                                aria-checked={isSelected}
+                                variant="outline"
+                                marginRight={0}
+                                marginBottom="-1px"
+                                aria-label={intl.formatMessage(
+                                    isSelected ? REMOVE_FILTER_HIT_COUNT : ADD_FILTER_HIT_COUNT,
+                                    value
+                                )}
                             >
-                                <Button
-                                    {...styles.swatch}
-                                    color={isSelected ? 'black' : 'gray.200'}
-                                    border={isSelected ? '1px' : '0'}
-                                    aria-checked={isSelected}
-                                    variant="outline"
+                                <Center
+                                    {...styles.swatchButton}
                                     marginRight={0}
-                                    marginBottom="-1px"
-                                    aria-label={intl.formatMessage(
-                                        isSelected ? REMOVE_FILTER_HIT_COUNT : ADD_FILTER_HIT_COUNT,
-                                        value
-                                    )}
+                                    border="1px solid black"
                                 >
-                                    <Center
-                                        {...styles.swatchButton}
+                                    <Box
                                         marginRight={0}
-                                        border="1px solid black"
-                                    >
-                                        <Box
-                                            marginRight={0}
-                                            height="100%"
-                                            width="100%"
-                                            minWidth="32px"
-                                            backgroundRepeat="no-repeat"
-                                            backgroundSize="cover"
-                                            backgroundColor={
-                                                cssColorGroups[value.presentationId.toLowerCase()]
-                                            }
-                                            background={
-                                                value.presentationId.toLowerCase() ===
-                                                    'miscellaneous' &&
-                                                cssColorGroups[value.presentationId.toLowerCase()]
-                                            }
-                                        />
-                                    </Center>
-                                </Button>
-                                <Text
-                                    display="flex"
-                                    alignItems="center"
-                                    fontSize="sm"
-                                    marginBottom="1px"
-                                    aria-hidden="true" // avoid redundant readout since swatch has aria label
-                                >
-                                    {intl.formatMessage(
-                                        {
-                                            id: 'colorRefinements.label.hitCount',
-                                            defaultMessage: '{colorLabel} ({colorHitCount})'
-                                        },
-                                        {colorLabel: value.label, colorHitCount: value.hitCount}
-                                    )}
-                                </Text>
-                            </HStack>
-                        </Box>
-                    )
-                })}
+                                        height="100%"
+                                        width="100%"
+                                        minWidth="32px"
+                                        backgroundRepeat="no-repeat"
+                                        backgroundSize="cover"
+                                        backgroundColor={
+                                            cssColorGroups[value.presentationId.toLowerCase()]
+                                        }
+                                        background={
+                                            value.presentationId.toLowerCase() ===
+                                                'miscellaneous' &&
+                                            cssColorGroups[value.presentationId.toLowerCase()]
+                                        }
+                                    />
+                                </Center>
+                            </Button>
+                            <Text
+                                display="flex"
+                                alignItems="center"
+                                fontSize="sm"
+                                marginBottom="1px"
+                                aria-hidden="true" // avoid redundant readout since swatch has aria label
+                            >
+                                {intl.formatMessage(
+                                    {
+                                        id: 'colorRefinements.label.hitCount',
+                                        defaultMessage: '{colorLabel} ({colorHitCount})'
+                                    },
+                                    {colorLabel: value.label, colorHitCount: value.hitCount}
+                                )}
+                            </Text>
+                        </HStack>
+                    </Box>
+                )
+            })}
         </SimpleGrid>
     )
 }

--- a/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/radio-refinements.jsx
@@ -14,10 +14,9 @@ import {
     REMOVE_FILTER
 } from '@salesforce/retail-react-app/app/pages/product-list/partials/refinements-utils'
 
-const RadioRefinement = ({filter, value, toggleFilter, selectedFilters}) => {
+const RadioRefinement = ({filter, value, toggleFilter, isSelected}) => {
     const buttonRef = useRef()
     const {formatMessage} = useIntl()
-    const selected = selectedFilters.includes(value.value)
     // Because choosing a refinement is equivalent to a form submission, the best semantic choice
     // for the refinement is a button or a link, rather than a radio input. The radio element here
     // is purely for visual purposes, and should probably be replaced with a simple icon.
@@ -26,7 +25,7 @@ const RadioRefinement = ({filter, value, toggleFilter, selectedFilters}) => {
             <Radio
                 display="inline-flex"
                 height={{base: '44px', lg: '24px'}}
-                isChecked={selected}
+                isChecked={isSelected}
                 // Ideally, this "icon" would be part of the button, but doing so with a radio input
                 // triggers `onClick` twice. The radio must be separate, and therefore we must add
                 // these workarounds to prevent it from receiving focus.
@@ -39,7 +38,7 @@ const RadioRefinement = ({filter, value, toggleFilter, selectedFilters}) => {
                 as="button"
                 fontSize="sm"
                 onClick={() => toggleFilter(value, filter.attributeId, false, false)}
-                aria-label={formatMessage(selected ? REMOVE_FILTER : ADD_FILTER, value)}
+                aria-label={formatMessage(isSelected ? REMOVE_FILTER : ADD_FILTER, value)}
             >
                 {value.label}
             </Text>
@@ -51,24 +50,27 @@ RadioRefinement.propTypes = {
     filter: PropTypes.object,
     value: PropTypes.object,
     toggleFilter: PropTypes.func,
-    selectedFilters: PropTypes.arrayOf(PropTypes.object)
+    isSelected: PropTypes.bool
 }
 
 const RadioRefinements = ({filter, toggleFilter, selectedFilters}) => {
     return (
         <Stack spacing={1}>
-            {filter.values.map(
-                (value) =>
-                    value.hitCount > 0 && (
-                        <RadioRefinement
-                            key={value.value}
-                            value={value}
-                            filter={filter}
-                            toggleFilter={toggleFilter}
-                            selectedFilters={selectedFilters}
-                        />
-                    )
-            )}
+            {filter.values.map((value) => {
+                const isSelected = selectedFilters.includes(value.value)
+                // Don't display refinements with no results, unless we got there by selecting too
+                // many refinements
+                if (value.hitCount === 0 && !isSelected) return
+                return (
+                    <RadioRefinement
+                        key={value.value}
+                        value={value}
+                        filter={filter}
+                        toggleFilter={toggleFilter}
+                        isSelected={isSelected}
+                    />
+                )
+            })}
         </Stack>
     )
 }

--- a/packages/template-retail-react-app/app/pages/product-list/partials/size-refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/size-refinements.jsx
@@ -27,35 +27,31 @@ const SizeRefinements = ({filter, toggleFilter, selectedFilters}) => {
 
     return (
         <SimpleGrid templateColumns="repeat(auto-fit, 44px)" spacing={4} mt={1}>
-            {filter.values
-                ?.filter((refinementValue) => refinementValue.hitCount > 0)
-                .map((value, idx) => {
-                    // Note the loose comparison, for "string == number" checks.
-                    const isSelected = selectedFilters.some(
-                        (filterValue) => filterValue == value.value
-                    )
+            {filter.values?.map((value, idx) => {
+                // Note the loose comparison, for "string == number" checks.
+                const isSelected = selectedFilters.some((filterValue) => filterValue == value.value)
+                // Don't display refinements with no results, unless we got there by selecting too
+                // many refinements
+                if (value.hitCount === 0 && !isSelected) return
 
-                    return (
-                        <Button
-                            key={idx}
-                            {...styles.swatch}
-                            borderColor={isSelected ? 'black' : 'gray.200'}
-                            backgroundColor={isSelected ? 'black' : 'white'}
-                            color={isSelected ? 'white' : 'gray.900'}
-                            onClick={() => toggleFilter(value, filter.attributeId, isSelected)}
-                            aria-checked={isSelected}
-                            variant="outline"
-                            marginBottom={0}
-                            marginRight={0}
-                            aria-label={formatMessage(
-                                isSelected ? REMOVE_FILTER : ADD_FILTER,
-                                value
-                            )}
-                        >
-                            <Center {...styles.swatchButton}>{value.label}</Center>
-                        </Button>
-                    )
-                })}
+                return (
+                    <Button
+                        key={idx}
+                        {...styles.swatch}
+                        borderColor={isSelected ? 'black' : 'gray.200'}
+                        backgroundColor={isSelected ? 'black' : 'white'}
+                        color={isSelected ? 'white' : 'gray.900'}
+                        onClick={() => toggleFilter(value, filter.attributeId, isSelected)}
+                        aria-checked={isSelected}
+                        variant="outline"
+                        marginBottom={0}
+                        marginRight={0}
+                        aria-label={formatMessage(isSelected ? REMOVE_FILTER : ADD_FILTER, value)}
+                    >
+                        <Center {...styles.swatchButton}>{value.label}</Center>
+                    </Button>
+                )
+            })}
         </SimpleGrid>
     )
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

| Screenshot | Description |
|---|---|
| ![Screenshot of color and size refinements, with Beige and 16 visible as selected](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/62956339/47ad5eac-c26e-488a-b180-89c08a2010ec) | By looking at the place where you choose refinements, can you tell which refinements you have chosen? |
| ![Screenshot of breadcrumbs and selected filters buttons, showing Beige, Orange, and 16 as selected](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/62956339/0f1e2dfb-ad38-4854-bb4b-13c3bf4d2893) | No, you can't! In this screenshot, we've also selected "Orange", but you can't tell unless you know to look at an entirely separate part of the page. |
| ![Screenshot of color and size refinements, with Beige, Orange, and 16 visible as selected](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/62956339/96a347f5-39ea-453a-82c5-604331d95168) | That's confusing! So this PR fixes that. Now you can see "Orange", even though it has zero results! This will help mitigate customer confusion as they tweak their refinements. |


<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

# How to Test-Drive This PR

- Start dev server
- View a PLP
- Apply filters that result in a refinement with zero hits ([example page from screenshots](http://localhost:3000/global/en-GB/category/womens-clothing?limit=25&refine=c_refinementColor%3DBeige%7COrange&refine=c_size%3D16&sort=best-matches))
- The refinement with zero hits should still be visible!

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
