### PR TITLE
Adjust SLAS private proxy logging

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -705,29 +705,25 @@ export const RemoteServerFactory = {
                 },
                 onProxyRes: (proxyRes, req) => {
                     if (proxyRes.statusCode && proxyRes.statusCode >= 400) {
-                        logger.error(
-                            `Failed to proxy SLAS Private Client request - ${proxyRes.statusCode}`,
-                            {
-                                namespace: '_setupSlasPrivateClientProxy',
-                                additionalProperties: {statusCode: proxyRes.statusCode}
-                            }
-                        )
-                        logger.error(
-                            `Please make sure you have enabled the SLAS Private Client Proxy in your ssr.js and set the correct environment variable PWA_KIT_SLAS_CLIENT_SECRET.`,
-                            {namespace: '_setupSlasPrivateClientProxy'}
-                        )
-                        logger.error(
-                            `SLAS Private Client Proxy Request URL - ${req.protocol}://${req.get(
-                                'host'
-                            )}${req.originalUrl}`,
-                            {
-                                namespace: '_setupSlasPrivateClientProxy',
-                                additionalProperties: {
-                                    protocol: req.protocol,
-                                    originalUrl: req.originalUrl
+                        proxyRes.on('data', (data) => {
+                            const errorMessage = data.toString('utf-8')
+                            logger.error(
+                                `Failed to proxy SLAS Private Client request to ${
+                                    req.protocol
+                                }://${req.get('host')}${req.originalUrl} - HTTP ${
+                                    proxyRes.statusCode
                                 }
-                            }
-                        )
+                                ${errorMessage}`,
+                                {
+                                    namespace: '_SlasPrivateClientProxy',
+                                    additionalProperties: {
+                                        statusCode: proxyRes.statusCode,
+                                        protocol: req.protocol,
+                                        originalUrl: req.originalUrl
+                                    }
+                                }
+                            )
+                        })
                     }
                 }
             })


### PR DESCRIPTION
This fixes a small bug in our logging.

Currently, when a private client request sent to SLAS returns an HTTP > 400, we are swallowing the error to print out a message about enabling the private client proxy.

This adjusts the logger so that the correct SLAS error message is surfaced in the logs.

Example message:
```
pwa-kit-runtime._SlasPrivateClientProxy ERROR Failed to proxy SLAS Private Client request to http://localhost:3000/mobify/slas/private/shopper/auth/v1/organizations/f_ecom_zzrf_001/oauth2/token - HTTP 401
                                {
  "status_code" : "401 UNAUTHORIZED",
  "message" : "incorrect client type"
} {"statusCode":401,"protocol":"http","originalUrl":"/mobify/slas/private/shopper/auth/v1/organizations/f_ecom_zzrf_001/oauth2/token"}
```

Testing this change:
* Check out this change
* Enable SLAS private client mode (there are switches in the app's _app-config and ssr.js)
* Start the app with some obviously incorrect client secret ie. `PWA_KIT_SLAS_CLIENT_SECRET=someSecret npm start`
* Check the outputted logs and verify that the error message from SLAS is not swallowed.