### PR TITLE
[SPIKE] Namespace /mobify

### DIFF
--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -15,7 +15,7 @@ import {jwtDecode, JwtPayload} from 'jwt-decode'
 import {ApiClientConfigParams, Prettify, RemoveStringIndex} from '../hooks/types'
 import {BaseStorage, LocalStorage, CookieStorage, MemoryStorage, StorageType} from './storage'
 import {CustomerType} from '../hooks/useCustomerType'
-import {getParentOrigin, isOriginTrusted, onClient} from '../utils'
+import {getParentOrigin, isOriginTrusted, onClient, getProxyPath, getSLASPath} from '../utils'
 import {
     SLAS_SECRET_WARNING_MSG,
     SLAS_SECRET_PLACEHOLDER,
@@ -175,8 +175,8 @@ class Auth {
 
     constructor(config: AuthConfig) {
         // Special endpoint for injecting SLAS private client secret
-        const baseUrl = config.proxy.split(`/mobify/proxy/api`)[0]
-        const privateClientEndpoint = `${baseUrl}/mobify/slas/private`
+        const baseUrl = config.proxy.split(`${getProxyPath()}`)[0]
+        const privateClientEndpoint = `${baseUrl}${getSLASPath()}`
 
         this.client = new ShopperLogin({
             proxy: config.enablePWAKitPrivateClient ? privateClientEndpoint : config.proxy,

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -15,7 +15,7 @@ import {jwtDecode, JwtPayload} from 'jwt-decode'
 import {ApiClientConfigParams, Prettify, RemoveStringIndex} from '../hooks/types'
 import {BaseStorage, LocalStorage, CookieStorage, MemoryStorage, StorageType} from './storage'
 import {CustomerType} from '../hooks/useCustomerType'
-import {getParentOrigin, isOriginTrusted, onClient, getProxyPath, getSLASPath} from '../utils'
+import {getParentOrigin, isOriginTrusted, onClient} from '../utils'
 import {
     SLAS_SECRET_WARNING_MSG,
     SLAS_SECRET_PLACEHOLDER,
@@ -175,8 +175,8 @@ class Auth {
 
     constructor(config: AuthConfig) {
         // Special endpoint for injecting SLAS private client secret
-        const baseUrl = config.proxy.split(`${getProxyPath()}`)[0]
-        const privateClientEndpoint = `${baseUrl}${getSLASPath()}`
+        const baseUrl = config.proxy.split(`/mobify`)[0]
+        const privateClientEndpoint = `${baseUrl}/mobify/slas/private`
 
         this.client = new ShopperLogin({
             proxy: config.enablePWAKitPrivateClient ? privateClientEndpoint : config.proxy,

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -29,6 +29,7 @@ interface AuthConfig extends ApiClientConfigParams {
     proxy: string
     fetchOptions?: ShopperLoginTypes.FetchOptions
     fetchedToken?: string
+    envNamespace?: string
     OCAPISessionsURL?: string
     enablePWAKitPrivateClient?: boolean
     clientSecret?: string
@@ -202,7 +203,7 @@ class Auth {
         })
 
         const options = {
-            keySuffix: config.siteId,
+            keySuffix: config.envNamespace ? `${config.envNamespace}_${config.siteId}` : config.siteId,
             // Setting this to true on the server allows us to reuse guest auth tokens across lambda runs
             sharedContext: !onClient()
         }

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import {ApiClients} from '../../hooks/types'
-import {DEVELOPMENT_ORIGIN, getParentOrigin, isOriginTrusted, getDevelopBundlePath} from '../../utils'
+import {DEVELOPMENT_ORIGIN, getParentOrigin, isOriginTrusted, getNamespace} from '../../utils'
 
 /** Detects whether the storefront is running in an iframe as part of Storefront Preview.
  * @private
@@ -21,8 +21,9 @@ export const detectStorefrontPreview = () => {
  */
 export const getClientScript = () => {
     const parentOrigin = getParentOrigin() ?? 'https://runtime.commercecloud.com'
+
     return parentOrigin === DEVELOPMENT_ORIGIN
-        ? `${parentOrigin}${getDevelopBundlePath()}/static/storefront-preview.js`
+        ? `${parentOrigin}${getNamespace()}/mobify/bundle/development/static/storefront-preview.js`
         : `${parentOrigin}/cc/b2c/preview/preview.client.js`
 }
 

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import {ApiClients} from '../../hooks/types'
-import {DEVELOPMENT_ORIGIN, getParentOrigin, isOriginTrusted} from '../../utils'
+import {DEVELOPMENT_ORIGIN, getParentOrigin, isOriginTrusted, getDevelopBundlePath} from '../../utils'
 
 /** Detects whether the storefront is running in an iframe as part of Storefront Preview.
  * @private
@@ -22,7 +22,7 @@ export const detectStorefrontPreview = () => {
 export const getClientScript = () => {
     const parentOrigin = getParentOrigin() ?? 'https://runtime.commercecloud.com'
     return parentOrigin === DEVELOPMENT_ORIGIN
-        ? `${parentOrigin}/mobify/bundle/development/static/storefront-preview.js`
+        ? `${parentOrigin}${getDevelopBundlePath()}/static/storefront-preview.js`
         : `${parentOrigin}/cc/b2c/preview/preview.client.js`
 }
 

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -31,6 +31,7 @@ export interface CommerceApiProviderProps extends ApiClientConfigParams {
     fetchOptions?: ShopperBasketsTypes.FetchOptions
     headers?: Record<string, string>
     fetchedToken?: string
+    envNamespace?: string
     OCAPISessionsURL?: string
     enablePWAKitPrivateClient?: boolean
     clientSecret?: string
@@ -107,6 +108,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
         locale,
         currency,
         fetchedToken,
+        envNamespace,
         OCAPISessionsURL,
         enablePWAKitPrivateClient,
         clientSecret,
@@ -162,6 +164,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             redirectURI,
             fetchOptions,
             fetchedToken,
+            envNamespace,
             OCAPISessionsURL,
             enablePWAKitPrivateClient,
             clientSecret,
@@ -176,6 +179,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
         redirectURI,
         fetchOptions,
         fetchedToken,
+        envNamespace,
         OCAPISessionsURL,
         enablePWAKitPrivateClient,
         clientSecret,
@@ -194,6 +198,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
                 proxy,
                 redirectURI,
                 fetchOptions,
+                envNamespace,
                 siteId,
                 shortCode,
                 locale,

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -8,6 +8,13 @@
 import Cookies, {CookieAttributes} from 'js-cookie'
 import {IFRAME_HOST_ALLOW_LIST} from './constant'
 
+declare global {
+    interface Window {
+        __CONFIG__: any;
+    }
+}
+
+
 /** Utility to determine if you are on the browser (client) or not. */
 export const onClient = (): boolean => typeof window !== 'undefined'
 
@@ -34,6 +41,26 @@ export const getParentOrigin = () => {
     }
 }
 
+export const getNamespace = () => {
+    /* tslint:disable-next-line */
+
+    if (!onClient()) {
+        return ''
+    }
+    const config = window.__CONFIG__
+    const isSSRNamespace = config.enableSSRNamespace
+
+    if (!isSSRNamespace) {
+        return ''
+    }
+
+    const defaultSiteId = config.app.defaultSite
+    const siteAliases = config.app.siteAliases
+    const alias = siteAliases[defaultSiteId]
+
+    return alias ? `/${alias}` : `/${defaultSiteId}`
+}
+
 /**
  * Determines whether the given origin is trusted to host the storefront in an iframe.
  * @private
@@ -45,14 +72,6 @@ export const isOriginTrusted = (origin: string | undefined) => {
                 ? origin === DEVELOPMENT_ORIGIN // Development
                 : IFRAME_HOST_ALLOW_LIST.includes(origin)) // Production
     )
-}
-
-export const getNamespace = () => {
-    return 'abc'
-}
-
-export const getDevelopBundlePath = () => {
-    return getNamespace() ? `/${getNamespace()}/mobify/bundle/development` :'/mobify/bundle/development'
 }
 
 /**

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -47,16 +47,12 @@ export const isOriginTrusted = (origin: string | undefined) => {
     )
 }
 
-export const getProxyPath = () => {
-    return '/mobify/proxy/api'
+export const getNamespace = () => {
+    return 'abc'
 }
 
 export const getDevelopBundlePath = () => {
-    return '/mobify/bundle/development'
-}
-
-export const getSLASPath = () => {
-    return '/mobify/slas/private'
+    return getNamespace() ? `/${getNamespace()}/mobify/bundle/development` :'/mobify/bundle/development'
 }
 
 /**

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -47,6 +47,18 @@ export const isOriginTrusted = (origin: string | undefined) => {
     )
 }
 
+export const getProxyPath = () => {
+    return '/mobify/proxy/api'
+}
+
+export const getDevelopBundlePath = () => {
+    return '/mobify/bundle/development'
+}
+
+export const getSLASPath = () => {
+    return '/mobify/slas/private'
+}
+
 /**
  * Gets the value to use for the `sameSite` cookie attribute.
  * @returns `undefined` if running on the server, `"none"` if running as an iframe on a trusted site

--- a/packages/pwa-kit-dev/src/configs/jest/jest.config.js
+++ b/packages/pwa-kit-dev/src/configs/jest/jest.config.js
@@ -6,6 +6,8 @@
  */
 import path from 'path'
 
+const LOCAL_ENV_NAMESPACE = process.env.LOCAL_ENV_NAMESPACE ? `/${process.env.LOCAL_ENV_NAMESPACE}` : ''
+
 module.exports = {
     testURL: 'http://localhost/',
     verbose: true,
@@ -26,7 +28,7 @@ module.exports = {
         DEBUG: true,
         NODE_ENV: 'test',
         Progressive: {
-            buildOrigin: '/mobify/bundle/development/'
+            buildOrigin: `${LOCAL_ENV_NAMESPACE}/mobify/bundle/development/`
         }
     },
     transform: {

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -38,6 +38,8 @@ const DEBUG = mode !== production && process.env.DEBUG === 'true'
 const CI = process.env.CI
 const disableHMR = process.env.HMR === 'false'
 
+const LOCAL_ENV_NAMESPACE = process.env.LOCAL_ENV_NAMESPACE ? `/${process.env.LOCAL_ENV_NAMESPACE}` : ''
+
 if ([production, development].indexOf(mode) < 0) {
     throw new Error(`Invalid mode "${mode}"`)
 }
@@ -407,7 +409,7 @@ const enableReactRefresh = (config) => {
         output: {
             ...config.output,
             // Setting this so that *.hot-update.json requests are resolving
-            publicPath: '/mobify/bundle/development/'
+            publicPath: `${LOCAL_ENV_NAMESPACE}/mobify/bundle/development/`
         }
     }
 }

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -18,7 +18,7 @@ import webpackHotMiddleware from 'webpack-hot-middleware'
 import open from 'open'
 import requireFromString from 'require-from-string'
 import {RemoteServerFactory} from '@salesforce/pwa-kit-runtime/ssr/server/build-remote-server'
-import {proxyConfigs} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
+import {proxyConfigs, getBundlePathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 import {
     SERVER,
     CLIENT,
@@ -166,7 +166,7 @@ export const DevServerMixin = {
             app.__hotServerMiddleware = webpackHotServerMiddleware(app.__compiler)
         }
 
-        app.use('/mobify/bundle/development', app.__devMiddleware)
+        app.use(`${getBundlePathBase()}/development`, app.__devMiddleware)
 
         app.__hmrMiddleware = (_, res) => res.status(501).send('Hot Module Reloading is disabled.')
         const clientCompiler = app.__compiler.compilers.find((compiler) => compiler.name === CLIENT)
@@ -209,7 +209,7 @@ export const DevServerMixin = {
         // Proxy bundle asset requests to the local
         // build directory.
         app.use(
-            '/mobify/bundle/development',
+            `${getBundlePathBase}/development`,
             express.static(path.resolve(process.cwd(), 'src'), {
                 dotFiles: 'deny',
                 setHeaders: setLocalAssetHeaders,

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.js
@@ -7,7 +7,7 @@
 /**
  * @module progressive-web-sdk/ssr/universal/utils
  */
-import {proxyConfigs} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
+import {proxyConfigs, getBundlePathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 
 const onClient = typeof window !== 'undefined'
 
@@ -22,7 +22,7 @@ export const getAssetUrl = (path) => {
     /* istanbul ignore next */
     const publicPath = onClient
         ? `${window.Progressive.buildOrigin}`
-        : `/mobify/bundle/${process.env.BUNDLE_ID || 'development'}/`
+        : `${getBundlePathBase()}/${process.env.BUNDLE_ID || 'development'}/`
     return path ? `${publicPath}${path}` : publicPath
 }
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -11,8 +11,7 @@ import {
     X_MOBIFY_QUERYSTRING,
     SET_COOKIE,
     CACHE_CONTROL,
-    NO_CACHE,
-    SLAS_CUSTOM_PROXY_PATH
+    NO_CACHE
 } from './constants'
 import {
     catchAndLog,
@@ -39,7 +38,7 @@ import fs from 'fs'
 import {RESOLVED_PROMISE} from './express'
 import http from 'http'
 import https from 'https'
-import {proxyConfigs, updatePackageMobify, startsWithMobify, getProxyPathBase, getHealtCheckPathBase} from '../../utils/ssr-shared'
+import {proxyConfigs, updatePackageMobify, startsWithMobify, getProxyPathBase, getHealtCheckPathBase, getSLASPrivateProxyPath} from '../../utils/ssr-shared'
 import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
 import awsServerlessExpress from 'aws-serverless-express'
 import expressLogging from 'morgan'
@@ -627,7 +626,7 @@ export const RemoteServerFactory = {
      * @private
      */
     _handleMissingSlasPrivateEnvVar(app) {
-        app.use(SLAS_CUSTOM_PROXY_PATH, (_, res) => {
+        app.use(getSLASPrivateProxyPath(), (_, res) => {
             return res.status(501).json({
                 message:
                     'Environment variable PWA_KIT_SLAS_CLIENT_SECRET not set: Please set this environment variable to proceed.'
@@ -642,7 +641,7 @@ export const RemoteServerFactory = {
         if (!options.useSLASPrivateClient) {
             return
         }
-        localDevLog(`Proxying ${SLAS_CUSTOM_PROXY_PATH} to ${options.slasTarget}`)
+        localDevLog(`Proxying ${getSLASPrivateProxyPath()} to ${options.slasTarget}`)
 
         const clientId = options.mobify?.app?.commerceAPI?.parameters?.clientId
         const clientSecret = process.env.PWA_KIT_SLAS_CLIENT_SECRET
@@ -654,16 +653,16 @@ export const RemoteServerFactory = {
         const encodedSlasCredentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
 
         app.use(
-            SLAS_CUSTOM_PROXY_PATH,
+            getSLASPrivateProxyPath(),
             createProxyMiddleware({
                 target: options.slasTarget,
                 changeOrigin: true,
-                pathRewrite: {[SLAS_CUSTOM_PROXY_PATH]: ''},
+                pathRewrite: {[getSLASPrivateProxyPath()]: ''},
                 onProxyReq: (proxyRequest, incomingRequest) => {
                     applyProxyRequestHeaders({
                         proxyRequest,
                         incomingRequest,
-                        proxyPath: SLAS_CUSTOM_PROXY_PATH,
+                        proxyPath: getSLASPrivateProxyPath(),
                         targetHost: options.slasHostName,
                         targetProtocol: 'https'
                     })

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -39,7 +39,7 @@ import fs from 'fs'
 import {RESOLVED_PROMISE} from './express'
 import http from 'http'
 import https from 'https'
-import {proxyConfigs, updatePackageMobify} from '../../utils/ssr-shared'
+import {proxyConfigs, updatePackageMobify, startsWithMobify, getProxyPathBase, getHealtCheckPathBase} from '../../utils/ssr-shared'
 import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
 import awsServerlessExpress from 'aws-serverless-express'
 import expressLogging from 'morgan'
@@ -432,7 +432,7 @@ export const RemoteServerFactory = {
         const processIncomingRequest = (req, res) => {
             const options = req.app.options
             // If the request is for a proxy or bundle path, do nothing
-            if (req.originalUrl.startsWith('/mobify/')) {
+            if (startsWithMobify(req.originalUrl)) {
                 return
             }
 
@@ -569,7 +569,7 @@ export const RemoteServerFactory = {
                     // different types of the 'req' object, and will
                     // always contain the original full path.
                     /* istanbul ignore else */
-                    if (!req.originalUrl.startsWith('/mobify/')) {
+                    if (!startsWithMobify(req.originalUrl)) {
                         req.app.sendMetric(
                             'RequestTime',
                             Date.now() - locals.requestStart,
@@ -615,7 +615,7 @@ export const RemoteServerFactory = {
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _setupProxying(app, options) {
-        app.all('/mobify/proxy/*', (_, res) => {
+        app.all(`${getProxyPathBase()}/*`, (_, res) => {
             return res.status(501).json({
                 message:
                     'Environment proxies are not set: https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/proxying-requests.html'
@@ -702,7 +702,7 @@ export const RemoteServerFactory = {
      * @private
      */
     _setupHealthcheck(app) {
-        app.get('/mobify/ping', (_, res) =>
+        app.get(`${getHealtCheckPathBase()}`, (_, res) =>
             res.set('cache-control', NO_CACHE).sendStatus(200).end()
         )
     },

--- a/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
@@ -30,6 +30,7 @@ import {
 } from './ssr-server'
 
 import {
+    getProxyPathBase,
     getPackageMobify,
     getSSRParameters,
     proxyConfigs,
@@ -43,8 +44,7 @@ import {
     CONTENT_ENCODING,
     CONTENT_TYPE,
     X_ORIGINAL_CONTENT_TYPE,
-    APPLICATION_OCTET_STREAM,
-    PROXY_PATH_PREFIX
+    APPLICATION_OCTET_STREAM
 } from '../ssr/server/constants'
 
 const baseMobify = {
@@ -117,11 +117,11 @@ describe('utils/ssr-server tests', () => {
 
         updatePackageMobify(baseMobify)
 
-        expect(getFullRequestURL(`${PROXY_PATH_PREFIX}/base/somepath`)).toBe(
+        expect(getFullRequestURL(`${getProxyPathBase()}/base/somepath`)).toBe(
             'https://www.merlinspotions.com/somepath'
         )
 
-        expect(getFullRequestURL(`${PROXY_PATH_PREFIX}/base2/somepath`)).toBe(
+        expect(getFullRequestURL(`${getProxyPathBase()}/base2/somepath`)).toBe(
             'https://api.merlinspotions.com/somepath'
         )
     })

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -6,21 +6,11 @@
  */
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import {rewriteProxyRequestHeaders, rewriteProxyResponseHeaders} from '../ssr-proxying'
-import {proxyConfigs} from '../ssr-shared'
+import {proxyConfigs, generalProxyPathRE} from '../ssr-shared'
 import {processExpressResponse} from './process-express-response'
 import {isRemote, localDevLog, verboseProxyLogging} from './utils'
 
 export const ALLOWED_CACHING_PROXY_REQUEST_METHODS = ['HEAD', 'GET', 'OPTIONS']
-
-/**
- * This path matching RE matches on /mobify/proxy and then skips one path
- * element. For example, /mobify/proxy/heffalump/woozle would be converted to
- * /woozle on whatever host /mobify/proxy/heffalump maps to.
- * Group 2 is the full path on the proxied host.
- * @private
- * @type {RegExp}
- */
-const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
 
 /**
  * Apply proxy headers to a request that is being proxied.

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -6,11 +6,21 @@
  */
 import {createProxyMiddleware} from 'http-proxy-middleware'
 import {rewriteProxyRequestHeaders, rewriteProxyResponseHeaders} from '../ssr-proxying'
-import {proxyConfigs, generalProxyPathRE} from '../ssr-shared'
+import {proxyConfigs} from '../ssr-shared'
 import {processExpressResponse} from './process-express-response'
 import {isRemote, localDevLog, verboseProxyLogging} from './utils'
 
 export const ALLOWED_CACHING_PROXY_REQUEST_METHODS = ['HEAD', 'GET', 'OPTIONS']
+
+/**
+ * This path matching RE matches on /mobify/proxy and then skips one path
+ * element. For example, /mobify/proxy/heffalump/woozle would be converted to
+ * /woozle on whatever host /mobify/proxy/heffalump maps to.
+ * Group 2 is the full path on the proxied host.
+ * @private
+ * @type {RegExp}
+ */
+const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
 
 /**
  * Apply proxy headers to a request that is being proxied.

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/utils.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/utils.js
@@ -11,8 +11,7 @@
 // ../ssr-server.js because it would create circular dependencies.
 
 import crypto from 'crypto'
-import {PROXY_PATH_PREFIX} from '../../ssr/server/constants'
-import {proxyConfigs} from '../ssr-shared'
+import {getProxyPathBase, getBundlePathBase, proxyConfigs} from '../ssr-shared'
 
 // TODO: Clean this up or provide a way to toggle
 export const verboseProxyLogging = false
@@ -21,7 +20,7 @@ export const isRemote = () =>
     Object.prototype.hasOwnProperty.call(process.env, 'AWS_LAMBDA_FUNCTION_NAME')
 
 export const getBundleBaseUrl = () => {
-    return `/mobify/bundle/${isRemote() ? process.env.BUNDLE_ID : 'development'}/`
+    return `${getBundlePathBase()}/${isRemote() ? process.env.BUNDLE_ID : 'development'}/`
 }
 
 let QUIET = false
@@ -82,16 +81,16 @@ export const getHashForString = (text) => {
 export const getFullRequestURL = (url) => {
     // If it starts with a protocol (e.g. http(s)://, file://), then it's already a full URL
     if (/^[a-zA-Z]+:\/\//.test(url)) return url
-    const proxy = proxyConfigs.find(({path}) => url.startsWith(`${PROXY_PATH_PREFIX}/${path}/`))
+    const proxy = proxyConfigs.find(({path}) => url.startsWith(`${getProxyPathBase()}/${path}/`))
     if (proxy) {
         return url.replace(
-            `${PROXY_PATH_PREFIX}/${proxy.path}`,
+            `${getProxyPathBase()}/${proxy.path}`,
             `${proxy.protocol}://${proxy.host}`
         )
     }
 
     throw new Error(
-        `Unable to fetch ${url}, relative paths must begin with ${PROXY_PATH_PREFIX} followed by a configured proxy path.`
+        `Unable to fetch ${url}, relative paths must begin with ${getProxyPathBase()} followed by a configured proxy path.`
     )
 }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -69,6 +69,26 @@ export let ssrFiles = []
  */
 const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
+export const startsWithMobify = (url) => {
+    return url.startsWith('/mobify/')
+}
+
+export const getProxyPathBase = () => {
+    return '/mobify/proxy'
+}
+
+export const getBundlePathBase = () => {
+    return '/mobify/bundle'
+}
+
+export const getCachingPathBase = () => {
+    return '/mobify/caching'
+}
+
+export const getHealtCheckPathBase = () => {
+    return '/mobify/ping'
+}
+
 /**
  * Updates the value of _packageMobify and dependent values.
  *
@@ -166,8 +186,8 @@ export const updatePackageMobify = (newValue) => {
         }
 
         // Generate paths
-        config.proxyPath = `/mobify/proxy/${config.path}`
-        config.cachingPath = `/mobify/caching/${config.path}`
+        config.proxyPath = `${getProxyPathBase()}/${config.path}`
+        config.cachingPath = `${getCachingPathBase()}/${config.path}`
 
         proxyConfigs.push(config)
     }

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+
+import { getConfig } from './ssr-config'
+
 /**
  * @module progressive-web-sdk/utils/ssr-shared
  * @private
  */
-
-import {getConfig} from './ssr-config'
-
 /*
  The ssr-shared-utils module is used in the PWA and in the Express app. It
  should contain ONLY the code that is required in both, to avoid adding
@@ -66,10 +66,8 @@ export let ssrFiles = []
  * @private
  */
 
-const config = getConfig()
-
 // TODO - make this available from config file & client side
-export let namespace = config.ssrNamespace
+const namespace = getConfig().ssrNamespace
 
 /**
  * RegExp that matches a proxy override string
@@ -93,7 +91,8 @@ const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 export const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
 
 export const startsWithMobify = (url) => {
-    return url.startsWith('/mobify/')
+    const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`
+    return url.startsWith(mobifyPath)
 }
 
 export const getProxyPathBase = () => {

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -78,14 +78,12 @@ export const getNamespace = () => {
     if (!isSSRNamespace) {
         return ''
     }
-    console.log(isSSRNamespace)
 
     const defaultSiteId = config.app.defaultSite
     const siteAliases = config.app.siteAliases
-
     const alias = siteAliases[defaultSiteId]
 
-    return alias ? `/${alias}` : `/${defaultSiteId}`
+    return alias ? `${alias}` : `${defaultSiteId}`
 }
 
 /**
@@ -101,33 +99,33 @@ const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
 export const startsWithMobify = (url) => {
     const namespace = getNamespace()
-    const mobifyPath = namespace ? `${namespace}/mobify` : `/mobify`
+    const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`
     return url.startsWith(mobifyPath)
 }
 
 export const getProxyPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `${namespace}/mobify/proxy` : '/mobify/proxy'
+    return namespace ? `/${namespace}/mobify/proxy` : '/mobify/proxy'
 }
 
 export const getBundlePathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `${namespace}/mobify/bundle` : '/mobify/bundle'
+    return namespace ? `/${namespace}/mobify/bundle` : '/mobify/bundle'
 }
 
 export const getCachingPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `${namespace}/mobify/caching` : '/mobify/caching'
+    return namespace ? `/${namespace}/mobify/caching` : '/mobify/caching'
 }
 
 export const getHealtCheckPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `${namespace}/mobify/ping` : '/mobify/ping'
+    return namespace ? `/${namespace}/mobify/ping` : '/mobify/ping'
 }
 
 export const getSLASPrivateProxyPath = () => {
     const namespace = getNamespace()
-    return namespace ? `${namespace}/mobify/slas/private` : '/mobify/slas/private'
+    return namespace ? `/${namespace}/mobify/slas/private` : '/mobify/slas/private'
 }
 
 /**

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -72,12 +72,20 @@ export let ssrFiles = []
 
 export const getNamespace = () => {
     const config = getConfig()
+
+    const isSSRNamespace = config.enableSSRNamespace
+
+    if (!isSSRNamespace) {
+        return ''
+    }
+    console.log(isSSRNamespace)
+
     const defaultSiteId = config.app.defaultSite
     const siteAliases = config.app.siteAliases
 
     const alias = siteAliases[defaultSiteId]
 
-    return alias ? alias : defaultSiteId
+    return alias ? `/${alias}` : `/${defaultSiteId}`
 }
 
 /**
@@ -93,33 +101,33 @@ const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
 export const startsWithMobify = (url) => {
     const namespace = getNamespace()
-    const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`
+    const mobifyPath = namespace ? `${namespace}/mobify` : `/mobify`
     return url.startsWith(mobifyPath)
 }
 
 export const getProxyPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `/${namespace}/mobify/proxy` : '/mobify/proxy'
+    return namespace ? `${namespace}/mobify/proxy` : '/mobify/proxy'
 }
 
 export const getBundlePathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `/${namespace}/mobify/bundle` : '/mobify/bundle'
+    return namespace ? `${namespace}/mobify/bundle` : '/mobify/bundle'
 }
 
 export const getCachingPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `/${namespace}/mobify/caching` : '/mobify/caching'
+    return namespace ? `${namespace}/mobify/caching` : '/mobify/caching'
 }
 
 export const getHealtCheckPathBase = () => {
     const namespace = getNamespace()
-    return namespace ? `/${namespace}/mobify/ping` : '/mobify/ping'
+    return namespace ? `${namespace}/mobify/ping` : '/mobify/ping'
 }
 
 export const getSLASPrivateProxyPath = () => {
     const namespace = getNamespace()
-    return namespace ? `/${namespace}/mobify/slas/private` : '/mobify/slas/private'
+    return namespace ? `${namespace}/mobify/slas/private` : '/mobify/slas/private'
 }
 
 /**

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -8,6 +8,9 @@
  * @module progressive-web-sdk/utils/ssr-shared
  * @private
  */
+
+import {getConfig} from './ssr-config'
+
 /*
  The ssr-shared-utils module is used in the PWA and in the Express app. It
  should contain ONLY the code that is required in both, to avoid adding
@@ -59,6 +62,16 @@ export let proxyConfigs = []
 export let ssrFiles = []
 
 /**
+ * A string that can be defined in the namespace property inside the config file.
+ * @private
+ */
+
+const config = getConfig()
+
+// TODO - make this available from config file & client side
+export let namespace = config.ssrNamespace
+
+/**
  * RegExp that matches a proxy override string
  * match[1] is the protocol
  * match[3] is the host
@@ -69,28 +82,39 @@ export let ssrFiles = []
  */
 const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
+/**
+ * This path matching RE matches on /mobify/proxy and then skips one path
+ * element. For example, /mobify/proxy/heffalump/woozle would be converted to
+ * /woozle on whatever host /mobify/proxy/heffalump maps to.
+ * Group 2 is the full path on the proxied host.
+ * @private
+ * @type {RegExp}
+ */
+export const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
+
 export const startsWithMobify = (url) => {
     return url.startsWith('/mobify/')
 }
 
 export const getProxyPathBase = () => {
-    return '/mobify/proxy'
+    return namespace ? `/${namespace}/mobify/proxy` : '/mobify/proxy'
 }
 
 export const getBundlePathBase = () => {
-    return '/mobify/bundle'
+    console.log(`Bundle Path Namespace: ${namespace}`)
+    return namespace ? `/${namespace}/mobify/bundle` : '/mobify/bundle'
 }
 
 export const getCachingPathBase = () => {
-    return '/mobify/caching'
+    return namespace ? `/${namespace}/mobify/caching` : '/mobify/caching'
 }
 
 export const getHealtCheckPathBase = () => {
-    return '/mobify/ping'
+    return namespace ? `/${namespace}/mobify/ping` : '/mobify/ping'
 }
 
 export const getSLASPrivateProxyPath = () => {
-    return '/mobify/slas/private'
+    return namespace ? `/${namespace}/mobify/slas/private` : '/mobify/slas/private'
 }
 
 /**
@@ -101,6 +125,9 @@ export const getSLASPrivateProxyPath = () => {
  */
 export const updatePackageMobify = (newValue) => {
     _packageMobify = newValue || _packageMobify || {}
+
+    // Read namespace from config if it exists
+    // namespace = _packageMobify.ssrNamespace || ''
 
     // Clear and update the proxyConfigs array
     proxyConfigs = []

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -70,6 +70,16 @@ export let ssrFiles = []
 // const namespace = getConfig().ssrNamespace
 // const namespace = 'abc'
 
+export const getNamespace = () => {
+    const config = getConfig()
+    const defaultSiteId = config.app.defaultSite
+    const siteAliases = config.app.siteAliases
+
+    const alias = siteAliases[defaultSiteId]
+
+    return alias ? alias : defaultSiteId
+}
+
 /**
  * RegExp that matches a proxy override string
  * match[1] is the protocol
@@ -82,33 +92,33 @@ export let ssrFiles = []
 const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
 export const startsWithMobify = (url) => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`
     return url.startsWith(mobifyPath)
 }
 
 export const getProxyPathBase = () => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     return namespace ? `/${namespace}/mobify/proxy` : '/mobify/proxy'
 }
 
 export const getBundlePathBase = () => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     return namespace ? `/${namespace}/mobify/bundle` : '/mobify/bundle'
 }
 
 export const getCachingPathBase = () => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     return namespace ? `/${namespace}/mobify/caching` : '/mobify/caching'
 }
 
 export const getHealtCheckPathBase = () => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     return namespace ? `/${namespace}/mobify/ping` : '/mobify/ping'
 }
 
 export const getSLASPrivateProxyPath = () => {
-    const namespace = getConfig().ssrNamespace
+    const namespace = getNamespace()
     return namespace ? `/${namespace}/mobify/slas/private` : '/mobify/slas/private'
 }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -89,6 +89,10 @@ export const getHealtCheckPathBase = () => {
     return '/mobify/ping'
 }
 
+export const getSLASPrivateProxyPath = () => {
+    return '/mobify/slas/private'
+}
+
 /**
  * Updates the value of _packageMobify and dependent values.
  *

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -67,7 +67,8 @@ export let ssrFiles = []
  */
 
 // TODO - make this available from config file & client side
-const namespace = getConfig().ssrNamespace
+// const namespace = getConfig().ssrNamespace
+const namespace = 'abc'
 
 /**
  * RegExp that matches a proxy override string
@@ -79,16 +80,6 @@ const namespace = getConfig().ssrNamespace
  * @type {RegExp}
  */
 const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
-
-/**
- * This path matching RE matches on /mobify/proxy and then skips one path
- * element. For example, /mobify/proxy/heffalump/woozle would be converted to
- * /woozle on whatever host /mobify/proxy/heffalump maps to.
- * Group 2 is the full path on the proxied host.
- * @private
- * @type {RegExp}
- */
-export const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
 
 export const startsWithMobify = (url) => {
     const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`

--- a/packages/pwa-kit-runtime/src/utils/ssr-shared.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-shared.js
@@ -68,7 +68,7 @@ export let ssrFiles = []
 
 // TODO - make this available from config file & client side
 // const namespace = getConfig().ssrNamespace
-const namespace = 'abc'
+// const namespace = 'abc'
 
 /**
  * RegExp that matches a proxy override string
@@ -82,28 +82,33 @@ const namespace = 'abc'
 const proxyOverrideRE = /^(http(s)?):\/\/([^/]+)(\/)?([^/]+)?(\/caching)?/
 
 export const startsWithMobify = (url) => {
+    const namespace = getConfig().ssrNamespace
     const mobifyPath = namespace ? `/${namespace}/mobify` : `/mobify`
     return url.startsWith(mobifyPath)
 }
 
 export const getProxyPathBase = () => {
+    const namespace = getConfig().ssrNamespace
     return namespace ? `/${namespace}/mobify/proxy` : '/mobify/proxy'
 }
 
 export const getBundlePathBase = () => {
-    console.log(`Bundle Path Namespace: ${namespace}`)
+    const namespace = getConfig().ssrNamespace
     return namespace ? `/${namespace}/mobify/bundle` : '/mobify/bundle'
 }
 
 export const getCachingPathBase = () => {
+    const namespace = getConfig().ssrNamespace
     return namespace ? `/${namespace}/mobify/caching` : '/mobify/caching'
 }
 
 export const getHealtCheckPathBase = () => {
+    const namespace = getConfig().ssrNamespace
     return namespace ? `/${namespace}/mobify/ping` : '/mobify/ping'
 }
 
 export const getSLASPrivateProxyPath = () => {
+    const namespace = getConfig().ssrNamespace
     return namespace ? `/${namespace}/mobify/slas/private` : '/mobify/slas/private'
 }
 

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -27,6 +27,7 @@ import {
     resolveLocaleFromUrl
 } from '@salesforce/retail-react-app/app/utils/site-utils'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+import {getProxyPathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
@@ -67,7 +68,7 @@ const AppConfig = ({children, locals = {}}) => {
             // Uncomment 'enablePWAKitPrivateClient' to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
             // enablePWAKitPrivateClient={true}
-            OCAPISessionsURL={`${appOrigin}/mobify/proxy/ocapi/s/${locals.site?.id}/dw/shop/v22_8/sessions`}
+            OCAPISessionsURL={`${appOrigin}${getProxyPathBase()}/ocapi/s/${locals.site?.id}/dw/shop/v22_8/sessions`}
         >
             <MultiSiteProvider site={locals.site} locale={locals.locale} buildUrl={locals.buildUrl}>
                 <ChakraProvider theme={theme}>{children}</ChakraProvider>

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -55,7 +55,7 @@ const AppConfig = ({children, locals = {}}) => {
     const commerceApiConfig = locals.appConfig.commerceAPI
 
     const proxy = getNamespace()
-        ? `${appOrigin}${getNamespace()}${commerceApiConfig.proxyPath}`
+        ? `${appOrigin}/${getNamespace()}${commerceApiConfig.proxyPath}`
         : `${appOrigin}${commerceApiConfig.proxyPath}`
 
     return (
@@ -68,6 +68,7 @@ const AppConfig = ({children, locals = {}}) => {
             currency={locals.locale?.preferredCurrency}
             redirectURI={`${appOrigin}/callback`}
             proxy={proxy}
+            envNamespace={getNamespace()}
             headers={headers}
             // Uncomment 'enablePWAKitPrivateClient' to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -67,7 +67,7 @@ const AppConfig = ({children, locals = {}}) => {
             headers={headers}
             // Uncomment 'enablePWAKitPrivateClient' to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
-            // enablePWAKitPrivateClient={true}
+            enablePWAKitPrivateClient={true}
             OCAPISessionsURL={`${appOrigin}${getProxyPathBase()}/ocapi/s/${locals.site?.id}/dw/shop/v22_8/sessions`}
         >
             <MultiSiteProvider site={locals.site} locale={locals.locale} buildUrl={locals.buildUrl}>

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -50,9 +50,13 @@ const AppConfig = ({children, locals = {}}) => {
         'correlation-id': correlationId
     }
 
+    const appOrigin = getAppOrigin()
+
     const commerceApiConfig = locals.appConfig.commerceAPI
 
-    const appOrigin = getAppOrigin()
+    const proxy = locals.ssrNamespace
+        ? `${appOrigin}/${locals.ssrNamespace}${commerceApiConfig.proxyPath}`
+        : `${appOrigin}${commerceApiConfig.proxyPath}`
 
     return (
         <CommerceApiProvider
@@ -63,7 +67,7 @@ const AppConfig = ({children, locals = {}}) => {
             locale={locals.locale?.id}
             currency={locals.locale?.preferredCurrency}
             redirectURI={`${appOrigin}/callback`}
-            proxy={`${appOrigin}${commerceApiConfig.proxyPath}`}
+            proxy={proxy}
             headers={headers}
             // Uncomment 'enablePWAKitPrivateClient' to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
@@ -85,8 +89,7 @@ AppConfig.restore = (locals = {}) => {
             : `${window.location.pathname}${window.location.search}`
     const site = resolveSiteFromUrl(path)
     const locale = resolveLocaleFromUrl(path)
-
-    const {app: appConfig} = getConfig()
+    const {app: appConfig, ssrNamespace} = getConfig()
     const apiConfig = {
         ...appConfig.commerceAPI,
         einsteinConfig: appConfig.einsteinAPI
@@ -95,6 +98,7 @@ AppConfig.restore = (locals = {}) => {
     apiConfig.parameters.siteId = site.id
 
     locals.buildUrl = createUrlTemplate(appConfig, site.alias || site.id, locale.id)
+    locals.ssrNamespace = ssrNamespace
     locals.site = site
     locals.locale = locale
     locals.appConfig = appConfig

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -55,7 +55,7 @@ const AppConfig = ({children, locals = {}}) => {
     const commerceApiConfig = locals.appConfig.commerceAPI
 
     const proxy = getNamespace()
-        ? `${appOrigin}/${getNamespace()}${commerceApiConfig.proxyPath}`
+        ? `${appOrigin}${getNamespace()}${commerceApiConfig.proxyPath}`
         : `${appOrigin}${commerceApiConfig.proxyPath}`
 
     return (

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -27,7 +27,7 @@ import {
     resolveLocaleFromUrl
 } from '@salesforce/retail-react-app/app/utils/site-utils'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
-import {getProxyPathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
+import {getNamespace, getProxyPathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
@@ -54,8 +54,8 @@ const AppConfig = ({children, locals = {}}) => {
 
     const commerceApiConfig = locals.appConfig.commerceAPI
 
-    const proxy = locals.ssrNamespace
-        ? `${appOrigin}/${locals.ssrNamespace}${commerceApiConfig.proxyPath}`
+    const proxy = getNamespace()
+        ? `${appOrigin}/${getNamespace()}${commerceApiConfig.proxyPath}`
         : `${appOrigin}${commerceApiConfig.proxyPath}`
 
     return (
@@ -89,7 +89,7 @@ AppConfig.restore = (locals = {}) => {
             : `${window.location.pathname}${window.location.search}`
     const site = resolveSiteFromUrl(path)
     const locale = resolveLocaleFromUrl(path)
-    const {app: appConfig, ssrNamespace} = getConfig()
+    const {app: appConfig} = getConfig()
     const apiConfig = {
         ...appConfig.commerceAPI,
         einsteinConfig: appConfig.einsteinAPI
@@ -98,7 +98,6 @@ AppConfig.restore = (locals = {}) => {
     apiConfig.parameters.siteId = site.id
 
     locals.buildUrl = createUrlTemplate(appConfig, site.alias || site.id, locale.id)
-    locals.ssrNamespace = ssrNamespace
     locals.site = site
     locals.locale = locale
     locals.appConfig = appConfig

--- a/packages/template-retail-react-app/app/hooks/use-active-data.js
+++ b/packages/template-retail-react-app/app/hooks/use-active-data.js
@@ -6,6 +6,7 @@
  */
 /*global dw*/
 import {ACTIVE_DATA_ENABLED} from '@salesforce/retail-react-app/app/constants'
+import {getProxyPathBase} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 
 const useActiveData = () => {
     // Returns true when the feature flag is enabled and the tracking scripts have been executed
@@ -68,11 +69,7 @@ const useActiveData = () => {
             if (!canTrack()) return
             try {
                 var activeDataUrl =
-                    '/mobify/proxy/ocapi/on/demandware.store/Sites-' +
-                    siteId +
-                    '-Site/' +
-                    localeId +
-                    '/__Analytics-Start'
+                    `${getProxyPathBase()}/ocapi/on/demandware.store/Sites-${siteId}-Site/${localeId}/__Analytics-Start`
                 var dwAnalytics = dw.__dwAnalytics.getTracker(activeDataUrl)
                 if (typeof dw.ac == 'undefined') {
                     dwAnalytics.trackPageView()

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -45,7 +45,7 @@ const options = {
     // Set this to false if using a SLAS public client
     // When setting this to true, make sure to also set the PWA_KIT_SLAS_CLIENT_SECRET
     // environment variable as this endpoint will return HTTP 501 if it is not set
-    useSLASPrivateClient: false
+    useSLASPrivateClient: true
 }
 
 const runtime = getRuntime()

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -24,10 +24,10 @@ module.exports = {
         commerceAPI: {
             proxyPath: `/mobify/proxy/api`,
             parameters: {
-                clientId: 'c9c45bfd-0ed3-4aa2-9971-40f88962b836',
+                clientId: 'c131a4df-2d7b-4a67-802f-45152e911cc2',
                 organizationId: 'f_ecom_zzrf_001',
-                shortCode: '8o7m175y',
-                siteId: 'RefArchGlobal'
+                shortCode: 'kv7kzm78',
+                siteId: 'RefArch'
             }
         },
         einsteinAPI: {

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -40,6 +40,7 @@ module.exports = {
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',
+    ssrNamespace: 'abc',
     ssrEnabled: true,
     ssrOnly: ['ssr.js', 'ssr.js.map', 'node_modules/**/*.*'],
     ssrShared: [

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -40,7 +40,7 @@ module.exports = {
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',
-    enableSSRNamespace: false,
+    enableSSRNamespace: true,
     ssrEnabled: true,
     ssrOnly: ['ssr.js', 'ssr.js.map', 'node_modules/**/*.*'],
     ssrShared: [

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -40,7 +40,7 @@ module.exports = {
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',
-    ssrNamespace: 'abc',
+    enableSSRNamespace: false,
     ssrEnabled: true,
     ssrOnly: ['ssr.js', 'ssr.js.map', 'node_modules/**/*.*'],
     ssrShared: [


### PR DESCRIPTION
This is a POC of #1767 

This PR shows how we can use the site alias defined in default.js as a namespace for the /mobify paths and for entries in local storage / cookie storage.

The document for this spike can be seen here: https://salesforce.quip.com/RaYKAunGpS3K

Testing this POC:

1. Check out the code base
2. Set an env variable called LOCAL_ENV_NAMESPACE to `global`
3. Start the app. See that /mobify paths are namespaced. ie. /global/mobify/...
4. Create a local.js config file and set the default site to RefArch
5. Set LOCAL_ENV_NAMESPACE to `us`
6. Restart the app. See that /mobify paths have a different namespace. ie. /us/mobify/...
