### PR TITLE
Bump `template-retail-react-app` to 2.3.1

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v2.3.1-preview.0 (Jan 23, 2024)
+## v2.3.1 (Jan 23, 2024)
 
 ### Bug Fixes
 

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "2.3.1-preview.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/retail-react-app",
-      "version": "2.3.1-preview.0",
+      "version": "2.3.1",
       "license": "See license in LICENSE",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.19",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "2.3.1-preview.0",
+  "version": "2.3.1",
   "license": "See license in LICENSE",
   "author": "cc-pwa-kit@salesforce.com",
   "ccExtensibility": {


### PR DESCRIPTION
# Description

We are bumping to a whole version here to release the changes in the following pr 👉 #1647 

# Changes

- Bump to 2.3.0 for template-retail-react-app

# How to Test-Drive This PR

```
> npx @salesforce/pwa-kit-create-app --templateVersion=2.3.1-preview.0 --preset retail-react-app-demo
> npm run extract-default-translations
```

Expected results are that your `/translations` folder contains to files (en-gb and en-us) that have defined messages inside them.

## General

- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
