### PR TITLE
[SPIKE] URL Mapping - Asynchronous Configuration Method

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import hoistNonReactStatic from 'hoist-non-react-statics'
 import ssrPrepass from 'react-ssr-prepass'
-import {dehydrate, Hydrate, QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {dehydrate, hydrate, Hydrate, QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {FetchStrategy} from '../fetch-strategy'
 
 const STATE_KEY = '__reactQuery'
@@ -25,18 +25,20 @@ export const withReactQuery = (Wrapped, options = {}) => {
     const isServerSide = typeof window === 'undefined'
     /* istanbul ignore next */
     const wrappedComponentName = Wrapped.displayName || Wrapped.name
-    const queryClientConfig = options.queryClientConfig
+    const {queryClientConfig, dehydratedState} = options
+
+    // DEVELOPER NOTE: Is this going to be an issue making the client scoped outside 
+    // of the class?
+    const __queryClient = new QueryClient(queryClientConfig)
 
     /**
      * @private
      */
     class WithReactQuery extends FetchStrategy {
-        render() {
-            this.props.locals.__queryClient =
-                this.props.locals.__queryClient || new QueryClient(queryClientConfig)
 
+        render() {
             return (
-                <QueryClientProvider client={this.props.locals.__queryClient}>
+                <QueryClientProvider client={__queryClient}>
                     <Hydrate state={isServerSide ? {} : window.__PRELOADED_STATE__?.[STATE_KEY]}>
                         <Wrapped {...this.props} />
                     </Hydrate>
@@ -47,25 +49,57 @@ export const withReactQuery = (Wrapped, options = {}) => {
         /**
          * @private
          */
-        static async doInitAppState({res, appJSX}) {
-            const queryClient = (res.locals.__queryClient =
-                res.locals.__queryClient || new QueryClient(queryClientConfig))
+        static async doInitAppState({req, appJSX}) {
+            // NOTE FOR SELF: This function only runs on the server, it does not run on the client/browser,
+            // so hydration is handled in the render function and we don't require this additional hydration.
+            let resolvedDehydratedState = {}
 
+            // DEVELOPER NOTE: We only need to do this when the `dehydratedState` is a function. So that 
+            // logic for that conditional check needs to be added. This is just some hacky code.
+            if (dehydratedState && !dehydratedState.__hasBeenResolved) {
+                // This context will be sent to the function so we can do condition work based on the pathname.
+                const context = {
+                    location: {
+                        pathname: req.originalUrl.split('?')[0]
+                    }
+                }
+                resolvedDehydratedState = await options.dehydratedState(context)
+                options.dehydratedState.__hasBeenResolved = true
+            }
+
+            const queryClient = __queryClient
+
+            // NOTE: This is where we are pre-populating the client cache.
+            hydrate(queryClient, resolvedDehydratedState)
+            
             // Use `ssrPrepass` to collect all uses of `useQuery`.
             await ssrPrepass(appJSX)
 
             const queryCache = queryClient.getQueryCache()
+            
             const queries = queryCache.getAll().filter((q) => q.options.enabled !== false)
             await Promise.all(
-                queries.map((q) =>
+                queries.map((q) => {
+                    // NOTE: dehydratedState queries do not have queryFn definitions at this point, so don't try
+                    // to refetch. 
+                    // NOTE: We might want to take a look at using a pattern of prefetching data.
+                    if (!q.options.queryFn) {
+                        return Promise.resolve()
+                    }
                     // If there's an error in this fetch, react-query will log the error
-                    q.fetch().catch(() => {
+                    return q.fetch().catch(() => {
                         // On our end, simply catch any error and move on to the next query
                     })
-                )
+                })
             )
-
-            return {[STATE_KEY]: dehydrate(queryClient)}
+            
+            return {
+                [STATE_KEY]: dehydrate(queryClient, {
+                    // QUESTION: It looks like more queries are getting dehydtrated that I thought when doing this. Why
+                    // are there basket queries in loading state? That might be something we need to fix.
+                    shouldDehydrateQuery: ({state}) => ['success', 'error'].includes(state.status)
+                })
+            }
         }
 
         /**

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -69,7 +69,6 @@ const AppConfig = ({children, locals = {}}) => {
         // it has this secondary page that we must show (loader) that happens on all links. 
         // 
         // DEVELOPER NOTE: I think its a really bad idea to implement redirects in a single page app.
-        console.log('location: ', location)
         // This gets caught by the catch-all route.
         return `/_seo-url-mapping?locationPathname=${location.pathname}&locationSearch=${location.search}`
     })
@@ -81,7 +80,7 @@ const AppConfig = ({children, locals = {}}) => {
 
     // DEVELOPER NOTE: Think about when we need to run this code, should we only be doing it when we are
     // on the server?
-    if (urlMapping) {
+    if (urlMapping?.redirectUrl) {
         return <Redirect to={`/global/en-GB/${urlMapping.redirectUrl.destinationType}/${urlMapping.redirectUrl.destinationId}${search}`} />
     }
 

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -7,6 +7,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {ChakraProvider} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {useLocation, Redirect} from 'react-router-dom'
 
 // Removes focus for non-keyboard interactions for the whole application
 import 'focus-visible/dist/focus-visible'
@@ -27,6 +28,7 @@ import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 import useBlock from '@salesforce/retail-react-app/app/hooks/use-block'
+import {useUrlMapping} from '@salesforce/retail-react-app/app/pages/seo-url-mapping/use-url-mapping'
 
 const wait = async (ms) => {
     return new Promise((resolve) => setTimeout(resolve, ms))
@@ -41,6 +43,7 @@ const wait = async (ms) => {
  */
 const AppConfig = ({children, locals = {}}) => {
     const {correlationId} = useCorrelationId()
+    const {pathname, search} = useLocation()
     const headers = {
         'correlation-id': correlationId
     }
@@ -70,6 +73,17 @@ const AppConfig = ({children, locals = {}}) => {
         // This gets caught by the catch-all route.
         return `/_seo-url-mapping?locationPathname=${location.pathname}&locationSearch=${location.search}`
     })
+    const {data: urlMapping} = useUrlMapping({
+        parameters: {
+            urlSegment: pathname
+        }
+    })
+
+    // DEVELOPER NOTE: Think about when we need to run this code, should we only be doing it when we are
+    // on the server?
+    if (urlMapping) {
+        return <Redirect to={`/global/en-GB/${urlMapping.redirectUrl.destinationType}/${urlMapping.redirectUrl.destinationId}${search}`} />
+    }
 
     return (
         <CommerceApiProvider

--- a/packages/template-retail-react-app/app/hooks/use-block.js
+++ b/packages/template-retail-react-app/app/hooks/use-block.js
@@ -24,7 +24,7 @@ export const useBlock = func => {
     funcRef.current = func
 
     useEffect(() => {
-        if (location === lastLocation.current || lastLocation.current?.pathname === '/_seo-url-mapping' || !funcRef.current){
+        if (location === lastLocation.current || lastLocation.current?.pathname === '/_seo-url-mapping' || !funcRef.current) {
             lastLocation.current = location
             return
         }

--- a/packages/template-retail-react-app/app/hooks/use-block.js
+++ b/packages/template-retail-react-app/app/hooks/use-block.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {useEffect, useRef} from 'react'
+import {useHistory} from 'react-router-dom'
+
+/*
+ * Return truthy if you wish to block. Empty return or false will not block
+ *
+ * THANK YOU --> https://stackoverflow.com/questions/37849933/react-router-how-to-wait-for-an-async-action-before-route-transition
+ */
+
+// NOTE: Use aren't using this hook as intended as we aren't blocking ever, we are using it as a way to 
+// overwirte all navigation transition behaviours. We could have done this in the link component as well.
+export const useBlock = func => {
+    const { block, push, location } = useHistory()
+    const lastLocation = useRef()
+    const funcRef = useRef()
+
+    funcRef.current = func
+
+    useEffect(() => {
+        if (location === lastLocation.current || lastLocation.current?.pathname === '/_seo-url-mapping' || !funcRef.current){
+            lastLocation.current = location
+            return
+        }
+
+        lastLocation.current = location
+
+        const unblock = block((location, action) => {
+            const doBlock = async () => {
+                const ret = await funcRef.current(location, action)
+                if (typeof ret === 'string') {
+                    unblock()
+                    const parts = ret.split(/\?(.*)/s)
+                    const newLocation = {
+                        pathname: parts[0],
+                        search: parts[1] ? `?${parts[1]}` : ''
+                    }
+                    push(newLocation)
+                } else if (!ret) {
+                    unblock()
+                    push(location)
+                }
+            }
+            doBlock()
+            return false
+        })
+    }, [location, block, push])
+}
+
+export default useBlock

--- a/packages/template-retail-react-app/app/pages/home/index.jsx
+++ b/packages/template-retail-react-app/app/pages/home/index.jsx
@@ -22,6 +22,7 @@ import {
     Container,
     Link
 } from '@salesforce/retail-react-app/app/components/shared/ui'
+import {Link as RouteLink} from 'react-router-dom'
 
 // Project Components
 import Hero from '@salesforce/retail-react-app/app/components/hero'
@@ -80,6 +81,28 @@ const Home = () => {
                 description="Commerce Cloud Retail React App"
                 keywords="Commerce Cloud, Retail React App, React Storefront"
             />
+            <Link
+                as={RouteLink}
+                to="/custom-product-path"
+                
+            >
+                This is a custom product page link!
+            </Link>
+            <br/>
+            <Link
+                as={RouteLink}
+                to="/custom-product-path-bad"
+                
+            >
+                This is a custom product page link that is not valid!
+            </Link>
+            <br/>
+            <Link
+                as={RouteLink}
+                to="/global/en-GB/product/52416781M"
+            >
+                This link has a redirect!
+            </Link>
 
             <Hero
                 title={intl.formatMessage({

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -48,7 +48,7 @@ import {useHistory, useLocation, useParams} from 'react-router-dom'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {useWishList} from '@salesforce/retail-react-app/app/hooks/use-wish-list'
 
-const ProductDetail = () => {
+const ProductDetail = (props = {}) => {
     const {formatMessage} = useIntl()
     const history = useHistory()
     const location = useLocation()
@@ -69,7 +69,10 @@ const ProductDetail = () => {
     const isBasketLoading = !basket?.basketId
 
     /*************************** Product Detail and Category ********************/
-    const {productId} = useParams()
+    let {productId} = useParams()
+    if (props.productId) {
+        productId = props.productId
+    }
     const urlParams = new URLSearchParams(location.search)
     const {
         data: product,
@@ -86,7 +89,8 @@ const ProductDetail = () => {
         {
             // When shoppers select a different variant (and the app fetches the new data),
             // the old data is still rendered (and not the skeletons).
-            keepPreviousData: true
+            keepPreviousData: true,
+            cacheTime: Infinity
         }
     )
 

--- a/packages/template-retail-react-app/app/pages/seo-url-mapping/index.jsx
+++ b/packages/template-retail-react-app/app/pages/seo-url-mapping/index.jsx
@@ -34,7 +34,7 @@ const SeoUrlMapping = () => {
     })
     
     const {resourceId, resourceType, refinements, redirectUrl} = data
-    debugger
+
     if (redirectUrl) {
         // This is were we will take the redrect information and generate a PWA link from it and redirect to it.
         // DEVELOPER NOTE: `destinationUrl` is also included in the data, this could be used is the partner has 
@@ -44,7 +44,6 @@ const SeoUrlMapping = () => {
     }
 
     if (error) {
-        debugger
         // DEVELOPER NOTE: This pathname is important!
         if (!!locationPathname) {
             return <Redirect to={locationPathname} />

--- a/packages/template-retail-react-app/app/pages/seo-url-mapping/index.jsx
+++ b/packages/template-retail-react-app/app/pages/seo-url-mapping/index.jsx
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {useLocation, Redirect} from 'react-router-dom'
+
+import {useUrlMapping} from './use-url-mapping'
+import PageNotFound from '../page-not-found/index'
+import ProductDetail from '../product-detail/index'
+import ProductList from '../product-list/index'
+
+/**
+ * 
+ */
+const SeoUrlMapping = () => {
+    const {pathname, search} = useLocation()
+    let urlSegment
+    const searchParams = new URLSearchParams(search)
+    const locationPathname = searchParams.get('locationPathname')
+    const locationSearch = searchParams.get('locationSearch')
+    if (locationPathname) {
+        urlSegment = `${locationPathname}${locationSearch}`
+    } else {
+        urlSegment = pathname
+    }
+    const {data = {}, error, isLoading} = useUrlMapping({
+        parameters: {
+            urlSegment
+        }
+    })
+    
+    const {resourceId, resourceType, refinements, redirectUrl} = data
+    debugger
+    if (redirectUrl) {
+        // This is were we will take the redrect information and generate a PWA link from it and redirect to it.
+        // DEVELOPER NOTE: `destinationUrl` is also included in the data, this could be used is the partner has 
+        // change thier url schema to be just like the SFRA site.
+        // DEVELOPER NOTE: Can a redirect goto a custom url mapping? I don't think we should support this initially.
+        return <Redirect to={`/global/en-GB/${redirectUrl.destinationType}/${redirectUrl.destinationId}`} />
+    }
+
+    if (error) {
+        debugger
+        // DEVELOPER NOTE: This pathname is important!
+        if (!!locationPathname) {
+            return <Redirect to={locationPathname} />
+        }
+
+        return <PageNotFound />
+    }
+
+    if (isLoading) {
+        return <div>LOADING...</div>
+    }
+
+    switch (resourceType) {
+        case 'CATEGORY':
+            return <ProductList categoryId={resourceId} refinements={refinements} />
+        case 'PRODUCT':
+            return <ProductDetail productId={resourceId} />
+        // Currently we will not support custom pages.
+        // case 'CONTENT_ASSET':
+        //     return <Page />
+        default:
+            return <PageNotFound />
+    }
+}
+
+SeoUrlMapping.getTemplateName = () => 'seo-url-mapping'
+
+export default SeoUrlMapping

--- a/packages/template-retail-react-app/app/pages/seo-url-mapping/use-url-mapping.js
+++ b/packages/template-retail-react-app/app/pages/seo-url-mapping/use-url-mapping.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {useQuery} from '@tanstack/react-query'
+
+// NOTE: This is sample data as the `commerce-sdk-isomorphic` currently does not support
+// the Shopper-SEO endpoints and thus our `commerce-sdk-react` does not either.
+// NOTE: On the server out rendering is a 2-step process, we render first to get the hooks
+// that should be executed, then we render a second time to ensure the html rendered has all
+// the data in it. Because of that, we won't know what product/category/context data to render
+// as it will never be fetched. The solution shold be to "pre-populate" the hook cache.
+const SEO_URL_MAPPINGS = {
+    '/custom-category-path': {
+        resourceId: 'mens-accessories-gloves',
+        resourceType: 'CATEGORY',
+        refinements: undefined
+    },
+    '/custom-product-path': {
+        resourceId: '66936828M',
+        resourceType: 'PRODUCT'
+    },
+    '/global/en-GB/product/52416781M': {
+        redirectUrl: {
+            copySourceParams: false,
+            destinationId: "42416786M",
+            destinationType: "product",
+            statusCode: "301",
+            destinationUrl: "https://staging-c7testing-cdd.demandware.net/s/SiteGenesis/casual%20to%20dressy%20trousers/?lang=en_US"
+        },
+        resourceId: '52416781M',
+        resourceType: 'product'
+    }
+} 
+
+// Small inline hook so that the commenent definition will look as close to the final
+// implimentation as possible. E.g. we are emulating a `commerce-sdk-react` hook here.
+export const useUrlMapping = ({parameters}) => {
+    return useQuery(['url-mappings', parameters.urlSegment], async () => {
+        // Synthetic wait
+        // await new Promise((resolve) => setTimeout(resolve, 100))
+        const match = SEO_URL_MAPPINGS[parameters.urlSegment]
+
+        if (!match) {
+            throw new Error('No seo url found!')
+        }
+        return match
+    })  
+}

--- a/packages/template-retail-react-app/app/routes.jsx
+++ b/packages/template-retail-react-app/app/routes.jsx
@@ -43,7 +43,12 @@ const ProductList = loadable(() => import('./pages/product-list'), {
 const Wishlist = loadable(() => import('./pages/account/wishlist'), {
     fallback
 })
+const SEOUrlMapping = loadable(() => import('./pages/seo-url-mapping'))
 const PageNotFound = loadable(() => import('./pages/page-not-found'))
+
+// Use the Configuration to set this value.
+const ENABLE_SEO_ROUTES = true
+const CatchAll = ENABLE_SEO_ROUTES ? SEOUrlMapping : PageNotFound
 
 export const routes = [
     {
@@ -107,7 +112,7 @@ export const routes = [
     },
     {
         path: '*',
-        component: PageNotFound
+        component: CatchAll
     }
 ]
 


### PR DESCRIPTION
# Description

In this PR we investigate implementing the Shopper SEO "Url Mapping" API endpoint into the PWA-Kit platform. The primary strategy for this PR is to use the `withReactQuery` higher-order component to allow us to _pre-populate_ the query client cache. 

### How does this PR work?

**Server-Side**: To make things work server-side we first need to know what type of page component we are rendering. Because the rendering is a 2-stage affair, aka we scan for queries to run then wait for them to complete and render again, it means we can't introduce a third blocking action as it would break rendering. 

To solve this problem we update the API for the with-react-query hoc allowing the developer to pass an initial 'dehydratedState' that will be use as the initial value in the clients cache. This in effect means when it comes to determining what hooks are running we are back to the 2-stage rending working. 

If it's not obvious the initial data that we'll be populating is the url mapping for the current url path if one exists. With this data we can update the rendering pipeline to see if we have a url map, and render a special page that will use that data to conditionally render either the category, product, page not found, redirect, or error pages.

**Client-Side**: As the PWA stands routing is a one shot snychronous event, you can't block it from happing. So we needed to solve how we could do this, as potentially any link/url on the website could be one that is either a redirect or custom, we just don't know it yet. This is where we introduced the `useBlock` hooks, this special hook will allow you to block transitions from one page to another, giving you time to make an API request for the desired page. We used this idea a little differently and simple redirect all transitions to that same special page that is used to determine what page type to render based on the url mapping data.

## Issues

1. This is a very complicated solution and will be prone to bugs over time.
2. Might not completely work as we use links for things like swatch items, although its totally valid to have a redirect for a single variation, it will make things SLOOOWWW
3. This will make everything slow and none PWA like.

## We should not implement redirects and custom urls solely in the PWA, we need to be working with other systems like mrt to get things working smoothly and in a less complex way.