### PR TITLE
Account for paths with '.'

### DIFF
--- a/packages/pwa-kit-dev/src/utils/resolver-utils.js
+++ b/packages/pwa-kit-dev/src/utils/resolver-utils.js
@@ -21,7 +21,7 @@ export const isSelfReference = (importPath, sourcePath) => {
     const indexRegExp = new RegExp(`(/${INDEX_FILE})$`)
 
     // Sanitize the input. Here we want to remove the file extension and index file if it exists.
-    sourcePath = sourcePath.split('.')[0]
+    sourcePath = sourcePath.replace(/\.[^/.]+$/, '')
     sourcePath = sourcePath.split(path.sep).join('/')
     sourcePath = sourcePath.replace(indexRegExp, '')
 

--- a/packages/pwa-kit-dev/src/utils/resolver-utils.test.js
+++ b/packages/pwa-kit-dev/src/utils/resolver-utils.test.js
@@ -8,6 +8,9 @@
 import path from 'path'
 import * as resolverUtils from './resolver-utils'
 
+const PROJECT_PATH_GOOD = '/home/user/testproject'
+const PROJECT_PATH_BAD = '/home/user/test.project'
+
 describe('resolverUtils', () => {
     describe('"isSelfReference" util returns whether or not a wildcard import is for the same module it is coming from.', () => {
         ;[
@@ -15,21 +18,33 @@ describe('resolverUtils', () => {
                 name: 'Importing the wildcard routes from the routes file',
                 importPath: 'app/routes',
                 sourcePath: path.join(
-                    process.cwd(),
+                    PROJECT_PATH_GOOD,
                     'node_modules',
                     '@salesforce',
                     'extension-module-extension-b',
                     'app',
                     'routes.jsx'
                 ),
-
+                expected: true
+            },
+            {
+                name: 'Importing the wildcard routes from the routes file where project path has dots in it',
+                importPath: 'app/routes',
+                sourcePath: path.join(
+                    PROJECT_PATH_BAD,
+                    'node_modules',
+                    '@salesforce',
+                    'extension-module-extension-b',
+                    'app',
+                    'routes.jsx'
+                ),
                 expected: true
             },
             {
                 name: 'Importing a page component from the routes file',
                 importPath: 'app/pages/new-home',
                 sourcePath: path.join(
-                    process.cwd(),
+                    PROJECT_PATH_GOOD,
                     'node_modules',
                     '@salesforce',
                     'extension-module-extension-b',


### PR DESCRIPTION
# Description

Small fix to `isSelfReference` utility. This is probably going to be one of many, but we'll fix them as we go.
