### PR TITLE
W-14867867 Fix invalid query params warnings and allow custom query

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## v1.4.0-dev (Jan 22, 2024)
+- Fix invalid query params warnings and allow custom query [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
+
 ## v1.3.0 (Jan 19, 2024)
 
 - Add support for node 20 [#1612](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1612)

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
-        "commerce-sdk-isomorphic": "^1.10.4",
+        "commerce-sdk-isomorphic": "^1.11.0",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -861,9 +861,9 @@
       "dev": true
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-1.10.4.tgz",
-      "integrity": "sha512-CydwGcwo3C6+qZbQNnbEGTifArUnWFv5yhvDvBwx2p2X1yn41TESVKclzxzpGLS88jLEmkzgNvfg2GFtmZgPsQ==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-1.11.0.tgz",
+      "integrity": "sha512-s3c2ZPWz2ekNj7aHn0pNEXhJ8ZsLfDUtzNNN/5SbMeCxUTZ5U4uP12nu9A53bmZPACNwYM841A664AebCSoG6g==",
       "dependencies": {
         "nanoid": "^3.3.4",
         "node-fetch": "2.6.12"

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "^1.10.4",
+    "commerce-sdk-isomorphic": "^1.11.0",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/paramKeys.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
- * SPDX-License-Identifier = BSD-3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/paramKeys.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier = BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getBasket = ['organizationId', 'basketId', 'siteId', 'locale'] as const
+
+const getPaymentMethodsForBasket = ['organizationId', 'basketId', 'siteId', 'locale'] as const
+const getPriceBooksForBasket = ['organizationId', 'basketId', 'siteId'] as const
+const getShippingMethodsForShipment = [
+    'organizationId',
+    'basketId',
+    'shipmentId',
+    'siteId',
+    'locale'
+] as const
+const getTaxesFromBasket = ['organizationId', 'basketId', 'siteId'] as const
+
+export default {
+    getBasket,
+    getPaymentMethodsForBasket,
+    getPriceBooksForBasket,
+    getShippingMethodsForShipment,
+    getTaxesFromBasket
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
@@ -39,10 +39,7 @@ export const useBasket = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -81,10 +78,7 @@ export const usePaymentMethodsForBasket = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -123,10 +117,7 @@ export const usePriceBooksForBasket = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -165,10 +156,7 @@ export const useShippingMethodsForShipment = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -202,16 +190,12 @@ export const useTaxesFromBasket = (
     const {shopperBaskets: client} = useCommerceApi()
     const methodName = 'getTaxesFromBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
-    type Params = Partial<Argument<Client['getTaxesFromBasket']>['parameters']>
 
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
@@ -37,13 +37,15 @@ export const useBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -73,13 +75,15 @@ export const usePaymentMethodsForBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -109,13 +113,15 @@ export const usePriceBooksForBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -145,13 +151,15 @@ export const useShippingMethodsForShipment = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -181,13 +189,15 @@ export const useTaxesFromBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperBaskets']
 
@@ -37,8 +38,12 @@ export const useBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -75,8 +80,12 @@ export const usePaymentMethodsForBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -113,8 +122,12 @@ export const usePriceBooksForBasket = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -151,8 +164,12 @@ export const useShippingMethodsForShipment = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -185,12 +202,17 @@ export const useTaxesFromBasket = (
     const {shopperBaskets: client} = useCommerceApi()
     const methodName = 'getTaxesFromBasket'
     const requiredParameters = ['organizationId', 'basketId', 'siteId'] as const
+    type Params = Partial<Argument<Client['getTaxesFromBasket']>['parameters']>
 
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
@@ -145,7 +145,6 @@ export const getTaxesFromBasket: QueryKeyHelper<'getTaxesFromBasket'> = {
         params.basketId,
         '/taxes'
     ],
-    //@ts-ignore
     queryKey: (params: Params<'getTaxesFromBasket'>) => {
         const paramKeys = [...paramKeysMap['getTaxesFromBasket'], ...getCustomKeys(params)]
         return [...getTaxesFromBasket.path(params), pick(params, paramKeys)]

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperBaskets} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from '../ShopperBaskets/paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperBaskets<{shortCode: string}>
@@ -63,11 +64,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -75,8 +71,6 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getBasket: QueryKeyHelper<'getBasket'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'basketId', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -84,15 +78,13 @@ export const getBasket: QueryKeyHelper<'getBasket'> = {
         '/baskets/',
         params.basketId
     ],
-    queryKey: (params: Params<'getBasket'>) => [
-        ...getBasket.path(params),
-        getBasket.parameters(params)
-    ]
+    queryKey: (params: Params<'getBasket'>) => {
+        const paramKeys = [...paramKeysMap['getBasket'], ...getCustomKeys(params)]
+        return [...getBasket.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPaymentMethodsForBasket: QueryKeyHelper<'getPaymentMethodsForBasket'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'basketId', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -101,15 +93,13 @@ export const getPaymentMethodsForBasket: QueryKeyHelper<'getPaymentMethodsForBas
         params.basketId,
         '/payment-methods'
     ],
-    queryKey: (params: Params<'getPaymentMethodsForBasket'>) => [
-        ...getPaymentMethodsForBasket.path(params),
-        getPaymentMethodsForBasket.parameters(params)
-    ]
+    queryKey: (params: Params<'getPaymentMethodsForBasket'>) => {
+        const paramKeys = [...paramKeysMap['getPaymentMethodsForBasket'], ...getCustomKeys(params)]
+        return [...getPaymentMethodsForBasket.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPriceBooksForBasket: QueryKeyHelper<'getPriceBooksForBasket'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'basketId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -118,22 +108,14 @@ export const getPriceBooksForBasket: QueryKeyHelper<'getPriceBooksForBasket'> = 
         params.basketId,
         '/price-books'
     ],
-    queryKey: (params: Params<'getPriceBooksForBasket'>) => [
-        ...getPriceBooksForBasket.path(params),
-        getPriceBooksForBasket.parameters(params)
-    ]
+    queryKey: (params: Params<'getPriceBooksForBasket'>) => {
+        const paramKeys = [...paramKeysMap['getPriceBooksForBasket'], ...getCustomKeys(params)]
+
+        return [...getPriceBooksForBasket.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getShippingMethodsForShipment: QueryKeyHelper<'getShippingMethodsForShipment'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'basketId',
-            'shipmentId',
-            'siteId',
-            'locale',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -144,15 +126,17 @@ export const getShippingMethodsForShipment: QueryKeyHelper<'getShippingMethodsFo
         params.shipmentId,
         '/shipping-methods'
     ],
-    queryKey: (params: Params<'getShippingMethodsForShipment'>) => [
-        ...getShippingMethodsForShipment.path(params),
-        getShippingMethodsForShipment.parameters(params)
-    ]
+    queryKey: (params: Params<'getShippingMethodsForShipment'>) => {
+        const paramKeys = [
+            ...paramKeysMap['getShippingMethodsForShipment'],
+            ...getCustomKeys(params)
+        ]
+
+        return [...getShippingMethodsForShipment.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getTaxesFromBasket: QueryKeyHelper<'getTaxesFromBasket'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'basketId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -161,8 +145,9 @@ export const getTaxesFromBasket: QueryKeyHelper<'getTaxesFromBasket'> = {
         params.basketId,
         '/taxes'
     ],
-    queryKey: (params: Params<'getTaxesFromBasket'>) => [
-        ...getTaxesFromBasket.path(params),
-        getTaxesFromBasket.parameters(params)
-    ]
+    //@ts-ignore
+    queryKey: (params: Params<'getTaxesFromBasket'>) => {
+        const paramKeys = [...paramKeysMap['getTaxesFromBasket'], ...getCustomKeys(params)]
+        return [...getTaxesFromBasket.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperBaskets} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperBaskets<{shortCode: string}>
@@ -75,7 +75,8 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getBasket: QueryKeyHelper<'getBasket'> = {
-    parameters: (params) => pick(params, ['organizationId', 'basketId', 'siteId', 'locale']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'basketId', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -90,7 +91,8 @@ export const getBasket: QueryKeyHelper<'getBasket'> = {
 }
 
 export const getPaymentMethodsForBasket: QueryKeyHelper<'getPaymentMethodsForBasket'> = {
-    parameters: (params) => pick(params, ['organizationId', 'basketId', 'siteId', 'locale']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'basketId', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -106,7 +108,8 @@ export const getPaymentMethodsForBasket: QueryKeyHelper<'getPaymentMethodsForBas
 }
 
 export const getPriceBooksForBasket: QueryKeyHelper<'getPriceBooksForBasket'> = {
-    parameters: (params) => pick(params, ['organizationId', 'basketId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'basketId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -123,7 +126,14 @@ export const getPriceBooksForBasket: QueryKeyHelper<'getPriceBooksForBasket'> = 
 
 export const getShippingMethodsForShipment: QueryKeyHelper<'getShippingMethodsForShipment'> = {
     parameters: (params) =>
-        pick(params, ['organizationId', 'basketId', 'shipmentId', 'siteId', 'locale']),
+        pick(params, [
+            'organizationId',
+            'basketId',
+            'shipmentId',
+            'siteId',
+            'locale',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -141,7 +151,8 @@ export const getShippingMethodsForShipment: QueryKeyHelper<'getShippingMethodsFo
 }
 
 export const getTaxesFromBasket: QueryKeyHelper<'getTaxesFromBasket'> = {
-    parameters: (params) => pick(params, ['organizationId', 'basketId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'basketId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/paramKeys.ts
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2024, Salesforce, Inc.
  * All rights reserved.
- * SPDX-License-Identifier = BSD-3-Clause
+ * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/paramKeys.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier = BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getShopperContext = ['organizationId', 'usid'] as const
+
+export default {
+    getShopperContext
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
@@ -40,10 +40,7 @@ export const useShopperContext = (
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
 
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperContexts']
 
@@ -37,13 +38,20 @@ export const useShopperContext = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperContexts} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperContexts<{shortCode: string}>
@@ -37,7 +37,7 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getShopperContext: QueryKeyHelper<'getShopperContext'> = {
-    parameters: (params) => pick(params, ['organizationId', 'usid']),
+    parameters: (params) => pick(params, ['organizationId', 'usid', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/queryKeyHelpers.ts
@@ -7,7 +7,7 @@
 import type {ShopperContexts} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
-
+import paramKeysMap from './paramKeys'
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperContexts<{shortCode: string}>
 type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
@@ -25,11 +25,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -37,7 +32,6 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getShopperContext: QueryKeyHelper<'getShopperContext'> = {
-    parameters: (params) => pick(params, ['organizationId', 'usid', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -45,8 +39,8 @@ export const getShopperContext: QueryKeyHelper<'getShopperContext'> = {
         '/shopper-context/',
         params.usid
     ],
-    queryKey: (params: Params<'getShopperContext'>) => [
-        ...getShopperContext.path(params),
-        getShopperContext.parameters(params)
-    ]
+    queryKey: (params: Params<'getShopperContext'>) => {
+        const paramKeys = [...paramKeysMap['getShopperContext'], ...getCustomKeys(params)]
+        return [...getShopperContext.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
@@ -41,8 +41,8 @@ export const getPublicProductListsBySearchTerm = [
     'siteId'
 ] as const
 export const getPublicProductList = ['organizationId', 'listId', 'siteId'] as const
-// TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
 export const getProductListItem = ['organizationId', 'listId', 'itemId', 'siteId'] as const
+// TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
 // export const getExternalProfile = [
 //     'organizationId',
 //     'externalId',

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
@@ -4,11 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {Argument, NullableParameters} from '../types'
-import {ShopperCustomers} from 'commerce-sdk-isomorphic'
-type Client = ShopperCustomers<{shortCode: string}>
-type Params = NullableParameters<Argument<Client['getCustomerBaskets']>>['parameters']
-type test = keyof Params
 export const getCustomer = ['organizationId', 'customerId', 'siteId'] as const
 export const getCustomerAddress = ['organizationId', 'customerId', 'addressName', 'siteId'] as const
 export const getCustomerBaskets = ['organizationId', 'customerId', 'siteId'] as const

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
@@ -40,9 +40,8 @@ export const getPublicProductListsBySearchTerm = [
     'lastName',
     'siteId'
 ] as const
-export const getPublicProductList = ['organizationId', 'siteId'] as const
+export const getPublicProductList = ['organizationId', 'listId', 'siteId'] as const
 // TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
-
 export const getProductListItem = ['organizationId', 'listId', 'itemId', 'siteId'] as const
 // export const getExternalProfile = [
 //     'organizationId',

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {Argument, NullableParameters} from '../types'
+import {ShopperCustomers} from 'commerce-sdk-isomorphic'
+type Client = ShopperCustomers<{shortCode: string}>
+type Params = NullableParameters<Argument<Client['getCustomerBaskets']>>['parameters']
+type test = keyof Params
+export const getCustomer = ['organizationId', 'customerId', 'siteId'] as const
+export const getCustomerAddress = ['organizationId', 'customerId', 'addressName', 'siteId'] as const
+export const getCustomerBaskets = ['organizationId', 'customerId', 'siteId'] as const
+export const getCustomerOrders = [
+    'organizationId',
+    'customerId',
+    'crossSites',
+    'from',
+    'until',
+    'status',
+    'siteId',
+    'offset',
+    'limit'
+] as const
+export const getCustomerPaymentInstrument = [
+    'organizationId',
+    'customerId',
+    'paymentInstrumentId',
+    'siteId'
+] as const
+export const getCustomerProductLists = ['organizationId', 'customerId', 'siteId'] as const
+export const getCustomerProductList = ['organizationId', 'customerId', 'listId', 'siteId'] as const
+export const getCustomerProductListItem = [
+    'organizationId',
+    'customerId',
+    'listId',
+    'itemId',
+    'siteId'
+] as const
+export const getPublicProductListsBySearchTerm = [
+    'organizationId',
+    'email',
+    'firstName',
+    'lastName',
+    'siteId'
+] as const
+export const getPublicProductList = ['organizationId', 'siteId'] as const
+export const getProductListItem = ['organizationId', 'listId', 'itemId', 'siteId'] as const
+export const getExternalProfile = ['organizationId', 'listId', 'itemId', 'siteId'] as const
+
+export default {
+    getCustomer,
+    getCustomerAddress,
+    getCustomerBaskets,
+    getCustomerOrders,
+    getCustomerPaymentInstrument,
+    getCustomerProductList,
+    getCustomerProductLists,
+    getCustomerProductListItem,
+    getPublicProductListsBySearchTerm,
+    getPublicProductList,
+    getProductListItem
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/paramKeys.ts
@@ -41,8 +41,15 @@ export const getPublicProductListsBySearchTerm = [
     'siteId'
 ] as const
 export const getPublicProductList = ['organizationId', 'siteId'] as const
+// TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
+
 export const getProductListItem = ['organizationId', 'listId', 'itemId', 'siteId'] as const
-export const getExternalProfile = ['organizationId', 'listId', 'itemId', 'siteId'] as const
+// export const getExternalProfile = [
+//     'organizationId',
+//     'externalId',
+//     'authenticationProviderId',
+//     'siteId'
+// ] as const
 
 export default {
     getCustomer,
@@ -56,4 +63,5 @@ export default {
     getPublicProductListsBySearchTerm,
     getPublicProductList,
     getProductListItem
+    // getExternalProfile
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
@@ -79,13 +79,15 @@ export const useCustomer = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -151,13 +153,14 @@ export const useCustomerBaskets = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
-
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -189,13 +192,15 @@ export const useCustomerOrders = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
-    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
+    // We don't use `netOptions` here because we manipulate the option in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -230,13 +235,15 @@ export const useCustomerPaymentInstrument = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -266,13 +273,15 @@ export const useCustomerProductLists = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -302,13 +311,15 @@ export const useCustomerProductList = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -344,13 +355,15 @@ export const useCustomerProductListItem = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -380,13 +393,15 @@ export const usePublicProductListsBySearchTerm = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -416,13 +431,15 @@ export const usePublicProductList = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -452,13 +469,15 @@ export const useProductListItem = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperCustomers']
 
@@ -76,11 +77,10 @@ export const useCustomer = (
     const methodName = 'getCustomer'
     const requiredParameters = ['organizationId', 'customerId', 'siteId'] as const
 
-    // Parameters can be set in `apiOptions` or `client.clientConfig`;
-    // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -117,13 +117,16 @@ export const useCustomerAddress = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -153,8 +156,9 @@ export const useCustomerBaskets = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -192,8 +196,9 @@ export const useCustomerOrders = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the option in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -235,8 +240,9 @@ export const useCustomerPaymentInstrument = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -273,8 +279,9 @@ export const useCustomerProductLists = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -311,8 +318,9 @@ export const useCustomerProductList = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -355,8 +363,9 @@ export const useCustomerProductListItem = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -393,8 +402,9 @@ export const usePublicProductListsBySearchTerm = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -431,8 +441,9 @@ export const usePublicProductList = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -469,8 +480,9 @@ export const useProductListItem = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperCustomers} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperCustomers<{shortCode: string}>
@@ -126,41 +127,35 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
+    // /**
+    //  * Reduces the given parameters (which may have additional, unknown properties) to an object
+    //  * containing *only* the properties required for an endpoint.
+    //  */
+    // parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
     queryKey: (params: Params<T>) => QueryKeys[T]
 }
 
-export const getExternalProfile: QueryKeyHelper<'getExternalProfile'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'externalId',
-            'authenticationProviderId',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
-    path: (params) => [
-        '/commerce-sdk-react',
-        '/organizations/',
-        params.organizationId,
-        '/customers/external-profile'
-    ],
-    queryKey: (params: Params<'getExternalProfile'>) => [
-        ...getExternalProfile.path(params),
-        getExternalProfile.parameters(params)
-    ]
-}
+// TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
+// export const getExternalProfile: QueryKeyHelper<'getExternalProfile'> = {
+//     path: (params) => [
+//         '/commerce-sdk-react',
+//         '/organizations/',
+//         params.organizationId,
+//         '/customers/external-profile'
+//     ],
+//     queryKey: (params: Params<'getExternalProfile'>) => {
+//         const paramKeys = [
+//             ...paramKeysMap['getExternalProfile'],
+//             ...getCustomKeys(getCustomerBaskets)
+//         ]
+//         return [...getExternalProfile.path(params), pick(params, paramKeys)]
+//     }
+// }
 
 export const getCustomer: QueryKeyHelper<'getCustomer'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -168,21 +163,13 @@ export const getCustomer: QueryKeyHelper<'getCustomer'> = {
         '/customers/',
         params.customerId
     ],
-    queryKey: (params: Params<'getCustomer'>) => [
-        ...getCustomer.path(params),
-        getCustomer.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomer'>) => {
+        const paramKeys = [...paramKeysMap['getCustomer'], ...getCustomKeys(params)]
+        return [...getCustomer.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerAddress: QueryKeyHelper<'getCustomerAddress'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'customerId',
-            'addressName',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -192,15 +179,14 @@ export const getCustomerAddress: QueryKeyHelper<'getCustomerAddress'> = {
         '/addresses/',
         params.addressName
     ],
-    queryKey: (params: Params<'getCustomerAddress'>) => [
-        ...getCustomerAddress.path(params),
-        getCustomerAddress.parameters(params)
-    ]
-}
+    queryKey: (params: Params<'getCustomerAddress'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerAddress'], ...getCustomKeys(params)]
 
+        return [...getCustomerAddress.path(params), pick(params, paramKeys)]
+    }
+}
+//@ts-ignore
 export const getCustomerBaskets: QueryKeyHelper<'getCustomerBaskets'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -209,26 +195,13 @@ export const getCustomerBaskets: QueryKeyHelper<'getCustomerBaskets'> = {
         params.customerId,
         '/baskets'
     ],
-    queryKey: (params: Params<'getCustomerBaskets'>) => [
-        ...getCustomerBaskets.path(params),
-        getCustomerBaskets.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerBaskets'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerBaskets'], ...getCustomKeys(params)]
+        return [...getCustomerBaskets.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerOrders: QueryKeyHelper<'getCustomerOrders'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'customerId',
-            'crossSites',
-            'from',
-            'until',
-            'status',
-            'siteId',
-            'offset',
-            'limit',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -237,21 +210,13 @@ export const getCustomerOrders: QueryKeyHelper<'getCustomerOrders'> = {
         params.customerId,
         '/orders'
     ],
-    queryKey: (params: Params<'getCustomerOrders'>) => [
-        ...getCustomerOrders.path(params),
-        getCustomerOrders.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerOrders'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerOrders'], ...getCustomKeys(params)]
+        return [...getCustomerOrders.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerPaymentInstrument: QueryKeyHelper<'getCustomerPaymentInstrument'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'customerId',
-            'paymentInstrumentId',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -261,15 +226,16 @@ export const getCustomerPaymentInstrument: QueryKeyHelper<'getCustomerPaymentIns
         '/payment-instruments/',
         params.paymentInstrumentId
     ],
-    queryKey: (params: Params<'getCustomerPaymentInstrument'>) => [
-        ...getCustomerPaymentInstrument.path(params),
-        getCustomerPaymentInstrument.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerPaymentInstrument'>) => {
+        const paramKeys = [
+            ...paramKeysMap['getCustomerPaymentInstrument'],
+            ...getCustomKeys(params)
+        ]
+        return [...getCustomerPaymentInstrument.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerProductLists: QueryKeyHelper<'getCustomerProductLists'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -278,21 +244,13 @@ export const getCustomerProductLists: QueryKeyHelper<'getCustomerProductLists'> 
         params.customerId,
         '/product-lists'
     ],
-    queryKey: (params: Params<'getCustomerProductLists'>) => [
-        ...getCustomerProductLists.path(params),
-        getCustomerProductLists.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerProductLists'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerProductLists'], ...getCustomKeys(params)]
+        return [...getCustomerProductLists.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerProductList: QueryKeyHelper<'getCustomerProductList'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'customerId',
-            'listId',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -302,22 +260,13 @@ export const getCustomerProductList: QueryKeyHelper<'getCustomerProductList'> = 
         '/product-lists/',
         params.listId
     ],
-    queryKey: (params: Params<'getCustomerProductList'>) => [
-        ...getCustomerProductList.path(params),
-        getCustomerProductList.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerProductList'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerProductList'], ...getCustomKeys(params)]
+        return [...getCustomerProductList.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCustomerProductListItem: QueryKeyHelper<'getCustomerProductListItem'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'customerId',
-            'listId',
-            'itemId',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -329,38 +278,30 @@ export const getCustomerProductListItem: QueryKeyHelper<'getCustomerProductListI
         '/items/',
         params.itemId
     ],
-    queryKey: (params: Params<'getCustomerProductListItem'>) => [
-        ...getCustomerProductListItem.path(params),
-        getCustomerProductListItem.parameters(params)
-    ]
+    queryKey: (params: Params<'getCustomerProductListItem'>) => {
+        const paramKeys = [...paramKeysMap['getCustomerProductListItem'], ...getCustomKeys(params)]
+        return [...getCustomerProductListItem.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPublicProductListsBySearchTerm: QueryKeyHelper<'getPublicProductListsBySearchTerm'> =
     {
-        parameters: (params) =>
-            pick(params, [
-                'organizationId',
-                'email',
-                'firstName',
-                'lastName',
-                'siteId',
-                ...getCustomKeys(params)
-            ]),
         path: (params) => [
             '/commerce-sdk-react',
             '/organizations/',
             params.organizationId,
             '/product-lists'
         ],
-        queryKey: (params: Params<'getPublicProductListsBySearchTerm'>) => [
-            ...getPublicProductListsBySearchTerm.path(params),
-            getPublicProductListsBySearchTerm.parameters(params)
-        ]
+        queryKey: (params: Params<'getPublicProductListsBySearchTerm'>) => {
+            const paramKeys = [
+                ...paramKeysMap['getPublicProductListsBySearchTerm'],
+                ...getCustomKeys(params)
+            ]
+            return [...getPublicProductListsBySearchTerm.path(params), pick(params, paramKeys)]
+        }
     }
 
 export const getPublicProductList: QueryKeyHelper<'getPublicProductList'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'listId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -368,15 +309,13 @@ export const getPublicProductList: QueryKeyHelper<'getPublicProductList'> = {
         '/product-lists/',
         params.listId
     ],
-    queryKey: (params: Params<'getPublicProductList'>) => [
-        ...getPublicProductList.path(params),
-        getPublicProductList.parameters(params)
-    ]
+    queryKey: (params: Params<'getPublicProductList'>) => {
+        const paramKeys = [...paramKeysMap['getPublicProductList'], ...getCustomKeys(params)]
+        return [...getPublicProductList.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getProductListItem: QueryKeyHelper<'getProductListItem'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'listId', 'itemId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -386,8 +325,8 @@ export const getProductListItem: QueryKeyHelper<'getProductListItem'> = {
         '/items/',
         params.itemId
     ],
-    queryKey: (params: Params<'getProductListItem'>) => [
-        ...getProductListItem.path(params),
-        getProductListItem.parameters(params)
-    ]
+    queryKey: (params: Params<'getProductListItem'>) => {
+        const paramKeys = [...paramKeysMap['getProductListItem'], ...getCustomKeys(params)]
+        return [...getProductListItem.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperCustomers} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperCustomers<{shortCode: string}>
@@ -139,7 +139,13 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 
 export const getExternalProfile: QueryKeyHelper<'getExternalProfile'> = {
     parameters: (params) =>
-        pick(params, ['organizationId', 'externalId', 'authenticationProviderId', 'siteId']),
+        pick(params, [
+            'organizationId',
+            'externalId',
+            'authenticationProviderId',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -153,7 +159,8 @@ export const getExternalProfile: QueryKeyHelper<'getExternalProfile'> = {
 }
 
 export const getCustomer: QueryKeyHelper<'getCustomer'> = {
-    parameters: (params) => pick(params, ['organizationId', 'customerId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -168,7 +175,14 @@ export const getCustomer: QueryKeyHelper<'getCustomer'> = {
 }
 
 export const getCustomerAddress: QueryKeyHelper<'getCustomerAddress'> = {
-    parameters: (params) => pick(params, ['organizationId', 'customerId', 'addressName', 'siteId']),
+    parameters: (params) =>
+        pick(params, [
+            'organizationId',
+            'customerId',
+            'addressName',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -185,7 +199,8 @@ export const getCustomerAddress: QueryKeyHelper<'getCustomerAddress'> = {
 }
 
 export const getCustomerBaskets: QueryKeyHelper<'getCustomerBaskets'> = {
-    parameters: (params) => pick(params, ['organizationId', 'customerId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -211,7 +226,8 @@ export const getCustomerOrders: QueryKeyHelper<'getCustomerOrders'> = {
             'status',
             'siteId',
             'offset',
-            'limit'
+            'limit',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',
@@ -229,7 +245,13 @@ export const getCustomerOrders: QueryKeyHelper<'getCustomerOrders'> = {
 
 export const getCustomerPaymentInstrument: QueryKeyHelper<'getCustomerPaymentInstrument'> = {
     parameters: (params) =>
-        pick(params, ['organizationId', 'customerId', 'paymentInstrumentId', 'siteId']),
+        pick(params, [
+            'organizationId',
+            'customerId',
+            'paymentInstrumentId',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -246,7 +268,8 @@ export const getCustomerPaymentInstrument: QueryKeyHelper<'getCustomerPaymentIns
 }
 
 export const getCustomerProductLists: QueryKeyHelper<'getCustomerProductLists'> = {
-    parameters: (params) => pick(params, ['organizationId', 'customerId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'customerId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -262,7 +285,14 @@ export const getCustomerProductLists: QueryKeyHelper<'getCustomerProductLists'> 
 }
 
 export const getCustomerProductList: QueryKeyHelper<'getCustomerProductList'> = {
-    parameters: (params) => pick(params, ['organizationId', 'customerId', 'listId', 'siteId']),
+    parameters: (params) =>
+        pick(params, [
+            'organizationId',
+            'customerId',
+            'listId',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -280,7 +310,14 @@ export const getCustomerProductList: QueryKeyHelper<'getCustomerProductList'> = 
 
 export const getCustomerProductListItem: QueryKeyHelper<'getCustomerProductListItem'> = {
     parameters: (params) =>
-        pick(params, ['organizationId', 'customerId', 'listId', 'itemId', 'siteId']),
+        pick(params, [
+            'organizationId',
+            'customerId',
+            'listId',
+            'itemId',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -301,7 +338,14 @@ export const getCustomerProductListItem: QueryKeyHelper<'getCustomerProductListI
 export const getPublicProductListsBySearchTerm: QueryKeyHelper<'getPublicProductListsBySearchTerm'> =
     {
         parameters: (params) =>
-            pick(params, ['organizationId', 'email', 'firstName', 'lastName', 'siteId']),
+            pick(params, [
+                'organizationId',
+                'email',
+                'firstName',
+                'lastName',
+                'siteId',
+                ...getCustomKeys(params)
+            ]),
         path: (params) => [
             '/commerce-sdk-react',
             '/organizations/',
@@ -315,7 +359,8 @@ export const getPublicProductListsBySearchTerm: QueryKeyHelper<'getPublicProduct
     }
 
 export const getPublicProductList: QueryKeyHelper<'getPublicProductList'> = {
-    parameters: (params) => pick(params, ['organizationId', 'listId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'listId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -330,7 +375,8 @@ export const getPublicProductList: QueryKeyHelper<'getPublicProductList'> = {
 }
 
 export const getProductListItem: QueryKeyHelper<'getProductListItem'> = {
-    parameters: (params) => pick(params, ['organizationId', 'listId', 'itemId', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'listId', 'itemId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
@@ -127,11 +127,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    // /**
-    //  * Reduces the given parameters (which may have additional, unknown properties) to an object
-    //  * containing *only* the properties required for an endpoint.
-    //  */
-    // parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -140,12 +135,6 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 
 // TODO: Re-implement (and update description from RAML spec) when the endpoint exits closed beta.
 // export const getExternalProfile: QueryKeyHelper<'getExternalProfile'> = {
-//     path: (params) => [
-//         '/commerce-sdk-react',
-//         '/organizations/',
-//         params.organizationId,
-//         '/customers/external-profile'
-//     ],
 //     queryKey: (params: Params<'getExternalProfile'>) => {
 //         const paramKeys = [
 //             ...paramKeysMap['getExternalProfile'],

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/queryKeyHelpers.ts
@@ -185,7 +185,6 @@ export const getCustomerAddress: QueryKeyHelper<'getCustomerAddress'> = {
         return [...getCustomerAddress.path(params), pick(params, paramKeys)]
     }
 }
-//@ts-ignore
 export const getCustomerBaskets: QueryKeyHelper<'getCustomerBaskets'> = {
     path: (params) => [
         '/commerce-sdk-react',

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/paramKeys.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getPages = [
+    'organizationId',
+    'categoryId',
+    'productId',
+    'aspectTypeId',
+    'aspectAttributes',
+    'parameters',
+    'siteId',
+    'locale'
+] as const
+const getPage = [
+    'organizationId',
+    'pageId',
+    'aspectAttributes',
+    'parameters',
+    'siteId',
+    'locale'
+] as const
+
+export default {
+    getPages,
+    getPage
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
@@ -8,9 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
-
+import paramKeysMap from './paramKeys'
 type Client = ApiClients['shopperExperience']
 
 /**
@@ -40,8 +40,12 @@ export const usePages = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -81,8 +85,12 @@ export const usePage = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
@@ -40,13 +40,15 @@ export const usePages = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -79,13 +81,15 @@ export const usePage = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/query.ts
@@ -41,10 +41,7 @@ export const usePages = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -86,10 +83,7 @@ export const usePage = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperExperience} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperExperience<{shortCode: string}>
@@ -32,11 +33,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -44,36 +40,14 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getPages: QueryKeyHelper<'getPages'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'categoryId',
-            'productId',
-            'aspectTypeId',
-            'aspectAttributes',
-            'parameters',
-            'siteId',
-            'locale',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => ['/commerce-sdk-react', '/organizations/', params.organizationId, '/pages'],
-    queryKey: (params: Params<'getPages'>) => [
-        ...getPages.path(params),
-        getPages.parameters(params)
-    ]
+    queryKey: (params: Params<'getPages'>) => {
+        const paramKeys = [...paramKeysMap['getPages'], ...getCustomKeys(params)]
+        return [...getPages.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPage: QueryKeyHelper<'getPage'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'pageId',
-            'aspectAttributes',
-            'parameters',
-            'siteId',
-            'locale',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -81,5 +55,8 @@ export const getPage: QueryKeyHelper<'getPage'> = {
         '/pages/',
         params.pageId
     ],
-    queryKey: (params: Params<'getPage'>) => [...getPage.path(params), getPage.parameters(params)]
+    queryKey: (params: Params<'getPage'>) => {
+        const paramKeys = [...paramKeysMap['getPage'], ...getCustomKeys(params)]
+        return [...getPage.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperExperience} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperExperience<{shortCode: string}>
@@ -53,7 +53,8 @@ export const getPages: QueryKeyHelper<'getPages'> = {
             'aspectAttributes',
             'parameters',
             'siteId',
-            'locale'
+            'locale',
+            ...getCustomKeys(params)
         ]),
     path: (params) => ['/commerce-sdk-react', '/organizations/', params.organizationId, '/pages'],
     queryKey: (params: Params<'getPages'>) => [
@@ -70,7 +71,8 @@ export const getPage: QueryKeyHelper<'getPage'> = {
             'aspectAttributes',
             'parameters',
             'siteId',
-            'locale'
+            'locale',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/paramKeys.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getGiftCertificate = ['organizationId', 'siteId'] as const
+
+export default {
+    getGiftCertificate
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
@@ -37,6 +37,8 @@ export const useGiftCertificate = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -44,7 +46,7 @@ export const useGiftCertificate = (
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
     return useQuery<Client, Options, Data>(
-        netOptions,
+        {...netOptions, parameters},
         {
             // !!! This is a violation of our design goal of minimal logic in the indivudal endpoint
             // endpoint hooks. This is because this method is a post method, rather than GET,

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperGiftCertificates']
 
@@ -37,9 +38,14 @@ export const useGiftCertificate = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/query.ts
@@ -39,10 +39,7 @@ export const useGiftCertificate = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
 

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperGiftCertificates} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperGiftCertificates<{shortCode: string}>
@@ -36,7 +36,7 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getGiftCertificate: QueryKeyHelper<'getGiftCertificate'> = {
-    parameters: (params) => pick(params, ['organizationId', 'siteId']),
+    parameters: (params) => pick(params, ['organizationId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperGiftCertificates/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperGiftCertificates} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperGiftCertificates<{shortCode: string}>
@@ -24,11 +25,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -36,15 +32,14 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getGiftCertificate: QueryKeyHelper<'getGiftCertificate'> = {
-    parameters: (params) => pick(params, ['organizationId', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/gift-certificate'
     ],
-    queryKey: (params: Params<'getGiftCertificate'>) => [
-        ...getGiftCertificate.path(params),
-        getGiftCertificate.parameters(params)
-    ]
+    queryKey: (params: Params<'getGiftCertificate'>) => {
+        const paramKeys = [...paramKeysMap['getGiftCertificate'], ...getCustomKeys(params)]
+        return [...getGiftCertificate.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/paramKeys.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getUserInfo = ['organizationId', 'channel_id'] as const
+const getWellknownOpenidConfiguration = ['organizationId'] as const
+const getJwksUri = ['organizationId'] as const
+
+export default {
+    getUserInfo,
+    getWellknownOpenidConfiguration,
+    getJwksUri
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.test.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {ShopperLoginTypes} from 'commerce-sdk-isomorphic'
 import nock from 'nock'
 import {
     mockQueryEndpoint,

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
@@ -37,13 +37,15 @@ export const useUserInfo = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -73,13 +75,15 @@ export const useWellknownOpenidConfiguration = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -109,13 +113,15 @@ export const useJwksUri = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperLogin']
 
@@ -37,8 +38,9 @@ export const useUserInfo = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -75,8 +77,9 @@ export const useWellknownOpenidConfiguration = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -113,8 +116,9 @@ export const useJwksUri = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperLogin} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperLogin<{shortCode: string}>
@@ -50,7 +50,8 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getUserInfo: QueryKeyHelper<'getUserInfo'> = {
-    parameters: (params) => pick(params, ['organizationId', 'channel_id']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'channel_id', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -64,7 +65,7 @@ export const getUserInfo: QueryKeyHelper<'getUserInfo'> = {
 }
 
 export const getWellknownOpenidConfiguration: QueryKeyHelper<'getWellknownOpenidConfiguration'> = {
-    parameters: (params) => pick(params, ['organizationId']),
+    parameters: (params) => pick(params, ['organizationId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -78,7 +79,7 @@ export const getWellknownOpenidConfiguration: QueryKeyHelper<'getWellknownOpenid
 }
 
 export const getJwksUri: QueryKeyHelper<'getJwksUri'> = {
-    parameters: (params) => pick(params, ['organizationId']),
+    parameters: (params) => pick(params, ['organizationId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperLogin} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperLogin<{shortCode: string}>
@@ -38,11 +39,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -50,44 +46,44 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getUserInfo: QueryKeyHelper<'getUserInfo'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'channel_id', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/oauth2/userinfo'
     ],
-    queryKey: (params: Params<'getUserInfo'>) => [
-        ...getUserInfo.path(params),
-        getUserInfo.parameters(params)
-    ]
+    queryKey: (params: Params<'getUserInfo'>) => {
+        const paramKeys = [...paramKeysMap['getUserInfo'], ...getCustomKeys(params)]
+        return [...getUserInfo.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getWellknownOpenidConfiguration: QueryKeyHelper<'getWellknownOpenidConfiguration'> = {
-    parameters: (params) => pick(params, ['organizationId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/oauth2/.well-known/openid-configuration'
     ],
-    queryKey: (params: Params<'getWellknownOpenidConfiguration'>) => [
-        ...getWellknownOpenidConfiguration.path(params),
-        getWellknownOpenidConfiguration.parameters(params)
-    ]
+    queryKey: (params: Params<'getWellknownOpenidConfiguration'>) => {
+        const paramKeys = [
+            ...paramKeysMap['getWellknownOpenidConfiguration'],
+            ...getCustomKeys(params)
+        ]
+
+        return [...getWellknownOpenidConfiguration.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getJwksUri: QueryKeyHelper<'getJwksUri'> = {
-    parameters: (params) => pick(params, ['organizationId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/oauth2/jwks'
     ],
-    queryKey: (params: Params<'getJwksUri'>) => [
-        ...getJwksUri.path(params),
-        getJwksUri.parameters(params)
-    ]
+    queryKey: (params: Params<'getJwksUri'>) => {
+        const paramKeys = [...paramKeysMap['getJwksUri'], ...getCustomKeys(params)]
+        return [...getJwksUri.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/paramKeys.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getOrder = ['organizationId', 'orderNo', 'siteId', 'locale'] as const
+const getPaymentMethodsForOrder = ['organizationId', 'orderNo', 'siteId', 'locale'] as const
+const getTaxesFromOrder = ['organizationId', 'orderNo', 'siteId'] as const
+
+export default {
+    getOrder,
+    getPaymentMethodsForOrder,
+    getTaxesFromOrder
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
@@ -37,13 +37,15 @@ export const useOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -73,13 +75,15 @@ export const usePaymentMethodsForOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -111,13 +115,15 @@ export const useTaxesFromOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperOrders']
 
@@ -37,8 +38,9 @@ export const useOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -75,8 +77,9 @@ export const usePaymentMethodsForOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -115,8 +118,9 @@ export const useTaxesFromOrder = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperOrders} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperOrders<{shortCode: string}>
@@ -43,11 +44,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -55,8 +51,6 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getOrder: QueryKeyHelper<'getOrder'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'orderNo', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -64,15 +58,14 @@ export const getOrder: QueryKeyHelper<'getOrder'> = {
         '/orders/',
         params.orderNo
     ],
-    queryKey: (params: Params<'getOrder'>) => [
-        ...getOrder.path(params),
-        getOrder.parameters(params)
-    ]
+    queryKey: (params: Params<'getOrder'>) => {
+        const paramKeys = [...paramKeysMap['getOrder'], ...getCustomKeys(params)]
+
+        return [...getOrder.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPaymentMethodsForOrder: QueryKeyHelper<'getPaymentMethodsForOrder'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'orderNo', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -81,15 +74,14 @@ export const getPaymentMethodsForOrder: QueryKeyHelper<'getPaymentMethodsForOrde
         params.orderNo,
         '/payment-methods'
     ],
-    queryKey: (params: Params<'getPaymentMethodsForOrder'>) => [
-        ...getPaymentMethodsForOrder.path(params),
-        getPaymentMethodsForOrder.parameters(params)
-    ]
+    queryKey: (params: Params<'getPaymentMethodsForOrder'>) => {
+        const paramKeys = [...paramKeysMap['getPaymentMethodsForOrder'], ...getCustomKeys(params)]
+
+        return [...getPaymentMethodsForOrder.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getTaxesFromOrder: QueryKeyHelper<'getTaxesFromOrder'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'orderNo', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -98,8 +90,9 @@ export const getTaxesFromOrder: QueryKeyHelper<'getTaxesFromOrder'> = {
         params.orderNo,
         '/taxes'
     ],
-    queryKey: (params: Params<'getTaxesFromOrder'>) => [
-        ...getTaxesFromOrder.path(params),
-        getTaxesFromOrder.parameters(params)
-    ]
+    queryKey: (params: Params<'getTaxesFromOrder'>) => {
+        const paramKeys = [...paramKeysMap['getTaxesFromOrder'], ...getCustomKeys(params)]
+
+        return [...getTaxesFromOrder.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperOrders} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperOrders<{shortCode: string}>
@@ -55,7 +55,8 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getOrder: QueryKeyHelper<'getOrder'> = {
-    parameters: (params) => pick(params, ['organizationId', 'orderNo', 'siteId', 'locale']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'orderNo', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -70,7 +71,8 @@ export const getOrder: QueryKeyHelper<'getOrder'> = {
 }
 
 export const getPaymentMethodsForOrder: QueryKeyHelper<'getPaymentMethodsForOrder'> = {
-    parameters: (params) => pick(params, ['organizationId', 'orderNo', 'siteId', 'locale']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'orderNo', 'siteId', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -86,7 +88,8 @@ export const getPaymentMethodsForOrder: QueryKeyHelper<'getPaymentMethodsForOrde
 }
 
 export const getTaxesFromOrder: QueryKeyHelper<'getTaxesFromOrder'> = {
-    parameters: (params) => pick(params, ['organizationId', 'orderNo', 'siteId']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'orderNo', 'siteId', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/paramKeys.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getProducts = [
+    'organizationId',
+    'ids',
+    'inventoryIds',
+    'select',
+    'currency',
+    'expand',
+    'locale',
+    'allImages',
+    'perPricebook',
+    'siteId'
+] as const
+
+const getProduct = [
+    'organizationId',
+    'id',
+    'inventoryIds',
+    'currency',
+    'expand',
+    'locale',
+    'allImages',
+    'perPricebook',
+    'siteId'
+] as const
+
+const getCategories = ['organizationId', 'ids', 'levels', 'locale', 'siteId'] as const
+const getCategory = ['organizationId', 'id', 'levels', 'locale', 'siteId'] as const
+
+export default {
+    getProducts,
+    getProduct,
+    getCategories,
+    getCategory
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -117,10 +117,7 @@ export const useCategories = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -161,10 +158,7 @@ export const useCategory = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -8,7 +8,7 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {clone, mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperProducts']
@@ -73,6 +73,7 @@ export const useProduct = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -37,13 +37,15 @@ export const useProducts = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -73,14 +75,15 @@ export const useProduct = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -110,13 +113,15 @@ export const useCategories = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -148,13 +153,15 @@ export const useCategory = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -8,7 +8,7 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {clone, mergeOptions, omitNullableParameters} from '../utils'
+import {mergeOptions, omitNullableParameters} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
 
 type Client = ApiClients['shopperProducts']

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperProducts']
 
@@ -37,8 +38,9 @@ export const useProducts = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -75,8 +77,9 @@ export const useProduct = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -113,8 +116,12 @@ export const useCategories = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -153,8 +160,12 @@ export const useCategory = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
@@ -7,7 +7,7 @@
 import type {ShopperProducts} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
-
+import paramKeysMap from './paramKeys'
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperProducts<{shortCode: string}>
 type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
@@ -47,11 +47,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -59,47 +54,19 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getProducts: QueryKeyHelper<'getProducts'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'ids',
-            'inventoryIds',
-            'select',
-            'currency',
-            'expand',
-            'locale',
-            'allImages',
-            'perPricebook',
-            'siteId',
-            'perPricebook',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/products'
     ],
-    queryKey: (params: Params<'getProducts'>) => [
-        ...getProducts.path(params),
-        getProducts.parameters(params)
-    ]
+    queryKey: (params: Params<'getProducts'>) => {
+        const paramKeys = [...paramKeysMap['getProducts'], ...getCustomKeys(params)]
+        return [...getProducts.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getProduct: QueryKeyHelper<'getProduct'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'id',
-            'inventoryIds',
-            'currency',
-            'expand',
-            'locale',
-            'allImages',
-            'perPricebook',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -107,44 +74,26 @@ export const getProduct: QueryKeyHelper<'getProduct'> = {
         '/products/',
         params.id
     ],
-    queryKey: (params: Params<'getProduct'>) => [
-        ...getProduct.path(params),
-        getProduct.parameters(params)
-    ]
+    queryKey: (params: Params<'getProduct'>) => {
+        const paramKeys = [...paramKeysMap['getProduct'], ...getCustomKeys(params)]
+        return [...getProduct.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCategories: QueryKeyHelper<'getCategories'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'ids',
-            'levels',
-            'locale',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/categories'
     ],
-    queryKey: (params: Params<'getCategories'>) => [
-        ...getCategories.path(params),
-        getCategories.parameters(params)
-    ]
+    queryKey: (params: Params<'getCategories'>) => {
+        const paramKeys = [...paramKeysMap['getCategories'], ...getCustomKeys(params)]
+        return [...getCategories.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getCategory: QueryKeyHelper<'getCategory'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'id',
-            'levels',
-            'locale',
-            'siteId',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -152,8 +101,8 @@ export const getCategory: QueryKeyHelper<'getCategory'> = {
         '/categories/',
         params.id
     ],
-    queryKey: (params: Params<'getCategory'>) => [
-        ...getCategory.path(params),
-        getCategory.parameters(params)
-    ]
+    queryKey: (params: Params<'getCategory'>) => {
+        const paramKeys = [...paramKeysMap['getCategory'], ...getCustomKeys(params)]
+        return [...getCategory.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
@@ -64,12 +64,14 @@ export const getProducts: QueryKeyHelper<'getProducts'> = {
             'organizationId',
             'ids',
             'inventoryIds',
+            'select',
             'currency',
             'expand',
             'locale',
             'allImages',
             'perPricebook',
             'siteId',
+            'perPricebook',
             ...getCustomKeys(params)
         ]),
     path: (params) => [

--- a/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperProducts/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperProducts} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperProducts<{shortCode: string}>
@@ -69,7 +69,8 @@ export const getProducts: QueryKeyHelper<'getProducts'> = {
             'locale',
             'allImages',
             'perPricebook',
-            'siteId'
+            'siteId',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',
@@ -94,7 +95,8 @@ export const getProduct: QueryKeyHelper<'getProduct'> = {
             'locale',
             'allImages',
             'perPricebook',
-            'siteId'
+            'siteId',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',
@@ -110,7 +112,15 @@ export const getProduct: QueryKeyHelper<'getProduct'> = {
 }
 
 export const getCategories: QueryKeyHelper<'getCategories'> = {
-    parameters: (params) => pick(params, ['organizationId', 'ids', 'levels', 'locale', 'siteId']),
+    parameters: (params) =>
+        pick(params, [
+            'organizationId',
+            'ids',
+            'levels',
+            'locale',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -124,7 +134,15 @@ export const getCategories: QueryKeyHelper<'getCategories'> = {
 }
 
 export const getCategory: QueryKeyHelper<'getCategory'> = {
-    parameters: (params) => pick(params, ['organizationId', 'id', 'levels', 'locale', 'siteId']),
+    parameters: (params) =>
+        pick(params, [
+            'organizationId',
+            'id',
+            'levels',
+            'locale',
+            'siteId',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/paramKeys.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const getPromotionsForCampaign = [
+    'organizationId',
+    'campaignId',
+    'siteId',
+    'startDate',
+    'endDate',
+    'currency'
+] as const
+
+const getPromotions = ['organizationId', 'siteId', 'ids', 'locale'] as const
+
+export default {
+    getPromotionsForCampaign,
+    getPromotions
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
@@ -37,13 +37,15 @@ export const usePromotions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -77,13 +79,16 @@ export const usePromotionsForCampaign = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperPromotions']
 
@@ -37,8 +38,12 @@ export const usePromotions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -79,8 +84,9 @@ export const usePromotionsForCampaign = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    // get param keys for the api from netOptions
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
+    const parameters = pick(netOptions.parameters, paramKeys)
 
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.ts
@@ -39,10 +39,7 @@ export const usePromotions = (
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
     // get param keys for the api from netOptions
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
@@ -7,6 +7,7 @@
 import type {ShopperPromotions} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
+import paramKeysMap from './paramKeys'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperPromotions<{shortCode: string}>
@@ -32,11 +33,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -44,31 +40,19 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getPromotions: QueryKeyHelper<'getPromotions'> = {
-    parameters: (params) =>
-        pick(params, ['organizationId', 'siteId', 'ids', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/promotions'
     ],
-    queryKey: (params: Params<'getPromotions'>) => [
-        ...getPromotions.path(params),
-        getPromotions.parameters(params)
-    ]
+    queryKey: (params: Params<'getPromotions'>) => {
+        const paramKeys = [...paramKeysMap['getPromotions'], ...getCustomKeys(params)]
+        return [...getPromotions.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getPromotionsForCampaign: QueryKeyHelper<'getPromotionsForCampaign'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'campaignId',
-            'siteId',
-            'startDate',
-            'endDate',
-            'currency',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -76,8 +60,8 @@ export const getPromotionsForCampaign: QueryKeyHelper<'getPromotionsForCampaign'
         '/promotions/campaigns/',
         params.campaignId
     ],
-    queryKey: (params: Params<'getPromotionsForCampaign'>) => [
-        ...getPromotionsForCampaign.path(params),
-        getPromotionsForCampaign.parameters(params)
-    ]
+    queryKey: (params: Params<'getPromotionsForCampaign'>) => {
+        const paramKeys = [...paramKeysMap['getPromotionsForCampaign'], ...getCustomKeys(params)]
+        return [...getPromotionsForCampaign.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperPromotions} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperPromotions<{shortCode: string}>
@@ -44,7 +44,8 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const getPromotions: QueryKeyHelper<'getPromotions'> = {
-    parameters: (params) => pick(params, ['organizationId', 'siteId', 'ids', 'locale']),
+    parameters: (params) =>
+        pick(params, ['organizationId', 'siteId', 'ids', 'locale', ...getCustomKeys(params)]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
@@ -65,7 +66,8 @@ export const getPromotionsForCampaign: QueryKeyHelper<'getPromotionsForCampaign'
             'siteId',
             'startDate',
             'endDate',
-            'currency'
+            'currency',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/paramKeys.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/paramKeys.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+const productSearch = [
+    'organizationId',
+    'siteId',
+    'q',
+    'refine',
+    'sort',
+    'currency',
+    'locale',
+    'expand',
+    'offset',
+    'limit'
+] as const
+const getSearchSuggestions = [
+    'organizationId',
+    'siteId',
+    'q',
+    'limit',
+    'currency',
+    'locale'
+] as const
+
+export default {
+    productSearch,
+    getSearchSuggestions
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
@@ -40,13 +40,15 @@ export const useProductSearch = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters
@@ -78,13 +80,15 @@ export const useSearchSuggestions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    // get valid params for the api from netOptions
+    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
 
     // For some reason, if we don't explicitly set these generic parameters, the inferred type for
     // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
-    return useQuery<Client, Options, Data>(netOptions, queryOptions, {
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
         method,
         queryKey,
         requiredParameters

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
@@ -41,10 +41,7 @@ export const useProductSearch = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -84,10 +81,7 @@ export const useSearchSuggestions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    const paramKeys = [
-        ...paramKeysMap[methodName],
-        ...getCustomKeys(netOptions.parameters)
-    ] as const
+    const paramKeys = [...paramKeysMap[methodName], ...getCustomKeys(netOptions.parameters)]
     const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/query.ts
@@ -8,8 +8,9 @@ import {UseQueryResult} from '@tanstack/react-query'
 import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
 import useCommerceApi from '../useCommerceApi'
 import {useQuery} from '../useQuery'
-import {mergeOptions, omitNullableParameters} from '../utils'
+import {getCustomKeys, mergeOptions, omitNullableParameters, pick} from '../utils'
 import * as queryKeyHelpers from './queryKeyHelpers'
+import paramKeysMap from './paramKeys'
 
 type Client = ApiClients['shopperSearch']
 
@@ -40,8 +41,11 @@ export const useProductSearch = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)
@@ -80,8 +84,11 @@ export const useSearchSuggestions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    // get valid params for the api from netOptions
-    const parameters = queryKeyHelpers[methodName].parameters(netOptions.parameters)
+    const paramKeys = [
+        ...paramKeysMap[methodName],
+        ...getCustomKeys(netOptions.parameters)
+    ] as const
+    const parameters = pick(netOptions.parameters, paramKeys)
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
     const method = async (options: Options) => await client[methodName](options)

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
@@ -7,7 +7,7 @@
 import type {ShopperSearch} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
 import {getCustomKeys, pick} from '../utils'
-
+import paramKeysMap from './paramKeys'
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperSearch<{shortCode: string}>
 type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
@@ -31,11 +31,6 @@ export type QueryKeys = {
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
 // and making those generic would add too much complexity.
 type QueryKeyHelper<T extends keyof QueryKeys> = {
-    /**
-     * Reduces the given parameters (which may have additional, unknown properties) to an object
-     * containing *only* the properties required for an endpoint.
-     */
-    parameters: (params: Params<T>) => Params<T>
     /** Generates the path component of the query key for an endpoint. */
     path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
     /** Generates the full query key for an endpoint. */
@@ -43,51 +38,29 @@ type QueryKeyHelper<T extends keyof QueryKeys> = {
 }
 
 export const productSearch: QueryKeyHelper<'productSearch'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'siteId',
-            'q',
-            'refine',
-            'sort',
-            'currency',
-            'locale',
-            'expand',
-            'offset',
-            'limit',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/product-search'
     ],
-    queryKey: (params: Params<'productSearch'>) => [
-        ...productSearch.path(params),
-        productSearch.parameters(params)
-    ]
+    queryKey: (params: Params<'productSearch'>) => {
+        const paramKeys = [...paramKeysMap['productSearch'], ...getCustomKeys(params)]
+
+        return [...productSearch.path(params), pick(params, paramKeys)]
+    }
 }
 
 export const getSearchSuggestions: QueryKeyHelper<'getSearchSuggestions'> = {
-    parameters: (params) =>
-        pick(params, [
-            'organizationId',
-            'siteId',
-            'q',
-            'limit',
-            'currency',
-            'locale',
-            ...getCustomKeys(params)
-        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',
         params.organizationId,
         '/search-suggestions'
     ],
-    queryKey: (params: Params<'getSearchSuggestions'>) => [
-        ...getSearchSuggestions.path(params),
-        getSearchSuggestions.parameters(params)
-    ]
+    queryKey: (params: Params<'getSearchSuggestions'>) => {
+        const paramKeys = [...paramKeysMap['getSearchSuggestions'], ...getCustomKeys(params)]
+
+        return [...getSearchSuggestions.path(params), pick(params, paramKeys)]
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperSearch/queryKeyHelpers.ts
@@ -6,7 +6,7 @@
  */
 import type {ShopperSearch} from 'commerce-sdk-isomorphic'
 import {Argument, ExcludeTail} from '../types'
-import {pick} from '../utils'
+import {getCustomKeys, pick} from '../utils'
 
 // We must use a client with no parameters in order to have required/optional match the API spec
 type Client = ShopperSearch<{shortCode: string}>
@@ -54,7 +54,8 @@ export const productSearch: QueryKeyHelper<'productSearch'> = {
             'locale',
             'expand',
             'offset',
-            'limit'
+            'limit',
+            ...getCustomKeys(params)
         ]),
     path: (params) => [
         '/commerce-sdk-react',
@@ -70,7 +71,15 @@ export const productSearch: QueryKeyHelper<'productSearch'> = {
 
 export const getSearchSuggestions: QueryKeyHelper<'getSearchSuggestions'> = {
     parameters: (params) =>
-        pick(params, ['organizationId', 'siteId', 'q', 'limit', 'currency', 'locale']),
+        pick(params, [
+            'organizationId',
+            'siteId',
+            'q',
+            'limit',
+            'currency',
+            'locale',
+            ...getCustomKeys(params)
+        ]),
     path: (params) => [
         '/commerce-sdk-react',
         '/organizations/',

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {ShopperBaskets} from 'commerce-sdk-isomorphic'
-import {mergeOptions} from './utils'
+import {mergeOptions, getCustomKeys} from './utils'
 
 describe('Hook utils', () => {
     test('mergeOptions merges body, header, and options', () => {
@@ -44,5 +44,28 @@ describe('Hook utils', () => {
                 optionsHeader: 'optionsHeader'
             }
         })
+    })
+})
+
+describe('getCustomerKey', function () {
+    test('returns empty array when input is not an object', () => {
+        const res = getCustomKeys([])
+        expect(res).toEqual([])
+    })
+
+    test('returns custom key c_ as output', () => {
+        const res = getCustomKeys({
+            some_key: 'hello',
+            c_key: 'custom key value',
+            c_custom: 'another value'
+        })
+        expect(res).toEqual(['c_key', 'c_custom'])
+    })
+
+    test('returns empty when there is no custom key in the input', () => {
+        const res = getCustomKeys({
+            some_key: 'hello'
+        })
+        expect(res).toEqual([])
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -49,7 +49,7 @@ describe('Hook utils', () => {
 
 describe('getCustomKey', function () {
     test('throw error for invalid input', () => {
-        //@ts-expect-error
+        //@ts-expect-error wrong typed arg is passed intentional to test error
         expect(() => getCustomKeys(null)).toThrow()
     })
 

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -49,7 +49,6 @@ describe('Hook utils', () => {
 
 describe('getCustomKey', function () {
     test('throw error for invalid input', () => {
-        const res = getCustomKeys([])
         //@ts-expect-error
         expect(() => getCustomKeys(null)).toThrow()
     })

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -47,10 +47,11 @@ describe('Hook utils', () => {
     })
 })
 
-describe('getCustomerKey', function () {
-    test('returns empty array when input is not an object', () => {
+describe('getCustomKey', function () {
+    test('throw error for invalid input', () => {
         const res = getCustomKeys([])
-        expect(res).toEqual([])
+        //@ts-expect-error
+        expect(() => getCustomKeys(null)).toThrow()
     })
 
     test('returns custom key c_ as output', () => {

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -133,6 +133,8 @@ export const clone = <T>(val: T): T => {
 
 /** get a list of custom key starting with c_**/
 export const getCustomKeys = <T extends object>(obj: T) => {
-    if (typeof obj !== 'object' || obj === null) return []
+    if (typeof obj !== 'object' || obj === null) {
+        throw new Error('Invalid input. Expecting an object as an input.')
+    }
     return Object.keys(obj).filter((key: string): key is `c_${string}` => key.startsWith('c_'))
 }

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -82,6 +82,7 @@ export const mergeOptions = <Client extends ApiClient, Options extends ApiOption
             ...options.headers
         }
     }
+
     return merged
 }
 

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -134,7 +134,5 @@ export const clone = <T>(val: T): T => {
 /** get a list of custom key starting with c_**/
 export const getCustomKeys = <T extends object>(obj: T) => {
     if (typeof obj !== 'object' || obj === null) return []
-    return Object.keys(obj).filter((key: string): key is `c_${string}` =>
-        key.startsWith('c_')
-    ) as Array<`c_${string}`>
+    return Object.keys(obj).filter((key: string): key is `c_${string}` => key.startsWith('c_'))
 }

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -82,7 +82,6 @@ export const mergeOptions = <Client extends ApiClient, Options extends ApiOption
             ...options.headers
         }
     }
-
     return merged
 }
 

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -130,3 +130,11 @@ export const clone = <T>(val: T): T => {
     const entries = Object.entries(val).map(([k, v]) => [k, clone(v)])
     return Object.fromEntries(entries) as T
 }
+
+/** get a list of custom key starting with c_**/
+export const getCustomKeys = <T extends object>(obj: T) => {
+    if (typeof obj !== 'object' || obj === null) return []
+    return Object.keys(obj).filter((key: string): key is `c_${string}` =>
+        key.startsWith('c_')
+    ) as Array<`c_${string}`>
+}

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## v2.4.0-dev (Jan 22, 2024)
+
+### Bug Fixes
+
 - Fix invalid query params warnings [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
 
 ## v2.3.1 (Jan 23, 2024)

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.4.0-dev (Jan 22, 2024)
+- Fix invalid query params warnings [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
 
 ## v2.3.1 (Jan 23, 2024)
 

--- a/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
@@ -109,9 +109,9 @@ const Payment = () => {
         // Using destructuring to remove properties from the object...
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const {addressId, creationDate, lastModified, preferred, ...address} = billingAddress
-        return updateBillingAddressForBasket({
+        return await updateBillingAddressForBasket({
             body: address,
-            parameters: {basketId: basket.basketId, shipmentId: 'me'}
+            parameters: {basketId: basket.basketId}
         })
     }
     const onPaymentRemoval = async () => {

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -99,7 +99,7 @@ const ProductDetail = () => {
     } = useCategory({
         parameters: {
             id: product?.primaryCategoryId,
-            level: 1
+            levels: 1
         }
     })
 

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -137,9 +137,8 @@ const ProductList = (props) => {
     )
 
     /**************** Query Actions ****************/
-    // make sure that there is no invalid params sent to SCAPI
-    const searchParamsCopied = {...searchParams}
-    delete searchParamsCopied._refine
+    // _refine is an invalid param for useProductSearch, we don't want to pass it to API call
+    const {_refine, ...restOfParams} = searchParams
 
     const {
         isLoading,
@@ -148,7 +147,7 @@ const ProductList = (props) => {
     } = useProductSearch(
         {
             parameters: {
-                ...searchParamsCopied,
+                ...restOfParams,
                 refine: searchParams._refine
             }
         },

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -137,6 +137,10 @@ const ProductList = (props) => {
     )
 
     /**************** Query Actions ****************/
+    // make sure that there is no invalid params sent to SCAPI
+    const searchParamsCopied = {...searchParams}
+    delete searchParamsCopied._refine
+
     const {
         isLoading,
         isRefetching,
@@ -144,7 +148,7 @@ const ProductList = (props) => {
     } = useProductSearch(
         {
             parameters: {
-                ...searchParams,
+                ...searchParamsCopied,
                 refine: searchParams._refine
             }
         },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
With the change from isomorphic that allow passing custom query (c_${string}). We'd want the commerce-react-sdk also adopt the changes. Commerce-react-sdk hooks will automatically accept any custom query key since we reuse type from isomorphic. However, we need to adjust our hooks to allow custom query key in react-query 

This PR
1. Fixes invalid params warnings seen on the retail react app. This is partially because commerce-react-sdk passes in invalid params from client config into isomorphic funcs
2. Allow custom query key to be present in query key in react query cache

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Check out code
- npm ci
- Run retail app
- Observe there is not more invalid params warning in the console from any page
- add custom query in any hook calls. E.g product-detail page
```
const {
        data: product,
        isLoading: isProductLoading,
        isError: isProductError,
        error: productError
    } = useProduct(
        {
            parameters: {
                id: urlParams.get('pid') || productId,
                allImages: true,
                c_customQuery: [true, false] => add it here
            }
        },
        {
            // When shoppers select a different variant (and the app fetches the new data),
            // the old data is still rendered (and not the skeletons).
            keepPreviousData: true
        }
    )
```
- Check the api calls, and see that custom query is present in payload. e.g

![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/9fa81dbf-15bf-4274-853a-b5c4c8cdc5f9)

- Check that custom query params is also present in react query cache. e.g 
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/186305a0-6deb-46e6-b97f-544f9a7daf67)

- Add an custom query that does not start with c_. You should see a warning in the console. E.g

![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/44dd3e1c-302b-4ff8-bf87-dbfa3b625d89)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
