### PR TITLE
W-13546967 - Fix change password form

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Bug Fixes
 
+- Fix password change functionality [#1634](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1634)
 - Remove internal linter rule that is missing in generated projects [#1554](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1554)
 - Fix bug where you can add duplicates of the same item to the wishlist. Also fixes bug where skeleton appears when removing last item from the wishlist. [#1560](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1560)
 - Replace max-age with s-maxage to only cache shared caches [#1564](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1564)

--- a/packages/template-retail-react-app/app/mocks/mock-data.js
+++ b/packages/template-retail-react-app/app/mocks/mock-data.js
@@ -5638,3 +5638,10 @@ export const mockCartVariant = {
     c_size: '9MD',
     c_width: 'Z'
 }
+
+export const mockPasswordUpdateFalure = {
+    title: 'Update Password',
+    type: 'https://api.commercecloud.salesforce.com/documentation/error/v1/errors/update-password',
+    detail: 'The update password request is invalid. Customer\u0027s current password is not valid',
+    errorMessage: 'Customer\u0027s current password is not valid'
+}

--- a/packages/template-retail-react-app/app/pages/account/profile.jsx
+++ b/packages/template-retail-react-app/app/pages/account/profile.jsx
@@ -234,7 +234,7 @@ const PasswordCard = () => {
     const {formatMessage} = useIntl()
 
     const {data: customer} = useCurrentCustomer()
-    const {isRegistered, customerId} = customer
+    const {isRegistered, customerId, email} = customer
 
     const login = useAuthHelper(AuthHelpers.LoginRegisteredUserB2C)
 
@@ -275,22 +275,17 @@ const PasswordCard = () => {
                             isClosable: true
                         })
                         login.mutate({
-                            email: values.email,
+                            username: email,
                             password: values.password
                         })
                         passwordHeading?.focus()
+                    },
+                    onError: async (err) => {
+                        const resObj = await err.response.json()
+                        form.setError('root.global', {type: 'manual', message: resObj.detail})
                     }
                 }
             )
-            setIsEditing(false)
-            toast({
-                title: formatMessage({
-                    defaultMessage: 'Password updated',
-                    id: 'password_card.info.password_updated'
-                }),
-                status: 'success',
-                isClosable: true
-            })
         } catch (error) {
             form.setError('global', {type: 'manual', message: error.message})
         }
@@ -313,11 +308,11 @@ const PasswordCard = () => {
                 <Container variant="form">
                     <form onSubmit={form.handleSubmit(submit)}>
                         <Stack spacing={6}>
-                            {form.formState.errors?.global && (
+                            {form.formState.errors?.root?.global && (
                                 <Alert status="error">
                                     <AlertIcon color="red.500" boxSize={4} />
                                     <Text fontSize="sm" ml={3}>
-                                        {form.formState.errors.global.message}
+                                        {form.formState.errors.root.global.message}
                                     </Text>
                                 </Alert>
                             )}

--- a/packages/template-retail-react-app/app/pages/account/profile.jsx
+++ b/packages/template-retail-react-app/app/pages/account/profile.jsx
@@ -279,6 +279,7 @@ const PasswordCard = () => {
                             password: values.password
                         })
                         passwordHeading?.focus()
+                        form.reset()
                     },
                     onError: async (err) => {
                         const resObj = await err.response.json()

--- a/packages/template-retail-react-app/app/pages/account/profile.jsx
+++ b/packages/template-retail-react-app/app/pages/account/profile.jsx
@@ -287,7 +287,7 @@ const PasswordCard = () => {
                 }
             )
         } catch (error) {
-            form.setError('global', {type: 'manual', message: error.message})
+            form.setError('root.global', {type: 'manual', message: error.message})
         }
     }
 
@@ -309,7 +309,7 @@ const PasswordCard = () => {
                     <form onSubmit={form.handleSubmit(submit)}>
                         <Stack spacing={6}>
                             {form.formState.errors?.root?.global && (
-                                <Alert status="error">
+                                <Alert data-testid="password-update-error" status="error">
                                     <AlertIcon color="red.500" boxSize={4} />
                                     <Text fontSize="sm" ml={3}>
                                         {form.formState.errors.root.global.message}


### PR DESCRIPTION
# Description

The "change password" form in V3 isn't working as expected as a result of a code regression. This was most likely due to the hook integration work. The user was able to change their password, but the follow up action of logging in with said _new_ password would fail as the login action was being called with the wrong arguments. Additionally, no error was being shown and 2 success toasts were being displayed. 

This PR fixes all these issues and adds some tests to ensure another regression doesn't happen.

In the below recording you'll see the broken behaviour. First I try to change the password using a current password that isn't the actual value, and as you can see, it visually succeeds. Next I try to change the password to something new using the actual current password, and as you can see there is a login error in the network window.

https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/291ad08a-ff6e-429c-a18b-4eb432addef7


Now in the recording below I do similar actions to which they are all working.

https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/aadda1c7-6895-4511-b7e4-5051ecf32333



# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Ensure correct arguments are being passed to the login action after the password changed.
- Add onError handler to set global error when one occurs changing the password.
- Fix global error setting (submit button was disabled when "root" namespace isn't used)
- Reset the current/new password fields after success

# How to Test-Drive This PR

- Follow the STR in [this](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001T3PtCYAV/view) Gus ticket

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
