### PR TITLE
@W-15752101: Tests for variant prices in PLP

### DIFF
--- a/packages/template-retail-react-app/app/components/item-variant/index.test.js
+++ b/packages/template-retail-react-app/app/components/item-variant/index.test.js
@@ -40,7 +40,7 @@ MockedComponent.propTypes = {
 describe('ItemPrice', function () {
     test('should display basket prices if variant is for cart page on mobile', () => {
         useMediaQuery.mockReturnValue([false])
-        const {getByText, container, getAllByText} = renderWithProviders(
+        const {getByText, getAllByText} = renderWithProviders(
             <MockedComponent variant={cartVariant} />
         )
         // current price
@@ -54,7 +54,7 @@ describe('ItemPrice', function () {
 
     test('should display basket prices if variant is for cart page on desktop', () => {
         useMediaQuery.mockReturnValue([true])
-        const {getByText, container, getAllByText} = renderWithProviders(
+        const {getByText, getAllByText} = renderWithProviders(
             <MockedComponent variant={cartVariant} />
         )
         // price per item

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -15,6 +15,17 @@ import {
     mockProductSetHit,
     mockStandardProductHit
 } from '@salesforce/retail-react-app/app/mocks/product-search-hit-data'
+import {useBreakpointValue} from '@salesforce/retail-react-app/app/components/shared/ui'
+
+jest.mock('@salesforce/retail-react-app/app/components/shared/ui', () => {
+    const originalModule = jest.requireActual(
+        '@salesforce/retail-react-app/app/components/shared/ui'
+    )
+    return {
+        ...originalModule,
+        useBreakpointValue: jest.fn()
+    }
+})
 
 test('Renders links and images', () => {
     const {getAllByRole} = renderWithProviders(<ProductTile product={mockProductSearchItem} />)
@@ -52,6 +63,8 @@ test('Remove from wishlist cannot be muti-clicked', () => {
 })
 
 test('Renders variant details based on the selected swatch', async () => {
+    useBreakpointValue.mockReturnValue(true)
+
     const {getAllByRole, getByTestId} = renderWithProviders(
         <ProductTile product={mockProductSearchItem} />
     )
@@ -72,8 +85,8 @@ test('Renders variant details based on the selected swatch', async () => {
     expect(within(strikethroughPriceTag[0]).getByText(/£320\.00/i)).toBeDefined()
 
     // Navigating to different color swatch changes the image & price.
-    const swatchGroup = screen.getByRole('radiogroup').parentNode
-    fireEvent.keyDown(swatchGroup, {key: 'ArrowLeft', code: 'ArrowRight', charCode: 37})
+    // Default selected swatch is swatches[1] as it is the represented product.
+    fireEvent.mouseOver(swatches[0])
     await waitFor(() => screen.getByTestId('product-tile-image'))
     expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw29b7f226/images/large/PG.52002RUBN4Q.NAVYWL.PZ.jpg'
@@ -85,8 +98,10 @@ test('Renders variant details based on the selected swatch', async () => {
     expect(screen.getByTestId('promo-callout')).toBeInTheDocument()
 })
 
-test('Renders price range with starting price and strikethrough price for master product with multiple variants', async () => {
-    const {getByText, getByTestId, container} = renderWithProviders(
+test.only('Renders price range with starting price and strikethrough price for master product with multiple variants', async () => {
+    useBreakpointValue.mockReturnValue(true)
+
+    const {getByText, getByTestId, getAllByRole, container} = renderWithProviders(
         <ProductTile product={mockMasterProductHitWithMultipleVariants} />
     )
     expect(getByText(/Long Sleeve Embellished Boat Neck Top/i)).toBeInTheDocument()
@@ -104,8 +119,9 @@ test('Renders price range with starting price and strikethrough price for master
     expect(within(strikethroughPriceTag[0]).getByText(/£31\.36/i)).toBeDefined()
 
     // Navigating to different color swatch changes the image but keeps the same price range.
-    const swatchGroup = screen.getByRole('radiogroup').parentNode
-    fireEvent.keyDown(swatchGroup, {key: 'ArrowLeft', code: 'ArrowRight', charCode: 37})
+    const swatches = getAllByRole('radio')
+    // Default selected swatch is swatches[1] as it is the represented product.
+    fireEvent.mouseOver(swatches[0])
     await waitFor(() => screen.getByTestId('product-tile-image'))
     expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg'

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -98,6 +98,42 @@ test('Renders variant details based on the selected swatch', async () => {
     expect(screen.getByTestId('promo-callout')).toBeInTheDocument()
 })
 
+test('Renders variant details based on the selected swatch on mobile', async () => {
+    useBreakpointValue.mockReturnValue(false)
+
+    const {getAllByRole, getByTestId} = renderWithProviders(
+        <ProductTile product={mockProductSearchItem} />
+    )
+    const swatches = getAllByRole('radio')
+    const productImage = getByTestId('product-tile-image')
+    const productTile = getByTestId('product-tile')
+
+    // Initial render will show swatched and the image will be the represented product variation
+    expect(swatches).toHaveLength(2)
+    expect(productImage.firstChild.getAttribute('src')).toBe(
+        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw175c1a89/images/large/PG.33698RUBN4Q.CHARCWL.PZ.jpg'
+    )
+    const currentPriceTag = productTile.querySelectorAll('b')
+    const strikethroughPriceTag = productTile.querySelectorAll('s')
+    expect(currentPriceTag).toHaveLength(1)
+    expect(within(currentPriceTag[0]).getByText(/£191\.99/i)).toBeDefined()
+    expect(strikethroughPriceTag).toHaveLength(1)
+    expect(within(strikethroughPriceTag[0]).getByText(/£320\.00/i)).toBeDefined()
+
+    // Navigating to different color swatch changes the image & price.
+    // Default selected swatch is swatches[1] as it is the represented product.
+    fireEvent.click(swatches[0])
+    await waitFor(() => screen.getByTestId('product-tile-image'))
+    expect(productImage.firstChild.getAttribute('src')).toBe(
+        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw29b7f226/images/large/PG.52002RUBN4Q.NAVYWL.PZ.jpg'
+    )
+    expect(currentPriceTag).toHaveLength(1)
+    expect(within(currentPriceTag[0]).getByText(/£143\.99/i)).toBeDefined()
+    expect(strikethroughPriceTag).toHaveLength(1)
+    expect(within(strikethroughPriceTag[0]).getByText(/£320\.00/i)).toBeDefined()
+    expect(screen.getByTestId('promo-callout')).toBeInTheDocument()
+})
+
 test('Renders price range with starting price and strikethrough price for master product with multiple variants', async () => {
     useBreakpointValue.mockReturnValue(true)
 

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -98,7 +98,7 @@ test('Renders variant details based on the selected swatch', async () => {
     expect(screen.getByTestId('promo-callout')).toBeInTheDocument()
 })
 
-test.only('Renders price range with starting price and strikethrough price for master product with multiple variants', async () => {
+test('Renders price range with starting price and strikethrough price for master product with multiple variants', async () => {
     useBreakpointValue.mockReturnValue(true)
 
     const {getByText, getByTestId, getAllByRole, container} = renderWithProviders(

--- a/packages/template-retail-react-app/app/components/product-tile/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-tile/index.test.js
@@ -57,15 +57,15 @@ test('Renders variant details based on the selected swatch', async () => {
     )
     const swatches = getAllByRole('radio')
     const productImage = getByTestId('product-tile-image')
-    let productTile = getByTestId('product-tile')
+    const productTile = getByTestId('product-tile')
 
     // Initial render will show swatched and the image will be the represented product variation
     expect(swatches).toHaveLength(2)
     expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw175c1a89/images/large/PG.33698RUBN4Q.CHARCWL.PZ.jpg'
     )
-    let currentPriceTag = productTile.querySelectorAll('b')
-    let strikethroughPriceTag = productTile.querySelectorAll('s')
+    const currentPriceTag = productTile.querySelectorAll('b')
+    const strikethroughPriceTag = productTile.querySelectorAll('s')
     expect(currentPriceTag).toHaveLength(1)
     expect(within(currentPriceTag[0]).getByText(/£191\.99/i)).toBeDefined()
     expect(strikethroughPriceTag).toHaveLength(1)
@@ -75,12 +75,9 @@ test('Renders variant details based on the selected swatch', async () => {
     const swatchGroup = screen.getByRole('radiogroup').parentNode
     fireEvent.keyDown(swatchGroup, {key: 'ArrowLeft', code: 'ArrowRight', charCode: 37})
     await waitFor(() => screen.getByTestId('product-tile-image'))
-    expect(screen.getByTestId('product-tile-image').firstChild.getAttribute('src')).toBe(
+    expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw29b7f226/images/large/PG.52002RUBN4Q.NAVYWL.PZ.jpg'
     )
-    productTile = screen.getByTestId('product-tile')
-    currentPriceTag = productTile.querySelectorAll('b')
-    strikethroughPriceTag = productTile.querySelectorAll('s')
     expect(currentPriceTag).toHaveLength(1)
     expect(within(currentPriceTag[0]).getByText(/£143\.99/i)).toBeDefined()
     expect(strikethroughPriceTag).toHaveLength(1)
@@ -93,7 +90,8 @@ test('Renders price range with starting price and strikethrough price for master
         <ProductTile product={mockMasterProductHitWithMultipleVariants} />
     )
     expect(getByText(/Long Sleeve Embellished Boat Neck Top/i)).toBeInTheDocument()
-    expect(getByTestId('product-tile-image').firstChild.getAttribute('src')).toBe(
+    const productImage = getByTestId('product-tile-image')
+    expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw3255ea4c/images/large/PG.10217069.JJ908XX.PZ.jpg'
     )
 
@@ -109,7 +107,7 @@ test('Renders price range with starting price and strikethrough price for master
     const swatchGroup = screen.getByRole('radiogroup').parentNode
     fireEvent.keyDown(swatchGroup, {key: 'ArrowLeft', code: 'ArrowRight', charCode: 37})
     await waitFor(() => screen.getByTestId('product-tile-image'))
-    expect(screen.getByTestId('product-tile-image').firstChild.getAttribute('src')).toBe(
+    expect(productImage.firstChild.getAttribute('src')).toBe(
         'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg'
     )
     expect(currentPriceTag).toHaveLength(1)

--- a/packages/template-retail-react-app/app/mocks/product-search-hit-data.js
+++ b/packages/template-retail-react-app/app/mocks/product-search-hit-data.js
@@ -348,7 +348,14 @@ const mockProductSearchItem = {
         }
     ],
     price: 299.99,
+    productId: '25686571M',
     productName: 'Charcoal Single Pleat Wool Suit',
+    productPromotions: [
+        {
+            calloutMsg: '25% off.',
+            promotionId: 'PromotionTest'
+        }
+    ],
     representedProduct: {
         id: '750518894461M'
     },
@@ -377,6 +384,13 @@ const mockProductSearchItem = {
         {
             price: 191.99,
             productId: '750518548272M',
+            productPromotions: [
+                {
+                    calloutMsg: '25% off.',
+                    promotionalPrice: 143.99,
+                    promotionId: 'PromotionTest'
+                }
+            ],
             tieredPrices: [
                 {
                     price: 320,
@@ -690,430 +704,631 @@ const mockMasterProductHitWithMultipleVariants = {
     currency: 'GBP',
     hitType: 'master',
     image: {
-        alt: 'Black Single Pleat Athletic Fit Wool Suit - Edit, , large',
+        alt: 'Long Sleeve Embellished Boat Neck Top, , large',
         disBaseLink:
-            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw5d64302b/images/large/PG.52001RUBN4Q.BLACKFB.PZ.jpg',
-        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw5d64302b/images/large/PG.52001RUBN4Q.BLACKFB.PZ.jpg',
-        title: 'Black Single Pleat Athletic Fit Wool Suit - Edit, '
+            'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+        link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+        title: 'Long Sleeve Embellished Boat Neck Top, '
     },
+    imageGroups: [
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwb2647cff/images/large/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwb2647cff/images/large/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                }
+            ],
+            viewType: 'large'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw7e4c00a0/images/large/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwb2647cff/images/large/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwb2647cff/images/large/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ5QZXX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'large'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw3255ea4c/images/large/PG.10217069.JJ908XX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw3255ea4c/images/large/PG.10217069.JJ908XX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, large',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw92f1b900/images/large/PG.10217069.JJ908XX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw92f1b900/images/large/PG.10217069.JJ908XX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ908XX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'large'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwed56b2da/images/medium/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwed56b2da/images/medium/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwead6d554/images/medium/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwead6d554/images/medium/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                }
+            ],
+            viewType: 'medium'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwed56b2da/images/medium/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwed56b2da/images/medium/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwead6d554/images/medium/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwead6d554/images/medium/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ5QZXX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'medium'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc9ce7da9/images/medium/PG.10217069.JJ908XX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc9ce7da9/images/medium/PG.10217069.JJ908XX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, medium',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw6b734040/images/medium/PG.10217069.JJ908XX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw6b734040/images/medium/PG.10217069.JJ908XX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ908XX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'medium'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwd4b35477/images/small/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwd4b35477/images/small/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, , small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc6e78825/images/small/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc6e78825/images/small/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, '
+                }
+            ],
+            viewType: 'small'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwd4b35477/images/small/PG.10217069.JJ5QZXX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwd4b35477/images/small/PG.10217069.JJ5QZXX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc6e78825/images/small/PG.10217069.JJ5QZXX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwc6e78825/images/small/PG.10217069.JJ5QZXX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ5QZXX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'small'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1d27b20/images/small/PG.10217069.JJ908XX.PZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe1d27b20/images/small/PG.10217069.JJ908XX.PZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                },
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, small',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe6f3f097/images/small/PG.10217069.JJ908XX.BZ.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dwe6f3f097/images/small/PG.10217069.JJ908XX.BZ.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ908XX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'small'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink, swatch',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2b23d065/images/swatch/PG.10217069.JJ5QZXX.CP.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw2b23d065/images/swatch/PG.10217069.JJ5QZXX.CP.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Begonia Pink'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ5QZXX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'swatch'
+        },
+        {
+            images: [
+                {
+                    alt: 'Long Sleeve Embellished Boat Neck Top, Grey Heather, swatch',
+                    disBaseLink:
+                        'https://edge.disstg.commercecloud.salesforce.com/dw/image/v2/ZZRF_001/on/demandware.static/-/Sites-apparel-m-catalog/default/dw747c5f3e/images/swatch/PG.10217069.JJ908XX.CP.jpg',
+                    link: 'https://zzrf-001.dx.commercecloud.salesforce.com/on/demandware.static/-/Sites-apparel-m-catalog/default/dw747c5f3e/images/swatch/PG.10217069.JJ908XX.CP.jpg',
+                    title: 'Long Sleeve Embellished Boat Neck Top, Grey Heather'
+                }
+            ],
+            variationAttributes: [
+                {
+                    id: 'color',
+                    values: [
+                        {
+                            value: 'JJ908XX'
+                        }
+                    ]
+                }
+            ],
+            viewType: 'swatch'
+        }
+    ],
     orderable: true,
-    price: 191.99,
-    pricePerUnit: 191.99,
+    price: 18.55,
+    pricePerUnit: 18.55,
     priceRanges: [
         {
-            maxPrice: 320,
-            minPrice: 191.99,
+            maxPrice: 31.36,
+            minPrice: 31.36,
             pricebook: 'gbp-m-list-prices'
         },
         {
-            maxPrice: 191.99,
-            minPrice: 191.99,
+            maxPrice: 18.55,
+            minPrice: 18.55,
             pricebook: 'gbp-m-sale-prices'
         }
     ],
-    productId: '25604524M',
-    productName: 'Black Single Pleat Athletic Fit Wool Suit - Edit',
+    productId: '25518101M',
+    productName: 'Long Sleeve Embellished Boat Neck Top',
+    productPromotions: [
+        {
+            calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+            promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+        },
+        {
+            calloutMsg: '$50 Fixed Products Amount Above 100',
+            promotionId: '$50FixedProductsAmountAbove100'
+        },
+        {
+            calloutMsg: 'Bonus Product for Order Amounts Above 250',
+            promotionId: 'BonusProductOnOrderOfAmountABove250'
+        }
+    ],
     productType: {
         master: true
     },
     representedProduct: {
-        id: '750518699660M'
+        id: '701642823919M'
     },
+    representedProducts: [
+        {
+            id: '701642823919M'
+        },
+        {
+            id: '701642823872M'
+        },
+        {
+            id: '701642823926M'
+        },
+        {
+            id: '701642823940M'
+        },
+        {
+            id: '701642823902M'
+        },
+        {
+            id: '701642823933M'
+        },
+        {
+            id: '701642823889M'
+        },
+        {
+            id: '701642823896M'
+        }
+    ],
     variants: [
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699660M',
+            price: 18.55,
+            productId: '701642823919M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 223.99,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '050',
-                width: 'V'
+                color: 'JJ908XX',
+                size: '9LG'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699585M',
+            price: 18.55,
+            productId: '701642823872M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 320,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '039',
-                width: 'V'
+                color: 'JJ5QZXX',
+                size: '9LG'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699653M',
+            price: 18.55,
+            productId: '701642823926M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 191.99,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '048',
-                width: 'V'
+                color: 'JJ908XX',
+                size: '9MD'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699615M',
+            price: 18.55,
+            productId: '701642823940M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 320,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '042',
-                width: 'V'
+                color: 'JJ908XX',
+                size: '9XL'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699608M',
+            price: 18.55,
+            productId: '701642823902M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 320,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '041',
-                width: 'V'
+                color: 'JJ5QZXX',
+                size: '9XL'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699646M',
+            price: 18.55,
+            productId: '701642823933M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 191.99,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '046',
-                width: 'V'
+                color: 'JJ908XX',
+                size: '9SM'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699592M',
+            price: 18.55,
+            productId: '701642823889M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 320,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '040',
-                width: 'V'
+                color: 'JJ5QZXX',
+                size: '9MD'
             }
         },
         {
             orderable: true,
-            price: 191.99,
-            productId: '750518699622M',
+            price: 18.55,
+            productId: '701642823896M',
+            productPromotions: [
+                {
+                    calloutMsg: 'Buy one Long Center Seam Skirt and get 2 tops',
+                    promotionId: 'ChoiceOfBonusProdect-ProductLevel-ruleBased'
+                },
+                {
+                    calloutMsg: '$50 Fixed Products Amount Above 100',
+                    promotionId: '$50FixedProductsAmountAbove100'
+                },
+                {
+                    calloutMsg: 'Bonus Product for Order Amounts Above 250',
+                    promotionId: 'BonusProductOnOrderOfAmountABove250'
+                }
+            ],
             tieredPrices: [
                 {
-                    price: 320,
+                    price: 31.36,
                     pricebook: 'gbp-m-list-prices',
                     quantity: 1
                 },
                 {
-                    price: 191.99,
+                    price: 18.55,
                     pricebook: 'gbp-m-sale-prices',
                     quantity: 1
                 }
             ],
             variationValues: {
-                color: 'BLACKFB',
-                size: '043',
-                width: 'V'
-            }
-        },
-        {
-            orderable: false,
-            price: 191.99,
-            productId: '750518699578M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '038',
-                width: 'V'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699875M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '046',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699868M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '044',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699820M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '040',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699882M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '048',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699851M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '043',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699844M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '042',
-                width: 'L'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699769M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '044',
-                width: 'S'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699721M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '040',
-                width: 'S'
-            }
-        },
-        {
-            orderable: true,
-            price: 191.99,
-            productId: '750518699745M',
-            tieredPrices: [
-                {
-                    price: 320,
-                    pricebook: 'gbp-m-list-prices',
-                    quantity: 1
-                },
-                {
-                    price: 191.99,
-                    pricebook: 'gbp-m-sale-prices',
-                    quantity: 1
-                }
-            ],
-            variationValues: {
-                color: 'BLACKFB',
-                size: '042',
-                width: 'S'
+                color: 'JJ5QZXX',
+                size: '9SM'
             }
         }
     ],
@@ -1123,9 +1338,14 @@ const mockMasterProductHitWithMultipleVariants = {
             name: 'Colour',
             values: [
                 {
-                    name: 'Black',
+                    name: 'Begonia Pink',
                     orderable: true,
-                    value: 'BLACKFB'
+                    value: 'JJ5QZXX'
+                },
+                {
+                    name: 'Grey Heather',
+                    orderable: true,
+                    value: 'JJ908XX'
                 }
             ]
         },
@@ -1134,75 +1354,24 @@ const mockMasterProductHitWithMultipleVariants = {
             name: 'Size',
             values: [
                 {
-                    name: '38',
-                    orderable: false,
-                    value: '038'
+                    name: 'S',
+                    orderable: true,
+                    value: '9SM'
                 },
                 {
-                    name: '39',
+                    name: 'M',
                     orderable: true,
-                    value: '039'
+                    value: '9MD'
                 },
                 {
-                    name: '40',
+                    name: 'L',
                     orderable: true,
-                    value: '040'
+                    value: '9LG'
                 },
                 {
-                    name: '41',
+                    name: 'XL',
                     orderable: true,
-                    value: '041'
-                },
-                {
-                    name: '42',
-                    orderable: true,
-                    value: '042'
-                },
-                {
-                    name: '43',
-                    orderable: true,
-                    value: '043'
-                },
-                {
-                    name: '44',
-                    orderable: true,
-                    value: '044'
-                },
-                {
-                    name: '46',
-                    orderable: true,
-                    value: '046'
-                },
-                {
-                    name: '48',
-                    orderable: true,
-                    value: '048'
-                },
-                {
-                    name: '50',
-                    orderable: true,
-                    value: '050'
-                }
-            ]
-        },
-        {
-            id: 'width',
-            name: 'Width',
-            values: [
-                {
-                    name: 'Short',
-                    orderable: true,
-                    value: 'S'
-                },
-                {
-                    name: 'Regular',
-                    orderable: true,
-                    value: 'V'
-                },
-                {
-                    name: 'Long',
-                    orderable: true,
-                    value: 'L'
+                    value: '9XL'
                 }
             ]
         }

--- a/packages/template-retail-react-app/app/utils/product-utils.js
+++ b/packages/template-retail-react-app/app/utils/product-utils.js
@@ -173,7 +173,7 @@ export const findLowestPrice = (product) => {
 
     // Look at all of the variants, only if it's a master product.
     // i.e. when a shopper has narrowed down to a variant, do not look into other variants
-    const isMaster = product.productType?.master || product.type?.master
+    const isMaster = product.hitType === 'master' || !!product.type?.master
     if (isMaster && !product.variants) {
         console.warn(
             'Expecting `product.variants` to exist. For more accuracy, please tweak your API request to ask for the variants details.'

--- a/packages/template-retail-react-app/app/utils/product-utils.test.js
+++ b/packages/template-retail-react-app/app/utils/product-utils.test.js
@@ -791,15 +791,15 @@ describe('getPriceData', function () {
     test('returns price data for master product that has more than one variant', () => {
         const priceData = getPriceData(mockMasterProductHitWithMultipleVariants)
         expect(priceData).toEqual({
-            currentPrice: 191.99,
-            listPrice: 223.99,
-            pricePerUnit: 191.99,
+            currentPrice: 18.55,
+            listPrice: 31.36,
+            pricePerUnit: 18.55,
             isOnSale: true,
             isASet: false,
             isMaster: true,
             isRange: true,
-            tieredPrice: 223.99,
-            maxPrice: 223.99
+            tieredPrice: 31.36,
+            maxPrice: 31.36
         })
     })
 


### PR DESCRIPTION
Extend Product tile tests to include swatch selection and corresponding price display

# Description

1. When the user navigates to a swatch, verify that the corresponding price and promotion are rendered
2. When there are multiple variants, swatch navigation still shows the price range `From <<Starting Price>>`
3. Found and fixed a issue with the main product flag in `product-utils `

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)


# How to Test-Drive This PR

- Checkout code
- `cd packages/template-retail-react-app`
- run `npm run test`


