### PR TITLE
@W-12627191: add error icon to error message

### DIFF
--- a/packages/template-retail-react-app/app/components/field/index.jsx
+++ b/packages/template-retail-react-app/app/components/field/index.jsx
@@ -10,14 +10,13 @@ import {Controller} from 'react-hook-form'
 import {
     FormControl,
     FormLabel,
+    FormErrorMessage,
     IconButton,
     Input,
     InputGroup,
     InputRightElement,
     Select,
-    Checkbox,
-    Alert,
-    Text
+    Checkbox
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import {
     VisibilityIcon,
@@ -136,12 +135,10 @@ const Field = ({
                         </InputGroup>
 
                         {error && type !== 'hidden' && (
-                            <Alert background="transparent" border="none" p={0}>
-                                <AlertIcon color="red.600" boxSize={4} />
-                                <Text fontSize="sm" ml={3} color="red.600">
-                                    {error.message}
-                                </Text>
-                            </Alert>
+                            <FormErrorMessage color="red.600">
+                                <AlertIcon aria-hidden="true" mr={2} />
+                                {error.message}
+                            </FormErrorMessage>
                         )}
 
                         {helpText}

--- a/packages/template-retail-react-app/app/components/field/index.jsx
+++ b/packages/template-retail-react-app/app/components/field/index.jsx
@@ -10,15 +10,20 @@ import {Controller} from 'react-hook-form'
 import {
     FormControl,
     FormLabel,
-    FormErrorMessage,
     IconButton,
     Input,
     InputGroup,
     InputRightElement,
     Select,
-    Checkbox
+    Checkbox,
+    Alert,
+    Text
 } from '@salesforce/retail-react-app/app/components/shared/ui'
-import {VisibilityIcon, VisibilityOffIcon} from '@salesforce/retail-react-app/app/components/icons'
+import {
+    VisibilityIcon,
+    VisibilityOffIcon,
+    AlertIcon
+} from '@salesforce/retail-react-app/app/components/icons'
 import {useIntl} from 'react-intl'
 
 const Field = ({
@@ -131,7 +136,12 @@ const Field = ({
                         </InputGroup>
 
                         {error && type !== 'hidden' && (
-                            <FormErrorMessage color="red.600">{error.message}</FormErrorMessage>
+                            <Alert background="transparent" border="none" p={0}>
+                                <AlertIcon color="red.600" boxSize={4} />
+                                <Text fontSize="sm" ml={3} color="red.600">
+                                    {error.message}
+                                </Text>
+                            </Alert>
                         )}
 
                         {helpText}

--- a/packages/template-retail-react-app/app/components/promo-code/index.jsx
+++ b/packages/template-retail-react-app/app/components/promo-code/index.jsx
@@ -53,14 +53,18 @@ export const usePromoCode = () => {
                 isClosable: true
             })
         } catch (e) {
-            form.setError('code', {
-                type: 'manual',
-                message: formatMessage({
-                    defaultMessage:
-                        'Check the code and try again, it may already be applied or the promo has expired.',
-                    id: 'use_promocode.error.check_the_code'
-                })
-            })
+            form.setError(
+                'code',
+                {
+                    type: 'manual',
+                    message: formatMessage({
+                        defaultMessage:
+                            'Check the code and try again, it may already be applied or the promo has expired.',
+                        id: 'use_promocode.error.check_the_code'
+                    })
+                },
+                {shouldFocus: true}
+            )
         }
     }
 

--- a/packages/template-retail-react-app/app/pages/checkout/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/index.jsx
@@ -29,11 +29,7 @@ import OrderSummary from '@salesforce/retail-react-app/app/components/order-summ
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import CheckoutSkeleton from '@salesforce/retail-react-app/app/pages/checkout/partials/checkout-skeleton'
-import {
-    useUsid,
-    useShopperOrdersMutation,
-    useShopperBasketsMutation
-} from '@salesforce/commerce-sdk-react'
+import {useShopperOrdersMutation, useShopperBasketsMutation} from '@salesforce/commerce-sdk-react'
 import UnavailableProductConfirmationModal from '@salesforce/retail-react-app/app/components/unavailable-product-confirmation-modal'
 import {
     API_ERROR_MESSAGE,
@@ -45,7 +41,6 @@ import LoadingSpinner from '@salesforce/retail-react-app/app/components/loading-
 const Checkout = () => {
     const {formatMessage} = useIntl()
     const navigate = useNavigation()
-    const {usid} = useUsid()
     const {step} = useCheckout()
     const [error, setError] = useState()
     const {data: basket} = useCurrentBasket()


### PR DESCRIPTION
Add error/red icon to the error message so that People who are blind, colorblind, or using a monochrome screen will be able detect error messages. This impacts multiple fields

1. promo code
2. Address fields
3. credit card fields
4. login fields
5. password change fields
6. registration fields

https://github.com/SalesforceCommerceCloud/pwa-kit/assets/59447810/f39238b1-91ee-4236-b962-a5549b37634b

# Types of Changes


- [x] **Bug fix** (non-breaking change that fixes an issue)


# How to Test-Drive This PR

1. Checkout code
2. Run Retail App template
4. Add a few items in cart
5. Go to Cart Page
6. Open VoiceOver (Cmd + f5)
7. Follow the steps in the demo video
