### PR TITLE
W-15784798 - Finalize Lazy Navigation Changes

### DIFF
--- a/packages/template-retail-react-app/app/components/nested-accordion/index.jsx
+++ b/packages/template-retail-react-app/app/components/nested-accordion/index.jsx
@@ -105,8 +105,6 @@ const NestedAccordion = (props) => {
                                 </h2>
 
                                 {/* Child Items */}
-                                {/* NOTE: Once the API is updated we'll modify this condition to only show if expanded and 
-                                the item has children */}
                                 {isExpanded && (
                                     <AccordionPanel {...styles.panel}>
                                         <ItemComponent


### PR DESCRIPTION
# Description

Nothing had to be done in this PR except for removing a comment about finalizing the solution when the API is updated. It looks like I had preemptively get the `itemsCountKey` to the new return value of `onlineSubCategoriesCount` so that once the API was released, it would just work, which it does. Below is a screen shot of the before and after of the API being updated. You can notice that menu items (like earrings) that don't have children were rendering a sub-menu ("shop all") when they aren't required to. 

Before:
<img width="239" alt="image" src="https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/494441ed-544d-4101-9d76-f22e3c967cc8">

After:
<img width="319" alt="image" src="https://github.com/SalesforceCommerceCloud/pwa-kit/assets/8902581/8d638387-aa0a-40c2-8c96-73bfee9fb130">


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Remove comment about updating code.
- 
# How to Test-Drive This PR

- Preview site, in mobile look at the womens/jewelry/earrings category
