### PR TITLE
@W-16161754 - [BUG 🐞] Fix `useCustomQuery` not using `throwOnBadResponse` argument

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,5 +1,5 @@
-## v2.1.0-dev (Jun 25, 2024)
-- Fix bug where `useCustomQuery` would always be a success even on error responses [#1879](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1879)
+## v2.0.1-dev (Jul 04, 2024)
+- Fix `useCustomQuery` error handling [#1879](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1879)
 
 ## v2.0.0 (Jun 25, 2024)
 - Add `useCustomQuery` and `useCustomMutation` for SCAPI custom endpoint support [#1793](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1793)

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v2.1.0-dev (Jun 25, 2024)
+- Fix bug where `useCustomQuery` would always be a success even on error responses [#1879](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1879)
 
 ## v2.0.0 (Jun 25, 2024)
 - Add `useCustomQuery` and `useCustomMutation` for SCAPI custom endpoint support [#1793](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1793)

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/commerce-sdk-react",
-  "version": "2.1.0-dev",
+  "version": "2.0.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/commerce-sdk-react",
-      "version": "2.1.0-dev",
+      "version": "2.0.1-dev",
       "license": "See license in LICENSE",
       "dependencies": {
         "commerce-sdk-isomorphic": "^2.1.0",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/commerce-sdk-react",
-  "version": "2.1.0-dev",
+  "version": "2.0.1-dev",
   "description": "A library that provides react hooks for fetching data from Commerce Cloud",
   "homepage": "https://github.com/SalesforceCommerceCloud/pwa-kit/tree/develop/packages/ecom-react-hooks#readme",
   "bugs": {

--- a/packages/commerce-sdk-react/src/hooks/useQuery.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/useQuery.test.ts
@@ -9,6 +9,7 @@ import nock from 'nock'
 import {
     mockQueryEndpoint,
     renderHookWithProviders,
+    waitAndExpectError,
     waitAndExpectSuccess,
     DEFAULT_TEST_CONFIG
 } from '../test-utils'
@@ -54,6 +55,44 @@ describe('useCustomQuery', () => {
         })
         await waitAndExpectSuccess(() => result.current)
         expect(result.current.data).toEqual(mockRes)
+    })
+    test('useCustomQuery throws error on failure', async () => {
+        const mockRes = {
+            title: 'Resource Not Found',
+            type: 'https://api.commercecloud.salesforce.com/documentation/error/v1/errors/resource-not-found',
+            detail: 'Could not find requested resource'
+        }
+        const apiName = 'hello-world'
+        mockQueryEndpoint(apiName, mockRes, 500)
+
+        const {result} = renderHookWithProviders(() => {
+            const clientConfig = {
+                parameters: {
+                    clientId: 'CLIENT_ID',
+                    siteId: 'SITE_ID',
+                    organizationId: 'ORG_ID',
+                    shortCode: 'SHORT_CODE'
+                },
+                proxy: 'http://localhost:8888/mobify/proxy/api'
+            }
+            return useCustomQuery({
+                options: {
+                    method: 'GET',
+                    customApiPathParameters: {
+                        apiVersion: 'v1',
+                        endpointPath: 'test-hello-world',
+                        apiName
+                    }
+                },
+                clientConfig,
+                rawResponse: false
+            })
+        })
+        await waitAndExpectError(() => result.current)
+
+        // Validate that we get a `ResponseError` from commerce-sdk-isomorphic. Ideally, we could do
+        // `.toBeInstanceOf(ResponseError)`, but the class isn't exported. :\
+        expect(result.current.error).toHaveProperty('response')
     })
     test('clientConfig is optional, default to CommerceApiProvider configs', async () => {
         const mockRes = {data: '123'}

--- a/packages/commerce-sdk-react/src/hooks/useQuery.ts
+++ b/packages/commerce-sdk-react/src/hooks/useQuery.ts
@@ -111,7 +111,8 @@ export const useCustomQuery = (
                         shortCode: config.organizationId
                     },
                     proxy: config.proxy,
-                    ...clientConfig
+                    ...clientConfig,
+                    throwOnBadResponse: true
                 }
             })
         }

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -45,7 +45,7 @@
     "@lhci/cli": "^0.11.0",
     "@loadable/component": "^5.15.3",
     "@peculiar/webcrypto": "^1.4.2",
-    "@salesforce/commerce-sdk-react": "2.1.0-dev",
+    "@salesforce/commerce-sdk-react": "2.0.1-dev",
     "@salesforce/pwa-kit-dev": "3.7.0-dev",
     "@salesforce/pwa-kit-react-sdk": "3.7.0-dev",
     "@salesforce/pwa-kit-runtime": "3.7.0-dev",

--- a/packages/test-commerce-sdk-react/app/pages/use-custom-endpoint.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/use-custom-endpoint.tsx
@@ -10,17 +10,23 @@ import {useCustomQuery} from '@salesforce/commerce-sdk-react'
 import Json from '../components/Json'
 
 const UseCustomEndpoint = () => {
-    const query = useCustomQuery({
+    const {data, error} = useCustomQuery({
         options: {
             method: 'GET',
             customApiPathParameters: {
+                apiVersion: 'v1',
                 endpointPath: 'test-hello-world',
                 apiName: 'hello-world'
             }
         },
         rawResponse: false
     })
-    return <Json data={query.data} />
+
+    if (error) {
+        return <h1 style={{color: 'red'}}>Something is wrong</h1>
+    }
+
+    return <Json data={data} />
 }
 
 UseCustomEndpoint.getTemplateName = () => 'UseCustomEndpoint'

--- a/packages/test-commerce-sdk-react/package.json
+++ b/packages/test-commerce-sdk-react/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.3",
-    "@salesforce/commerce-sdk-react": "2.1.0-dev",
+    "@salesforce/commerce-sdk-react": "2.0.1-dev",
     "@salesforce/pwa-kit-dev": "3.7.0-dev",
     "@salesforce/pwa-kit-react-sdk": "3.7.0-dev",
     "@salesforce/pwa-kit-runtime": "3.7.0-dev",


### PR DESCRIPTION
# Description

We recently added the `useCustomQuery` hook to the `commerce-sdk-react` library. But we forgot to ensure that we are passing the `throwOnBadResponse=true` argument. This meant that custom apis that were returning error status codes weren't throwing errors resulting in the hooks query status being a "success" when it should be an "error". This PR fixes this by passing this argument in.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Pass `throwOnBadResponse=true` to isomorphic helper in `useCustomQuery`
- Add tests
- Update test commerce sdk react project to visualize errors
- Bump verion
- Add change log

# How to Test-Drive This PR

- Run the `test-commerce-sdk-react` project and goto `http://localhost:3000/custom-endpoint`
- You should see a some successful response data.
- Now change line 19 of the `pages/use-custom-endpoint.tsx` to be `apiName: 'hello-world-bad'`
- The page should refresh showing "something is wrong" implying an error was thrown and the "error" object was defined for the query return value.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
