### PR TITLE
W-15040197: lazy basket creation

### DIFF
--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -17,6 +17,7 @@
         "@tanstack/react-query": "^4.28.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
+        "@testing-library/user-event": "^14.4.3",
         "@types/js-cookie": "~3.0.3",
         "@types/jsdom": "^16.2.15",
         "@types/jsonwebtoken": "~9.0.0",
@@ -431,6 +432,19 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -49,6 +49,7 @@
     "@tanstack/react-query": "^4.28.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.4.3",
     "@types/js-cookie": "~3.0.3",
     "@types/jsdom": "^16.2.15",
     "@types/jsonwebtoken": "~9.0.0",

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.test.tsx
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.test.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {useShopperBasketsMutationHelper} from './helpers'
+import {useCustomerBaskets} from '../ShopperCustomers'
+import {renderWithProviders} from '../../test-utils'
+import {screen, waitFor} from '@testing-library/react'
+import jwt from 'jsonwebtoken'
+
+const basketId = '10cf6aa40edba4fcfcc6915594'
+const mockAsyncMutate = jest.fn()
+
+jest.mock('../ShopperCustomers', () => {
+    const originalModule = jest.requireActual('../ShopperCustomers')
+    return {
+        ...originalModule,
+        useCustomerBaskets: jest.fn()
+    }
+})
+jest.mock('../index', () => {
+    const originalModule = jest.requireActual('./index')
+    return {
+        ...originalModule,
+        useCustomerId: jest.fn(() => 'customer-id')
+    }
+})
+
+jest.mock('./mutation', () => {
+    const originalModule = jest.requireActual('./mutation')
+    return {
+        ...originalModule,
+        useShopperBasketsMutation: () => ({
+            mutateAsync: mockAsyncMutate
+        })
+    }
+})
+const MockComponent = () => {
+    const helpers = useShopperBasketsMutationHelper()
+    return (
+        <div>
+            <button
+                onClick={() => {
+                    helpers
+                        .addItemToNewOrExistingBasket([
+                            {
+                                productId: 'product-123',
+                                price: 100,
+                                quantity: 1
+                            }
+                        ])
+                        .catch((e) => console.log('e', e))
+                }}
+            >
+                Add to cart
+            </button>
+        </div>
+    )
+}
+describe('useShopperBasketsMutationHelper.addItemToNewOrExistingBasket', function () {
+    afterEach(() => {
+        jest.resetModules()
+    })
+
+    test('should perform add to cart mutation when basket is already created', async () => {
+        mockAsyncMutate.mockImplementationOnce(() => ({
+            productItems: [{id: 'product-id-111', quantity: 20}],
+            basketId
+        }))
+        // @ts-expect-error ts complains because mockImplementation is not part of declared type from useCustomerBaskets queries
+        useCustomerBaskets.mockImplementation(() => {
+            return {
+                data: {total: 1, baskets: [{basketId}]},
+                isLoading: false
+            }
+        })
+        const fetchedToken = jwt.sign(
+            {
+                sub: `cc-slas::zzrf_001::scid:xxxxxx::usid:usidddddd`,
+                isb: `uido:ecom::upn:Guest::uidn:firstname lastname::gcid:customerId::rcid:registeredCid::chid:siteId`
+            },
+            'secret'
+        )
+        const {user} = renderWithProviders(<MockComponent />, {
+            fetchedToken
+        })
+        const addToCartBtn = screen.getByText(/add to cart/i)
+        await user.click(addToCartBtn)
+
+        await waitFor(() =>
+            expect(mockAsyncMutate.mock.calls[0][0]).toEqual({
+                parameters: {basketId},
+                body: [
+                    {
+                        productId: 'product-123',
+                        price: 100,
+                        quantity: 1
+                    }
+                ]
+            })
+        )
+    })
+
+    test('should call a basket mutation before calling add to cart mutation', async () => {
+        // order is important since mockAsyncMutate will represent createBasket and addToBasket mutation in the order of executions
+        mockAsyncMutate
+            .mockImplementationOnce(() => ({
+                productItems: [],
+                basketId
+            }))
+            .mockImplementationOnce(() => ({
+                productItems: [{id: 'product-id', quantity: 2}],
+                basketId
+            }))
+        // @ts-expect-error ts complains because mockImplementation is not part of declared type from useCustomerBaskets queries
+        useCustomerBaskets.mockImplementation(() => {
+            return {
+                data: {total: 0},
+                isLoading: false
+            }
+        })
+        const fetchedToken = jwt.sign(
+            {
+                sub: `cc-slas::zzrf_001::scid:xxxxxx::usid:usidddddd`,
+                isb: `uido:ecom::upn:Guest::uidn:firstname lastname::gcid:customerId::rcid:registeredCid::chid:siteId`
+            },
+            'secret'
+        )
+        const {user} = renderWithProviders(<MockComponent />, {
+            fetchedToken
+        })
+        const addToCartBtn = screen.getByText(/add to cart/i)
+        await user.click(addToCartBtn)
+        expect(mockAsyncMutate).toHaveBeenCalledTimes(2)
+
+        await waitFor(() => expect(mockAsyncMutate.mock.calls[0][0]).toEqual({body: {}}))
+        await waitFor(() =>
+            expect(mockAsyncMutate.mock.calls[1][0]).toEqual({
+                parameters: {basketId},
+                body: [
+                    {
+                        productId: 'product-123',
+                        price: 100,
+                        quantity: 1
+                    }
+                ]
+            })
+        )
+    })
+})

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.ts
@@ -7,7 +7,6 @@
 
 import {useCustomerId, useShopperBasketsMutation} from '../index'
 import {useCustomerBaskets} from '../ShopperCustomers'
