### PR TITLE
fix: unable extract translation messages

### DIFF
--- a/packages/template-retail-react-app/scripts/translations/extract-default-messages.js
+++ b/packages/template-retail-react-app/scripts/translations/extract-default-messages.js
@@ -14,23 +14,9 @@
 const {exec} = require('child_process')
 const fs = require('fs')
 const path = require('path')
+
 const packagePath = path.join(process.cwd(), 'package.json')
 const pkgJSON = JSON.parse(fs.readFileSync(packagePath))
-
-const getAllFilesByExtensions = (dirPath, arrayOfFiles = [], extensions = []) => {
-    const files = fs.readdirSync(dirPath, {withFileTypes: true})
-
-    files.forEach(function (file) {
-        const filePath = path.join(dirPath, file.name)
-        if (file.isDirectory()) {
-            arrayOfFiles = getAllFilesByExtensions(filePath, arrayOfFiles, extensions)
-        } else if (extensions.length === 0 || extensions.includes(path.extname(filePath))) {
-            arrayOfFiles.push(filePath)
-        }
-    })
-
-    return arrayOfFiles
-}
 
 function extract(locale) {
     // `extends` is a reserved word (`class A extends B {}`)
@@ -41,32 +27,21 @@ function extract(locale) {
             `--out-file translations/${locale}.json`,
             '--id-interpolation-pattern [sha512:contenthash:base64:6]'
         ].join(' ')
+
         exec(command, (err) => {
             if (err) {
                 console.error(err)
             }
         })
     } else {
-        const overridesPath = path.join(process.cwd(), overridesDir)
-        // get all the files in extended app
-        const files = getAllFilesByExtensions(
-            path.join(overridesPath, 'app'),
-            [],
-            ['.js', '.jsx', '.ts', '.tsx']
-        )
-        // get the file names that are overridden in base template
-        const overriddenFiles = files
-            .map((path) => path.replace(overridesDir, `node_modules/${extendsPkg}`))
-            .filter((file) => fs.existsSync(file))
         const extractCommand = [
             'formatjs extract',
-            '"./node_modules/${extendsPkg}/app/**/*.{js,jsx,ts,tsx}"',
-            '"${overridesDir}/app/**/*.{js,jsx,ts,tsx}"',
+            `"./node_modules/${extendsPkg}/app/**/*.{js,jsx,ts,tsx}"`,
+            `"${overridesDir}/app/**/*.{js,jsx,ts,tsx}"`,
             `--out-file translations/${locale}.json`,
-            '--id-interpolation-pattern [sha512:contenthash:base64:6]',
-            '--ignore',
-            ...overriddenFiles.map((file) => `'${file}'`)
+            '--id-interpolation-pattern [sha512:contenthash:base64:6]'
         ].join(' ')
+
         exec(extractCommand, (err) => {
             if (err) {
                 console.error(err)


### PR DESCRIPTION
# Description

There are some issues in the translation messages extraction

1. Use expressions within regular strings
2. `formatjs extract` command is failing when a large number of override files are present, exceeding the maximum allowed command length.
3. Ineffective file ignoring using absolute paths
    - The `--ignore` option is designed to accept glob patterns. By using a list of absolute file paths will not matching any files. Thereforce, no files being ignored.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Change regular strings which contains expressions to literal strings
- Remove `--ignore` option from the command
    - The order of file patterns to extract the messages are matter. By load after `extends` packages,  messages in the `overrides` folder take precedence over existing keys from other packages.
    - **\*\*** However, messages unused in the overridden components will remain. This behavior is same as how SFCC merge properties files accross multiple cartridges and can be an acceptable behavior.

---

If we look at the implementation history, there's a solution that renames overridden files to `{filename}.ignore` before running the `extract` command. This is a great idea in principle, but it can lead to unexpected issues if:

- The files are renamed to `.ignore` and an error occurs during execute the command _(e.g., I/O exceptions, extraction failure, etc.)_
- This error prevents the script restore the files to their original names.

In these cases, developers might be left completely puzzled about why a file in `node_modules` is missing. Debugging this issue could take a whole day and might only be resolved by deleting the `node_modules` folder and reinstalling dependencies.

# Checklists

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

- [x] There are no changes to UI

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)

Close #1645