### PR TITLE
@W-15725921@ Memoize server config

### DIFF
--- a/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
@@ -10,6 +10,8 @@ const SUPPORTED_FILE_TYPES = ['js', 'yml', 'yaml', 'json']
 
 const IS_REMOTE = Object.prototype.hasOwnProperty.call(process.env, 'AWS_LAMBDA_FUNCTION_NAME')
 
+let targetConfig
+
 /**
  * Returns the express app configuration file in object form. The file will be resolved in the
  * the following order:
@@ -36,10 +38,11 @@ const IS_REMOTE = Object.prototype.hasOwnProperty.call(process.env, 'AWS_LAMBDA_
  */
 /* istanbul ignore next */
 export const getConfig = (opts = {}) => {
+    if (targetConfig) return targetConfig
+
     const {buildDirectory} = opts
     const configDirBase = IS_REMOTE ? 'build' : ''
     let targetName = process?.env?.DEPLOY_TARGET || ''
-
     const targetSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/${targetName}.${ext}`)
     const localeSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/local.${ext}`)
     const defaultSearchPlaces = SUPPORTED_FILE_TYPES.map((ext) => `config/default.${ext}`)
@@ -85,5 +88,6 @@ export const getConfig = (opts = {}) => {
         )
     }
 
+    targetConfig = config
     return config
 }

--- a/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.server.js
@@ -10,7 +10,13 @@ const SUPPORTED_FILE_TYPES = ['js', 'yml', 'yaml', 'json']
 
 const IS_REMOTE = Object.prototype.hasOwnProperty.call(process.env, 'AWS_LAMBDA_FUNCTION_NAME')
 
-let targetConfig
+/**
+ * The implementation of getConfig below is expensive as it performs a file lookup.
+ *
+ * Since the environment config will not change unless the bundle is redeployed,
+ * this global variable helps prevent unnecessary file lookups when the server calls getConfig multiple times.
+ */
+let memoizedConfig
 
 /**
  * Returns the express app configuration file in object form. The file will be resolved in the
@@ -38,7 +44,7 @@ let targetConfig
  */
 /* istanbul ignore next */
 export const getConfig = (opts = {}) => {
-    if (targetConfig) return targetConfig
+    if (memoizedConfig) return memoizedConfig
 
     const {buildDirectory} = opts
     const configDirBase = IS_REMOTE ? 'build' : ''
@@ -88,6 +94,6 @@ export const getConfig = (opts = {}) => {
         )
     }
 
-    targetConfig = config
+    memoizedConfig = config
     return config
 }

--- a/packages/pwa-kit-runtime/src/utils/ssr-config.server.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-config.server.test.js
@@ -27,4 +27,28 @@ describe('Server "getConfig"', () => {
         process.env.AWS_LAMBDA_FUNCTION_NAME = ''
         expect(getConfig).toThrow()
     })
+
+    test('config is cached', () => {
+        const mockConfig = {
+            test: 'test'
+        }
+        const mockConfigSearch = jest.fn().mockReturnValue({
+            config: mockConfig
+        })
+        jest.doMock('cosmiconfig', () => {
+            const originalModule = jest.requireActual('cosmiconfig')
+
+            return {
+                ...originalModule,
+                cosmiconfigSync: () => ({
+                    search: mockConfigSearch
+                })
+            }
+        })
+        // Call getConfig multiple times
+        expect(getConfig()).toBe(mockConfig)
+        expect(getConfig()).toBe(mockConfig)
+
+        expect(mockConfigSearch).toHaveBeenCalledTimes(1)
+    })
 })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Whenever getConfig is called server-side, it performs a file system lookup, which is expensive. The environment config will not change unless the PWA bundle is redeployed so the config lookup is safe to memoize so that repeated calls do not result in repeated file system lookups.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Memoize getConfig server side

# How to Test-Drive This PR

- Modify the code so that you call getConfig multiple times serverside.
- Check that response times are not negatively impacted.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
