### PR TITLE
[commerce-sdk-react] upgrade isomorphic library version to 2.0.0

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.0.0-dev (May 21, 2024)
+- Upgrade to commerce-sdk-isomorphic v2.0.0 [#1794](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1794)
 ## v1.4.2 (Apr 17, 2024)
 - Update SLAS private proxy path [#1752](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1752)
 

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.5.0-dev (Apr 17, 2024)
+## v2.0.0-dev (May 21, 2024)
 ## v1.4.2 (Apr 17, 2024)
 - Update SLAS private proxy path [#1752](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1752)
 

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/commerce-sdk-react",
-  "version": "1.5.0-dev",
+  "version": "2.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/commerce-sdk-react",
-      "version": "1.5.0-dev",
+      "version": "2.0.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
         "commerce-sdk-isomorphic": "^2.0.0",

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.5.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
-        "commerce-sdk-isomorphic": "^1.13.1",
+        "commerce-sdk-isomorphic": "^2.0.0",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -861,12 +861,13 @@
       "dev": true
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-1.13.1.tgz",
-      "integrity": "sha512-yTzOnTOIwXaCQWgSh9yZ0OByYfOwruW2Ck8opl6fDktTqpbSrcY05am011rdWb31Q5o+lZ3sR9g9Ka+OH06tWA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-9359TxC1P6olgWhv4py7rgMprBJGQm8+NCXjzxO0C3javynqGX8ccVe7FmHKpjTe+rvI/PEp9doy/fvPtHZEvQ==",
       "dependencies": {
         "nanoid": "^3.3.4",
-        "node-fetch": "2.6.12"
+        "node-fetch": "2.6.12",
+        "seedrandom": "^3.0.5"
       },
       "engines": {
         "node": ">=10"
@@ -2661,6 +2662,11 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
     },
     "node_modules/semver": {
       "version": "7.5.4",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/commerce-sdk-react",
-  "version": "1.5.0-dev",
+  "version": "2.0.0-dev",
   "description": "A library that provides react hooks for fetching data from Commerce Cloud",
   "homepage": "https://github.com/SalesforceCommerceCloud/pwa-kit/tree/develop/packages/ecom-react-hooks#readme",
   "bugs": {

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "^1.13.1",
+    "commerce-sdk-isomorphic": "^2.0.0",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/index.test.ts
@@ -17,9 +17,6 @@ describe('Shopper Customers hooks', () => {
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
         expect(unimplemented).toEqual([
-            'invalidateCustomerAuth', // DEPRECATED, not included
-            'authorizeCustomer', // DEPRECATED, not included
-            'authorizeTrustedSystem', // DEPRECATED, not included
             'registerExternalProfile', // TODO: Implement when the endpoint exits closed beta
             'getExternalProfile' // TODO: Implement when the endpoint exits closed beta
         ])

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
@@ -16,7 +16,7 @@ describe('Shopper Orders hooks', () => {
         const unimplemented = getUnimplementedEndpoints(ShopperOrders, queries, mutations)
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
-        expect(unimplemented).toEqual([])
+        expect(unimplemented).toEqual(['guestOrderLookup'])
     })
     test('all mutations have cache update logic', () => {
         // unimplemented = value in mutations enum, but no method in cache update matrix

--- a/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPromotions/query.test.ts
@@ -28,8 +28,8 @@ const OPTIONS = {parameters: {campaignId: 'campaignId', ids: 'a,b'}}
 type TestMap = {[K in keyof Queries]: NonNullable<ReturnType<Queries[K]>['data']>}
 // This is an object rather than an array to more easily ensure we cover all hooks
 const testMap: TestMap = {
-    usePromotions: {count: 0, data: [], total: 0},
-    usePromotionsForCampaign: {count: 0, data: [], total: 0}
+    usePromotions: {limit: 0, data: [], total: 0},
+    usePromotionsForCampaign: {limit: 0, data: [], total: 0}
 }
 // Type assertion is necessary because `Object.entries` is limited
 const testCases = Object.entries(testMap) as Array<[keyof TestMap, TestMap[keyof TestMap]]>

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/package.json.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/package.json.hbs
@@ -21,7 +21,7 @@
   "bundlesize": [
     {
       "path": "build/main.js",
-      "maxSize": "43 kB"
+      "maxSize": "44 kB"
     },
     {
       "path": "build/vendor.js",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -45,7 +45,7 @@
     "@lhci/cli": "^0.11.0",
     "@loadable/component": "^5.15.3",
     "@peculiar/webcrypto": "^1.4.2",
-    "@salesforce/commerce-sdk-react": "1.5.0-dev",
+    "@salesforce/commerce-sdk-react": "2.0.0-dev",
     "@salesforce/pwa-kit-dev": "3.6.0-dev",
     "@salesforce/pwa-kit-react-sdk": "3.6.0-dev",
     "@salesforce/pwa-kit-runtime": "3.6.0-dev",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -93,7 +93,7 @@
   "bundlesize": [
     {
       "path": "build/main.js",
-      "maxSize": "43 kB"
+      "maxSize": "44 kB"
     },
     {
       "path": "build/vendor.js",

--- a/packages/test-commerce-sdk-react/package.json
+++ b/packages/test-commerce-sdk-react/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.3",
-    "@salesforce/commerce-sdk-react": "1.5.0-dev",
+    "@salesforce/commerce-sdk-react": "2.0.0-dev",
     "@salesforce/pwa-kit-dev": "3.6.0-dev",
     "@salesforce/pwa-kit-react-sdk": "3.6.0-dev",
     "@salesforce/pwa-kit-runtime": "3.6.0-dev",


### PR DESCRIPTION
Consume the new `commerce-sdk-isomorphic` v2 changes.

Since the isomorphic upgrade contains a breaking change, and that affects the `commerce-sdk-react` api. So this PR bumps a major version for `commerce-sdk-react`

# Changes
- consume `commerce-sdk-isomorphic` v2
- fix broken tests
- bump commerce-sdk-react **MAJOR** version
- bump bundle size limit up by 1kb