### PR TITLE
[🐞 Bug Fix] Fix Locale Selector Switching Back to Default Locale

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 - Fix invalid query params warnings [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
+- Fix locale selector navigating back to default locale [#1670](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1670)
 
 ## v2.3.1 (Jan 23, 2024)
 

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -147,8 +147,6 @@ export const getPathWithLocale = (shortCode, buildUrl, opts = {}) => {
     // remove ending any &
     search = search.replace(/&$/, '')
 
-    const defaultSite = getDefaultSite()
-
     // Remove query parameters
     const {disallowParams = []} = opts
 
@@ -161,7 +159,6 @@ export const getPathWithLocale = (shortCode, buildUrl, opts = {}) => {
     }
 
     const site = getSiteByReference(siteRef)
-
     const locale = getLocaleByReference(site, shortCode)
 
     // rebuild the url with new locale,
@@ -169,7 +166,7 @@ export const getPathWithLocale = (shortCode, buildUrl, opts = {}) => {
         `${pathname}${Array.from(queryString).length !== 0 ? `?${queryString}` : ''}`,
         // By default, as for home page, when the values of site and locale belongs to the default site,
         // they will be not shown in the url just
-        defaultSite.alias || defaultSite.id,
+        site.alias || site.id,
         locale?.alias || locale?.id
     )
     return newUrl


### PR DESCRIPTION
# Description

This PR fixes #1661.

The locale selector in the footer would always use the default site for url generation even if you were currently on a non-default site.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Remove explicit use of defaultSite in url generation. 

# How to Test-Drive This PR

- See issue for steps to repro

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
