### PR TITLE
@14947897@ Use refresh token expiry from SLAS response

### DIFF
--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -101,7 +101,7 @@ describe('Auth', () => {
             token_type: 'token_type',
             usid: 'usid',
             customer_type: 'guest',
-            refresh_token_expires_in: 30 * 24 * 3600
+            refresh_token_expires_in: 'refresh_token_expires_in'
         }
         // Convert stored format to exposed format
         const result = {...sample, refresh_token: 'refresh_token_guest'}
@@ -228,7 +228,7 @@ describe('Auth', () => {
             token_type: 'token_type',
             usid: 'usid',
             customer_type: 'guest',
-            refresh_token_expires_in: 30 * 24 * 3600
+            refresh_token_expires_in: 'refresh_token_expires_in'
         }
         // Convert stored format to exposed format
         const result = {...data, refresh_token: 'refresh_token_guest'}
@@ -315,7 +315,7 @@ describe('Auth', () => {
             token_type: 'token_type',
             usid: 'usid',
             customer_type: 'guest',
-            refresh_token_expires_in: 30 * 24 * 3600
+            refresh_token_expires_in: 'refresh_token_expires_in'
         }
 
         Object.keys(data).forEach((key) => {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -162,8 +162,6 @@ class Auth {
     private shopperCustomersClient: ShopperCustomers<ApiClientConfigParams>
     private redirectURI: string
     private pendingToken: Promise<TokenResponse> | undefined
-    private REFRESH_TOKEN_EXPIRATION_DAYS_REGISTERED = 90
-    private REFRESH_TOKEN_EXPIRATION_DAYS_GUEST = 30
     private stores: Record<StorageType, BaseStorage>
     private fetchedToken: string
     private OCAPISessionsURL: string
@@ -316,15 +314,11 @@ class Auth {
             ? 'refresh_token_guest_copy'
             : 'refresh_token_registered_copy'
 
-        const refreshTokenExpiry = isGuest
-            ? this.REFRESH_TOKEN_EXPIRATION_DAYS_GUEST
-            : this.REFRESH_TOKEN_EXPIRATION_DAYS_REGISTERED
-
         this.set(refreshTokenKey, res.refresh_token, {
-            expires: refreshTokenExpiry
+            expires: res.refresh_token_expires_in
         })
         this.set(refreshTokenCopyKey, res.refresh_token, {
-            expires: refreshTokenExpiry
+            expires: res.refresh_token_expires_in
         })
     }
 

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/mutation.test.ts
@@ -63,7 +63,7 @@ const TOKEN_RESPONSE: ShopperLoginTypes.TokenResponse = {
     token_type: 'token_type',
     usid: 'usid',
     idp_access_token: 'idp_access_token',
-    refresh_token_expires_in: 30 * 24 * 3600
+    refresh_token_expires_in: 'refresh_token_expires_in'
 }
 
 // --- TEST CASES --- //


### PR DESCRIPTION
Companion PR to https://github.com/SalesforceCommerceCloud/plugin_slas/pull/154

This PR modifies the way we are setting refresh token cookie expiry so that we use the refresh_token_expires_in property included in the SLAS response rather than hard coded values.

This is relevant in non-production environments where refresh tokens are valid for less than 30 days (see https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas.html?q=refresh+token#access-tokens-and-refresh-tokens for the details)

Testing this PR:
Consume the changes and start the app
Check the refresh token expiry for cc-nx-g (TODO: on zzrf, this is still 30 days so I am trying to find another environment where this is different)
Log in to a registered user account
Check the refresh token expiry for cc-nx (on zzrf, this is now being set to 30 days rather than the old hard coded 90 day value)

Note:
This would be good to test on other internal environments such as bdpx or bjnl for additional verification.

For hybrid environments, make sure both the changes here and in Plugin_SLAS are consumed