### PR TITLE
[App Ext] Install the sample extension in the typescript-minimal project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,11 @@ jobs:
       - name: Setup Ubuntu Machine
         uses: "./.github/actions/setup_ubuntu"
 
+      - name: Update identity in git config
+        run: |-
+          git config --global user.name ${{ secrets.GIT_CONFIG_USERNAME }}
+          git config --global user.email ${{ secrets.GIT_CONFIG_EMAIL }}
+
       - name: Generate ${{ matrix.template }} project
         run: |-
           node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir ${{ env.PROJECT_DIR }}
@@ -299,6 +304,11 @@ jobs:
 
       - name: Setup Windows Machine
         uses: "./.github/actions/setup_windows"
+
+      - name: Update identity in git config
+        run: |-
+          git config --global user.name ${{ secrets.GIT_CONFIG_USERNAME }}
+          git config --global user.email ${{ secrets.GIT_CONFIG_EMAIL }}
 
       - name: Generate ${{ matrix.template }} project
         run: |-

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js
@@ -54,7 +54,7 @@ const logFileName = p.join(__dirname, '..', 'local-npm-repo', 'verdaccio.log')
 const makePublic = (pkgLocation) => {
     sh.exec('npm pkg delete private', {cwd: pkgLocation})
 
-    sh.exec('git add .', {silent: true})
+    sh.exec('git add .')
     sh.exec('git commit -m "temporary commit to have clean working tree"', {silent: true})
 
     const revertChanges = () => {
@@ -122,7 +122,7 @@ const withLocalNPMRepo = (func) => {
             // the public NPM repo.
             console.log('Publishing packages to the local NPM repository')
 
-            // TODO: delete this when done
+            // TODO: revert PR #2001 when done
             revertChangesToSampleExtension = makePublic(
                 p.join(monorepoRoot, 'packages', 'extension-sample')
             )

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -133,6 +133,10 @@ const Home = ({value}: Props) => {
                             Client-side JS works if this counter increments: {counter}
                             <br />
                             <br />
+                            App Extensions work if you can navigate to this link:{' '}
+                            <Link to="/sample-page">sample page</Link>.
+                            <br />
+                            <br />
                             <b>You can mix-and-match JS and TS</b>
                             <br />
                             <br />

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -30,14 +30,17 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "react-router-dom": "^5.3.4",
-    "typescript": "4.9.5"
+    "typescript": "4.9.5",
+    "@salesforce/extension-sample": "1.0.0-dev"
   },
   "engines": {
     "node": "^16.11.0 || ^18.0.0 || ^20.0.0",
     "npm": "^8.0.0 || ^9.0.0 || ^10.0.0"
   },
   "mobify": {
-    "app":{},
+    "app": {
+      "extensions": ["@salesforce/extension-sample"]
+    },
     "ssrEnabled": true,
     "ssrOnly": [
       "ssr.js",


### PR DESCRIPTION
To make it easier for testing our development of the App Extensibility feature, we've created this sample app extension. Now the remaining piece is to use/install it in the typescript-minimal project. 

Credit goes to the instruction found in this PR description: #1978 

When the feature is done and its feature branch is ready to merge, then we can clean up and revert the changes in this PR if we want to.

## How to test-drive

```bash
npm ci  # at the monorepo root
cd packages/template-typescript-minimal
npm start
```

Then verify that the loaded page has red border around it. There's also a link to navigate to a sample page: click that and verify the resulting page.