### PR TITLE
[Hotfix] Fix `extract-default-translations` script not working in generated projects

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fix `extract-default-translations` script [#1647](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1647)
 
-## v2.3.0
+## v2.3.0 (Jan 19, 2024)
 
 ### Accessibility improvements
 

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,8 @@
-## v2.3.0 (Jan 19, 2024)
+## v2.3.1-preview.1 (Jan 23, 2024)
+
+### Bug Fixes
+
+- Fix `extract-default-translations` script [#1647](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1647)
 
 ### Accessibility improvements
 

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.3.1-preview.1 (Jan 23, 2024)
+## v2.3.1-preview.0 (Jan 23, 2024)
 
 ### Bug Fixes
 

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix `extract-default-translations` script [#1647](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1647)
 
+## v2.3.0
+
 ### Accessibility improvements
 
 - Add correct keyboard interaction behavior for variation attribute radio buttons [#1587](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1587)

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "2.3.0",
+  "version": "2.3.1-preview.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/retail-react-app",
-      "version": "2.3.0",
+      "version": "2.3.1-preview.0",
       "license": "See license in LICENSE",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.19",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "2.3.0",
+  "version": "2.3.1-preview.0",
   "license": "See license in LICENSE",
   "author": "cc-pwa-kit@salesforce.com",
   "ccExtensibility": {

--- a/packages/template-retail-react-app/scripts/translations/extract-default-messages.js
+++ b/packages/template-retail-react-app/scripts/translations/extract-default-messages.js
@@ -60,8 +60,8 @@ function extract(locale) {
             .filter((file) => fs.existsSync(file))
         const extractCommand = [
             'formatjs extract',
-            '"./node_modules/${extendsPkg}/app/**/*.{js,jsx,ts,tsx}"',
-            '"${overridesDir}/app/**/*.{js,jsx,ts,tsx}"',
+            `"./node_modules/${extendsPkg}/app/**/*.{js,jsx,ts,tsx}"`,
+            `"${overridesDir}/app/**/*.{js,jsx,ts,tsx}"`,
             `--out-file translations/${locale}.json`,
             '--id-interpolation-pattern [sha512:contenthash:base64:6]',
             '--ignore',


### PR DESCRIPTION
# Description

The `extract-default-translations` script is broken dues to a couple string literals that are supposed to be string templates.

This PR will be followed up with a bump to `2.3.1` for the `template-retail-react-app` if everything is good.

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)


# Changes

- Fix `extract-default-translations` extract command
- Bump to 2.3.1-preview.0
# How to Test-Drive This PR

```
> npm ci
> node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --preset retail-react-app-demo --outputDir=test-project
> cd test-project
> npm run extract-default-translations
```

The result of above should be the translations fold having 2 files with messages in them. Previously those files were empty.

# Checklists

## General

- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
