### PR TITLE
@W-14959704@ Set private client proxy headers

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1047,6 +1047,8 @@ describe('SLAS private client proxy', () => {
     const slasTarget = `http://localhost:${proxyPort}${proxyPath}`
 
     beforeAll(() => {
+        // by setting slasTarget, rather than forwarding the request to SLAS,
+        // we send the proxy request here so we can return the request headers
         proxyApp = express()
         proxyApp.use(proxyPath, (req, res) => {
             res.send(req.headers)
@@ -1096,6 +1098,8 @@ describe('SLAS private client proxy', () => {
             .get('/mobify/scapi/shopper/auth/somePath')
             .then((response) => {
                 expect(response.body.authorization).toBeUndefined()
+                expect(response.body.host).toBe('shortCode.api.commercecloud.salesforce.com')
+                expect(response.body['x-mobify']).toBe('true')
             })
     }, 15000)
 
@@ -1125,6 +1129,8 @@ describe('SLAS private client proxy', () => {
             .get('/mobify/scapi/shopper/auth/oauth2/token')
             .then((response) => {
                 expect(response.body.authorization).toBe(`Basic ${encodedCredentials}`)
+                expect(response.body.host).toBe('shortCode.api.commercecloud.salesforce.com')
+                expect(response.body['x-mobify']).toBe('true')
             })
     }, 15000)
 })


### PR DESCRIPTION
This PR updates the proxy that injects SLAS client secrets onto request so that other proxy-relevant headers (ie. x-mobify, updates to host and origin headers, etc.) that are applied to other proxies are also applied here.