### PR TITLE
@W-16660178@ Small bug fixes

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,9 +3,12 @@
 ### Bug Fixes
 - The unused `njwt` npm package had a security vulnerability, since it was unused, the package has been dropped
 - Remove save/edit billing action in checkout page for the registered user [#1976](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1976)
+- Product scroller: don't skip tiles if window is too large [#2003](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2003)
+- PDP / PLP: Render non HTTP 404 erros [#2003](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2003)
+- Error page: Render home page when clicking nav icon [#2003](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2003)
 
 ### Accessibility Improvements
-- [a11y] Hide svg from screenreader as they are decorative on homepage [#1980](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1980) 
+- [a11y] Hide svg from screenreader as they are decorative on homepage [#1980](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1980)
 
 
 ### Accessibility Improvements

--- a/packages/template-retail-react-app/app/components/_error/index.jsx
+++ b/packages/template-retail-react-app/app/components/_error/index.jsx
@@ -18,7 +18,6 @@ import {
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 
 import {BrandLogo, FileIcon} from '@salesforce/retail-react-app/app/components/icons'
-import {useHistory} from 'react-router-dom'
 
 // <Error> is rendered when:
 //
@@ -30,7 +29,6 @@ import {useHistory} from 'react-router-dom'
 
 const Error = (props) => {
     const {message, stack} = props
-    const history = useHistory()
 
     const title = "This page isn't working"
     return (
@@ -52,7 +50,7 @@ const Error = (props) => {
                         icon={<BrandLogo width={[8, 8, 8, 12]} height={[6, 6, 6, 8]} />}
                         marginBottom={[1, 1, 2, 0]}
                         variant="unstyled"
-                        onClick={() => history.push('/')}
+                        onClick={() => (window.location.href = '/')}
                     />
                 </Box>
             </Box>

--- a/packages/template-retail-react-app/app/components/_error/index.jsx
+++ b/packages/template-retail-react-app/app/components/_error/index.jsx
@@ -50,6 +50,9 @@ const Error = (props) => {
                         icon={<BrandLogo width={[8, 8, 8, 12]} height={[6, 6, 6, 8]} />}
                         marginBottom={[1, 1, 2, 0]}
                         variant="unstyled"
+                        // We need to use window.location.href here rather than history
+                        // as the application is in an error state. We need to force a
+                        // hard navigation to get back to the normal state.
                         onClick={() => (window.location.href = '/')}
                     />
                 </Box>

--- a/packages/template-retail-react-app/app/components/product-scroller/index.jsx
+++ b/packages/template-retail-react-app/app/components/product-scroller/index.jsx
@@ -49,7 +49,7 @@ const ProductScroller = forwardRef(
         const scroll = (direction = 1) => {
             scrollRef.current?.scrollBy({
                 top: 0,
-                left: direction * window.innerWidth,
+                left: direction * scrollRef.current?.offsetWidth,
                 behavior: 'smooth'
             })
         }

--- a/packages/template-retail-react-app/app/components/product-scroller/index.test.js
+++ b/packages/template-retail-react-app/app/components/product-scroller/index.test.js
@@ -53,13 +53,13 @@ describe('Product Scroller', () => {
         await user.click(screen.getByTestId('product-scroller-nav-right'))
         expect(window.HTMLElement.prototype.scrollBy).toHaveBeenCalledWith({
             top: 0,
-            left: 1024,
+            left: 0,
             behavior: 'smooth'
         })
         await user.click(screen.getByTestId('product-scroller-nav-left'))
         expect(window.HTMLElement.prototype.scrollBy).toHaveBeenCalledWith({
             top: 0,
-            left: -1024,
+            left: -0,
             behavior: 'smooth'
         })
         expect(screen.getByTestId('product-scroller-nav-left')).toBeInTheDocument()

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -178,7 +178,7 @@ const ProductDetail = () => {
             case 404:
                 throw new HTTPNotFound('Product Not Found.')
             default:
-                throw new HTTPError(`HTTP Error ${errorStatus} occurred.`)
+                throw new HTTPError(errorStatus, `HTTP Error ${errorStatus} occurred.`)
         }
     }
     if (isCategoryError) {
@@ -187,7 +187,7 @@ const ProductDetail = () => {
             case 404:
                 throw new HTTPNotFound('Category Not Found.')
             default:
-                throw new HTTPError(`HTTP Error ${errorStatus} occurred.`)
+                throw new HTTPError(errorStatus, `HTTP Error ${errorStatus} occurred.`)
         }
     }
 

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -192,7 +192,7 @@ const ProductList = (props) => {
         case 404:
             throw new HTTPNotFound('Category Not Found.')
         default:
-            throw new HTTPError(`HTTP Error ${errorStatus} occurred.`)
+            throw new HTTPError(errorStatus, `HTTP Error ${errorStatus} occurred.`)
     }
 
     /**************** Response Handling ****************/


### PR DESCRIPTION
This PR fixes the bugs reported in #1946 and #1941

Testing:

For #1946 (Default product-scroller skips tiles (desktop)),

Start the app on the home page then scroll down to the recommended product scroller. Scroll the products and make sure no tiles are skipped

Before:

https://github.com/user-attachments/assets/278301f1-b05b-48d5-b5b8-291de3573b99

After:

https://github.com/user-attachments/assets/869d23d9-d6bc-4d00-afdb-2d26434ce47b



For #1941 (Error handling issues)

PDP / PLP error handling:
Make the app throw a non 404 error and verify that the error page is rendered.
(I just commented out the HTTP 404 case so that the default HTTPError constructor is called when I render a 404)

Navigating back to the home page from error page
Once on the error page, click the Salesforce cloud icon to navigate back to home. Ensure that the home page renders.

Before:

https://github.com/user-attachments/assets/ed7bed60-a2a6-4bde-8c58-a0a7b417baab

After:

https://github.com/user-attachments/assets/fdacbf16-2894-4f28-96ca-a919b356af09


