### PR TITLE
More responsive useLocalStorage hook

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix invalid query params warnings and allow custom query [#1655](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1655)
 - Fix cannot read properties of undefined (reading 'unshift') [#1689](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1689)
 - Add Shopper SEO hook [#1688](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1688)
+- Update useLocalStorage implementation to be more responsive [#1703](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1703)
 
 ## v1.3.0 (Jan 19, 2024)
 

--- a/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
+++ b/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {useEffect, useState, useCallback, useSyncExternalStore} from 'react'
+import {useSyncExternalStore} from 'react'
 
 type Value = string | null
 
@@ -13,7 +13,6 @@ type Value = string | null
  *
  */
 function useLocalStorage(key: string): Value {
-
     const readValue = (): Value => {
         // TODO: Use detectLocalStorageAvailable when app can better handle clients without storage
         if (typeof window === 'undefined') {
@@ -26,46 +25,20 @@ function useLocalStorage(key: string): Value {
     const useLocalStorageSubscribe = (callback: any) => {
         window.addEventListener('storage', callback)
         return () => window.removeEventListener('storage', callback)
-    };
+    }
 
     const getLocalStorageServerSnapshot = () => {
         // local store is not available on the server
         return null
-    };
+    }
 
-    // function dispatchStorageEvent(newValue: Value) {
-    //     window.dispatchEvent(new StorageEvent("storage", { key, newValue }));
-    // }
-
-    const getSnapshot = () => readValue();
+    const getLocalStorageSnapshot = () => readValue()
 
     const store: Value = useSyncExternalStore(
         useLocalStorageSubscribe,
-        getSnapshot,
+        getLocalStorageSnapshot,
         getLocalStorageServerSnapshot
-    );
-
-    // const setStoredValue = useCallback(() => {
-    //     try {
-    //         const nextState = readValue()
-    //         if (nextState === null) {
-    //             window.localStorage.removeItem(key);
-    //         } else {
-    //             window.localStorage.setItem(key, nextState);
-    //         }
-    //     } catch (e) {
-    //         console.warn(e);
-    //     }
-    // }, [key, store])
-
-    // const handleStorageChange = (event: StorageEvent) => {
-    //     if (event.key !== key) {
-    //         return
-    //     }
-    //     setStoredValue()
-    // }
-
-    // const [storedValue, setStoredValue] = useState<Value>(readValue)
+    )
 
     return store
 }

--- a/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
+++ b/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
@@ -22,20 +22,20 @@ function useLocalStorage(key: string): Value {
         return window.localStorage.getItem(key)
     }
 
-    const useLocalStorageSubscribe = (callback: any) => {
+    const subscribeToLocalStorage = (callback: any) => {
         window.addEventListener('storage', callback)
         return () => window.removeEventListener('storage', callback)
     }
 
     const getLocalStorageServerSnapshot = () => {
-        // local store is not available on the server
+        // local storage is not available on the server
         return null
     }
 
     const getLocalStorageSnapshot = () => readValue()
 
     const store: Value = useSyncExternalStore(
-        useLocalStorageSubscribe,
+        subscribeToLocalStorage,
         getLocalStorageSnapshot,
         getLocalStorageServerSnapshot
     )

--- a/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
+++ b/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
@@ -29,7 +29,8 @@ function useLocalStorage(key: string): Value {
     };
 
     const getLocalStorageServerSnapshot = () => {
-        throw Error("useLocalStorage is a client-only hook");
+        // local store is not available on the server
+        return null
     };
 
     // function dispatchStorageEvent(newValue: Value) {

--- a/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
+++ b/packages/commerce-sdk-react/src/hooks/useLocalStorage.ts
@@ -10,29 +10,36 @@ type Value = string | null
 
 /**
  * @internal
- *
  */
-function useLocalStorage(key: string): Value {
-    const readValue = (): Value => {
-        // TODO: Use detectLocalStorageAvailable when app can better handle clients without storage
-        if (typeof window === 'undefined') {
-            return null
-        }
-
-        return window.localStorage.getItem(key)
-    }
-
-    const subscribeToLocalStorage = (callback: any) => {
-        window.addEventListener('storage', callback)
-        return () => window.removeEventListener('storage', callback)
-    }
-
-    const getLocalStorageServerSnapshot = () => {
-        // local storage is not available on the server
+const readValue = (key: string): Value => {
+    // TODO: Use detectLocalStorageAvailable when app can better handle clients without storage
+    if (typeof window === 'undefined') {
         return null
     }
+    return window.localStorage.getItem(key)
+}
 
-    const getLocalStorageSnapshot = () => readValue()
+/**
+ * @internal
+ */
+const subscribeToLocalStorage = (callback: any) => {
+    window.addEventListener('storage', callback)
+    return () => window.removeEventListener('storage', callback)
+}
+
+/**
+ * @internal
+ */
+const getLocalStorageServerSnapshot = () => {
+    // local storage is not available on the server
+    return null
+}
+
+/**
+ * @internal
+ */
+function useLocalStorage(key: string): Value {
+    const getLocalStorageSnapshot = () => readValue(key)
 
     const store: Value = useSyncExternalStore(
         subscribeToLocalStorage,


### PR DESCRIPTION
In order to trigger react re-renders when the contents of local store are modified, our commerce-sdk-react hooks utilize an in internal hook `useLocalStorage`. However, our current implementation can get into situations where it does not readily pick up changes in local store and instead holds onto previous state. When this occurs, components that call the hook fail to re-render when they should.

This PR changes the implementation of `useLocalStorage` to be more responsive to changes in local storage. 

Testing:
Do the following steps (you can compare these changes on an instance of the PWA with the old implementation of useLocalStorage)
* Start the app and navigate to a PDP
* (Optional) Log in
* Clear local storage

Before the changes:
* Observe that nothing happens. If you logged in, you can see that the header still shows you are logged in.

After the changes:
* UI elements are updated to reflect that things in local store are no longer present such as the add to cart button being disabled, and the header updating to show you are now logged out.