### PR TITLE
Fix e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -194,9 +194,6 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
 
-    needs: [run-generator-retail-app-ext]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
   run-generator-private-client:
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,9 +1,15 @@
 name: SalesforceCommerceCloud/pwa-kit/e2e
 on:
-  workflow_dispatch:
-  schedule:
-    # Run every day at 12am (PST) - cron uses UTC times
-    - cron: "0 8 * * *"
+  # PRs from forks trigger `pull_request`, but do NOT have access to secrets.
+  # More info:
+  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories-1
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  # https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
+  pull_request: # Default: opened, reopened, synchronize (head branch updated)
+  merge_group: # Trigger GA workflow when a pull request is added to a merge queue.
+  push:
+    branches:
+      - develop
 
 jobs:
   run-generator-demo:
@@ -118,35 +124,8 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
-  notify-slack-pwa-no-ext:
-    needs: [run-generator-retail-app-no-ext]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-success
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-no-ext.result == 'success' }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "✅ All PWA Kit no-ext E2E tests passed!"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-failure
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-no-ext.result != 'success'  }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "❌ One or more PWA Kit no-ext E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  run-generator-retail-app-ext:
+run-generator-retail-app-ext:
     # Run after the previous job completes irrespective of its result
     if: ${{ always() }}
     needs: [run-generator-retail-app-no-ext]
@@ -216,35 +195,11 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
 
-  notify-slack-pwa-ext:
     needs: [run-generator-retail-app-ext]
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-success
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-ext.result == 'success' }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "✅ All PWA Kit ext E2E tests passed!"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-failure
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-ext.result != 'success'  }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "❌ One or more PWA Kit ext E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-  run-generator-private-client:
+run-generator-private-client:
     strategy:
       fail-fast: false
       # Run one matrix env at a time because we need to deploy each app to MRT and run e2e tests there
@@ -308,32 +263,3 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
-
-  notify-slack-pwa-private-client:
-    needs: [run-generator-private-client]
-    if: ${{ always() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-success
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-private-client.result == 'success' }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "✅ All PWA Kit Private Client E2E tests passed!"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Send GitHub Action data to Slack workflow (Generated)
-        id: slack-failure
-        if: ${{ github.event_name == 'schedule' && needs.run-generator-private-client.result != 'success'  }}
-        uses: slackapi/slack-github-action@v1.23.0
-        with:
-          payload: |
-            {
-              "message": "❌ One or more PWA Kit Private Client E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,15 +1,9 @@
 name: SalesforceCommerceCloud/pwa-kit/e2e
 on:
-  # PRs from forks trigger `pull_request`, but do NOT have access to secrets.
-  # More info:
-  # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories-1
-  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-  # https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
-  pull_request: # Default: opened, reopened, synchronize (head branch updated)
-  merge_group: # Trigger GA workflow when a pull request is added to a merge queue.
-  push:
-    branches:
-      - '**'
+  workflow_dispatch:
+  schedule:
+    # Run every day at 12am (PST) - cron uses UTC times
+    - cron: "0 8 * * *"
 
 jobs:
   run-generator-demo:
@@ -124,6 +118,34 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
+  notify-slack-pwa-no-ext:
+    needs: [run-generator-retail-app-no-ext]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-success
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-no-ext.result == 'success' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "✅ All PWA Kit no-ext E2E tests passed!"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-failure
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-no-ext.result != 'success'  }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "❌ One or more PWA Kit no-ext E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   run-generator-retail-app-ext:
     # Run after the previous job completes irrespective of its result
     if: ${{ always() }}
@@ -194,6 +216,34 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
 
+  notify-slack-pwa-ext:
+    needs: [run-generator-retail-app-ext]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-success
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-ext.result == 'success' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "✅ All PWA Kit ext E2E tests passed!"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-failure
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-retail-app-ext.result != 'success'  }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "❌ One or more PWA Kit ext E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
   run-generator-private-client:
     strategy:
       fail-fast: false
@@ -258,3 +308,32 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
+
+  notify-slack-pwa-private-client:
+    needs: [run-generator-private-client]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-success
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-private-client.result == 'success' }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "✅ All PWA Kit Private Client E2E tests passed!"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - name: Send GitHub Action data to Slack workflow (Generated)
+        id: slack-failure
+        if: ${{ github.event_name == 'schedule' && needs.run-generator-private-client.result != 'success'  }}
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "message": "❌ One or more PWA Kit Private Client E2E tests failed! (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
   merge_group: # Trigger GA workflow when a pull request is added to a merge queue.
   push:
     branches:
-      - develop
+      - '**'
 
 jobs:
   run-generator-demo:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -124,8 +124,7 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
-
-run-generator-retail-app-ext:
+  run-generator-retail-app-ext:
     # Run after the previous job completes irrespective of its result
     if: ${{ always() }}
     needs: [run-generator-retail-app-no-ext]
@@ -198,8 +197,7 @@ run-generator-retail-app-ext:
     needs: [run-generator-retail-app-ext]
     if: ${{ always() }}
     runs-on: ubuntu-latest