-import {onClient} from '../../utils'
 import {ApiClients, Argument} from '../types'
 import {ShopperBasketsTypes} from 'commerce-sdk-isomorphic'
 type Client = ApiClients['shopperBaskets']
@@ -41,7 +40,6 @@ export function useShopperBasketsMutationHelper() {
             enabled: !!customerId
         }
     )
-    console.log('customerId', customerId)
     const createBasket = useShopperBasketsMutation('createBasket')
     const addItemToBasketMutation = useShopperBasketsMutation('addItemToBasket')
     return {
@@ -61,7 +59,6 @@ export function useShopperBasketsMutationHelper() {
                 const data = await createBasket.mutateAsync({
                     body: {}
                 })
-                console.log('data', data)
                 if (!data) {
                     throw Error('Something is wrong. Please try again')
                 } else {

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/helpers.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {useCustomerId, useShopperBasketsMutation} from '../index'
+import {useCustomerBaskets} from '../ShopperCustomers'
+import {onClient} from '../../utils'
+import {ApiClients, Argument} from '../types'
+import {ShopperBasketsTypes} from 'commerce-sdk-isomorphic'
+type Client = ApiClients['shopperBaskets']
+type Basket = ShopperBasketsTypes.Basket
+
+/**
+ * This is a helper function for Basket Mutations.
+ * useShopperBasketsMutationHelper.addItemToNewOrExistingBasket: is responsible for managing the process of adding an item to a basket.
+ *  - If a basket already exists, add the item to the basket immediately.
+ *  - If a basket does not exist, create a new basket using the createBasket mutation
+ * and then add the item to the newly created basket using the addItemToBasket mutation.
+ *
+ * @example
+ * import useShopperBasketsMutationHelper from '@salesforce/commerce-sdk-react'
+ *
+ * const Page = () => {
+ *      const helpers = useShopperBasketsMutationHelper()
+ *
+ *      const addToCart = async () => {
+ *          const productItems = [{id: 123, quantity: 2}]
+ *          await basketMutationHelpers.addItemToNewOrExistingBasket(productItems)
+ *      }
+ *
+ * }
+ */
+export function useShopperBasketsMutationHelper() {
+    const customerId = useCustomerId()
+    const {data: basketsData} = useCustomerBaskets(
+        {parameters: {customerId}},
+        {
+            enabled: !!customerId
+        }
+    )
+    console.log('customerId', customerId)
+    const createBasket = useShopperBasketsMutation('createBasket')
+    const addItemToBasketMutation = useShopperBasketsMutation('addItemToBasket')
+    return {
+        addItemToNewOrExistingBasket: async (
+            productItem: Argument<Client['addItemToBasket']> extends {body: infer B} ? B : undefined
+        ): Promise<Basket> => {
+            if (basketsData && basketsData.total > 0) {
+                // we know that if basketData.total > 0, current basket will always be available
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                const currentBasket = basketsData?.baskets && basketsData.baskets[0]!
+                return await addItemToBasketMutation.mutateAsync({
+                    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                    parameters: {basketId: currentBasket!.basketId!},
+                    body: productItem
+                })
+            } else {
+                const data = await createBasket.mutateAsync({
+                    body: {}
+                })
+                console.log('data', data)
+                if (!data) {
+                    throw Error('Something is wrong. Please try again')
+                } else {
+                    return await addItemToBasketMutation.mutateAsync({
+                        // we know that data is always available here
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        parameters: {basketId: data.basketId!},
+                        body: productItem
+                    })
+                }
+            }
+        }
+    }
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/index.ts
@@ -6,3 +6,4 @@
  */
 export * from './mutation'
 export * from './query'
+export * from './helpers'

--- a/packages/commerce-sdk-react/src/test-utils.tsx
+++ b/packages/commerce-sdk-react/src/test-utils.tsx
@@ -15,7 +15,7 @@ import {
 } from '@tanstack/react-query'
 import nock from 'nock'
 import CommerceApiProvider, {CommerceApiProviderProps} from './provider'
-
+import userEvent from '@testing-library/user-event'
 // Note: this host does NOT exist
 // it is intentional b/c we can catch those unintercepted requests
 // from log easily. You should always make sure all requests are nocked.
@@ -71,13 +71,15 @@ export const renderWithProviders = (
     children: React.ReactElement,
     props?: TestProviderProps,
     options?: Omit<RenderOptions, 'wrapper'>
-): void => {
-    render(children, {
+) => {
+    const user = userEvent.setup()
+    const res = render(children, {
         wrapper: ({children}: {children?: React.ReactNode}) => (
             <TestProviders {...props}>{children}</TestProviders>
         ),
         ...options
     })
+    return {user, ...res}
 }
 
 /**

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -187,6 +187,7 @@ const App = (props) => {
     const {data: basket} = useCurrentBasket()
 
     const updateBasket = useShopperBasketsMutation('updateBasket')
+    const updateCustomerForBasket = useShopperBasketsMutation('updateCustomerForBasket')
 
     useEffect(() => {
         // update the basket currency if it doesn't match the current locale currency

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -184,24 +184,9 @@ const App = (props) => {
     // Handle creating a new basket if there isn't one already assigned to the current
     // customer.
     const {data: customer} = useCurrentCustomer()
-    const {data: baskets} = useCustomerBaskets(
-        {parameters: {customerId: customer.customerId}},
-        {enabled: !!customer.customerId && !isServer}
-    )
     const {data: basket} = useCurrentBasket()
 
-    const createBasket = useShopperBasketsMutation('createBasket')
     const updateBasket = useShopperBasketsMutation('updateBasket')
-    const updateCustomerForBasket = useShopperBasketsMutation('updateCustomerForBasket')
-
-    useEffect(() => {
-        // Create a new basket if the current customer doesn't have one.
-        if (baskets?.total === 0) {
-            createBasket.mutate({
-                body: {}
-            })
-        }
-    }, [baskets])
 
     useEffect(() => {
         // update the basket currency if it doesn't match the current locale currency

--- a/packages/template-retail-react-app/app/hooks/use-current-basket.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-current-basket.test.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {screen, waitFor} from '@testing-library/react'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import {useCustomerBaskets} from '@salesforce/commerce-sdk-react'
+import {
+    mockCustomerBaskets,
+    mockEmptyBasket
+} from '@salesforce/retail-react-app/app/mocks/mock-data'
+
+const MOCK_USE_QUERY_RESULT = {
+    data: undefined,
+    dataUpdatedAt: 0,
+    error: null,
+    errorUpdatedAt: 0,
+    failureCount: 0,
+    isError: false,
+    isFetched: false,
+    isFetchedAfterMount: false,
+    isFetching: false,
+    isIdle: false,
+    isLoading: false,
+    isLoadingError: false,
+    isPlaceholderData: false,
+    isPreviousData: false,
+    isRefetchError: false,
+    isRefetching: false,
+    isStale: false,
+    isSuccess: true,
+    status: 'success',
+    refetch: jest.fn(),
+    remove: jest.fn()
+}
+
+const basketId = '10cf6aa40edba4fcfcc6915594'
+const mockAsyncMutate = jest.fn()
+jest.mock('@salesforce/commerce-sdk-react', () => {
+    const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
+    return {
+        ...originalModule,
+        useCustomerId: jest.fn(() => 'abmuc2wupJxeoRxuo3wqYYmbhI'),
+        useCustomerBaskets: jest.fn(),
+        useShopperBasketsMutation: () => ({
+            mutateAsync: mockAsyncMutate
+        })
+    }
+})
+
+const MockComponent = () => {
+    const {
+        data: currentBasket,
+        derivedData: {hasBasket, totalItems}
+    } = useCurrentBasket()
+    return (
+        <div>
+            <div data-testid="basket-id">{currentBasket?.basketId}</div>
+            <div data-testid="total-items">{totalItems}</div>
+            <div data-testid="has-basket">{hasBasket.toString()}</div>
+        </div>
+    )
+}
+
+describe('useCurrentBasket', function () {
+    beforeEach(() => {
+        jest.resetModules()
+    })
+
+    test('returns current basket and derivedData when both customerId and basket are defined', async () => {
+        mockAsyncMutate.mockImplementationOnce(() => ({
+            ...mockCustomerBaskets.baskets[0],
+            basketId
+        }))
+        useCustomerBaskets.mockImplementation(() => {
+            return {
+                ...MOCK_USE_QUERY_RESULT,
+                data: mockCustomerBaskets,
+                isLoading: false
+            }
+        })
+        const expectedBasketId = mockCustomerBaskets.baskets[0].basketId
+        await renderWithProviders(<MockComponent />)
+        expect(screen.getByTestId('basket-id').innerHTML).toEqual(expectedBasketId)
+        expect(screen.getByTestId('total-items').innerHTML).toBe('2')
+        expect(screen.getByTestId('has-basket').innerHTML).toBeTruthy()
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.jsx
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.jsx
@@ -6,14 +6,13 @@
  */
 import React, {useState} from 'react'
 import {Button, useDisclosure} from '@salesforce/retail-react-app/app/components/shared/ui'
-import {useShopperBasketsMutation} from '@salesforce/commerce-sdk-react'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {useItemVariant} from '@salesforce/retail-react-app/app/components/item-variant'
 import ProductViewModal from '@salesforce/retail-react-app/app/components/product-view-modal'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {API_ERROR_MESSAGE} from '@salesforce/retail-react-app/app/constants'
-import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import Link from '@salesforce/retail-react-app/app/components/link'
+import {useShopperBasketsMutationHelper} from '@salesforce/commerce-sdk-react'
 
 /**
  * Renders primary action on a product-item card in the form of a button.
@@ -22,15 +21,13 @@ import Link from '@salesforce/retail-react-app/app/components/link'
  */
 const WishlistPrimaryAction = () => {
     const variant = useItemVariant()
-    const {data: basket} = useCurrentBasket()
+    const {addItemToNewOrExistingBasket} = useShopperBasketsMutationHelper()
     const {formatMessage} = useIntl()
     const isMasterProduct = variant?.type?.master || false
     const isProductASet = variant?.type?.set
     const showToast = useToast()
     const [isLoading, setIsLoading] = useState(false)
     const {isOpen, onOpen, onClose} = useDisclosure()
-
-    const addItemToBasket = useShopperBasketsMutation('addItemToBasket')
 
     const handleAddToCart = async (item, quantity) => {
         setIsLoading(true)
@@ -50,34 +47,28 @@ const WishlistPrimaryAction = () => {
                   }
               ]
 
-        addItemToBasket.mutate(
-            {body: productItems, parameters: {basketId: basket?.basketId}},
-            {
-                onSuccess: () => {
-                    showToast({
-                        title: formatMessage(
-                            {
-                                defaultMessage:
-                                    '{quantity} {quantity, plural, one {item} other {items}} added to cart',
-                                id: 'wishlist_primary_action.info.added_to_cart'
-                            },
-                            {quantity: isAddingASet ? quantity * item.setProducts.length : quantity}
-                        ),
-                        status: 'success'
-                    })
-                    onClose()
-                },
-                onError: () => {
-                    showToast({
-                        title: formatMessage(API_ERROR_MESSAGE),
-                        status: 'error'
-                    })
-                },
-                onSettled: () => {
-                    setIsLoading(false)
-                }
-            }
-        )
+        try {
+            await addItemToNewOrExistingBasket(productItems)
+            showToast({
+                title: formatMessage(
+                    {
+                        defaultMessage:
+                            '{quantity} {quantity, plural, one {item} other {items}} added to cart',
+                        id: 'wishlist_primary_action.info.added_to_cart'
+                    },
+                    {quantity: isAddingASet ? quantity * item.setProducts.length : quantity}
+                ),
+                status: 'success'
+            })
+            onClose()
+        } catch (e) {
+            showToast({
+                title: formatMessage(API_ERROR_MESSAGE),
+                status: 'error'
+            })
+        } finally {
+            setIsLoading(false)
+        }
     }
 
     const buttonText = {

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -60,7 +60,7 @@ const ProductDetail = () => {
     const childProductRefs = React.useRef({})
     const customerId = useCustomerId()
     /****************************** Basket *********************************/
-    const {isLoading: isBasketLoading, mutations} = useCurrentBasket()
+    const {isLoading: isBasketLoading} = useCurrentBasket()
     const {addItemToNewOrExistingBasket} = useShopperBasketsMutationHelper()
     const {res} = useServerContext()
     if (res) {

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -15,9 +15,9 @@ import {Box, Button, Stack} from '@salesforce/retail-react-app/app/components/sh
 import {
     useProduct,
     useCategory,
-    useShopperBasketsMutation,
     useShopperCustomersMutation,
-    useCustomerId
+    useCustomerId,
+    useShopperBasketsMutationHelper
 } from '@salesforce/commerce-sdk-react'
 
 // Hooks
@@ -60,13 +60,12 @@ const ProductDetail = () => {
     const childProductRefs = React.useRef({})
     const customerId = useCustomerId()
     /****************************** Basket *********************************/
-    const {data: basket} = useCurrentBasket()
-    const addItemToBasketMutation = useShopperBasketsMutation('addItemToBasket')
+    const {isLoading: isBasketLoading, mutations} = useCurrentBasket()
+    const {addItemToNewOrExistingBasket} = useShopperBasketsMutationHelper()
     const {res} = useServerContext()
     if (res) {
         res.set('Cache-Control', `s-maxage=${MAX_CACHE_AGE}`)
     }
-    const isBasketLoading = !basket?.basketId
 
     /*************************** Product Detail and Category ********************/
     const {productId} = useParams()
@@ -234,10 +233,7 @@ const ProductDetail = () => {
                 quantity
             }))
 
-            await addItemToBasketMutation.mutateAsync({
-                parameters: {basketId: basket.basketId},
-                body: productItems
-            })
+            await addItemToNewOrExistingBasket(productItems)
 
             einstein.sendAddToCart(productItems)
 
@@ -245,6 +241,7 @@ const ProductDetail = () => {
             // by the add to cart modal.
             return productSelectionValues
         } catch (error) {
+            console.log('error', error)
             showError(error)
         }
     }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
Current: today the PWA Kit calls SCAPI endpoints to create a basket on session start. This has two consequences:

- An extra API that may/may not be helpful, this takes up more network bandwidth. A user may not interact with the baskets until they add an item to basket
- In hybrid sites create the possibility of a condition between cart instantiation and retrieval between SFRA and PWA Kit

This PR added a helper function in commerce-sdk-react useShopperBasketsMutationHelper that returns a map of helpers. Currently, it has addItemToNewOrExistingBasket that is responsible for managing the process of adding an item to a basket.

If a basket already exists, add the item to the basket immediately.
If a basket does not exist, create a new basket using the createBasket mutation
and then add the item to the newly created basket using the addItemToBasket mutation.
addAnItemToCart is the only mutation that needs to be aware of basket creation. The other mutations (e.g removeItem or updateItem or the rest) are actions that always come after addAnItemToCart has been called.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- add a helper in commerce react
- product detail and wishlist page in retail app

# How to Test-Drive This PR

- Check out code
- `npm ci`
- Start the retail app
- Delete your localstrage and cookie
- Confirm that when the app boosts up, basket creation is not called until and an item is added to cart on PDP or on wishlist page

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
