### PR TITLE
@W-15940856: Fix Swatch Tests

### DIFF
--- a/packages/template-retail-react-app/app/components/swatch-group/index.test.js
+++ b/packages/template-retail-react-app/app/components/swatch-group/index.test.js
@@ -123,7 +123,7 @@ describe('Swatch Component', () => {
         expect(screen.getAllByRole('radio')).toHaveLength(data.values.length)
     })
 
-    test('swatch can be selected', () => {
+    test('swatch can be selected', async () => {
         const history = createMemoryHistory()
         history.push('/en-GB/swatch-example')
 
@@ -136,12 +136,12 @@ describe('Swatch Component', () => {
         expect(screen.getAllByRole('radio')).toHaveLength(data.values.length)
         const firstSwatch = screen.getAllByRole('radio')[0]
         fireEvent.click(firstSwatch)
-        waitFor(() => {
-            expect(history.search).toBe('?color=BLACKFB')
+        await waitFor(() => {
+            expect(history.location.search).toBe('?color=BLACKFB')
         })
     })
 
-    test('swatch can be changed with arrow keys', () => {
+    test('swatch can be changed with arrow keys', async () => {
         const history = createMemoryHistory()
         history.push('/en-GB/swatch-example?color=JJ2XNXX')
 
@@ -182,15 +182,15 @@ describe('Swatch Component', () => {
         ]
 
         // Test initial state
-        waitFor(() => {
-            expect(history.search).toBe('?color=BLACKFB')
+        await waitFor(() => {
+            expect(history.location.search).toBe('?color=JJ2XNXX')
         })
 
         // Navigate according to the event array. This also tests that looping over the end or front works.
-        keyDownEvents.forEach(({keyEvent, expectedValue}) => {
+        keyDownEvents.forEach(async ({keyEvent, expectedValue}) => {
             fireEvent.keyDown(swatchGroup, keyEvent)
-            waitFor(() => {
-                expect(history.search).toBe(`?color=${expectedValue}`)
+            await waitFor(() => {
+                expect(history.location.search).toBe(`?color=${expectedValue}`)
             })
         })
     })


### PR DESCRIPTION
Fix failing tests for swatch component

# Description

Since the verifications are done async using "waitFor", the test results are not reported. Adding await causes the tests to fail. Below is test result before and after the fix. 

```
Swatch Component
  ✓ renders component (171 ms)
  ✕ swatch can be selected (1101 ms)
  ✕ swatch can be changed with arrow keys (1075 ms)

 ● Swatch Component › swatch can be selected
  expect(received).toBe(expected) // [Object.is](https://object.is/) equality
  Expected: "?color=BLACKFB1"
  Received: undefined

 ● Swatch Component › swatch can be changed with arrow keys
  expect(received).toBe(expected) // [Object.is](https://object.is/) equality
  Expected: "?color=BLACKFB"
  Received: undefined

```
Result with the fix:
```
  Swatch Component
    ✓ renders component (167 ms)
    ✓ swatch can be selected (98 ms)
    ✓ swatch can be changed with arrow keys (101 ms)

```
# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)

# How to Test-Drive This PR

How to Test-Drive This PR

- Checkout code
- cd packages/template-retail-react-app
- run npm run test
