### PR TITLE
Hide x-sfdc-access-control header

### DIFF
--- a/packages/pwa-kit-runtime/src/utils/ssr-proxying.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-proxying.js
@@ -683,7 +683,7 @@ export const rewriteProxyResponseHeaders = ({
  * @private
  * @type {string[]}
  */
-export const X_HEADERS_TO_REMOVE_PROXY = ['x-mobify-access-key']
+export const X_HEADERS_TO_REMOVE_PROXY = ['x-mobify-access-key', 'x-sfdc-access-control']
 
 /**
  * List of x- headers that are removed from origin requests.
@@ -694,7 +694,8 @@ export const X_HEADERS_TO_REMOVE_ORIGIN = [
     'x-api-key',
     'x-apigateway-event',
     'x-apigateway-context',
-    'x-mobify-access-key'
+    'x-mobify-access-key',
+    'x-sfdc-access-control'
 ]
 
 /**

--- a/packages/pwa-kit-runtime/src/utils/ssr-proxying.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-proxying.test.js
@@ -584,7 +584,8 @@ describe('rewriteProxyRequestHeaders tests', () => {
                 'x-api-key': '1234567890',
                 'x-mobify-access-key': 'abcdefghijk',
                 'x-apigateway-event': '{}',
-                'x-apigateway-context': '{}'
+                'x-apigateway-context': '{}',
+                'x-sfdc-access-control': '123456789'
             },
             expected: {
                 'accept-encoding': 'deflate, gzip',
@@ -592,7 +593,8 @@ describe('rewriteProxyRequestHeaders tests', () => {
                 'x-api-key': '1234567890',
                 'x-mobify-access-key': undefined,
                 'x-apigateway-event': '{}',
-                'x-apigateway-context': '{}'
+                'x-apigateway-context': '{}',
+                'x-sfdc-access-control': undefined
             }
         },
         {


### PR DESCRIPTION
Hide the secret `x-sfdc-access-control` header value from the SSR server and proxied requests.

# Description

MRT is releasing an origin lockdown feature that locks down the MRT origin only to authorized services (i.e. a stacked CDN). An incoming HTTP request will contain the header `x-sfdc-access-control: <some-secret-value>` that MRT will verify.
To avoid this secret value from being leaked, this PR strips the header from the SSR origin server and proxied requests.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Remove the header value from proxied requests
- Remove the header value from the SSR origin request

# How to Test-Drive This PR

- Upload and deploy a bundle with these changes
- Make a request to a proxy, and verify the proxy does not receive the header (can proxy back to the same storefront for ease)
- Make a request to the SSR server, and verify the ssr code does not receive the header (can confirm through logs)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
