### PR TITLE
[Product Tile] Fix flaky e2e tests when selecting a different swatch (@W-16116401@)

### DIFF
--- a/e2e/tests/desktop/guest-shopper.spec.js
+++ b/e2e/tests/desktop/guest-shopper.spec.js
@@ -24,11 +24,12 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
 
   await topsNav.click();
   // PLP
-  const productTile = await page.getByRole("link", {
+  const productTile = page.getByRole("link", {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
   const productTileImg = productTile.locator("img");
+  productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/desktop/guest-shopper.spec.js
+++ b/e2e/tests/desktop/guest-shopper.spec.js
@@ -28,17 +28,19 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
-  const initialImgEl = await productTile.locator("img");
-  const initialSrc = await initialImgEl.getAttribute("src");
+  const productTileImg = productTile.locator("img");
+  const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 
   await productTile.getByLabel(/Black/, { exact: true }).hover();
-  const changedImgEl = await productTile.locator("img");
-  const changeImgSrc = await changedImgEl.getAttribute("src");
+  // Make sure the image src has changed
+  await expect(async () => {
+    const newSrc = await productTileImg.getAttribute("src")
+    expect(newSrc).not.toBe(initialSrc)
+  }).toPass()
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
-
-  expect(changeImgSrc).not.toBe(initialSrc);
   await productTile.click();
+
   // PDP
   await expect(
     page.getByRole("heading", { name: /Cotton Turtleneck Sweater/i })

--- a/e2e/tests/desktop/guest-shopper.spec.js
+++ b/e2e/tests/desktop/guest-shopper.spec.js
@@ -29,7 +29,7 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
   });
   // selecting swatch
   const productTileImg = productTile.locator("img");
-  productTileImg.waitFor({state: 'visible'})
+  await productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/desktop/registered-shopper.spec.js
+++ b/e2e/tests/desktop/registered-shopper.spec.js
@@ -60,7 +60,7 @@ test("Registered shopper can checkout items", async ({ page }) => {
   });
   // selecting swatch
   const productTileImg = productTile.locator("img");
-  productTileImg.waitFor({state: 'visible'})
+  await productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/desktop/registered-shopper.spec.js
+++ b/e2e/tests/desktop/registered-shopper.spec.js
@@ -55,11 +55,12 @@ test("Registered shopper can checkout items", async ({ page }) => {
   await topsNav.click();
 
   // PLP
-  const productTile = await page.getByRole("link", {
+  const productTile = page.getByRole("link", {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
   const productTileImg = productTile.locator("img");
+  productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/desktop/registered-shopper.spec.js
+++ b/e2e/tests/desktop/registered-shopper.spec.js
@@ -59,16 +59,17 @@ test("Registered shopper can checkout items", async ({ page }) => {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
-  const initialImgEl = await productTile.locator("img");
-  const initialSrc = await initialImgEl.getAttribute("src");
+  const productTileImg = productTile.locator("img");
+  const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 
   await productTile.getByLabel(/Black/, { exact: true }).hover();
-  const changedImgEl = await productTile.locator("img");
-  const changeImgSrc = await changedImgEl.getAttribute("src");
+  // Make sure the image src has changed
+  await expect(async () => {
+    const newSrc = await productTileImg.getAttribute("src")
+    expect(newSrc).not.toBe(initialSrc)
+  }).toPass()
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
-
-  expect(changeImgSrc).not.toBe(initialSrc);
   await productTile.click();
 
   // PDP

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -34,7 +34,7 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
 
   await clothingNav.click();
 
-  const topsLink = page.getByRole("link", { name: "Tops" })
+  const topsLink = page.getByLabel('Womens').getByRole("link", { name: "Tops" })
   await topsLink.click();
   // Wait for the nav menu to close first
   await topsLink.waitFor({state: 'hidden'})

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -34,7 +34,10 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
 
   await clothingNav.click();
 
-  await page.getByRole("link", { name: "Tops" }).click();
+  const topsLink = page.getByRole("link", { name: "Tops" })
+  await topsLink.click();
+  // Wait for the nav menu to close first
+  await topsLink.waitFor({state: 'hidden'})
 
   await expect(page.getByRole("heading", { name: "Tops" })).toBeVisible();
 
@@ -43,15 +46,17 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
-  const initialImgEl = await productTile.locator("img");
-  const initialSrc = await initialImgEl.getAttribute("src");
+  const productTileImg = productTile.locator("img");
+  const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 
   await productTile.getByLabel(/Black/, { exact: true }).click();
-  const changedImgEl = await productTile.locator("img");
-  const changeImgSrc = await changedImgEl.getAttribute("src");
+  // Make sure the image src has changed
+  await expect(async () => {
+    const newSrc = await productTileImg.getAttribute("src")
+    expect(newSrc).not.toBe(initialSrc)
+  }).toPass()
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
-  expect(changeImgSrc).not.toBe(initialSrc);
   await productTile.click();
 
   // PDP

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -42,11 +42,13 @@ test("Guest shopper can checkout items as guest", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Tops" })).toBeVisible();
 
   // PLP
-  const productTile = await page.getByRole("link", {
+  const productTile = page.getByRole("link", {
     name: /Cotton Turtleneck Sweater/i,
   });
+  await productTile.scrollIntoViewIfNeeded()
   // selecting swatch
   const productTileImg = productTile.locator("img");
+  await productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -67,11 +67,13 @@ test("Registered shopper can checkout items", async ({ page }) => {
 
   await expect(page.getByRole("heading", { name: "Tops" })).toBeVisible();
   // PLP
-  const productTile = await page.getByRole("link", {
+  const productTile = page.getByRole("link", {
     name: /Cotton Turtleneck Sweater/i,
   });
+  await productTile.scrollIntoViewIfNeeded()
   // selecting swatch
   const productTileImg = productTile.locator("img");
+  await productTileImg.waitFor({state: 'visible'})
   const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -63,7 +63,6 @@ test("Registered shopper can checkout items", async ({ page }) => {
   const topsLink = page.getByRole("link", { name: "Tops" })
   await topsLink.click();
   // Wait for the nav menu to close first
-  // TODO: repeat change for other test files
   await topsLink.waitFor({state: 'hidden'})
 
   await expect(page.getByRole("heading", { name: "Tops" })).toBeVisible();
@@ -83,8 +82,8 @@ test("Registered shopper can checkout items", async ({ page }) => {
     expect(newSrc).not.toBe(initialSrc)
   }).toPass()
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
-
   await productTile.click();
+
   // PDP
   await expect(
     page.getByRole("heading", { name: /Cotton Turtleneck Sweater/i })

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -60,7 +60,7 @@ test("Registered shopper can checkout items", async ({ page }) => {
 
   await clothingNav.click();
 
-  const topsLink = page.getByRole("link", { name: "Tops" })
+  const topsLink = page.getByLabel('Womens').getByRole("link", { name: "Tops" })
   await topsLink.click();
   // Wait for the nav menu to close first
   await topsLink.waitFor({state: 'hidden'})

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -60,7 +60,11 @@ test("Registered shopper can checkout items", async ({ page }) => {
 
   await clothingNav.click();
 
-  await page.getByRole("link", { name: "Tops" }).click();
+  const topsLink = page.getByRole("link", { name: "Tops" })
+  await topsLink.click();
+  // Wait for the nav menu to close first
+  // TODO: repeat change for other test files
+  await topsLink.waitFor({state: 'hidden'})
 
   await expect(page.getByRole("heading", { name: "Tops" })).toBeVisible();
   // PLP

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -72,15 +72,18 @@ test("Registered shopper can checkout items", async ({ page }) => {
     name: /Cotton Turtleneck Sweater/i,
   });
   // selecting swatch
-  const initialImgEl = await productTile.locator("img");
-  const initialSrc = await initialImgEl.getAttribute("src");
+  const productTileImg = productTile.locator("img");
+  const initialSrc = await productTileImg.getAttribute("src");
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
 
   await productTile.getByLabel(/Black/, { exact: true }).click();
-  const changedImgEl = await productTile.locator("img");
-  const changeImgSrc = await changedImgEl.getAttribute("src");
+  // Make sure the image src has changed
+  await expect(async () => {
+    const newSrc = await productTileImg.getAttribute("src")
+    expect(newSrc).not.toBe(initialSrc)
+  }).toPass()
   await expect(productTile.getByText(/From \$39\.99/i)).toBeVisible();
-  expect(changeImgSrc).not.toBe(initialSrc);
+
   await productTile.click();
   // PDP
   await expect(


### PR DESCRIPTION
This PR attempts at fixing the flaky E2E tests for Product Tile. We noticed on selecting a different swatch, the tests sometimes failed at detecting whether the image src has changed. It looks like we need to wait a bit for this image src to change.

# How to Test-Drive This PR

What you can test right now:
1. Checkout this PR branch
2. Run `npm run test:e2e:ui` in your terminal
3. Click on the Play button in the resulting GUI window
4. It will run the E2E tests against https://scaffold-pwa-e2e-tests-pwa-kit.mobify-storefront.com/

But yes, the real test would happen tonight when the E2E tests are run nightly.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