-
-run-generator-private-client:
+  run-generator-private-client:
     strategy:
       fail-fast: false
       # Run one matrix env at a time because we need to deploy each app to MRT and run e2e tests there

--- a/e2e/scripts/execute-shell-commands.js
+++ b/e2e/scripts/execute-shell-commands.js
@@ -15,14 +15,9 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     if (cliResponses && cliResponses.length) {
       ({ expectedPrompt, response } = cliResponses.shift());
     }
-    let isGenratorRunning = false;
 
     child.stdout.on("data", (data) => {
       console.log(data);
-      if (isPrompt(data, /Running the generator/i)) {
-        isGenratorRunning = true;
-        return;
-      }
       if (isPrompt(data, expectedPrompt)) {
         child.stdin.write(response);
         if (cliResponses.length > 0) {
@@ -32,12 +27,7 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     });
 
     child.stderr.on("data", (err) => {
-      // Lerna warnings are also seen as errors but we want to continue in those cases
-      // We exit the process if something breaks after the generator is actually running.
-      // if (isGenratorRunning) {
-      //   console.error(err);
-      //   reject(err);
-      // }
+      console.error(err);
     });
 
     child.on("error", (code) => {

--- a/e2e/scripts/execute-shell-commands.js
+++ b/e2e/scripts/execute-shell-commands.js
@@ -39,10 +39,10 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
       console.log(err);
       // Lerna warnings are also seen as errors but we want to continue in those cases
       // We exit the process if something breaks after the generator is actually running.
-      if (isGenratorRunning) {
-        console.error(err);
-        reject(err);
-      }
+      // if (isGenratorRunning) {
+      //   console.error(err);
+      //   reject(err);
+      // }
     });
 
     child.on("error", (code) => {

--- a/e2e/scripts/execute-shell-commands.js
+++ b/e2e/scripts/execute-shell-commands.js
@@ -9,8 +9,10 @@ const { exec } = require("child_process");
 const { isPrompt } = require("./utils.js");
 
 const runGeneratorWithResponses = (cmd, cliResponses = []) => {
+  console.log("runGeneratorWithResponses");
   const child = exec(cmd);
   return new Promise((resolve, reject) => {
+    console.log("promise");
     let expectedPrompt, response;
     if (cliResponses && cliResponses.length) {
       ({ expectedPrompt, response } = cliResponses.shift());
@@ -18,6 +20,7 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     let isGenratorRunning = false;
 
     child.stdout.on("data", (data) => {
+      console.log("data");
       console.log(data);
       if (isPrompt(data, /Running the generator/i)) {
         isGenratorRunning = true;
@@ -32,6 +35,8 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     });
 
     child.stderr.on("data", (err) => {
+      console.log("error");
+      console.log(err);
       // Lerna warnings are also seen as errors but we want to continue in those cases
       // We exit the process if something breaks after the generator is actually running.
       if (isGenratorRunning) {

--- a/e2e/scripts/execute-shell-commands.js
+++ b/e2e/scripts/execute-shell-commands.js
@@ -9,10 +9,8 @@ const { exec } = require("child_process");
 const { isPrompt } = require("./utils.js");
 
 const runGeneratorWithResponses = (cmd, cliResponses = []) => {
-  console.log("runGeneratorWithResponses");
   const child = exec(cmd);
   return new Promise((resolve, reject) => {
-    console.log("promise");
     let expectedPrompt, response;
     if (cliResponses && cliResponses.length) {
       ({ expectedPrompt, response } = cliResponses.shift());
@@ -20,8 +18,6 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     let isGenratorRunning = false;
 
     child.stdout.on("data", (data) => {
-      console.log("data");
-      console.log(data);
       if (isPrompt(data, /Running the generator/i)) {
         isGenratorRunning = true;
         return;
@@ -35,8 +31,6 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     });
 
     child.stderr.on("data", (err) => {
-      console.log("error");
-      console.log(err);
       // Lerna warnings are also seen as errors but we want to continue in those cases
       // We exit the process if something breaks after the generator is actually running.
       // if (isGenratorRunning) {

--- a/e2e/scripts/execute-shell-commands.js
+++ b/e2e/scripts/execute-shell-commands.js
@@ -18,6 +18,7 @@ const runGeneratorWithResponses = (cmd, cliResponses = []) => {
     let isGenratorRunning = false;
 
     child.stdout.on("data", (data) => {
+      console.log(data);
       if (isPrompt(data, /Running the generator/i)) {
         isGenratorRunning = true;
         return;


### PR DESCRIPTION
E2E tests was failing due to `npm` outputs warning logs to `stderr`, we previously rejects any stderr logs.

It is weird that npm outputs warnings to stderr, some people have also complaint this behavior https://github.com/npm/cli/issues/4989

![CleanShot 2024-05-28 at 23 12 32](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/10948652/eb7dc59a-e89c-405f-9b92-134b08a12b39)

## Solution

Remove the promise.reject when encounter `stderr` logs. We already listen to child_process on error event so it should be sufficient.