### PR TITLE
[A11y][Header] Avoid forced focus changes that are not user-initiated (@W-12627128@) (@W-12627141@)

### DIFF
--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -106,6 +106,7 @@ const Header = ({
     ...props
 }) => {
     const intl = useIntl()
+    const popoverTriggerRef = useRef(null)
     const {
         derivedData: {totalItems},
         data: basket
@@ -143,6 +144,14 @@ const Header = ({
         }, 100)
     }
 
+    const handleKeyDown = (event) => {
+        if (event.key === 'Tab' && event.shiftKey && isAccountMenuOpen) {
+            // Prevent default behavior to keep focus on the popup trigger
+            event.preventDefault()
+            popoverTriggerRef.current.focus()
+        }
+    }
+
     return (
         <Box {...styles.container} {...props}>
             <Box {...styles.content}>
@@ -153,6 +162,7 @@ const Header = ({
                             id: 'header.button.assistive_msg.menu',
                             defaultMessage: 'Menu'
                         })}
+                        title="Opens a dialog"
                         icon={<HamburgerIcon />}
                         variant="unstyled"
                         display={{lg: 'none'}}
@@ -206,6 +216,8 @@ const Header = ({
                                     {...getAccountMenuButtonProps()}
                                     onMouseOver={onAccountMenuOpen}
                                     onMouseLeave={handleIconsMouseLeave}
+                                    ref={popoverTriggerRef}
+                                    onKeyDown={handleKeyDown}
                                 />
                             </PopoverTrigger>
 

--- a/packages/template-retail-react-app/app/components/header/index.jsx
+++ b/packages/template-retail-react-app/app/components/header/index.jsx
@@ -162,7 +162,10 @@ const Header = ({
                             id: 'header.button.assistive_msg.menu',
                             defaultMessage: 'Menu'
                         })}
-                        title="Opens a dialog"
+                        title={intl.formatMessage({
+                            id: 'header.button.assistive_msg.menu.open_dialog',
+                            defaultMessage: 'Opens a dialog'
+                        })}
                         icon={<HamburgerIcon />}
                         variant="unstyled"
                         display={{lg: 'none'}}

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -1527,6 +1527,12 @@
       "value": "Menu"
     }
   ],
+  "header.button.assistive_msg.menu.open_dialog": [
+    {
+      "type": 0,
+      "value": "Opens a dialog"
+    }
+  ],
   "header.button.assistive_msg.my_account": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -1527,6 +1527,12 @@
       "value": "Menu"
     }
   ],
+  "header.button.assistive_msg.menu.open_dialog": [
+    {
+      "type": 0,
+      "value": "Opens a dialog"
+    }
+  ],
   "header.button.assistive_msg.my_account": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -3175,6 +3175,20 @@
       "value": "]"
     }
   ],
+  "header.button.assistive_msg.menu.open_dialog": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ǿƥḗḗƞş ȧȧ ḓīȧȧŀǿǿɠ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "header.button.assistive_msg.my_account": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -93,7 +93,7 @@
   "bundlesize": [
     {
       "path": "build/main.js",
-      "maxSize": "47 kB"
+      "maxSize": "48 kB"
     },
     {
       "path": "build/vendor.js",

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -621,6 +621,9 @@
   "header.button.assistive_msg.menu": {
     "defaultMessage": "Menu"
   },
+  "header.button.assistive_msg.menu.open_dialog": {
+    "defaultMessage": "Opens a dialog"
+  },
   "header.button.assistive_msg.my_account": {
     "defaultMessage": "My account"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -621,6 +621,9 @@
   "header.button.assistive_msg.menu": {
     "defaultMessage": "Menu"
   },
+  "header.button.assistive_msg.menu.open_dialog": {
+    "defaultMessage": "Opens a dialog"
+  },
   "header.button.assistive_msg.my_account": {
     "defaultMessage": "My account"
   },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

The PR adds the title attribute to indicate the link opens a dialogue and keeps the focus on the My Account control element.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Added title attribute and keep the focus on the popup trigger when using Shift+Tab.

# How to Test-Drive This PR

1. Verify the hamburger icon on mobile now has the title attribute.
2. Verify the focus is kept in the My Account menu trigger when using Shift + Tab.
    2.1. Open the My Account menu.
    2.2. Press the Tab key to navigate between the options.
    2.3. Press Shift+Tab multiple times and verify the focus is kept in the popup trigger.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
