### PR TITLE
@W-15200182@ PWA Kit V2 Hybrid session handling - WIP

### DIFF
--- a/packages/template-retail-react-app/app/commerce-api/auth.js
+++ b/packages/template-retail-react-app/app/commerce-api/auth.js
@@ -52,8 +52,8 @@ class Auth {
 
         // To store tokens as cookies
         // change the next line to
-        this._storage = this._onClient ? new CookieStorage() : new Map()
-        // this._storage = this._onClient ? new LocalStorage() : new Map()
+        // this._storage = this._onClient ? new CookieStorage() : new MemoryStorage()
+        this._storage = this._onClient ? new LocalStorage() : new MemoryStorage()
 
         const configOid = api._config.parameters.organizationId
         if (!this.oid) {
@@ -161,6 +161,10 @@ class Auth {
 
     get isTokenValid() {
         return !isTokenExpired(this.authToken)
+    }
+
+    get storage() {
+        return this._storage
     }
 
     /**
@@ -578,6 +582,7 @@ class Storage {
     set(key, value, options) {}
     get(key) {}
     delete(key) {}
+    type() {}
 }
 
 class CookieStorage extends Storage {
@@ -596,6 +601,9 @@ class CookieStorage extends Storage {
     delete(key) {
         Cookies.remove(key)
     }
+    type() {
+        return 'cookie-store'
+    }
 }
 
 class LocalStorage extends Storage {
@@ -613,5 +621,27 @@ class LocalStorage extends Storage {
     }
     delete(key) {
         window.localStorage.removeItem(key)
+    }
+    type() {
+        return 'local-store'
+    }
+}
+
+class MemoryStorage extends Storage {
+    constructor(...args) {
+        super(args)
+        this.map = new Map()
+    }
+    set(key, value) {
+        this.map.set(key, value)
+    }
+    get(key) {
+        return this.map.get(key)
+    }
+    delete(key) {
+        this.map.delete(key)
+    }
+    type() {
+        return 'memory-store'
     }
 }

--- a/packages/template-retail-react-app/app/commerce-api/constants.js
+++ b/packages/template-retail-react-app/app/commerce-api/constants.js
@@ -11,6 +11,7 @@ export const encUserIdStorageKey = 'enc-user-id'
 export const tokenStorageKey = 'token'
 export const refreshTokenRegisteredStorageKey = 'cc-nx'
 export const refreshTokenGuestStorageKey = 'cc-nx-g'
+export const accessTokenFromSFRAKey = 'cc-at'
 export const oidStorageKey = 'oid'
 export const dwSessionIdKey = 'dwsid'
 export const REFRESH_TOKEN_COOKIE_AGE = 90 // 90 days. This value matches SLAS cartridge.

--- a/packages/template-retail-react-app/app/commerce-api/hooks/useStorage.js
+++ b/packages/template-retail-react-app/app/commerce-api/hooks/useStorage.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {useSyncExternalStore} from 'use-sync-external-store/shim'
+import {useCommerceAPI} from '../contexts'
+import Cookies from 'js-cookie'
+
+/**
+ * @internal
+ */
+const readLocalStorageValue = (key) => {
+    if (typeof window === 'undefined') {
+        return null
+    }
+    return window.localStorage.getItem(key)
+}
+
+/**
+ * @internal
+ */
+const subscribeToLocalStorage = (callback) => {
+    window.addEventListener('storage', callback)
+    return () => window.removeEventListener('storage', callback)
+}
+
+/**
+ * @internal
+ */
+const readCookieStorageValue = (key) => {
+    if (typeof document === 'undefined') {
+        return null
+    }
+    return Cookies.get(key)
+}
+
+/**
+ * @internal
+ */
+const subscribeToCookieStorage = (callback) => {
+    console.log('event fired')
+    window.addEventListener('change', callback)
+    return () => window.removeEventListener('change', callback)
+}
+
+/**
+ * @internal
+ */
+const getStorageServerSnapshot = () => {
+    // local store and cookie store are not available on the server
+    return null
+}
+
+/**
+ * @internal
+ */
+function useStorage(key) {
+    const api = useCommerceAPI()
+    const storage = api.auth.storage
+
+    // This conditional is a constant value based on the environment + what
+    // is set in auth.js. Options are either local or cookie for client and
+    // in memory for the server, so the same path will always be followed.
+    if (storage.type() == 'local-store') {
+        const getLocalStorageSnapshot = () => readLocalStorageValue(key)
+
+        return useSyncExternalStore(
+            subscribeToLocalStorage,
+            getLocalStorageSnapshot,
+            getStorageServerSnapshot
+        )
+    } else if (storage.type() == 'cookie-store') {
+        const getCookieStorageSnapshot = () => readCookieStorageValue(key)
+
+        return useSyncExternalStore(
+            subscribeToCookieStorage,
+            getCookieStorageSnapshot,
+            getStorageServerSnapshot
+        )
+    } else if (storage.type() == 'memory-store') {
+        return storage.get(key)
+    } else {
+        return null
+    }
+}
+
+export default useStorage

--- a/packages/template-retail-react-app/app/commerce-api/index.js
+++ b/packages/template-retail-react-app/app/commerce-api/index.js
@@ -199,6 +199,11 @@ class CommerceAPI {
             await pendingLogin
         }
 
+        // If SFRA sent us an access token, replace our access token with that
+        if (this.auth.accessTokenFromSFRA) {
+            this.auth.updateTokenWithSFRAToken()
+        }
+
         // If the token is invalid (missing, past/nearing expiration), we issue
         //  a login call, which will attempt to refresh the token or get a new
         //  guest token. Once login is complete, we can proceed.

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "retail-react-app",
+	"name": "scaffold-pwa",
 	"version": "2.8.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "retail-react-app",
+			"name": "scaffold-pwa",
 			"version": "2.8.2",
 			"license": "See license in LICENSE",
 			"devDependencies": {
@@ -50,7 +50,8 @@
 				"react-helmet": "^6.1.0",
 				"react-hook-form": "^6.15.8",
 				"react-intl": "^5.25.1",
-				"react-router-dom": "^5.3.4"
+				"react-router-dom": "^5.3.4",
+				"use-sync-external-store": "1.2.0"
 			},
 			"engines": {
 				"node": "^14.0.0 || ^16.0.0 || ^18.0.0",
@@ -8588,6 +8589,15 @@
 				}
 			}
 		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"dev": true,
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/utils-merge": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -15636,6 +15646,13 @@
 				"detect-node-es": "^1.1.0",
 				"tslib": "^2.0.0"
 			}
+		},
+		"use-sync-external-store": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+			"dev": true,
+			"requires": {}
 		},
 		"utils-merge": {
 			"version": "1.0.1",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -52,7 +52,8 @@
         "react-helmet": "^6.1.0",
         "react-hook-form": "^6.15.8",
         "react-intl": "^5.25.1",
-        "react-router-dom": "^5.3.4"
+        "react-router-dom": "^5.3.4",
+        "use-sync-external-store": "1.2.0"
     },
     "peerDependencies": {
         "@chakra-ui/system": "^1.12.1"


### PR DESCRIPTION
This PR ports the approach taken in #1696 to reduce the amount of sessions that are churned as a shopper navigates between PWA v2 and SFRA. 

These changes require the plugin_slas changes added in https://github.com/SalesforceCommerceCloud/plugin_slas/pull/187 to work

DONE
Single tab cases
- no more constantly regenerating the dwsid as a shopper jumps between SFRA/PWA
a benefit of this is the tracking consent form no longer appears on each PWA -> SFRA transition since the user selection is remembered because we've kept the same dwsid
- logging in on PWA / SFRA logs you in on the other (ie. log in via SFRA checkout logs you into PWA also)
- logging out of one system logs you out of the other

Multi tab cases
- handle login on multi tab - a log in on one tab should log you in on other tabs
- handling logout on multi tab - a log out on one tab should log you out of other tabs
- updating PWA headers on multi tab auth change

TODO
Multi tab cases
- Make the update snappier. It should happen in the background rather than when user hovers over the header
- CSRF token errors on SFRA forms when session changes

AKA - we need a v2 version of #1703 to handle re-rendering PWA if SFRA changes the access token (which is in cookie store not local store)

Notes:
On SFRA, login state updates once the tab navigates to a new page. If a form is on the current SFRA page, we cannot do anything about that form's CSRF token being invalidated by a session change in a different tab.
* The main affected forms are the tracking consent form and checkout when a PWA login occurs
* Persisting the same DWSID through login is probably the way to keep these forms valid.