### PR TITLE
update locale selector to use current site, not default site

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fix invalid query params warnings [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
+- Fix locale selector navigating back to default locale [#1662](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1662)
 
 ## v2.3.1 (Jan 23, 2024)
 
@@ -141,7 +142,7 @@ The versions published below were not published on npm, and the versioning match
 
 - Dynamic footer Copyright date [#741](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/741)
 - Footer copyright: remove the remaining hardcoded year [#760](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/760)
-- ImageGallery uses image.link when DIS is not set [#786](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/786)
+- ImageGallery uses image.link when DIS is not set [#786](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/786)
 - Use default locale as target if none is specified [#788](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/788)
 - Password change bug fix [#803](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/803)
 - pwa-kit-dev command for tailing logs [#789](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/789)

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -147,8 +147,6 @@ export const getPathWithLocale = (shortCode, buildUrl, opts = {}) => {
     // remove ending any &
     search = search.replace(/&$/, '')
 
-    const defaultSite = getDefaultSite()
-
     // Remove query parameters
     const {disallowParams = []} = opts
 
@@ -169,7 +167,7 @@ export const getPathWithLocale = (shortCode, buildUrl, opts = {}) => {
         `${pathname}${Array.from(queryString).length !== 0 ? `?${queryString}` : ''}`,
         // By default, as for home page, when the values of site and locale belongs to the default site,
         // they will be not shown in the url just
-        defaultSite.alias || defaultSite.id,
+        site.alias || site.id,
         locale?.alias || locale?.id
     )
     return newUrl


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

fixes issue #1661
When using the locale selector, the site ID is always updated to the default site, instead of the current site ID.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- update utils/url.js to remove `defaultSite`, use `site` (getSiteByReference) in the url

# How to Test-Drive This PR

- Open pwa-kit using the non-default site, http://localhost:3000/us/
- in the footer, change the locale to `English (Canada)`
- Confirm that locale is updated and current site remains the same

## Current State (Actual Result)
https://github.com/SalesforceCommerceCloud/pwa-kit/assets/375787/d8e92b28-5926-43db-bdfa-ca8fcd2876dc

## Fixed State (Expected Result)

https://github.com/SalesforceCommerceCloud/pwa-kit/assets/375787/bd763a54-89f2-42d2-9dce-ac31be54e980

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
