### PR TITLE
[BUG] 🪳 Fix unwanted re-fetching of data on first page load

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.7.0-dev (Jun 25, 2024)
+- Ensure server fetched query data is not stale [#1912](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1912)
 - Add server side rendering performance metrics via query parameter `__server_timing` or environment variable `SERVER_TIMING`, the metrics is available in the console logs and response header `server-timing`. [#1895](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1895)
 
 ## v3.6.0 (Jun 25, 2024)

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v3.7.0-dev (Jun 25, 2024)
-- Ensure server fetched query data is not stale [#1912](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1912)
+- Add `beforeHydrate` option to withReactQuery component [#1912](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1912)
 - Add server side rendering performance metrics via query parameter `__server_timing` or environment variable `SERVER_TIMING`, the metrics is available in the console logs and response header `server-timing`. [#1895](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1895)
 
 ## v3.6.0 (Jun 25, 2024)

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
@@ -46,7 +46,7 @@ export const withReactQuery = (Wrapped, options = {}) => {
                     preloadedState = beforeHydrate(window.__PRELOADED_STATE__?.[STATE_KEY] || {})
                 } catch (e) {
                     logger.error('Client `beforeHydrate` failed', {
-                        namespace: 'WithReactQuery render',
+                        namespace: 'with-react-query.render',
                         additionalProperties: {error: e}
                     })
                 }

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.test.js
@@ -78,7 +78,7 @@ describe('withReactQuery', function () {
         expect(logger.error).toHaveBeenCalledTimes(1)
         expect(logger.error).toHaveBeenCalledWith('Client `beforeHydrate` failed', {
             additionalProperties: {error: mockError},
-            namespace: 'WithReactQuery render'
+            namespace: 'with-react-query.render'
         })
     })
 

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.test.js
@@ -7,9 +7,17 @@
 import {withReactQuery} from './index'
 import {render, screen} from '@testing-library/react'
 import React from 'react'
+import logger from '../../../../utils/logger-instance'
+
+jest.mock('../../../../utils/logger-instance', () => {
+    return {
+        error: jest.fn()
+    }
+})
 
 describe('withReactQuery', function () {
     let windowSpy
+    let oldPreloadedState = window.__PRELOADED_STATE__
 
     beforeEach(() => {
         windowSpy = jest.spyOn(window, 'window', 'get')
@@ -19,6 +27,8 @@ describe('withReactQuery', function () {
     afterEach(() => {
         console.warn.mockRestore()
         windowSpy.mockRestore()
+
+        window.__PRELOADED_STATE__ = oldPreloadedState
     })
 
     test('Renders correctly', () => {
@@ -27,6 +37,49 @@ describe('withReactQuery', function () {
         render(<Component locals={{}} />)
 
         expect(screen.getByText(/Hello world/i)).toBeInTheDocument()
+    })
+
+    test('`beforeHydrate` called on mount', () => {
+        const mockPreloadedState = {payload: {}}
+        const mockBeforeHydrate = jest.fn()
+
+        const Wrapped = () => <p>Hello world</p>
+        const Component = withReactQuery(Wrapped, {
+            beforeHydrate: mockBeforeHydrate
+        })
+
+        window.__PRELOADED_STATE__ = {__reactQuery: mockPreloadedState}
+        render(<Component locals={{}} />)
+
+        expect(screen.getByText(/Hello world/i)).toBeInTheDocument()
+        expect(mockBeforeHydrate).toHaveBeenCalledTimes(1)
+        expect(mockBeforeHydrate).toHaveBeenCalledWith(mockPreloadedState)
+    })
+
+    test('Renders correctly when `beforeHydrate` throws', () => {
+        const mockPreloadedState = {payload: {}}
+        const mockError = new Error('Test Error')
+        const mockBeforeHydrate = jest.fn().mockImplementation(() => {
+            throw mockError
+        })
+
+        const Wrapped = () => <p>Hello world</p>
+        const Component = withReactQuery(Wrapped, {
+            beforeHydrate: mockBeforeHydrate
+        })
+
+        window.__PRELOADED_STATE__ = {__reactQuery: mockPreloadedState}
+        logger.error = jest.fn()
+        render(<Component locals={{}} />)
+
+        expect(screen.getByText(/Hello world/i)).toBeInTheDocument()
+        expect(mockBeforeHydrate).toHaveBeenCalledTimes(1)
+        expect(mockBeforeHydrate).toHaveBeenCalledWith(mockPreloadedState)
+        expect(logger.error).toHaveBeenCalledTimes(1)
+        expect(logger.error).toHaveBeenCalledWith('Client `beforeHydrate` failed', {
+            additionalProperties: {error: mockError},
+            namespace: 'WithReactQuery render'
+        })
     })
 
     test(`Has working getInitializers method`, () => {

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 
+- Update serialized query data via `beforeHydrate` to prevent data re-fetching on load [#1912](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1912)
 - A11y: Add aria-label to the address form based on the address type [#1904](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1904)
 - A11y: Account Nav fixes [#1884](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1884)
 - A11y: Replace `<p>` tags with header tag in home page Features section [#1902](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1902)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -138,7 +138,7 @@ const options = {
     beforeHydrate: (data) => {
         const now = Date.now()
 
-        // Helper for removing the data timestamp.
+        // Helper to reset the data timestamp to time of app load.
         const updateQueryTimeStamp = ({state}) => {
             state.dataUpdatedAt = now
         }

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -119,8 +119,6 @@ AppConfig.propTypes = {
 
 const isServerSide = typeof window === 'undefined'
 
-const now = Date.now() // 396687600000
-
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 // retry is always disabled on server side regardless of the value from the options
@@ -139,13 +137,16 @@ const options = {
         }
     },
     beforeHydrate: (data) => {
-        // Helper for updating the data timestamp.
-        const updateQueryTimeStamp = ({state}) => state.dataUpdatedAt = now
-        
-        // Update serialized mutations and queries.
+        // Helper for removing the data timestamp.
+        const updateQueryTimeStamp = ({state}) => {
+            delete state.dataUpdatedAt
+        }
+
+        // Update serialized mutations and queries to ensure that the cached data is
+        // considered fresh on first load.
         data?.mutations?.forEach(updateQueryTimeStamp)
         data?.queries?.forEach(updateQueryTimeStamp)
-        
+
         return data
     }
 }

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -118,7 +118,6 @@ AppConfig.propTypes = {
 }
 
 const isServerSide = typeof window === 'undefined'
-
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 // retry is always disabled on server side regardless of the value from the options
@@ -137,9 +136,11 @@ const options = {
         }
     },
     beforeHydrate: (data) => {
+        const now = Date.now()
+
         // Helper for removing the data timestamp.
         const updateQueryTimeStamp = ({state}) => {
-            delete state.dataUpdatedAt
+            state.dataUpdatedAt = now
         }
 
         // Update serialized mutations and queries to ensure that the cached data is

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -139,12 +139,12 @@ const options = {
         }
     },
     beforeHydrate: (data) => {
-        console.log('beforeHydrate!', data, data['mutations'], data['queries'])
-        ;['mutations', 'queries'].forEach((type) => {
-            ;(data[type] || []).forEach(({state}) => {
-                state.dataUpdatedAt = now
-            })
-        })
+        // Helper for updating the data timestamp.
+        const updateQueryTimeStamp = ({state}) => state.dataUpdatedAt = now
+        
+        // Update serialized mutations and queries.
+        data?.mutations?.forEach(updateQueryTimeStamp)
+        data?.queries?.forEach(updateQueryTimeStamp)
         
         return data
     }

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -119,6 +119,8 @@ AppConfig.propTypes = {
 
 const isServerSide = typeof window === 'undefined'
 
+const now = Date.now() // 396687600000
+
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 // retry is always disabled on server side regardless of the value from the options
@@ -135,6 +137,16 @@ const options = {
                 retry: false
             }
         }
+    },
+    beforeHydrate: (data) => {
+        console.log('beforeHydrate!', data, data['mutations'], data['queries'])
+        ;['mutations', 'queries'].forEach((type) => {
+            ;(data[type] || []).forEach(({state}) => {
+                state.dataUpdatedAt = now
+            })
+        })
+        
+        return data
     }
 }
 


### PR DESCRIPTION
# Description

Currently the `template-retail-react-app` uses a `staleTime` of _10 seconds_ for React Query. We use this value, in part, to avoid re-fetching data on the first page load.

Unfortunately we have not accounted for **cached** pages. This means a cached response can be up to 10 minutes old (by default) and the data within the cached responses is almost always stale unless the cached pages is less that 10 seconds old.

This isn't the behaviour we want or had intended. We want the data to be fresh for the 10 seconds as defined in the stale time prop. Meaning the data's `dataUpdatedAt` should always be the same time the app loads.

In this PR we ensure that we "fudge" the data's timestamp and assign it the _datetime_ that the app of loaded, not the value it was initially fetched.

**NOTE: This isn't a great solution so I'm looking for some feedback, below are some alternative solutions that I've looked in to or considered.**

1. Ensure the stale time is longer than the ssr page cache time. (This should effect the user experience after page load as data would stay fresh longer)
2. Instead of deleting the timestamp we set it to the current time. (This works, but is finicky as it takes time from hydration of the provider to the time the plp requests data, so we almost need a buffer time to add to it)
3. Use APIs in ReactQuery like prefetchData or initialData and initialDataUpdatedAt (none seemed to do exactly what we wanted) 


https://github.com/user-attachments/assets/1228ddd9-9b8c-4dd5-8c42-d117f744e699


### Lighthouse Scores

Before:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/ec34b38f-2017-435f-8d9b-70d7544b6bb5">

After:

<img width="891" alt="image" src="https://github.com/user-attachments/assets/8814f9df-2bcc-45d1-952a-7102449cabe7">

Note: Score values seemed to be more unpredictable on the pre-fix and were all over the place (probably as sometimes the loading skeleton was shown and sometimes not) on the fixed version they were more consistent. 

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Overwrite time stamp for all serialized queries and mutations in the _withReactQuery_ HOC.
- Added tests.

# How to Test-Drive This PR

- Run dev-server
- Goto [http://localhost:3000/global/en-GB/category/mens](http://localhost:3000/global/en-GB/category/mens)
- Open the chrome inspector and set your network speed to `fast 3g` (maybe even `slow 3g`)
- Refresh the page.
- Notice that you don't see loading skeletons (you would have see them on https://pwa-kit.mobify-storefront.com/global/en-GB/category/mens)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
