### PR TITLE
@W-12627114: Set aria label for the address forms based on the address type

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- A11y: Add aria-label to the address form based on the address type [#1904](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1904)
 - A11y: Account Nav fixes [#1884](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1884)
 - A11y: Replace `<p>` tags with header tag in home page Features section [#1902](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1902)
 - Out of stock and low stock items are removed from cart and checkout as unavailable products [#1865](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1865)

--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {useEffect, useRef} from 'react'
-import {useIntl} from 'react-intl'
+import {defineMessage, useIntl} from 'react-intl'
 import PropTypes from 'prop-types'
 import {
     Grid,
@@ -17,17 +17,16 @@ import useAddressFields from '@salesforce/retail-react-app/app/components/forms/
 import Field from '@salesforce/retail-react-app/app/components/field'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 
-const AddressFields = ({form, prefix = '', ariaLabel}) => {
+const defaultAriaLabel = defineMessage({
+    defaultMessage: 'use_address_fields.label.address_form',
+    id: 'Address Form'
+})
+
+const AddressFields = ({form, prefix = '', ariaLabel = defaultAriaLabel}) => {
     const {data: customer} = useCurrentCustomer()
     const fields = useAddressFields({form, prefix})
     const intl = useIntl()
 
-    if (!ariaLabel) {
-        ariaLabel = intl.formatMessage({
-            id: 'use_address_fields.label.address_form',
-            defaultMessage: 'Address Form'
-        })
-    }
     const addressFormRef = useRef()
     useEffect(() => {
         // Focus on the form when the component mounts for accessibility
@@ -35,7 +34,12 @@ const AddressFields = ({form, prefix = '', ariaLabel}) => {
     }, [])
 
     return (
-        <Stack spacing={5} aria-label={ariaLabel} tabIndex="0" ref={addressFormRef}>
+        <Stack
+            spacing={5}
+            aria-label={intl.formatMessage(ariaLabel)}
+            tabIndex="0"
+            ref={addressFormRef}
+        >
             <SimpleGrid columns={[1, 1, 2]} gap={5}>
                 <Field {...fields.firstName} />
                 <Field {...fields.lastName} />
@@ -65,7 +69,7 @@ AddressFields.propTypes = {
     prefix: PropTypes.string,
 
     /** Optional aria label to use for the address group */
-    ariaLabel: PropTypes.string
+    ariaLabel: PropTypes.MESSAGE_PROPTYPE
 }
 
 export default AddressFields

--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -16,6 +16,7 @@ import {
 import useAddressFields from '@salesforce/retail-react-app/app/components/forms/useAddressFields'
 import Field from '@salesforce/retail-react-app/app/components/field'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
+import {MESSAGE_PROPTYPE} from '@salesforce/retail-react-app/app/utils/locale'
 
 const defaultFormTitleAriaLabel = defineMessage({
     defaultMessage: 'Address Form',
@@ -69,7 +70,7 @@ AddressFields.propTypes = {
     prefix: PropTypes.string,
 
     /** Optional aria label to use for the address form */
-    formTitleAriaLabel: PropTypes.MESSAGE_PROPTYPE
+    formTitleAriaLabel: MESSAGE_PROPTYPE
 }
 
 export default AddressFields

--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -18,8 +18,8 @@ import Field from '@salesforce/retail-react-app/app/components/field'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 
 const defaultAriaLabel = defineMessage({
-    defaultMessage: 'use_address_fields.label.address_form',
-    id: 'Address Form'
+    defaultMessage: 'Address Form',
+    id: 'use_address_fields.label.address_form'
 })
 
 const AddressFields = ({form, prefix = '', ariaLabel = defaultAriaLabel}) => {

--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -17,12 +17,12 @@ import useAddressFields from '@salesforce/retail-react-app/app/components/forms/
 import Field from '@salesforce/retail-react-app/app/components/field'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 
-const defaultAriaLabel = defineMessage({
+const defaultFormTitleAriaLabel = defineMessage({
     defaultMessage: 'Address Form',
     id: 'use_address_fields.label.address_form'
 })
 
-const AddressFields = ({form, prefix = '', ariaLabel = defaultAriaLabel}) => {
+const AddressFields = ({form, prefix = '', formTitleAriaLabel = defaultFormTitleAriaLabel}) => {
     const {data: customer} = useCurrentCustomer()
     const fields = useAddressFields({form, prefix})
     const intl = useIntl()
@@ -36,7 +36,7 @@ const AddressFields = ({form, prefix = '', ariaLabel = defaultAriaLabel}) => {
     return (
         <Stack
             spacing={5}
-            aria-label={intl.formatMessage(ariaLabel)}
+            aria-label={intl.formatMessage(formTitleAriaLabel)}
             tabIndex="0"
             ref={addressFormRef}
         >
@@ -68,8 +68,8 @@ AddressFields.propTypes = {
     /** Optional prefix for field names */
     prefix: PropTypes.string,
 
-    /** Optional aria label to use for the address group */
-    ariaLabel: PropTypes.MESSAGE_PROPTYPE
+    /** Optional aria label to use for the address form */
+    formTitleAriaLabel: PropTypes.MESSAGE_PROPTYPE
 }
 
 export default AddressFields

--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -17,11 +17,17 @@ import useAddressFields from '@salesforce/retail-react-app/app/components/forms/
 import Field from '@salesforce/retail-react-app/app/components/field'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 
-const AddressFields = ({form, prefix = ''}) => {
+const AddressFields = ({form, prefix = '', ariaLabel}) => {
     const {data: customer} = useCurrentCustomer()
     const fields = useAddressFields({form, prefix})
     const intl = useIntl()
 
+    if (!ariaLabel) {
+        ariaLabel = intl.formatMessage({
+            id: 'use_address_fields.label.address_form',
+            defaultMessage: 'Address Form'
+        })
+    }
     const addressFormRef = useRef()
     useEffect(() => {
         // Focus on the form when the component mounts for accessibility
@@ -29,15 +35,7 @@ const AddressFields = ({form, prefix = ''}) => {
     }, [])
 
     return (
-        <Stack
-            spacing={5}
-            aria-label={intl.formatMessage({
-                id: 'use_address_fields.label.address_form',
-                defaultMessage: 'Address Form'
-            })}
-            tabIndex="0"
-            ref={addressFormRef}
-        >
+        <Stack spacing={5} aria-label={ariaLabel} tabIndex="0" ref={addressFormRef}>
             <SimpleGrid columns={[1, 1, 2]} gap={5}>
                 <Field {...fields.firstName} />
                 <Field {...fields.lastName} />
@@ -64,7 +62,10 @@ AddressFields.propTypes = {
     form: PropTypes.object.isRequired,
 
     /** Optional prefix for field names */
-    prefix: PropTypes.string
+    prefix: PropTypes.string,
+
+    /** Optional aria label to use for the address group */
+    ariaLabel: PropTypes.string
 }
 
 export default AddressFields

--- a/packages/template-retail-react-app/app/pages/account/addresses.test.js
+++ b/packages/template-retail-react-app/app/pages/account/addresses.test.js
@@ -100,7 +100,27 @@ test('Allows customer to add addresses', async () => {
         expect(screen.getByText(/no saved addresses/i)).toBeInTheDocument()
     })
 
-    await helperAddNewAddress(user)
+    // Add new address
+    await user.click(screen.getByText(/add address/i))
+
+    // Address Form must be present
+    expect(screen.getByLabelText('Address Form')).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText('First Name'), 'Test')
+    await user.type(screen.getByLabelText('Last Name'), 'McTester')
+    await user.type(screen.getByLabelText('Phone'), '7275551234')
+    await user.type(screen.getByLabelText('Address'), '123 Main St')
+    await user.type(screen.getByLabelText('City'), 'Tampa')
+    await user.selectOptions(screen.getByLabelText(/state/i), ['FL'])
+    await user.type(screen.getByLabelText('Zip Code'), '33712')
+
+    global.server.use(
+        rest.get('*/customers/:customerId', (req, res, ctx) =>
+            res(ctx.delay(0), ctx.status(200), ctx.json(mockedRegisteredCustomer))
+        )
+    )
+    await user.click(screen.getByText(/^Save$/i))
+
     expect(await screen.findByText(/123 Main St/i)).toBeInTheDocument()
 })
 

--- a/packages/template-retail-react-app/app/pages/checkout/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/index.test.js
@@ -347,6 +347,9 @@ test('Can proceed through checkout steps as guest', async () => {
     // Email should be displayed in previous step summary
     expect(screen.getByText('test@test.com')).toBeInTheDocument()
 
+    // Shipping Address Form must be present
+    expect(screen.getByLabelText('Shipping Address Form')).toBeInTheDocument()
+
     // Fill out shipping address form and submit
     await user.type(screen.getByLabelText(/first name/i), 'Tester')
     await user.type(screen.getByLabelText(/last name/i), 'McTesting')
@@ -540,6 +543,8 @@ test('Can edit address during checkout as a registered customer', async () => {
         expect(screen.getByTestId('sf-shipping-address-edit-form')).not.toBeEmptyDOMElement()
     )
 
+    // Shipping Address Form must be present
+    expect(screen.getByLabelText('Shipping Address Form')).toBeInTheDocument()
     expect(screen.getByLabelText(/first name/i)).toBeInTheDocument()
 
     // Edit and save the address
@@ -580,6 +585,9 @@ test('Can add address during checkout as a registered customer', async () => {
     })
     // Add address
     await user.click(screen.getByText(/add new address/i))
+
+    // Shipping Address Form must be present
+    expect(screen.getByLabelText('Shipping Address Form')).toBeInTheDocument()
 
     const firstName = await screen.findByLabelText(/first name/i)
     await user.type(firstName, 'Test2')

--- a/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
@@ -225,7 +225,7 @@ const Payment = () => {
                         <ShippingAddressSelection
                             form={billingAddressForm}
                             selectedAddress={selectedBillingAddress}
-                            ariaLabel={billingAddressAriaLabel}
+                            formTitleAriaLabel={billingAddressAriaLabel}
                             hideSubmitButton
                         />
                     )}

--- a/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
@@ -6,7 +6,7 @@
  */
 import React, {useState} from 'react'
 import PropTypes from 'prop-types'
-import {FormattedMessage, useIntl} from 'react-intl'
+import {defineMessage, FormattedMessage, useIntl} from 'react-intl'
 import {
     Box,
     Button,
@@ -141,6 +141,11 @@ const Payment = () => {
         }
     })
 
+    const billingAddressAriaLabel = defineMessage({
+        defaultMessage: 'Billing Address Form',
+        id: 'checkout_payment.label.billing_address_form'
+    })
+
     return (
         <ToggleCard
             id="step-3"
@@ -219,11 +224,8 @@ const Payment = () => {
                     {!billingSameAsShipping && (
                         <ShippingAddressSelection
                             form={billingAddressForm}
-                            title={formatMessage({
-                                defaultMessage: 'Billing Address',
-                                id: 'checkout_payment.heading.billing_address'
-                            })}
                             selectedAddress={selectedBillingAddress}
+                            ariaLabel={billingAddressAriaLabel}
                             hideSubmitButton
                         />
                     )}

--- a/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/payment.jsx
@@ -219,6 +219,10 @@ const Payment = () => {
                     {!billingSameAsShipping && (
                         <ShippingAddressSelection
                             form={billingAddressForm}
+                            title={formatMessage({
+                                defaultMessage: 'Billing Address',
+                                id: 'checkout_payment.heading.billing_address'
+                            })}
                             selectedAddress={selectedBillingAddress}
                             hideSubmitButton
                         />

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
@@ -412,7 +412,7 @@ ShippingAddressSelection.propTypes = {
     submitButtonLabel: MESSAGE_PROPTYPE,
 
     /** aria label to use for the address group */
-    formTitleAriaLabel: PropTypes.MESSAGE_PROPTYPE,
+    formTitleAriaLabel: MESSAGE_PROPTYPE,
 
     /** Show or hide the submit button (for controlling the form from outside component) */
     hideSubmitButton: PropTypes.bool,

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
@@ -38,7 +38,8 @@ const ShippingAddressEditForm = ({
     toggleAddressEdit,
     hideSubmitButton,
     form,
-    submitButtonLabel
+    submitButtonLabel,
+    ariaLabel
 }) => {
     const {formatMessage} = useIntl()
 
@@ -62,7 +63,7 @@ const ShippingAddressEditForm = ({
                 )}
 
                 <Stack spacing={6}>
-                    <AddressFields form={form} ariaLabel={title} />
+                    <AddressFields form={form} ariaLabel={ariaLabel} />
 
                     {hasSavedAddresses && !hideSubmitButton ? (
                         <FormActionButtons
@@ -96,7 +97,8 @@ ShippingAddressEditForm.propTypes = {
     toggleAddressEdit: PropTypes.func,
     hideSubmitButton: PropTypes.bool,
     form: PropTypes.object,
-    submitButtonLabel: MESSAGE_PROPTYPE
+    submitButtonLabel: MESSAGE_PROPTYPE,
+    ariaLabel: MESSAGE_PROPTYPE
 }
 
 const submitButtonMessage = defineMessage({
@@ -106,9 +108,9 @@ const submitButtonMessage = defineMessage({
 
 const ShippingAddressSelection = ({
     form,
-    title,
     selectedAddress,
     submitButtonLabel = submitButtonMessage,
+    ariaLabel,
     hideSubmitButton = false,
     onSubmit = async () => null
 }) => {
@@ -262,9 +264,7 @@ const ShippingAddressSelection = ({
         // Don't render anything yet, to make sure values like hasSavedAddresses are correct
         return null
     }
-    console.log('**************isGuest=', customer.isGuest)
-    console.log('**************isEditingAddress=', isEditingAddress)
-    console.log('**************selectedAddressId=', selectedAddressId)
+
     return (
         <form onSubmit={form.handleSubmit(submitForm)}>
             <Stack spacing={4}>
@@ -316,15 +316,16 @@ const ShippingAddressSelection = ({
                                             {isEditingAddress &&
                                                 address.addressId === selectedAddressId && (
                                                     <ShippingAddressEditForm
-                                                        title={`${formatMessage({
-                                                            defaultMessage: 'Edit',
-                                                            id: 'shipping_address_selection.title.edit'
-                                                        })} ${title}`}
+                                                        title={formatMessage({
+                                                            defaultMessage: 'Edit Shipping Address',
+                                                            id: 'shipping_address_selection.title.edit_shipping'
+                                                        })}
                                                         hasSavedAddresses={hasSavedAddresses}
                                                         toggleAddressEdit={toggleAddressEdit}
                                                         hideSubmitButton={hideSubmitButton}
                                                         form={form}
                                                         submitButtonLabel={submitButtonLabel}
+                                                        ariaLabel={ariaLabel}
                                                     />
                                                 )}
                                         </React.Fragment>
@@ -369,15 +370,16 @@ const ShippingAddressSelection = ({
 
                 {(customer.isGuest || (isEditingAddress && !selectedAddressId)) && (
                     <ShippingAddressEditForm
-                        title={`${formatMessage({
-                            defaultMessage: 'Add New',
-                            id: 'shipping_address_selection.title.add_new'
-                        })} ${title}`}
+                        title={formatMessage({
+                            defaultMessage: 'Add New Address',
+                            id: 'shipping_address_selection.title.add_address'
+                        })}
                         hasSavedAddresses={hasSavedAddresses}
                         toggleAddressEdit={toggleAddressEdit}
                         hideSubmitButton={hideSubmitButton}
                         form={form}
                         submitButtonLabel={submitButtonLabel}
+                        ariaLabel={ariaLabel}
                     />
                 )}
 
@@ -403,14 +405,14 @@ ShippingAddressSelection.propTypes = {
     /** The form object returnd from `useForm` */
     form: PropTypes.object,
 
-    /** The title for the address */
-    title: PropTypes.string,
-
     /** Optional address to use as default selection */
     selectedAddress: PropTypes.object,
 
     /** Override the submit button label */
     submitButtonLabel: MESSAGE_PROPTYPE,
+
+    /** aria label to use for the address group */
+    ariaLabel: PropTypes.MESSAGE_PROPTYPE,
 
     /** Show or hide the submit button (for controlling the form from outside component) */
     hideSubmitButton: PropTypes.bool,

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
@@ -62,7 +62,7 @@ const ShippingAddressEditForm = ({
                 )}
 
                 <Stack spacing={6}>
-                    <AddressFields form={form} />
+                    <AddressFields form={form} ariaLabel={title} />
 
                     {hasSavedAddresses && !hideSubmitButton ? (
                         <FormActionButtons
@@ -106,6 +106,7 @@ const submitButtonMessage = defineMessage({
 
 const ShippingAddressSelection = ({
     form,
+    title,
     selectedAddress,
     submitButtonLabel = submitButtonMessage,
     hideSubmitButton = false,
@@ -261,7 +262,9 @@ const ShippingAddressSelection = ({
         // Don't render anything yet, to make sure values like hasSavedAddresses are correct
         return null
     }
-
+    console.log('**************isGuest=', customer.isGuest)
+    console.log('**************isEditingAddress=', isEditingAddress)
+    console.log('**************selectedAddressId=', selectedAddressId)
     return (
         <form onSubmit={form.handleSubmit(submitForm)}>
             <Stack spacing={4}>
@@ -313,10 +316,10 @@ const ShippingAddressSelection = ({
                                             {isEditingAddress &&
                                                 address.addressId === selectedAddressId && (
                                                     <ShippingAddressEditForm
-                                                        title={formatMessage({
-                                                            defaultMessage: 'Edit Shipping Address',
-                                                            id: 'shipping_address_selection.title.edit_shipping'
-                                                        })}
+                                                        title={`${formatMessage({
+                                                            defaultMessage: 'Edit',
+                                                            id: 'shipping_address_selection.title.edit'
+                                                        })} ${title}`}
                                                         hasSavedAddresses={hasSavedAddresses}
                                                         toggleAddressEdit={toggleAddressEdit}
                                                         hideSubmitButton={hideSubmitButton}
@@ -366,10 +369,10 @@ const ShippingAddressSelection = ({
 
                 {(customer.isGuest || (isEditingAddress && !selectedAddressId)) && (
                     <ShippingAddressEditForm
-                        title={formatMessage({
-                            defaultMessage: 'Add New Address',
-                            id: 'shipping_address_selection.title.add_address'
-                        })}
+                        title={`${formatMessage({
+                            defaultMessage: 'Add New',
+                            id: 'shipping_address_selection.title.add_new'
+                        })} ${title}`}
                         hasSavedAddresses={hasSavedAddresses}
                         toggleAddressEdit={toggleAddressEdit}
                         hideSubmitButton={hideSubmitButton}
@@ -399,6 +402,9 @@ const ShippingAddressSelection = ({
 ShippingAddressSelection.propTypes = {
     /** The form object returnd from `useForm` */
     form: PropTypes.object,
+
+    /** The title for the address */
+    title: PropTypes.string,
 
     /** Optional address to use as default selection */
     selectedAddress: PropTypes.object,

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address-selection.jsx
@@ -39,7 +39,7 @@ const ShippingAddressEditForm = ({
     hideSubmitButton,
     form,
     submitButtonLabel,
-    ariaLabel
+    formTitleAriaLabel
 }) => {
     const {formatMessage} = useIntl()
 
@@ -63,7 +63,7 @@ const ShippingAddressEditForm = ({
                 )}
 
                 <Stack spacing={6}>
-                    <AddressFields form={form} ariaLabel={ariaLabel} />
+                    <AddressFields form={form} formTitleAriaLabel={formTitleAriaLabel} />
 
                     {hasSavedAddresses && !hideSubmitButton ? (
                         <FormActionButtons
@@ -98,7 +98,7 @@ ShippingAddressEditForm.propTypes = {
     hideSubmitButton: PropTypes.bool,
     form: PropTypes.object,
     submitButtonLabel: MESSAGE_PROPTYPE,
-    ariaLabel: MESSAGE_PROPTYPE
+    formTitleAriaLabel: MESSAGE_PROPTYPE
 }
 
 const submitButtonMessage = defineMessage({
@@ -110,7 +110,7 @@ const ShippingAddressSelection = ({
     form,
     selectedAddress,
     submitButtonLabel = submitButtonMessage,
-    ariaLabel,
+    formTitleAriaLabel,
     hideSubmitButton = false,
     onSubmit = async () => null
 }) => {
@@ -325,7 +325,7 @@ const ShippingAddressSelection = ({
                                                         hideSubmitButton={hideSubmitButton}
                                                         form={form}
                                                         submitButtonLabel={submitButtonLabel}
-                                                        ariaLabel={ariaLabel}
+                                                        formTitleAriaLabel={formTitleAriaLabel}
                                                     />
                                                 )}
                                         </React.Fragment>
@@ -379,7 +379,7 @@ const ShippingAddressSelection = ({
                         hideSubmitButton={hideSubmitButton}
                         form={form}
                         submitButtonLabel={submitButtonLabel}
-                        ariaLabel={ariaLabel}
+                        formTitleAriaLabel={formTitleAriaLabel}
                     />
                 )}
 
@@ -412,7 +412,7 @@ ShippingAddressSelection.propTypes = {
     submitButtonLabel: MESSAGE_PROPTYPE,
 
     /** aria label to use for the address group */
-    ariaLabel: PropTypes.MESSAGE_PROPTYPE,
+    formTitleAriaLabel: PropTypes.MESSAGE_PROPTYPE,
 
     /** Show or hide the submit button (for controlling the form from outside component) */
     hideSubmitButton: PropTypes.bool,

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
@@ -103,13 +103,15 @@ export default function ShippingAddress() {
         setIsLoading(false)
     }
 
+    const title = formatMessage({
+        defaultMessage: 'Shipping Address',
+        id: 'shipping_address.title.shipping_address'
+    })
+
     return (
         <ToggleCard
             id="step-1"
-            title={formatMessage({
-                defaultMessage: 'Shipping Address',
-                id: 'shipping_address.title.shipping_address'
-            })}
+            title={title}
             editing={step === STEPS.SHIPPING_ADDRESS}
             isLoading={isLoading}
             disabled={step === STEPS.CONTACT_INFO && !selectedShippingAddress}
@@ -120,6 +122,7 @@ export default function ShippingAddress() {
                     selectedAddress={selectedShippingAddress}
                     submitButtonLabel={submitButtonMessage}
                     onSubmit={submitAndContinue}
+                    title={title}
                 />
             </ToggleCardEdit>
             {selectedShippingAddress && (

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
@@ -124,7 +124,7 @@ export default function ShippingAddress() {
                     selectedAddress={selectedShippingAddress}
                     submitButtonLabel={submitButtonMessage}
                     onSubmit={submitAndContinue}
-                    ariaLabel={shippingAddressAriaLabel}
+                    formTitleAriaLabel={shippingAddressAriaLabel}
                 />
             </ToggleCardEdit>
             {selectedShippingAddress && (

--- a/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/shipping-address.jsx
@@ -26,6 +26,10 @@ const submitButtonMessage = defineMessage({
     defaultMessage: 'Continue to Shipping Method',
     id: 'shipping_address.button.continue_to_shipping'
 })
+const shippingAddressAriaLabel = defineMessage({
+    defaultMessage: 'Shipping Address Form',
+    id: 'shipping_address.label.shipping_address_form'
+})
 
 export default function ShippingAddress() {
     const {formatMessage} = useIntl()
@@ -103,15 +107,13 @@ export default function ShippingAddress() {
         setIsLoading(false)
     }
 
-    const title = formatMessage({
-        defaultMessage: 'Shipping Address',
-        id: 'shipping_address.title.shipping_address'
-    })
-
     return (
         <ToggleCard
             id="step-1"
-            title={title}
+            title={formatMessage({
+                defaultMessage: 'Shipping Address',
+                id: 'shipping_address.title.shipping_address'
+            })}
             editing={step === STEPS.SHIPPING_ADDRESS}
             isLoading={isLoading}
             disabled={step === STEPS.CONTACT_INFO && !selectedShippingAddress}
@@ -122,7 +124,7 @@ export default function ShippingAddress() {
                     selectedAddress={selectedShippingAddress}
                     submitButtonLabel={submitButtonMessage}
                     onSubmit={submitAndContinue}
-                    title={title}
+                    ariaLabel={shippingAddressAriaLabel}
                 />
             </ToggleCardEdit>
             {selectedShippingAddress && (

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -1,10 +1,4 @@
 {
-  "Address Form": [
-    {
-      "type": 0,
-      "value": "use_address_fields.label.address_form"
-    }
-  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -3075,6 +3069,12 @@
     {
       "type": 0,
       "value": "Address"
+    }
+  ],
+  "use_address_fields.label.address_form": [
+    {
+      "type": 0,
+      "value": "Address Form"
     }
   ],
   "use_address_fields.label.city": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -1,4 +1,10 @@
 {
+  "Address Form": [
+    {
+      "type": 0,
+      "value": "use_address_fields.label.address_form"
+    }
+  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -823,6 +829,12 @@
     {
       "type": 0,
       "value": "Credit Card"
+    }
+  ],
+  "checkout_payment.label.billing_address_form": [
+    {
+      "type": 0,
+      "value": "Billing Address Form"
     }
   ],
   "checkout_payment.label.same_as_shipping": [
@@ -2881,6 +2893,12 @@
       "value": "Continue to Shipping Method"
     }
   ],
+  "shipping_address.label.shipping_address_form": [
+    {
+      "type": 0,
+      "value": "Shipping Address Form"
+    }
+  ],
   "shipping_address.title.shipping_address": [
     {
       "type": 0,
@@ -3057,12 +3075,6 @@
     {
       "type": 0,
       "value": "Address"
-    }
-  ],
-  "use_address_fields.label.address_form": [
-    {
-      "type": 0,
-      "value": "Address Form"
     }
   ],
   "use_address_fields.label.city": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -1,10 +1,4 @@
 {
-  "Address Form": [
-    {
-      "type": 0,
-      "value": "use_address_fields.label.address_form"
-    }
-  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -3075,6 +3069,12 @@
     {
       "type": 0,
       "value": "Address"
+    }
+  ],
+  "use_address_fields.label.address_form": [
+    {
+      "type": 0,
+      "value": "Address Form"
     }
   ],
   "use_address_fields.label.city": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -1,4 +1,10 @@
 {
+  "Address Form": [
+    {
+      "type": 0,
+      "value": "use_address_fields.label.address_form"
+    }
+  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -823,6 +829,12 @@
     {
       "type": 0,
       "value": "Credit Card"
+    }
+  ],
+  "checkout_payment.label.billing_address_form": [
+    {
+      "type": 0,
+      "value": "Billing Address Form"
     }
   ],
   "checkout_payment.label.same_as_shipping": [
@@ -2881,6 +2893,12 @@
       "value": "Continue to Shipping Method"
     }
   ],
+  "shipping_address.label.shipping_address_form": [
+    {
+      "type": 0,
+      "value": "Shipping Address Form"
+    }
+  ],
   "shipping_address.title.shipping_address": [
     {
       "type": 0,
@@ -3057,12 +3075,6 @@
     {
       "type": 0,
       "value": "Address"
-    }
-  ],
-  "use_address_fields.label.address_form": [
-    {
-      "type": 0,
-      "value": "Address Form"
     }
   ],
   "use_address_fields.label.city": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1,4 +1,18 @@
 {
+  "Address Form": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ŭŭşḗḗ_ȧȧḓḓřḗḗşş_ƒīḗḗŀḓş.ŀȧȧƀḗḗŀ.ȧȧḓḓřḗḗşş_ƒǿǿřḿ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -1675,6 +1689,20 @@
     {
       "type": 0,
       "value": "Ƈřḗḗḓīŧ Ƈȧȧřḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_payment.label.billing_address_form": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓīŀŀīƞɠ Ȧḓḓřḗḗşş Ƒǿǿřḿ"
     },
     {
       "type": 0,
@@ -6121,6 +6149,20 @@
       "value": "]"
     }
   ],
+  "shipping_address.label.shipping_address_form": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şħīƥƥīƞɠ Ȧḓḓřḗḗşş Ƒǿǿřḿ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "shipping_address.title.shipping_address": [
     {
       "type": 0,
@@ -6525,20 +6567,6 @@
     {
       "type": 0,
       "value": "Ȧḓḓřḗḗşş"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
-  "use_address_fields.label.address_form": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ȧḓḓřḗḗşş Ƒǿǿřḿ"
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1,18 +1,4 @@
 {
-  "Address Form": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "ŭŭşḗḗ_ȧȧḓḓřḗḗşş_ƒīḗḗŀḓş.ŀȧȧƀḗḗŀ.ȧȧḓḓřḗḗşş_ƒǿǿřḿ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
   "account.accordion.button.my_account": [
     {
       "type": 0,
@@ -6567,6 +6553,20 @@
     {
       "type": 0,
       "value": "Ȧḓḓřḗḗşş"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "use_address_fields.label.address_form": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ȧḓḓřḗḗşş Ƒǿǿřḿ"
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -1,4 +1,7 @@
 {
+  "Address Form": {
+    "defaultMessage": "use_address_fields.label.address_form"
+  },
   "account.accordion.button.my_account": {
     "defaultMessage": "My Account"
   },
@@ -321,6 +324,9 @@
   },
   "checkout_payment.heading.credit_card": {
     "defaultMessage": "Credit Card"
+  },
+  "checkout_payment.label.billing_address_form": {
+    "defaultMessage": "Billing Address Form"
   },
   "checkout_payment.label.same_as_shipping": {
     "defaultMessage": "Same as shipping address"
@@ -1229,6 +1235,9 @@
   "shipping_address.button.continue_to_shipping": {
     "defaultMessage": "Continue to Shipping Method"
   },
+  "shipping_address.label.shipping_address_form": {
+    "defaultMessage": "Shipping Address Form"
+  },
   "shipping_address.title.shipping_address": {
     "defaultMessage": "Shipping Address"
   },
@@ -1317,9 +1326,6 @@
   },
   "use_address_fields.label.address": {
     "defaultMessage": "Address"
-  },
-  "use_address_fields.label.address_form": {
-    "defaultMessage": "Address Form"
   },
   "use_address_fields.label.city": {
     "defaultMessage": "City"

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -1,7 +1,4 @@
 {
-  "Address Form": {
-    "defaultMessage": "use_address_fields.label.address_form"
-  },
   "account.accordion.button.my_account": {
     "defaultMessage": "My Account"
   },
@@ -1326,6 +1323,9 @@
   },
   "use_address_fields.label.address": {
     "defaultMessage": "Address"
+  },
+  "use_address_fields.label.address_form": {
+    "defaultMessage": "Address Form"
   },
   "use_address_fields.label.city": {
     "defaultMessage": "City"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -1,4 +1,7 @@
 {
+  "Address Form": {
+    "defaultMessage": "use_address_fields.label.address_form"
+  },
   "account.accordion.button.my_account": {
     "defaultMessage": "My Account"
   },
@@ -321,6 +324,9 @@
   },
   "checkout_payment.heading.credit_card": {
     "defaultMessage": "Credit Card"
+  },
+  "checkout_payment.label.billing_address_form": {
+    "defaultMessage": "Billing Address Form"
   },
   "checkout_payment.label.same_as_shipping": {
     "defaultMessage": "Same as shipping address"
@@ -1229,6 +1235,9 @@
   "shipping_address.button.continue_to_shipping": {
     "defaultMessage": "Continue to Shipping Method"
   },
+  "shipping_address.label.shipping_address_form": {
+    "defaultMessage": "Shipping Address Form"
+  },
   "shipping_address.title.shipping_address": {
     "defaultMessage": "Shipping Address"
   },
@@ -1317,9 +1326,6 @@
   },
   "use_address_fields.label.address": {
     "defaultMessage": "Address"
-  },
-  "use_address_fields.label.address_form": {
-    "defaultMessage": "Address Form"
   },
   "use_address_fields.label.city": {
     "defaultMessage": "City"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -1,7 +1,4 @@
 {
-  "Address Form": {
-    "defaultMessage": "use_address_fields.label.address_form"
-  },
   "account.accordion.button.my_account": {
     "defaultMessage": "My Account"
   },
@@ -1326,6 +1323,9 @@
   },
   "use_address_fields.label.address": {
     "defaultMessage": "Address"
+  },
+  "use_address_fields.label.address_form": {
+    "defaultMessage": "Address Form"
   },
   "use_address_fields.label.city": {
     "defaultMessage": "City"


### PR DESCRIPTION
Pass custom aria label for the address forms depending on the adress type (Billing/Shipping)

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)



# How to Test-Drive This PR

1. Checkout code
2. Run Retail App template
3. Check out cart with VoiceOver (Cmd + f5)
4. Add & Edit address with in a registered user account
