### PR TITLE
[Bug fix] commerce-sdk-react hooks missing API errors

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
@@ -260,8 +260,6 @@ describe('ShopperBaskets mutations', () => {
             expect(result.current.mutation.error).toBeNull()
             act(() => result.current.mutation.mutate(options))
             await waitAndExpectError(() => result.current.mutation)
-            // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
-            // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
             expect(result.current.mutation.error).toStrictEqual(mutationResponse)
             assertUpdateQuery(result.current.basket, oldBasket)
             assertUpdateQuery(result.current.customerBaskets, oldCustomerBaskets)

--- a/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperBaskets/mutation.test.ts
@@ -220,9 +220,7 @@ describe('ShopperBaskets mutations', () => {
         expect(result.current.error).toBeNull()
         act(() => result.current.mutate(options))
         await waitAndExpectError(() => result.current)
-        // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
-        // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
-        expect(result.current.error).toHaveProperty('response')
+        expect(result.current.error).toStrictEqual({error: true})
     })
     test.each(nonEmptyResponseTestCases)(
         '`%s` updates the cache on success',
@@ -249,7 +247,8 @@ describe('ShopperBaskets mutations', () => {
         async (mutationName, options) => {
             mockQueryEndpoint(basketsEndpoint, oldBasket) // getBasket
             mockQueryEndpoint(customersEndpoint, oldCustomerBaskets) // getCustomerBaskets
-            mockMutationEndpoints(basketsEndpoint, {error: true}, 400) // this mutation
+            const mutationResponse = {error: true}
+            mockMutationEndpoints(basketsEndpoint, mutationResponse, 400) // this mutation
             const {result} = renderHookWithProviders(() => ({
                 basket: queries.useBasket(getBasketOptions),
                 customerBaskets: useCustomerBaskets(getCustomerBasketsOptions),
@@ -263,7 +262,7 @@ describe('ShopperBaskets mutations', () => {
             await waitAndExpectError(() => result.current.mutation)
             // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
             // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
-            expect(result.current.mutation.error).toHaveProperty('response')
+            expect(result.current.mutation.error).toStrictEqual(mutationResponse)
             assertUpdateQuery(result.current.basket, oldBasket)
             assertUpdateQuery(result.current.customerBaskets, oldCustomerBaskets)
         }

--- a/packages/commerce-sdk-react/src/hooks/ShopperContexts/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperContexts/mutation.test.ts
@@ -76,7 +76,7 @@ describe('Shopper Contexts mutation hooks', () => {
         // 1. Populate cache with initial data
         expect(result.current.query.error).toBeNull()
         await waitAndExpectError(() => result.current.query)
-        expect(result.current.query.error).toHaveProperty('response')
+        expect(result.current.query.error).toBeTruthy()
 
         // 2. Do creation mutation
         act(() => result.current.mutation.mutate(options))

--- a/packages/commerce-sdk-react/src/hooks/ShopperLogin/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperLogin/mutation.test.ts
@@ -109,8 +109,6 @@ describe('ShopperLogin mutations', () => {
         expect(result.current.error).toBeNull()
         act(() => result.current.mutate(options))
         await waitAndExpectError(() => result.current)
-        // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
-        // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
-        expect(result.current.error).toHaveProperty('response')
+        expect(result.current.error).toStrictEqual({error: true})
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
@@ -117,9 +117,7 @@ describe('ShopperOrders mutations', () => {
             result.current.mutate(options as Opts)
         })
         await waitAndExpectError(() => result.current)
-        // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
-        // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
-        expect(result.current.error).toHaveProperty('response')
+        expect(result.current.error).toStrictEqual({error: true})
     })
     test('`createOrder` updates the cache on success', async () => {
         const [mutationName, options] = createTestCase

--- a/packages/commerce-sdk-react/src/hooks/useMutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/useMutation.ts
@@ -8,7 +8,7 @@ import {useMutation as useReactQueryMutation, useQueryClient} from '@tanstack/re
 import {CacheUpdateGetter, ApiOptions, ApiMethod, ApiClient, MergedOptions} from './types'
 import {useAuthorizationHeader} from './useAuthorizationHeader'
 import useCustomerId from './useCustomerId'
-import {mergeOptions, updateCache} from './utils'
+import {mergeOptions, updateCache, handleApiError} from './utils'
 
 /**
  * Helper for mutation hooks, contains most of the logic in order to keep individual hooks small.
@@ -27,8 +27,11 @@ export const useMutation = <
     const queryClient = useQueryClient()
     const customerId = useCustomerId()
     const authenticatedMethod = useAuthorizationHeader(hookConfig.method)
+    const wrappedMethod: ApiMethod<Options, Data> = (...args) => {
+        return handleApiError(() => authenticatedMethod(...args))
+    }
 
-    return useReactQueryMutation(authenticatedMethod, {
+    return useReactQueryMutation(wrappedMethod, {
         onSuccess(data, options) {
             // commerce-sdk-isomorphic merges `clientConfig` and `options` under the hood,
             // so we also need to do that to get the "net" options that are actually sent to SCAPI.

--- a/packages/commerce-sdk-react/src/hooks/useQuery.ts
+++ b/packages/commerce-sdk-react/src/hooks/useQuery.ts
@@ -16,7 +16,7 @@ import {
     NullableParameters,
     OmitNullableParameters
 } from './types'
-import {hasAllKeys} from './utils'
+import {hasAllKeys, handleApiError} from './utils'
 import {onClient} from '../utils'
 
 /**
@@ -48,16 +48,10 @@ export const useQuery = <Client extends ApiClient, Options extends ApiOptions, D
     // missing parameters. This will result in a runtime error. I think that this is an acceptable
     // trade-off, as the behavior is opt-in by the end user, and it feels like adding type safety
     // for this case would add significantly more complexity.
-    const wrappedMethod = async () => {
-        try {
-            return await authenticatedMethod(apiOptions as Options)
-        } catch (e) {
-            if (typeof e === 'object' && e !== null && 'response' in e) {
-                const json = await (e.response as Response).json()
-                throw json
-            }
-            throw e
-        }
+    const wrappedMethod = () => {
+        return handleApiError(() => {
+            return authenticatedMethod(apiOptions as Options)
+        })
     }
     return useReactQuery(hookConfig.queryKey, wrappedMethod, {
         enabled:

--- a/packages/commerce-sdk-react/src/hooks/useQuery.ts
+++ b/packages/commerce-sdk-react/src/hooks/useQuery.ts
@@ -48,7 +48,17 @@ export const useQuery = <Client extends ApiClient, Options extends ApiOptions, D
     // missing parameters. This will result in a runtime error. I think that this is an acceptable
     // trade-off, as the behavior is opt-in by the end user, and it feels like adding type safety
     // for this case would add significantly more complexity.
-    const wrappedMethod = async () => await authenticatedMethod(apiOptions as Options)
+    const wrappedMethod = async () => {
+        try {
+            return await authenticatedMethod(apiOptions as Options)
+        } catch (e) {
+            if (typeof e === 'object' && e !== null && 'response' in e) {
+                const json = await (e.response as Response).json()
+                throw json
+            }
+            throw e
+        }
+    }
     return useReactQuery(hookConfig.queryKey, wrappedMethod, {
         enabled:
             // Individual hooks can provide `enabled` checks that are done in ADDITION to

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {ShopperBaskets} from 'commerce-sdk-isomorphic'
-import {mergeOptions, getCustomKeys} from './utils'
+import {mergeOptions, getCustomKeys, handleApiError} from './utils'
 
 describe('Hook utils', () => {
     test('mergeOptions merges body, header, and options', () => {
@@ -67,5 +67,25 @@ describe('getCustomKey', function () {
             some_key: 'hello'
         })
         expect(res).toEqual([])
+    })
+})
+
+describe('handleApiError', () => {
+    test('should return the result of the function if no error is thrown', async () => {
+        const mockFunc = jest.fn().mockResolvedValue('success')
+        const result = await handleApiError(mockFunc)
+        expect(result).toBe('success')
+    })
+
+    test('should throw the error response if the error is an object with a response property', async () => {
+        const mockResponse = {json: jest.fn().mockResolvedValue('error response')}
+        const mockFunc = jest.fn().mockRejectedValue({response: mockResponse})
+        await expect(handleApiError(mockFunc)).rejects.toEqual('error response')
+        expect(mockResponse.json).toHaveBeenCalled()
+    })
+
+    test('should throw the original error if the error is not an object with a response property', async () => {
+        const mockFunc = jest.fn().mockRejectedValue('error')
+        await expect(handleApiError(mockFunc)).rejects.toEqual('error')
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/utils.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.test.ts
@@ -80,12 +80,12 @@ describe('handleApiError', () => {
     test('should throw the error response if the error is an object with a response property', async () => {
         const mockResponse = {json: jest.fn().mockResolvedValue('error response')}
         const mockFunc = jest.fn().mockRejectedValue({response: mockResponse})
-        await expect(handleApiError(mockFunc)).rejects.toEqual('error response')
+        await expect(handleApiError(mockFunc)).rejects.toBe('error response')
         expect(mockResponse.json).toHaveBeenCalled()
     })
 
     test('should throw the original error if the error is not an object with a response property', async () => {
         const mockFunc = jest.fn().mockRejectedValue('error')
-        await expect(handleApiError(mockFunc)).rejects.toEqual('error')
+        await expect(handleApiError(mockFunc)).rejects.toBe('error')
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -139,6 +139,10 @@ export const getCustomKeys = <T extends object>(obj: T) => {
     return Object.keys(obj).filter((key: string): key is `c_${string}` => key.startsWith('c_'))
 }
 
+// The error thrown by the commerce-sdk-isomorphic methods is an object with a `response` property
+// that contains the error response. We make the hooks eaiser to use by awaiting the error response
+// and throw it directly. This enables access to error directly via query.error or mutation.error
+// Otherwise it's a pain to access errors.
 export const handleApiError = async <T>(func: () => Promise<T>): Promise<T> => {
     try {
         return await func()

--- a/packages/commerce-sdk-react/src/hooks/utils.ts
+++ b/packages/commerce-sdk-react/src/hooks/utils.ts
@@ -138,3 +138,15 @@ export const getCustomKeys = <T extends object>(obj: T) => {
     }
     return Object.keys(obj).filter((key: string): key is `c_${string}` => key.startsWith('c_'))
 }
+
+export const handleApiError = async <T>(func: () => Promise<T>): Promise<T> => {
+    try {
+        return await func()
+    } catch (e) {
+        if (typeof e === 'object' && e !== null && 'response' in e) {
+            const json = await (e.response as Response).json()
+            throw json
+        }
+        throw e
+    }
+}

--- a/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
@@ -16,7 +16,14 @@ const QueryErrors = () => {
 
     // Type assertion because we're explicitly violating the expected type
     const products = useProducts({parameters: {FOO: ''}} as any, {enabled: true})
-    const product = useProduct({parameters: {id: '25502228Mxxx'}})
+    const product = useProduct(
+        {parameters: {id: '25502228Mxxx'}},
+        {
+            onError: async (error) => {
+                console.log(await error.response.json())
+            }
+        }
+    )
     /** Errors don't nicely serialize to JSON, so we have to do it ourselves. */
     const toLoggable = (err: unknown) => {
         if (err instanceof Error) {

--- a/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
@@ -16,14 +16,7 @@ const QueryErrors = () => {
 
     // Type assertion because we're explicitly violating the expected type
     const products = useProducts({parameters: {FOO: ''}} as any, {enabled: true})
-    const product = useProduct(
-        {parameters: {id: '25502228Mxxx'}},
-        {
-            onError: async (error) => {
-                console.log(await error.response.json())
-            }
-        }
-    )
+    const product = useProduct({parameters: {id: '25502228Mxxx'}})
     /** Errors don't nicely serialize to JSON, so we have to do it ourselves. */
     const toLoggable = (err: unknown) => {
         if (err instanceof Error) {
@@ -33,6 +26,9 @@ const QueryErrors = () => {
         }
         return err
     }
+
+    console.log('product.error')
+    console.log(product.error)
 
     return (
         <>

--- a/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/query-errors.tsx
@@ -17,18 +17,6 @@ const QueryErrors = () => {
     // Type assertion because we're explicitly violating the expected type
     const products = useProducts({parameters: {FOO: ''}} as any, {enabled: true})
     const product = useProduct({parameters: {id: '25502228Mxxx'}})
-    /** Errors don't nicely serialize to JSON, so we have to do it ourselves. */
-    const toLoggable = (err: unknown) => {
-        if (err instanceof Error) {
-            // Clone all keys onto a plain object
-            const keys = Object.getOwnPropertyNames(err) as Array<keyof Error>
-            return keys.reduce((acc, key) => ({...acc, [key]: err[key]}), {})
-        }
-        return err
-    }
-
-    console.log('product.error')
-    console.log(product.error)
 
     return (
         <>
@@ -58,7 +46,7 @@ const QueryErrors = () => {
                 <Json
                     data={{
                         isLoading: products.isLoading,
-                        error: toLoggable(products.error),
+                        error: products.error,
                         data: products.data
                     }}
                 />
@@ -73,7 +61,7 @@ const QueryErrors = () => {
                 <Json
                     data={{
                         isLoading: product.isLoading,
-                        error: toLoggable(product.error),
+                        error: product.error,
                         data: product.data
                     }}
                 />

--- a/packages/test-commerce-sdk-react/app/pages/use-shopper-baskets.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/use-shopper-baskets.tsx
@@ -51,8 +51,24 @@ function UseShopperBaskets() {
                     >
                         Change Basket Currency to GBP
                     </button>
+                    <button
+                        onClick={() => {
+                            updateBasket.mutate({
+                                parameters: {basketId: 'wrong id'},
+                                body: {currency: 'GBP'}
+                            })
+                        }}
+                    >
+                        Test mutation error
+                    </button>
                     <hr />
                 </>
+            )}
+            {updateBasket && updateBasket.error && (
+                <div>
+                    <h2>Error</h2>
+                    <pre>{JSON.stringify(updateBasket.error, null, 2)}</pre>
+                </div>
             )}
         </>
     )


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

See https://github.com/SalesforceCommerceCloud/pwa-kit/issues/1659

The `commerce-sdk-isomorphic` errors are not being catched, causing the API errors missing from `query.error`. This PR checks if the error is in the form of a Response, if it is, then await the json response and throw it.

### Before 
![CleanShot 2024-03-18 at 10 58 34](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/10948652/419e7548-07b7-417d-8a06-ddec84e1fe7e)

### After
![CleanShot 2024-03-18 at 10 46 54](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/10948652/af1c055d-e91f-4b1f-ac66-19b12691a546)

# Question: is this a breaking change?? 🤔 

# Types of Changes


<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Serialize API response errors

# How to Test-Drive This PR

- `npm start` in `test-commerce-sdk-react` pacakge and go to the query error page

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
