### PR TITLE
@W-13974739 Showing strikethrough price on PLP

### DIFF
--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/pages/home/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/pages/home/index.jsx.hbs
@@ -57,6 +57,16 @@ const Home = () => {
     const {data: productSearchResult, isLoading} = useProductSearch({
         parameters: {
             refine: [`cgid=${HOME_SHOP_PRODUCTS_CATEGORY_ID}`, 'htype=master'],
+            perPricebook: true,
+            allVariationProperties: true,
+            expand: [
+                'availability',
+                'prices',
+                'represented_products',
+                'variations',
+                'custom_properties',
+                'images'
+            ],
             limit: HOME_SHOP_PRODUCTS_LIMIT
         }
     })

--- a/packages/template-retail-react-app/app/components/display-price/index.jsx
+++ b/packages/template-retail-react-app/app/components/display-price/index.jsx
@@ -42,7 +42,7 @@ const DisplayPrice = ({
                 </Text>
             )}
             {typeof discountPrice === 'number' && (
-                <Text as="b" {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
+                <Text {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
                     {discountPriceText}
                 </Text>
             )}

--- a/packages/template-retail-react-app/app/components/display-price/index.jsx
+++ b/packages/template-retail-react-app/app/components/display-price/index.jsx
@@ -42,7 +42,7 @@ const DisplayPrice = ({
                 </Text>
             )}
             {typeof discountPrice === 'number' && (
-                <Text {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
+                <Text as="b" {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
                     {discountPriceText}
                 </Text>
             )}

--- a/packages/template-retail-react-app/app/components/display-price/index.jsx
+++ b/packages/template-retail-react-app/app/components/display-price/index.jsx
@@ -30,6 +30,7 @@ const DisplayPrice = ({
         style: 'currency',
         currency: currency || activeCurrency
     })
+
     return (
         <Skeleton isLoaded={basePrice} display={'flex'} {...skeletonProps}>
             {isProductASet && (

--- a/packages/template-retail-react-app/app/components/display-price/index.jsx
+++ b/packages/template-retail-react-app/app/components/display-price/index.jsx
@@ -22,34 +22,40 @@ const DisplayPrice = ({
 }) => {
     const intl = useIntl()
     const {currency: activeCurrency} = useCurrency()
+    const discountPriceText = intl.formatNumber(discountPrice, {
+        style: 'currency',
+        currency: currency || activeCurrency
+    })
+    const basePriceText = intl.formatNumber(basePrice, {
+        style: 'currency',
+        currency: currency || activeCurrency
+    })
     return (
         <Skeleton isLoaded={basePrice} display={'flex'} {...skeletonProps}>
-            <Text fontWeight="bold" fontSize="md" mr={1}>
-                {isProductASet &&
-                    `${intl.formatMessage({
+            {isProductASet && (
+                <Text fontWeight="bold" fontSize="md" mr={1}>
+                    {intl.formatMessage({
                         id: 'product_view.label.starting_at_price',
                         defaultMessage: 'Starting at'
-                    })} `}
-            </Text>
-            {typeof discountPrice === 'number' && (
-                <Text as="b" {...discountPriceProps}>
-                    {intl.formatNumber(discountPrice, {
-                        style: 'currency',
-                        currency: currency || activeCurrency
                     })}
                 </Text>
             )}
-            <Text
-                as={typeof discountPrice === 'number' ? 's' : 'b'}
-                ml={typeof discountPrice === 'number' ? 2 : 0}
-                fontWeight={discountPrice ? 'normal' : 'bold'}
-                {...basePriceProps}
-            >
-                {intl.formatNumber(basePrice, {
-                    style: 'currency',
-                    currency: currency || activeCurrency
-                })}
-            </Text>
+            {typeof discountPrice === 'number' && (
+                <Text as="b" {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
+                    {discountPriceText}
+                </Text>
+            )}
+            {basePrice > discountPrice && (
+                <Text
+                    aria-label={`Original price ${basePriceText}`}
+                    as={typeof discountPrice === 'number' ? 's' : 'b'}
+                    ml={typeof discountPrice === 'number' ? 2 : 0}
+                    fontWeight={discountPrice ? 'normal' : 'bold'}
+                    {...basePriceProps}
+                >
+                    {basePriceText}
+                </Text>
+            )}
         </Skeleton>
     )
 }

--- a/packages/template-retail-react-app/app/components/display-price/index.jsx
+++ b/packages/template-retail-react-app/app/components/display-price/index.jsx
@@ -42,13 +42,33 @@ const DisplayPrice = ({
                 </Text>
             )}
             {typeof discountPrice === 'number' && (
-                <Text as="b" {...discountPriceProps} aria-label={`Sale price ${discountPriceText}`}>
+                <Text
+                    as="b"
+                    {...discountPriceProps}
+                    aria-label={intl.formatMessage(
+                        {
+                            id: 'product_tile.assistive_msg.sale_price',
+                            defaultMessage: 'Sale price {discountPrice}'
+                        },
+                        {
+                            discountPrice: discountPriceText
+                        }
+                    )}
+                >
                     {discountPriceText}
                 </Text>
             )}
             {basePrice > discountPrice && (
                 <Text
-                    aria-label={`Original price ${basePriceText}`}
+                    aria-label={intl.formatMessage(
+                        {
+                            id: 'product_tile.assistive_msg.base_price',
+                            defaultMessage: 'Sale price {basePrice}'
+                        },
+                        {
+                            basePrice: basePriceText
+                        }
+                    )}
                     as={typeof discountPrice === 'number' ? 's' : 'b'}
                     ml={typeof discountPrice === 'number' ? 2 : 0}
                     fontWeight={discountPrice ? 'normal' : 'bold'}

--- a/packages/template-retail-react-app/app/components/display-price/index.test.js
+++ b/packages/template-retail-react-app/app/components/display-price/index.test.js
@@ -16,7 +16,7 @@ describe('DisplayPrice', function () {
         expect(screen.getByText(/£100\.00/i)).toBeInTheDocument()
     })
 
-    test('should render according html tag for prices', () => {
+    test('should render html tags for prices accordingly', () => {
         const {container} = renderWithProviders(
             <DisplayPrice currency="GBP" basePrice={100} discountPrice={90} />
         )
@@ -28,9 +28,9 @@ describe('DisplayPrice', function () {
         expect(basePriceTag).toHaveLength(1)
     })
 
-    test('should not render discount price if not available', () => {
-        renderWithProviders(<DisplayPrice currency="GBP" basePrice={100} />)
+    test('should not render base price if discount price is the same as base price', () => {
+        renderWithProviders(<DisplayPrice currency="GBP" basePrice={100} discountPrice={100} />)
         expect(screen.queryByText(/£90\.00/i)).not.toBeInTheDocument()
-        expect(screen.getByText(/£100\.00/i)).toBeInTheDocument()
+        expect(screen.queryByText(/£100\.00/i)).toBeInTheDocument()
     })
 })

--- a/packages/template-retail-react-app/app/components/product-tile/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-tile/index.jsx
@@ -208,6 +208,7 @@ ProductTile.propTypes = {
      */
     product: PropTypes.shape({
         currency: PropTypes.string,
+        representedProduct: PropTypes.object,
         image: PropTypes.shape({
             alt: PropTypes.string,
             disBaseLink: PropTypes.string,
@@ -233,7 +234,9 @@ ProductTile.propTypes = {
         hitType: PropTypes.string,
         variants: PropTypes.array,
         type: PropTypes.shape({
-            set: PropTypes.bool
+            set: PropTypes.bool,
+            bundle: PropTypes.bool,
+            item: PropTypes.bool
         })
     }),
     /**

--- a/packages/template-retail-react-app/app/components/product-tile/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-tile/index.jsx
@@ -128,8 +128,13 @@ const ProductTile = (props) => {
                 {/*/!* Price *!/*/}
                 {/*Price and discount price will show for first variant for now. We will implement the swatch into PLP later*/}
                 <DisplayPrice
-                    basePrice={isProductASet ? listPrice?.minPrice : listPrice?.price}
+                    basePrice={isProductASet ? listPrice?.maxPrice : listPrice?.price}
                     isProductASet={isProductASet}
+                    discountPriceProps={
+                        listPrice?.maxPrice > currentPrice || listPrice?.price > currentPrice
+                            ? {as: 'b'}
+                            : {as: 'p'}
+                    }
                     discountPrice={currentPrice}
                 />
             </Link>

--- a/packages/template-retail-react-app/app/components/product-tile/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-tile/index.jsx
@@ -143,7 +143,6 @@ const ProductTile = (props) => {
                 <Text {...styles.title}>{localizedProductName}</Text>
 
                 {/*/!* Price *!/*/}
-                {/*Price and discount price will show for first variant for now. We will implement the swatch into PLP later*/}
                 <DisplayPrice
                     basePrice={isProductASet ? listPrice?.maxPrice : listPrice?.price}
                     isProductASet={isProductASet}

--- a/packages/template-retail-react-app/app/components/product-tile/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-tile/index.jsx
@@ -28,7 +28,6 @@ import {useIntl} from 'react-intl'
 import {productUrlBuilder} from '@salesforce/retail-react-app/app/utils/url'
 import Link from '@salesforce/retail-react-app/app/components/link'
 import withRegistration from '@salesforce/retail-react-app/app/components/with-registration'
-import {useCurrency} from '@salesforce/retail-react-app/app/hooks'
 import DisplayPrice from '@salesforce/retail-react-app/app/components/display-price'
 
 const IconButtonWithRegistration = withRegistration(IconButton)
@@ -90,7 +89,9 @@ const ProductTile = (props) => {
         : product?.tieredPrices
 
     // we will choose the list price from the price book that contains the highest value to display strike through price
-    const maxPriceTier = Math.max(...tieredPrices?.map((item) => item.price || item.maxPrice))
+    const maxPriceTier = tieredPrices
+        ? Math.max(...(tieredPrices || []).map((item) => item.price || item.maxPrice))
+        : 0
     let listPrice = tieredPrices?.find(
         (tier) => tier.price === maxPriceTier || tier.maxPrice === maxPriceTier
     )
@@ -191,6 +192,9 @@ ProductTile.propTypes = {
             link: PropTypes.string
         }),
         price: PropTypes.number,
+        priceRanges: PropTypes.array,
+        tieredPrices: PropTypes.array,
+
         // `name` is present and localized when `product` is provided by a RecommendedProducts component
         // (from Shopper Products `getProducts` endpoint), but is not present when `product` is
         // provided by a ProductList component.
@@ -204,7 +208,11 @@ ProductTile.propTypes = {
         // Note: useEinstein() transforms snake_case property names from the API response to camelCase
         productName: PropTypes.string,
         productId: PropTypes.string,
-        hitType: PropTypes.string
+        hitType: PropTypes.string,
+        variants: PropTypes.array,
+        type: PropTypes.shape({
+            set: PropTypes.bool
+        })
     }),
     /**
      * Enable adding/removing product as a favourite.

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import ProductTile, {Skeleton} from '@salesforce/retail-react-app/app/components/product-tile/index'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
-import {fireEvent, within, screen} from '@testing-library/react'
+import {fireEvent, within} from '@testing-library/react'
 
 test('Renders links and images', () => {
     const {getAllByRole} = renderWithProviders(<ProductTile product={mockProductSearchItem} />)

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -7,70 +7,7 @@
 import React from 'react'
 import ProductTile, {Skeleton} from '@salesforce/retail-react-app/app/components/product-tile/index'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
-import {fireEvent} from '@testing-library/react'
-import mockProductSet from '@salesforce/retail-react-app/app/mocks/product-set-winter-lookM'
-
-const mockProductSearchItem = {
-    currency: 'USD',
-    image: {
-        alt: 'Charcoal Single Pleat Wool Suit, , large',
-        disBaseLink:
-            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4de8166b/images/large/PG.33698RUBN4Q.CHARCWL.PZ.jpg'
-    },
-    price: 299.99,
-    productName: 'Charcoal Single Pleat Wool Suit'
-}
-
-// const mockProductSet = {
-//     currency: 'GBP',
-//     hitType: 'set',
-//     image: {
-//         alt: 'Winter Look, , large',
-//         disBaseLink:
-//             'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
-//         link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
-//         title: 'Winter Look, '
-//     },
-//     orderable: true,
-//     price: 44.16,
-//     priceMax: 71.03,
-//     pricePerUnit: 44.16,
-//     pricePerUnitMax: 71.03,
-//     productId: 'winter-lookM',
-//     productName: 'Winter Look',
-//     productType: {
-//         set: true
-//     },
-//     representedProduct: {
-//         id: '701642853695M'
-//     },
-//     representedProducts: [
-//         {id: '701642853695M'},
-//         {id: '701642853718M'},
-//         {id: '701642853725M'},
-//         {id: '701642853701M'},
-//         {id: '740357357531M'},
-//         {id: '740357358095M'},
-//         {id: '740357357623M'},
-//         {id: '740357357609M'},
-//         {id: '740357358156M'},
-//         {id: '740357358132M'},
-//         {id: '740357358101M'},
-//         {id: '740357357562M'},
-//         {id: '740357357548M'},
-//         {id: '740357358187M'},
-//         {id: '740357357593M'},
-//         {id: '740357357555M'},
-//         {id: '740357357524M'},
-//         {id: '740357358149M'},
-//         {id: '740357358088M'},
-//         {id: '701642867098M'},
-//         {id: '701642867111M'},
-//         {id: '701642867104M'},
-//         {id: '701642867128M'},
-//         {id: '701642867135M'}
-//     ]
-// }
+import {fireEvent, within, screen} from '@testing-library/react'
 
 test('Renders links and images', () => {
     const {getAllByRole} = renderWithProviders(<ProductTile product={mockProductSearchItem} />)
@@ -91,7 +28,7 @@ test('Renders Skeleton', () => {
 })
 
 test('Product set - renders the appropriate price label', async () => {
-    const {getByText} = renderWithProviders(<ProductTile product={mockProductSet} />)
+    const {getByText} = renderWithProviders(<ProductTile product={mockProductSearchItemSet} />)
 
     expect(getByText(/starting at/i)).toBeInTheDocument()
 })
@@ -100,7 +37,11 @@ test('Remove from wishlist cannot be muti-clicked', () => {
     const onClick = jest.fn()
 
     const {getByTestId} = renderWithProviders(
-        <ProductTile product={mockProductSet} enableFavourite={true} onFavouriteToggle={onClick} />
+        <ProductTile
+            product={mockProductSearchItemSet}
+            enableFavourite={true}
+            onFavouriteToggle={onClick}
+        />
     )
     const wishlistButton = getByTestId('wishlist-button')
 
@@ -110,25 +51,102 @@ test('Remove from wishlist cannot be muti-clicked', () => {
 })
 
 test('renders strike through price with variants product', () => {
-    const {getByText} = renderWithProviders(<ProductTile product={mockProductWithVariants} />)
+    const {getByText, container} = renderWithProviders(
+        <ProductTile product={mockProductWithVariants} />
+    )
     expect(getByText(/black flat front wool suit/i)).toBeInTheDocument()
     expect(getByText(/£191\.99/i)).toBeInTheDocument()
     expect(getByText(/£320\.00/i)).toBeInTheDocument()
+
+    const discountPriceTag = container.querySelectorAll('b')
+    const basePriceTag = container.querySelectorAll('s')
+    expect(within(discountPriceTag[0]).getByText(/£191\.99/i)).toBeDefined()
+    expect(within(basePriceTag[0]).getByText(/£320\.00/i)).toBeDefined()
+    expect(discountPriceTag).toHaveLength(1)
+    expect(basePriceTag).toHaveLength(1)
 })
 
 test('renders strike through price with set', () => {
-    const {getByText} = renderWithProviders(<ProductTile product={mockProductSet} />)
+    const {getByText, container} = renderWithProviders(
+        <ProductTile product={mockProductSearchItemSet} />
+    )
     expect(getByText(/Winter Look/i)).toBeInTheDocument()
     expect(getByText(/Starting at/i)).toBeInTheDocument()
     expect(getByText(/£44\.16/i)).toBeInTheDocument()
+    expect(getByText(/£101\.76/i)).toBeInTheDocument()
+
+    const discountPriceTag = container.querySelectorAll('b')
+    const basePriceTag = container.querySelectorAll('s')
+    expect(within(discountPriceTag[0]).getByText(/£44\.16/i)).toBeDefined()
+    expect(within(basePriceTag[0]).getByText(/£101\.76/i)).toBeDefined()
+    expect(discountPriceTag).toHaveLength(1)
+    expect(basePriceTag).toHaveLength(1)
 })
 
 test('renders strike through price with standard product', () => {
-    const {getByText} = renderWithProviders(<ProductTile product={mockStandardProduct} />)
+    const {getByText, container} = renderWithProviders(
+        <ProductTile product={mockStandardProduct} />
+    )
     expect(getByText(/Laptop Briefcase with wheels \(37L\)/i)).toBeInTheDocument()
     expect(getByText(/£63\.99/i)).toBeInTheDocument()
+    const discountPriceTag = container.querySelectorAll('b')
+    const basePriceTag = container.querySelectorAll('s')
+    expect(within(discountPriceTag[0]).getByText(/£63\.99/i)).toBeDefined()
+    expect(within(basePriceTag[0]).getByText(/£67\.99/i)).toBeDefined()
+    expect(discountPriceTag).toHaveLength(1)
+    expect(basePriceTag).toHaveLength(1)
 })
 
+const mockProductSearchItem = {
+    currency: 'USD',
+    image: {
+        alt: 'Charcoal Single Pleat Wool Suit, , large',
+        disBaseLink:
+            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw4de8166b/images/large/PG.33698RUBN4Q.CHARCWL.PZ.jpg'
+    },
+    price: 299.99,
+    productName: 'Charcoal Single Pleat Wool Suit'
+}
+const mockProductSearchItemSet = {
+    currency: 'GBP',
+    hitType: 'set',
+    image: {
+        alt: 'Winter Look, , large',
+        disBaseLink:
+            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
+        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
+        title: 'Winter Look, '
+    },
+    orderable: true,
+    price: 44.16,
+    priceMax: 71.03,
+    pricePerUnit: 44.16,
+    pricePerUnitMax: 71.03,
+    priceRanges: [
+        {
+            maxPrice: 101.76,
+            minPrice: 44.16,
+            pricebook: 'gbp-m-list-prices'
+        },
+        {
+            maxPrice: 71.03,
+            minPrice: 44.16,
+            pricebook: 'gbp-m-sale-prices'
+        }
+    ],
+    productId: 'winter-lookM',
+    productName: 'Winter Look',
+    productType: {
+        set: true
+    },
+    representedProduct: {
+        id: '740357357531M',
+        c_color: 'BLACKLE',
+        c_refinementColor: 'black',
+        c_size: '065',
+        c_width: 'M'
+    }
+}
 const mockStandardProduct = {
     currency: 'GBP',
     hitType: 'product',
@@ -162,7 +180,7 @@ const mockStandardProduct = {
     ],
     tieredPrices: [
         {
-            price: 63.99,
+            price: 67.99,
             pricebook: 'gbp-m-list-prices',
             quantity: 1
         }

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -90,10 +90,9 @@ test('Renders Skeleton', () => {
 })
 
 test('Product set - renders the appropriate price label', async () => {
-    const {getByTestId} = renderWithProviders(<ProductTile product={mockProductSet} />)
+    const {getByText} = renderWithProviders(<ProductTile product={mockProductSet} />)
 
-    const container = getByTestId('product-tile-price')
-    expect(container).toHaveTextContent(/starting at/i)
+    expect(getByText(/starting at/i)).toBeInTheDocument()
 })
 
 test('Remove from wishlist cannot be muti-clicked', () => {
@@ -108,3 +107,203 @@ test('Remove from wishlist cannot be muti-clicked', () => {
     fireEvent.click(wishlistButton)
     expect(onClick).toHaveBeenCalledTimes(1)
 })
+
+test.only('renders strike through price', () => {
+    const {getByText} = renderWithProviders(<ProductTile product={data} />)
+    expect(getByText(/black flat front wool suit/i)).toBeInTheDocument()
+    expect(getByText(/£191\.99/i)).toBeInTheDocument()
+    expect(getByText(/£320\.00/i)).toBeInTheDocument()
+})
+
+const data = {
+    currency: 'GBP',
+    hitType: 'master',
+    image: {
+        alt: 'Black Flat Front Wool Suit, , large',
+        disBaseLink:
+            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw3d8972fe/images/large/PG.52001DAN84Q.BLACKWL.PZ.jpg',
+        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw3d8972fe/images/large/PG.52001DAN84Q.BLACKWL.PZ.jpg',
+        title: 'Black Flat Front Wool Suit, '
+    },
+    orderable: true,
+    price: 191.99,
+    pricePerUnit: 191.99,
+    priceRanges: [
+        {
+            maxPrice: 320,
+            minPrice: 320,
+            pricebook: 'gbp-m-list-prices'
+        },
+        {
+            maxPrice: 191.99,
+            minPrice: 191.99,
+            pricebook: 'gbp-m-sale-prices'
+        }
+    ],
+    productId: '25686544M',
+    productName: 'Black Flat Front Wool Suit',
+    productType: {
+        master: true
+    },
+    representedProduct: {
+        id: '750518703077M',
+        c_color: 'BLACKWL',
+        c_refinementColor: 'black',
+        c_size: '048',
+        c_width: 'V'
+    },
+    representedProducts: [
+        {
+            id: '750518703077M'
+        },
+        {
+            id: '750518703060M'
+        },
+        {
+            id: '750518703039M'
+        },
+        {
+            id: '750518703046M'
+        }
+    ],
+    variants: [
+        {
+            orderable: true,
+            price: 191.99,
+            productId: '750518703077M',
+            tieredPrices: [
+                {
+                    price: 320,
+                    pricebook: 'gbp-m-list-prices',
+                    quantity: 1
+                },
+                {
+                    price: 191.99,
+                    pricebook: 'gbp-m-sale-prices',
+                    quantity: 1
+                }
+            ],
+            variationValues: {
+                color: 'BLACKWL',
+                size: '048',
+                width: 'V'
+            }
+        },
+        {
+            orderable: true,
+            price: 191.99,
+            productId: '750518703060M',
+            tieredPrices: [
+                {
+                    price: 320,
+                    pricebook: 'gbp-m-list-prices',
+                    quantity: 1
+                },
+                {
+                    price: 191.99,
+                    pricebook: 'gbp-m-sale-prices',
+                    quantity: 1
+                }
+            ],
+            variationValues: {
+                color: 'BLACKWL',
+                size: '046',
+                width: 'V'
+            }
+        },
+        {
+            orderable: true,
+            price: 191.99,
+            productId: '750518703039M',
+            tieredPrices: [
+                {
+                    price: 320,
+                    pricebook: 'gbp-m-list-prices',
+                    quantity: 1
+                },
+                {
+                    price: 191.99,
+                    pricebook: 'gbp-m-sale-prices',
+                    quantity: 1
+                }
+            ],
+            variationValues: {
+                color: 'BLACKWL',
+                size: '042',
+                width: 'V'
+            }
+        },
+        {
+            orderable: true,
+            price: 191.99,
+            productId: '750518703046M',
+            tieredPrices: [
+                {
+                    price: 320,
+                    pricebook: 'gbp-m-list-prices',
+                    quantity: 1
+                },
+                {
+                    price: 191.99,
+                    pricebook: 'gbp-m-sale-prices',
+                    quantity: 1
+                }
+            ],
+            variationValues: {
+                color: 'BLACKWL',
+                size: '043',
+                width: 'V'
+            }
+        }
+    ],
+    variationAttributes: [
+        {
+            id: 'color',
+            name: 'Colour',
+            values: [
+                {
+                    name: 'Black',
+                    orderable: true,
+                    value: 'BLACKWL'
+                }
+            ]
+        },
+        {
+            id: 'size',
+            name: 'Size',
+            values: [
+                {
+                    name: '42',
+                    orderable: true,
+                    value: '042'
+                },
+                {
+                    name: '43',
+                    orderable: true,
+                    value: '043'
+                },
+                {
+                    name: '46',
+                    orderable: true,
+                    value: '046'
+                },
+                {
+                    name: '48',
+                    orderable: true,
+                    value: '048'
+                }
+            ]
+        },
+        {
+            id: 'width',
+            name: 'Width',
+            values: [
+                {
+                    name: 'Regular',
+                    orderable: true,
+                    value: 'V'
+                }
+            ]
+        }
+    ]
+}

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -108,7 +108,7 @@ test('Remove from wishlist cannot be muti-clicked', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
 })
 
-test.only('renders strike through price', () => {
+test('renders strike through price', () => {
     const {getByText} = renderWithProviders(<ProductTile product={data} />)
     expect(getByText(/black flat front wool suit/i)).toBeInTheDocument()
     expect(getByText(/£191\.99/i)).toBeInTheDocument()

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -8,6 +8,7 @@ import React from 'react'
 import ProductTile, {Skeleton} from '@salesforce/retail-react-app/app/components/product-tile/index'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 import {fireEvent} from '@testing-library/react'
+import mockProductSet from '@salesforce/retail-react-app/app/mocks/product-set-winter-lookM'
 
 const mockProductSearchItem = {
     currency: 'USD',
@@ -20,56 +21,56 @@ const mockProductSearchItem = {
     productName: 'Charcoal Single Pleat Wool Suit'
 }
 
-const mockProductSet = {
-    currency: 'GBP',
-    hitType: 'set',
-    image: {
-        alt: 'Winter Look, , large',
-        disBaseLink:
-            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
-        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
-        title: 'Winter Look, '
-    },
-    orderable: true,
-    price: 44.16,
-    priceMax: 71.03,
-    pricePerUnit: 44.16,
-    pricePerUnitMax: 71.03,
-    productId: 'winter-lookM',
-    productName: 'Winter Look',
-    productType: {
-        set: true
-    },
-    representedProduct: {
-        id: '701642853695M'
-    },
-    representedProducts: [
-        {id: '701642853695M'},
-        {id: '701642853718M'},
-        {id: '701642853725M'},
-        {id: '701642853701M'},
-        {id: '740357357531M'},
-        {id: '740357358095M'},
-        {id: '740357357623M'},
-        {id: '740357357609M'},
-        {id: '740357358156M'},
-        {id: '740357358132M'},
-        {id: '740357358101M'},
-        {id: '740357357562M'},
-        {id: '740357357548M'},
-        {id: '740357358187M'},
-        {id: '740357357593M'},
-        {id: '740357357555M'},
-        {id: '740357357524M'},
-        {id: '740357358149M'},
-        {id: '740357358088M'},
-        {id: '701642867098M'},
-        {id: '701642867111M'},
-        {id: '701642867104M'},
-        {id: '701642867128M'},
-        {id: '701642867135M'}
-    ]
-}
+// const mockProductSet = {
+//     currency: 'GBP',
+//     hitType: 'set',
+//     image: {
+//         alt: 'Winter Look, , large',
+//         disBaseLink:
+//             'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
+//         link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1c4cd52/images/large/PG.10205921.JJ5FUXX.PZ.jpg',
+//         title: 'Winter Look, '
+//     },
+//     orderable: true,
+//     price: 44.16,
+//     priceMax: 71.03,
+//     pricePerUnit: 44.16,
+//     pricePerUnitMax: 71.03,
+//     productId: 'winter-lookM',
+//     productName: 'Winter Look',
+//     productType: {
+//         set: true
+//     },
+//     representedProduct: {
+//         id: '701642853695M'
+//     },
+//     representedProducts: [
+//         {id: '701642853695M'},
+//         {id: '701642853718M'},
+//         {id: '701642853725M'},
+//         {id: '701642853701M'},
+//         {id: '740357357531M'},
+//         {id: '740357358095M'},
+//         {id: '740357357623M'},
+//         {id: '740357357609M'},
+//         {id: '740357358156M'},
+//         {id: '740357358132M'},
+//         {id: '740357358101M'},
+//         {id: '740357357562M'},
+//         {id: '740357357548M'},
+//         {id: '740357358187M'},
+//         {id: '740357357593M'},
+//         {id: '740357357555M'},
+//         {id: '740357357524M'},
+//         {id: '740357358149M'},
+//         {id: '740357358088M'},
+//         {id: '701642867098M'},
+//         {id: '701642867111M'},
+//         {id: '701642867104M'},
+//         {id: '701642867128M'},
+//         {id: '701642867135M'}
+//     ]
+// }
 
 test('Renders links and images', () => {
     const {getAllByRole} = renderWithProviders(<ProductTile product={mockProductSearchItem} />)
@@ -108,14 +109,66 @@ test('Remove from wishlist cannot be muti-clicked', () => {
     expect(onClick).toHaveBeenCalledTimes(1)
 })
 
-test('renders strike through price', () => {
-    const {getByText} = renderWithProviders(<ProductTile product={data} />)
+test('renders strike through price with variants product', () => {
+    const {getByText} = renderWithProviders(<ProductTile product={mockProductWithVariants} />)
     expect(getByText(/black flat front wool suit/i)).toBeInTheDocument()
     expect(getByText(/£191\.99/i)).toBeInTheDocument()
     expect(getByText(/£320\.00/i)).toBeInTheDocument()
 })
 
-const data = {
+test('renders strike through price with set', () => {
+    const {getByText} = renderWithProviders(<ProductTile product={mockProductSet} />)
+    expect(getByText(/Winter Look/i)).toBeInTheDocument()
+    expect(getByText(/Starting at/i)).toBeInTheDocument()
+    expect(getByText(/£44\.16/i)).toBeInTheDocument()
+})
+
+test('renders strike through price with standard product', () => {
+    const {getByText} = renderWithProviders(<ProductTile product={mockStandardProduct} />)
+    expect(getByText(/Laptop Briefcase with wheels \(37L\)/i)).toBeInTheDocument()
+    expect(getByText(/£63\.99/i)).toBeInTheDocument()
+})
+
+const mockStandardProduct = {
+    currency: 'GBP',
+    hitType: 'product',
+    image: {
+        alt: 'Laptop Briefcase with wheels (37L), , large',
+        disBaseLink:
+            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7cb2d401/images/large/P0048_001.jpg',
+        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7cb2d401/images/large/P0048_001.jpg',
+        title: 'Laptop Briefcase with wheels (37L), '
+    },
+    orderable: true,
+    price: 63.99,
+    pricePerUnit: 63.99,
+    productId: 'P0048M',
+    productName: 'Laptop Briefcase with wheels (37L)',
+    productType: {
+        item: true
+    },
+    representedProduct: {
+        id: 'P0048M',
+        c_styleNumber: 'P0048',
+        c_tabDescription:
+            'Perfect for business travel, this briefcase is ultra practical with plenty of space for your laptop and all its extras, as well as storage for documents, paperwork and all your essential items. The wheeled system allows you to travel comfortably with your work and when you reach your destination, you can remove the laptop compartment and carry over your shoulder to meetings. It’s the business.',
+        c_tabDetails:
+            '1682 ballistic nylon and genuine leather inserts| Spacious main storage compartment for documents and binders|Removable, padded laptop sleeve with D-rings for carrying with shoulder strap|Change handle system and cantilever wheels|Zip pull in gunmetal with black rubber insert Leather “comfort” insert detailed handle|Internal storage pockets for CD-Rom and peripherals|Real leather inserts'
+    },
+    representedProducts: [
+        {
+            id: 'P0048M'
+        }
+    ],
+    tieredPrices: [
+        {
+            price: 63.99,
+            pricebook: 'gbp-m-list-prices',
+            quantity: 1
+        }
+    ]
+}
+const mockProductWithVariants = {
     currency: 'GBP',
     hitType: 'master',
     image: {

--- a/packages/template-retail-react-app/app/components/product-view/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-view/index.jsx
@@ -58,6 +58,7 @@ const ProductViewHeader = ({name, basePrice, discountPrice, currency, category, 
             <DisplayPrice
                 basePrice={basePrice}
                 discountPrice={discountPrice}
+                discountPriceProps={{as: 'b'}}
                 currency={currency}
                 isProductASet={isProductASet}
             />

--- a/packages/template-retail-react-app/app/hooks/use-einstein.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.js
@@ -405,7 +405,11 @@ const useEinstein = () => {
             const token = await getTokenWhenReady()
             // Fetch the product details for the recommendations
             const products = await api.shopperProducts.getProducts({
-                parameters: {ids: ids.join(',')},
+                parameters: {
+                    ids: ids.join(','),
+                    perPricebook: true,
+                    expand: ['prices', 'variations', 'availability', 'promotions']
+                },
                 headers: {
                     Authorization: `Bearer ${token}`
                 }

--- a/packages/template-retail-react-app/app/hooks/use-einstein.js
+++ b/packages/template-retail-react-app/app/hooks/use-einstein.js
@@ -408,7 +408,7 @@ const useEinstein = () => {
                 parameters: {
                     ids: ids.join(','),
                     perPricebook: true,
-                    expand: ['prices', 'variations', 'availability', 'promotions']
+                    expand: ['availability', 'promotions', 'images', 'prices', 'variations']
                 },
                 headers: {
                     Authorization: `Bearer ${token}`

--- a/packages/template-retail-react-app/app/pages/home/index.jsx
+++ b/packages/template-retail-react-app/app/pages/home/index.jsx
@@ -66,14 +66,7 @@ const Home = () => {
             refine: [`cgid=${HOME_SHOP_PRODUCTS_CATEGORY_ID}`, 'htype=master'],
             perPricebook: true,
             allVariationProperties: true,
-            expand: [
-                'availability',
-                'prices',
-                'represented_products',
-                'variations',
-                'custom_properties',
-                'images'
-            ],
+            expand: ['availability', 'prices', 'variations', 'custom_properties', 'images'],
             limit: HOME_SHOP_PRODUCTS_LIMIT
         }
     })

--- a/packages/template-retail-react-app/app/pages/home/index.jsx
+++ b/packages/template-retail-react-app/app/pages/home/index.jsx
@@ -64,6 +64,16 @@ const Home = () => {
     const {data: productSearchResult, isLoading} = useProductSearch({
         parameters: {
             refine: [`cgid=${HOME_SHOP_PRODUCTS_CATEGORY_ID}`, 'htype=master'],
+            perPricebook: true,
+            allVariationProperties: true,
+            expand: [
+                'availability',
+                'prices',
+                'represented_products',
+                'variations',
+                'custom_properties',
+                'images'
+            ],
             limit: HOME_SHOP_PRODUCTS_LIMIT
         }
     })

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -150,7 +150,15 @@ const ProductList = (props) => {
                 ...restOfParams,
                 perPricebook: true,
                 allVariationProperties: true,
-                expand: ['availability', 'prices', 'variations', 'custom_properties', 'images'],
+                expand: [
+                    'availability',
+                    'prices',
+                    'variations',
+                    'custom_properties',
+                    'images',
+                    'promotions',
+                    'represented_products'
+                ],
                 refine: _refine
             }
         },

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -148,6 +148,16 @@ const ProductList = (props) => {
         {
             parameters: {
                 ...restOfParams,
+                perPricebook: true,
+                allVariationProperties: true,
+                expand: [
+                    'availability',
+                    'prices',
+                    'represented_products',
+                    'variations',
+                    'custom_properties',
+                    'images'
+                ],
                 refine: _refine
             }
         },

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -150,14 +150,7 @@ const ProductList = (props) => {
                 ...restOfParams,
                 perPricebook: true,
                 allVariationProperties: true,
-                expand: [
-                    'availability',
-                    'prices',
-                    'represented_products',
-                    'variations',
-                    'custom_properties',
-                    'images'
-                ],
+                expand: ['availability', 'prices', 'variations', 'custom_properties', 'images'],
                 refine: _refine
             }
         },

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -2475,6 +2475,16 @@
       "value": " to wishlist"
     }
   ],
+  "product_tile.assistive_msg.base_price": [
+    {
+      "type": 0,
+      "value": "Sale price "
+    },
+    {
+      "type": 1,
+      "value": "basePrice"
+    }
+  ],
   "product_tile.assistive_msg.remove_from_wishlist": [
     {
       "type": 0,
@@ -2487,6 +2497,16 @@
     {
       "type": 0,
       "value": " from wishlist"
+    }
+  ],
+  "product_tile.assistive_msg.sale_price": [
+    {
+      "type": 0,
+      "value": "Sale price "
+    },
+    {
+      "type": 1,
+      "value": "discountPrice"
     }
   ],
   "product_view.button.add_set_to_cart": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -2489,16 +2489,6 @@
       "value": " from wishlist"
     }
   ],
-  "product_tile.label.starting_at_price": [
-    {
-      "type": 0,
-      "value": "Starting at "
-    },
-    {
-      "type": 1,
-      "value": "price"
-    }
-  ],
   "product_view.button.add_set_to_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -2475,6 +2475,16 @@
       "value": " to wishlist"
     }
   ],
+  "product_tile.assistive_msg.base_price": [
+    {
+      "type": 0,
+      "value": "Sale price "
+    },
+    {
+      "type": 1,
+      "value": "basePrice"
+    }
+  ],
   "product_tile.assistive_msg.remove_from_wishlist": [
     {
       "type": 0,
@@ -2487,6 +2497,16 @@
     {
       "type": 0,
       "value": " from wishlist"
+    }
+  ],
+  "product_tile.assistive_msg.sale_price": [
+    {
+      "type": 0,
+      "value": "Sale price "
+    },
+    {
+      "type": 1,
+      "value": "discountPrice"
     }
   ],
   "product_view.button.add_set_to_cart": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -2489,16 +2489,6 @@
       "value": " from wishlist"
     }
   ],
-  "product_tile.label.starting_at_price": [
-    {
-      "type": 0,
-      "value": "Starting at "
-    },
-    {
-      "type": 1,
-      "value": "price"
-    }
-  ],
   "product_view.button.add_set_to_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -5289,24 +5289,6 @@
       "value": "]"
     }
   ],
-  "product_tile.label.starting_at_price": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Şŧȧȧřŧīƞɠ ȧȧŧ "
-    },
-    {
-      "type": 1,
-      "value": "price"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
   "product_view.button.add_set_to_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -5267,6 +5267,24 @@
       "value": "]"
     }
   ],
+  "product_tile.assistive_msg.base_price": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şȧȧŀḗḗ ƥřīƈḗḗ "
+    },
+    {
+      "type": 1,
+      "value": "basePrice"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "product_tile.assistive_msg.remove_from_wishlist": [
     {
       "type": 0,
@@ -5283,6 +5301,24 @@
     {
       "type": 0,
       "value": " ƒřǿǿḿ ẇīşħŀīşŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "product_tile.assistive_msg.sale_price": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şȧȧŀḗḗ ƥřīƈḗḗ "
+    },
+    {
+      "type": 1,
+      "value": "discountPrice"
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -93,7 +93,7 @@
   "bundlesize": [
     {
       "path": "build/main.js",
-      "maxSize": "43 kB"
+      "maxSize": "44 kB"
     },
     {
       "path": "build/vendor.js",

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -1063,9 +1063,6 @@
   "product_tile.assistive_msg.remove_from_wishlist": {
     "defaultMessage": "Remove {product} from wishlist"
   },
-  "product_tile.label.starting_at_price": {
-    "defaultMessage": "Starting at {price}"
-  },
   "product_view.button.add_set_to_cart": {
     "defaultMessage": "Add Set to Cart"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -1060,8 +1060,14 @@
   "product_tile.assistive_msg.add_to_wishlist": {
     "defaultMessage": "Add {product} to wishlist"
   },
+  "product_tile.assistive_msg.base_price": {
+    "defaultMessage": "Sale price {basePrice}"
+  },
   "product_tile.assistive_msg.remove_from_wishlist": {
     "defaultMessage": "Remove {product} from wishlist"
+  },
+  "product_tile.assistive_msg.sale_price": {
+    "defaultMessage": "Sale price {discountPrice}"
   },
   "product_view.button.add_set_to_cart": {
     "defaultMessage": "Add Set to Cart"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -1063,9 +1063,6 @@
   "product_tile.assistive_msg.remove_from_wishlist": {
     "defaultMessage": "Remove {product} from wishlist"
   },
-  "product_tile.label.starting_at_price": {
-    "defaultMessage": "Starting at {price}"
-  },
   "product_view.button.add_set_to_cart": {
     "defaultMessage": "Add Set to Cart"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -1060,8 +1060,14 @@
   "product_tile.assistive_msg.add_to_wishlist": {
     "defaultMessage": "Add {product} to wishlist"
   },
+  "product_tile.assistive_msg.base_price": {
+    "defaultMessage": "Sale price {basePrice}"
+  },
   "product_tile.assistive_msg.remove_from_wishlist": {
     "defaultMessage": "Remove {product} from wishlist"
+  },
+  "product_tile.assistive_msg.sale_price": {
+    "defaultMessage": "Sale price {discountPrice}"
   },
   "product_view.button.add_set_to_cart": {
     "defaultMessage": "Add Set to Cart"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
This PR implemented strikethrough price for products on PLP if any product has a listing sale price 
![image](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/52219283/cb18c0c0-0426-4d26-8dd3-5706eedee0d4)

NOTE: this PR does not take into account changes needed for PDP

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Checkout the code
- npm ci at root
- start retail app
- go to PLP http://localhost:3000/global/en-GB/category/mens-accessories-ties or http://localhost:3000/global/en-GB/category/mens-clothing-suits to see that original price is showing with a strike through line. 
- Go to a PDP, and check the recommended section and recently view section. Make sure that the produc tiles also display strikethrough prices if applicable.

There will be some differences between showing price for variant product PLP Product Tile and Recommendation Section Product Tile due to the data differences

- For PLP, we call getProductSearch which will return data that has represent_product that we will use to display price
- For recommendation section, it is not the case because we use getProducts to retrieve data that does not have `represent_product`. In this case we will show the price of the first variant (if applicable)
- For other product types like standard/set/bundles, they will be the same for both

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
