### PR TITLE
@W-12627171@ Add explicit headers to cart modal

### DIFF
--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -145,7 +145,13 @@ export const AddToCartModal = () => {
                                             </Box>
 
                                             <Box>
-                                                <Heading as="h2" fontSize="16px" fontWeight="semibold">{product.name}</Heading>
+                                                <Heading
+                                                    as="h2"
+                                                    fontSize="16px"
+                                                    fontWeight="semibold"
+                                                >
+                                                    {product.name}
+                                                </Heading>
                                                 <Box
                                                     color="gray.600"
                                                     fontSize="sm"

--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -85,7 +85,7 @@ export const AddToCartModal = () => {
                 containerProps={{'data-testid': 'add-to-cart-modal'}}
             >
                 <ModalHeader paddingY="8" bgColor="white">
-                    <Heading as="h1" fontSize="24px">
+                    <Heading as="h1" fontSize="2xl">
                         {intl.formatMessage(
                             {
                                 defaultMessage:
@@ -147,8 +147,9 @@ export const AddToCartModal = () => {
                                             <Box>
                                                 <Heading
                                                     as="h2"
-                                                    fontSize="16px"
-                                                    fontWeight="semibold"
+                                                    fontSize="md"
+                                                    fontFamily="body"
+                                                    fontWeight="700"
                                                 >
                                                     {product.name}
                                                 </Heading>

--- a/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-add-to-cart-modal.js
@@ -13,6 +13,7 @@ import {
     Box,
     Button,
     Flex,
+    Heading,
     Text,
     Modal,
     ModalHeader,
@@ -83,15 +84,17 @@ export const AddToCartModal = () => {
                 bgColor="gray.50"
                 containerProps={{'data-testid': 'add-to-cart-modal'}}
             >
-                <ModalHeader paddingY="8" bgColor="white" fontSize="2xl" fontWeight="700">
-                    {intl.formatMessage(
-                        {
-                            defaultMessage:
-                                '{quantity} {quantity, plural, one {item} other {items}} added to cart',
-                            id: 'add_to_cart_modal.info.added_to_cart'
-                        },
-                        {quantity: numerOfItemsAdded}
-                    )}
+                <ModalHeader paddingY="8" bgColor="white">
+                    <Heading as="h1" fontSize="24px">
+                        {intl.formatMessage(
+                            {
+                                defaultMessage:
+                                    '{quantity} {quantity, plural, one {item} other {items}} added to cart',
+                                id: 'add_to_cart_modal.info.added_to_cart'
+                            },
+                            {quantity: numerOfItemsAdded}
+                        )}
+                    </Heading>
                 </ModalHeader>
                 <ModalCloseButton />
                 <ModalBody bgColor="white" padding="0" marginBottom={{base: 40, lg: 0}}>
@@ -142,7 +145,7 @@ export const AddToCartModal = () => {
                                             </Box>
 
                                             <Box>
-                                                <Text fontWeight="700">{product.name}</Text>
+                                                <Heading as="h2" fontSize="16px" fontWeight="semibold">{product.name}</Heading>
                                                 <Box
                                                     color="gray.600"
                                                     fontSize="sm"


### PR DESCRIPTION
Adds an explicit H1 to the AddToCart modal's **X items added** header.
Replaces the p tag on the AddToCart modal's product name with an H2

Note:
On my mac, my screen reader is unable to focus on either header.

Testing this change:
Start the app
Add something to cart
In the add to cart modal:
* Verify **X items added** is wrapped in a H1
* Verify the product name is wrapped in an H2

At the root of the project, run `npx playwright test` and verify the e2e tests passes.

Compare the styling of the Add To Cart modal from before & after the change. They should look very similar.