### PR TITLE
@W-14902130 - Allow `ProductId` and `CategoryId` to be passed directly their respective pages

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix handling of offline products on Cart, Checkout, Order History, and Wishlist pages [#1691](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1691)
 - Fix tracking of `viewSearch` event for Einstein analytics, in the case of no-search-results [#1702](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1702)
 - Remove invalid header `_sfdc_customer_id` due to recent MRT HTTP3 upgrade [#1731](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1731)
+- Add `productId` and `categoryId` to the ProductDetail and ProductList components respectively [#1738](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1738)
 
 ## v2.3.1 (Jan 23, 2024)
 

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -48,7 +48,7 @@ import {useHistory, useLocation, useParams} from 'react-router-dom'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {useWishList} from '@salesforce/retail-react-app/app/hooks/use-wish-list'
 
-const ProductDetail = () => {
+const ProductDetail = (props) => {
     const {formatMessage} = useIntl()
     const history = useHistory()
     const location = useLocation()
@@ -56,9 +56,11 @@ const ProductDetail = () => {
     const activeData = useActiveData()
     const toast = useToast()
     const navigate = useNavigation()
+    const params = useParams()
     const [productSetSelection, setProductSetSelection] = useState({})
     const childProductRefs = React.useRef({})
     const customerId = useCustomerId()
+
     /****************************** Basket *********************************/
     const {data: basket} = useCurrentBasket()
     const addItemToBasketMutation = useShopperBasketsMutation('addItemToBasket')
@@ -69,7 +71,7 @@ const ProductDetail = () => {
     const isBasketLoading = !basket?.basketId
 
     /*************************** Product Detail and Category ********************/
-    const {productId} = useParams()
+    const productId = props?.productId || params?.productId
     const urlParams = new URLSearchParams(location.search)
     const {
         data: product,

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -123,9 +123,10 @@ const ProductList = (props) => {
     const urlParams = new URLSearchParams(location.search)
     let searchQuery = urlParams.get('q')
     const isSearch = !!searchQuery
+    const categoryId = props?.categoryId || params?.categoryId
 
-    if (params.categoryId) {
-        searchParams._refine.push(`cgid=${params.categoryId}`)
+    if (categoryId) {
+        searchParams._refine.push(`cgid=${categoryId}`)
     }
 
     /**************** Mutation Actions ****************/
@@ -159,11 +160,11 @@ const ProductList = (props) => {
     const {error, data: category} = useCategory(
         {
             parameters: {
-                id: params.categoryId
+                id: categoryId
             }
         },
         {
-            enabled: !isSearch && !!params.categoryId
+            enabled: !isSearch && !!categoryId
         }
     )
 
@@ -340,7 +341,7 @@ const ProductList = (props) => {
         if (isSearch) {
             navigate(`/search?${stringifySearchParams(searchParamsCopy)}`)
         } else {
-            navigate(`/category/${params.categoryId}?${stringifySearchParams(searchParamsCopy)}`)
+            navigate(`/category/${categoryId}?${stringifySearchParams(searchParamsCopy)}`)
         }
     }
 
@@ -352,7 +353,7 @@ const ProductList = (props) => {
         }
         const newPath = isSearch
             ? `/search?${stringifySearchParams(newSearchParams)}`
-            : `/category/${params.categoryId}?${stringifySearchParams(newSearchParams)}`
+            : `/category/${categoryId}?${stringifySearchParams(newSearchParams)}`
 
         navigate(newPath)
     }

--- a/packages/template-retail-react-app/app/routes.jsx
+++ b/packages/template-retail-react-app/app/routes.jsx
@@ -91,7 +91,7 @@ export const routes = [
     },
     {
         path: '/product/:productId',
-        component: ProductDetail
+        component: () => <ProductDetail productId="52416781M" />
     },
     {
         path: '/search',
@@ -99,7 +99,7 @@ export const routes = [
     },
     {
         path: '/category/:categoryId',
-        component: ProductList
+        component: () => <ProductList categoryId="mens" />
     },
     {
         path: '/account/wishlist',


### PR DESCRIPTION
# Description

This simple PR makes small change to the <ProductDetail /> and <ProductList /> pages to allow you to pass in the `ProductId` and `CategoryId` respectively. We are adding this ability in preparation for work adding the Shopper SEO API to the template.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)


# Changes

- Add 'productId' prop to the ProductDetail page component
- - Add 'categoryId' prop to the ProductList page component


# How to Test-Drive This PR

- (step1)

# TODO

- [ ] Revert changes to routes.jsx
- [ ] Update tests.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
