### PR TITLE
@W-12627224@ Account menu a11y

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### Bug Fixes
 
+- A11y: Account Nav fixes [#1884](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1884)
 - Out of stock and low stock items are removed from cart and checkout as unavailable products [#1865](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1865)
 
 ## v3.0.1 (Jul 9, 2024)
 
-### Bug Fixes 
+### Bug Fixes
 
 - Fix basket transfer during checkout login [#1887](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1887)
 
@@ -15,8 +16,8 @@
 ### Improvements
 
 - Product Tile Revamp
-  - Display different pricing for various products on Product tiles and PDP [#1760](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1760) 
-  - Display pricing for cart, checkout and wishlist page [#1796](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1796) 
+  - Display different pricing for various products on Product tiles and PDP [#1760](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1760)
+  - Display pricing for cart, checkout and wishlist page [#1796](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1796)
   - Shows promotional callout message on Product List and Product Detail pages [#1786](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1786) [#1804](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1804)
   - Display selectable swatch groups for attributes like color [#1773](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1773)
   - Show badges [#1791](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1791)
@@ -33,7 +34,7 @@
 - Add explicit headers to cart modal [#1811](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1811)
 - Add autocomplete to text input fields [#1840](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1840)
 - Add error icon to error messages [#1839](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1839)
-  
+
 ### Performance Improvements
 
 - Make navigation components lazy load their categories [#1656](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1656) [#1673](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1673)

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -212,23 +212,34 @@ const Header = ({
                                     </Text>
                                 </PopoverHeader>
                                 <PopoverBody>
-                                    <Stack spacing={0} as="nav" data-testid="account-detail-nav">
-                                        {navLinks.map((link) => {
-                                            const LinkIcon = link.icon
-                                            return (
-                                                <Button
-                                                    key={link.name}
-                                                    as={Link}
-                                                    to={`/account${link.path}`}
-                                                    useNavLink={true}
-                                                    variant="menu-link"
-                                                    leftIcon={<LinkIcon boxSize={5} />}
-                                                >
-                                                    {intl.formatMessage(messages[link.name])}
-                                                </Button>
-                                            )
-                                        })}
-                                    </Stack>
+                                    <Box as="nav">
+                                        <Stack spacing={0} as="ul" data-testid="account-detail-nav">
+                                            {navLinks.map((link) => {
+                                                const LinkIcon = link.icon
+                                                return (
+                                                    <Box
+                                                        key={link.name}
+                                                        position="relative"
+                                                        as="li"
+                                                        listStyleType="none"
+                                                    >
+                                                        <Button
+                                                            as={Link}
+                                                            to={`/account${link.path}`}
+                                                            useNavLink={true}
+                                                            variant="menu-link"
+                                                            leftIcon={<LinkIcon boxSize={5} />}
+                                                            width="100%"
+                                                        >
+                                                            {intl.formatMessage(
+                                                                messages[link.name]
+                                                            )}
+                                                        </Button>
+                                                    </Box>
+                                                )
+                                            })}
+                                        </Stack>
+                                    </Box>
                                 </PopoverBody>
                                 <PopoverFooter onClick={onSignoutClick} cursor="pointer">
                                     <Divider colorScheme="gray" />

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -204,7 +204,7 @@ const Header = ({
                             >
                                 <PopoverArrow />
                                 <PopoverHeader>
-                                    <Text>
+                                    <Text as="h2" fontSize="l" fontFamily="body" fontWeight="700">
                                         {intl.formatMessage({
                                             defaultMessage: 'My Account',
                                             id: 'header.popover.title.my_account'

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -42,11 +42,11 @@ export default {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: '#181818'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
                 bg: 'gray.100',
                 border: 'solid',
-                borderColor: '#0176D3',
+                borderColor: 'blue.600',
                 borderWidth: '1px'
             }
         },
@@ -54,11 +54,11 @@ export default {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: '#181818'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
                 bg: 'gray.100',
                 border: 'solid',
-                borderColor: '#0176D3',
+                borderColor: 'blue.600',
                 borderWidth: '1px'
             }
         },

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -45,9 +45,9 @@ export default {
             _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
                 bg: 'gray.50',
-                border: 'solid',
-                borderColor: 'blue.600',
-                borderWidth: '1px'
+                borderLeft: 'solid',
+                borderLeftColor: 'gray.600',
+                borderLeftWidth: '4px'
             }
         },
         'menu-link-mobile': {
@@ -57,9 +57,9 @@ export default {
             _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
                 bg: 'gray.50',
-                border: 'solid',
-                borderColor: 'blue.600',
-                borderWidth: '1px'
+                borderLeft: 'solid',
+                borderLeftColor: 'gray.300',
+                borderLeftWidth: '4px'
             }
         },
         'search-link': {

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -42,10 +42,11 @@ export default {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'none'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline'},
             _activeLink: {
                 bg: 'gray.50',
-                textDecoration: 'none'
+                borderBlock: 'solid',
+                borderBlockWidth: '1px'
             }
         },
         'menu-link-mobile': {

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -44,7 +44,7 @@ export default {
             fontSize: 'sm',
             _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
-                bg: 'gray.100',
+                bg: 'gray.50',
                 border: 'solid',
                 borderColor: 'blue.600',
                 borderWidth: '1px'
@@ -56,7 +56,7 @@ export default {
             fontSize: 'sm',
             _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: 'gray.900'},
             _activeLink: {
-                bg: 'gray.100',
+                bg: 'gray.50',
                 border: 'solid',
                 borderColor: 'blue.600',
                 borderWidth: '1px'

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -53,10 +53,11 @@ export default {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'none'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline'},
             _activeLink: {
                 bg: 'gray.100',
-                textDecoration: 'none'
+                borderBlock: 'solid',
+                borderBlockWidth: '1px'
             }
         },
         'search-link': {

--- a/packages/template-retail-react-app/app/theme/components/base/button.js
+++ b/packages/template-retail-react-app/app/theme/components/base/button.js
@@ -42,22 +42,24 @@ export default {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'underline'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: '#181818'},
             _activeLink: {
-                bg: 'gray.50',
-                borderBlock: 'solid',
-                borderBlockWidth: '1px'
+                bg: 'gray.100',
+                border: 'solid',
+                borderColor: '#0176D3',
+                borderWidth: '1px'
             }
         },
         'menu-link-mobile': {
             color: 'black',
             justifyContent: 'flex-start',
             fontSize: 'sm',
-            _hover: {bg: 'gray.50', textDecoration: 'underline'},
+            _hover: {bg: 'gray.50', textDecoration: 'underline', textDecorationColor: '#181818'},
             _activeLink: {
                 bg: 'gray.100',
-                borderBlock: 'solid',
-                borderBlockWidth: '1px'
+                border: 'solid',
+                borderColor: '#0176D3',
+                borderWidth: '1px'
             }
         },
         'search-link': {


### PR DESCRIPTION
This PR contains a couple of a11y fixes for the account dropdown

* Using a header instead of `<p>` tag on the account drop down menu header
* Using box to indicate current selection in addition to color. This change also affects other `menu-link` items.
* Using underline to indicate hover in addition to color. This change also affects other `menu-link` items.
* Wrapping the menu items in a `<li>` tag 

Desktop view changes: (Order History is active page, Account Details is hovered)
![Screenshot 2024-07-08 at 5 16 49 PM](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/47404250/f2d8c283-8ec3-48c7-a179-b2e567d6d333)

Mobile view changes:  (Wishlist is active page, Order History is hovered)
![Screenshot 2024-07-08 at 5 28 01 PM](https://github.com/SalesforceCommerceCloud/pwa-kit/assets/47404250/40c74ec3-4abf-4ddc-91d7-2a2a52e9eb23)

Testing these changes:
* Pull down these changes and start the app
* Log in
* Expand the 'My Account' drop down menu
* Verify menu header is `<h2>` instead of `<p>`. Also verify that the text styling is the same as before
* Verify each menu item is wrapped in a `<li>`
* Verify that hovering over menu items now underlines the selection
* Click a menu item
* Verify the selected page is now indicated in the drop down menu as well as the left account page nav