### PR TITLE
@W-16795135@ [App Extensibility ⚙️] Use ApplicationExtension abstract class over Typescript interface

### DIFF
--- a/packages/extension-sample/src/setup-server.ts
+++ b/packages/extension-sample/src/setup-server.ts
@@ -5,21 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { IExpressApplicationExtension } from '@salesforce/pwa-kit-runtime/ssr/server/extensibility/types'
-import { Application } from 'express'
+import {
+    Application as ExpressApplication,
+    ApplicationExtension as ExpressApplicationExtension
+} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
 
-class SampleExtension implements IExpressApplicationExtension {
-    private options: any
+class SampleExtension extends ExpressApplicationExtension {
 
-    constructor(options: any) {
-        this.options = options
-    }
-
-    getName(): string {
-        return 'SampleExtension'
-    }
-
-    extendApp(app: Application): Application {
+    extendApp(app: ExpressApplication): ExpressApplication {
 
         app.get('/sample', (req, res) => {
             console.log('SampleExtension extendApp GET /sample')

--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v4.0.0-dev (Jun 21, 2024)
-- Change Webpack logic to include all installed Application Extensions in the app bundle. (#2004)[https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2004]
+- Replace `IApplicationExtension` with `ApplicationExtension` abstract class. [#2019](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2019)
+- Change Webpack logic to include all installed Application Extensions in the app bundle. [#2004](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2004)
 
 ## v3.6.0 (Apr 17, 2024)
 - Implement core wildcard import logic to be used in upcoming webpack/babel plugins [#1826](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1826)

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.js
@@ -19,6 +19,8 @@ import open from 'open'
 import logger from '../../utils/logger-instance'
 import requireFromString from 'require-from-string'
 import {RemoteServerFactory} from '@salesforce/pwa-kit-runtime/ssr/server/build-remote-server'
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
+
 import {proxyConfigs} from '@salesforce/pwa-kit-runtime/utils/ssr-shared'
 import {bundleBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-paths'
 import {
@@ -166,6 +168,7 @@ export const DevServerMixin = {
 
             let ExtensionClass
             try {
+                console.log('filePath, __filename: ', filePath, __filename)
                 ExtensionClass = tsx.require(filePath, __filename).default
             } catch (e) {
                 logger.error(`Error loading extension ${extension}:`, {
@@ -175,9 +178,19 @@ export const DevServerMixin = {
                 return
             }
 
-            // Ensure that the default export is a class that implements IExpressApplicationExtension
-            if (ExtensionClass && typeof ExtensionClass !== 'function') {
-                logger.warn(`Extension ${extension} does not export a valid class. Skipping.`)
+            // Ensure that the default export is a class that extends abstract class "ApplicationExtension".
+            const isPrototype = Object.prototype.isPrototypeOf.call(
+                ApplicationExtension.prototype,
+                ExtensionClass?.prototype
+            )
+
+            if (!isPrototype) {
+                logger.error(
+                    `'${extension}' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`,
+                    {
+                        namespace: 'DevServerMixin._setupExtensions'
+                    }
+                )
                 return
             }
 
@@ -191,17 +204,6 @@ export const DevServerMixin = {
                     namespace: 'DevServerMixin._setupExtensions',
                     additionalProperties: {error: e}
                 })
-                return
-            }
-
-            // Verify the instance has the methods defined by IExpressApplicationExtension
-            if (
-                typeof extensionInstance.getName !== 'function' ||
-                typeof extensionInstance.extendApp !== 'function'
-            ) {
-                logger.warn(
-                    `Extension ${extension} does not implement IExpressApplicationExtension interface. Skipping.`
-                )
                 return
             }
 

--- a/packages/pwa-kit-dev/src/ssr/server/build-dev-server.test.js
+++ b/packages/pwa-kit-dev/src/ssr/server/build-dev-server.test.js
@@ -855,7 +855,7 @@ describe('extensions', () => {
 
         expect(errorlog.mock.calls).toEqual([
             [
-                'pwa-kit-dev.DevServerMixin._setupExtensions ERROR Error instantiating extension extension-with-setup-server-no-default-export: {"error":{}}'
+                `pwa-kit-dev.DevServerMixin._setupExtensions ERROR 'extension-with-setup-server-no-default-export' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`
             ]
         ])
     })

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/another-extension/src/setup-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/another-extension/src/setup-server.js
@@ -5,16 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-class AnotherExtension {
-    options
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
 
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'AnotherExtension'
-    }
+class AnotherExtension extends ApplicationExtension {
 
     extendApp(app) {
         app.get('/another-extension', (req, res) => {

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/extension-with-bad-setup-server/src/setup-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/extension-with-bad-setup-server/src/setup-server.js
@@ -5,16 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-class Extension {
-    options
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
 
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'Extension'
-    }
+class Extension extends ApplicationExtension {
 
     extendApp(app) {
         throw new Error('extension will fail to initialize because of me')

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/extension-with-setup-server-no-default-export/src/setup-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/extension-with-setup-server-no-default-export/src/setup-server.js
@@ -4,18 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
 
-class AnotherExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'AnotherExtension'
-    }
-
+class AnotherExtension extends ApplicationExtension {
     extendApp(app) {
         app.get('/another-extension', (req, res) => {
             res.send('test')

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/test-extension/setup-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/test-extension/setup-server.js
@@ -4,18 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-
-class TestExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'TestExtension'
-    }
-
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
+console.log('ApplicationExtension ApplicationExtension ApplicationExtension: ', ApplicationExtension)
+class TestExtension extends ApplicationExtension {
     extendApp(app) {
         app.get('/test-extension', (req, res) => {
             res.send('test')

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/test-extension/src/setup-server.js
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/test-extension/src/setup-server.js
@@ -4,18 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
 
-class TestExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'TestExtension'
-    }
-
+class TestExtension extends ApplicationExtension{
     extendApp(app) {
         app.get('/test-extension', (req, res) => {
             res.send('test')

--- a/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/ts-extension/src/setup-server.ts
+++ b/packages/pwa-kit-dev/src/ssr/server/test_fixtures/node_modules/ts-extension/src/setup-server.ts
@@ -5,19 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { IApplicationExtension } from '@salesforce/pwa-kit-runtime/ssr/server/extensibility/types'
-import { Application } from 'express'
+import {Application, ApplicationExtension} from '@salesforce/pwa-kit-runtime/ssr/server/extensibility'
+// import {Application} from 'express'
 
-class TypeScriptExtension implements IApplicationExtension {
-    private options: any
-
-    constructor(options: any) {
-        this.options = options
-    }
-
-    getName(): string {
-        return 'TypeScriptExtension'
-    }
+class TypeScriptExtension extends ApplicationExtension {
 
     extendApp(app: Application): Application {
 

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
@@ -31,7 +31,7 @@ export const getAssetUrl = (path: string) => {
     const publicPath = onClient
         ? // @ts-ignore
           `${window.Progressive.buildOrigin as string}`
-        : `${bundleBasePath as string}/${process.env.BUNDLE_ID || 'development'}/`
+        : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}/`
     return path ? `${publicPath}${path}` : publicPath
 }
 

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v4.0.0-dev (Jun 21, 2024)
+- Replace `IApplicationExtension` with `ApplicationExtension` abstract class. [#2019](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2019)
 
 ## v3.7.0 (Aug 07, 2024)
 

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -26,6 +26,7 @@
       "devDependencies": {
         "@loadable/component": "^5.15.3",
         "@serverless/event-mocks": "^1.1.1",
+        "@types/express": "^4.17.21",
         "aws-lambda-mock-context": "^3.2.1",
         "fs-extra": "^11.1.1",
         "nock": "^13.3.0",
@@ -493,6 +494,55 @@
       "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.5.tgz",
+      "integrity": "sha512-y6W03tvrACO72aijJ5uF02FRq5cgDR9lUxddQ8vyF+GvmjJQqbzDcJngEjURc+ZsG31VI3hODNZJ2URj86pzmg==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "devOptional": true
+    },
     "node_modules/@types/http-proxy": {
       "version": "1.17.15",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
@@ -507,12 +557,51 @@
       "integrity": "sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==",
       "dev": true
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "devOptional": true
+    },
     "node_modules/@types/node": {
       "version": "22.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.1.tgz",
       "integrity": "sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==",
       "dependencies": {
         "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.16",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
+      "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
+      "devOptional": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "devOptional": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "devOptional": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@vendia/serverless-express": {

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -19,7 +19,7 @@
     "utils"
   ],
   "scripts": {
-    "build": "cross-env NODE_ENV=production internal-lib-build build",
+    "build": "cross-env NODE_ENV=production internal-lib-build build && tsc",
     "build:watch": "nodemon --watch 'src/**' --exec 'npm run build'",
     "format": "internal-lib-build format \"**/*.{js,jsx}\"",
     "lint": "npm run lint:js",
@@ -48,6 +48,7 @@
     "@loadable/component": "^5.15.3",
     "@salesforce/pwa-kit-dev": "4.0.0-dev",
     "@serverless/event-mocks": "^1.1.1",
+    "@types/express": "^4.17.21",
     "aws-lambda-mock-context": "^3.2.1",
     "fs-extra": "^11.1.1",
     "internal-lib-build": "4.0.0-dev",

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -716,7 +716,7 @@ export const RemoteServerFactory = {
                 logger.error(
                     `'${extension}' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`,
                     {
-                        namespace: 'DevServerMixin._setupExtensions'
+                        namespace: 'RemoteServerFactory._setupExtensions'
                     }
                 )
                 return

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -143,7 +143,7 @@ describe('extensions', () => {
 
         expect(errorlog.mock.calls).toEqual([
             [
-                'pwa-kit-runtime.RemoteServerFactory._setupExtensions ERROR Error instantiating extension extension-with-setup-server-no-default-export: {"error":{}}'
+                `pwa-kit-runtime.DevServerMixin._setupExtensions ERROR 'extension-with-setup-server-no-default-export' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`
             ]
         ])
     })

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -143,7 +143,7 @@ describe('extensions', () => {
 
         expect(errorlog.mock.calls).toEqual([
             [
-                `pwa-kit-runtime.DevServerMixin._setupExtensions ERROR 'extension-with-setup-server-no-default-export' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`
+                `pwa-kit-runtime.RemoteServerFactory._setupExtensions ERROR 'extension-with-setup-server-no-default-export' is not a valid PWA-Kit Application Extension, please ensure you are exporting a class of type 'ApplicationExtension'. Skipping.`
             ]
         ])
     })

--- a/packages/pwa-kit-runtime/src/ssr/server/extensibility/application-extension.ts
+++ b/packages/pwa-kit-runtime/src/ssr/server/extensibility/application-extension.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-// import {Application} from './types'
-import {Application} from 'express'
+import {Application} from './types'
+
 /**
  * An abstract class representing an Application Extension. This class provides
  * foundational methods and properties for extending an application with additional

--- a/packages/pwa-kit-runtime/src/ssr/server/extensibility/application-extension.ts
+++ b/packages/pwa-kit-runtime/src/ssr/server/extensibility/application-extension.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+// import {Application} from './types'
+import {Application} from 'express'
+/**
+ * An abstract class representing an Application Extension. This class provides
+ * foundational methods and properties for extending an application with additional
+ * configuration and routing capabilities. It is designed to be subclassed
+ * by other Application Extensions that need to augment the base application, particularly
+ * during server and client-side rendering.
+ *
+ * @abstract
+ */
+export default abstract class ApplicationExtension {
+    private config: Record<string, any>
+
+    /**
+     * Constructs a new instance of the ApplicationExtension class.
+     *
+     * @param config - The configuration object used to set up the extension.
+     */
+    constructor(config?: any) {
+        this.config = config
+    }
+
+    /**
+     * Returns the configuration that was used to instantiate this application extension.
+     *
+     * @protected
+     * @returns config - The configuration object.
+     */
+    public getConfig(): Record<string, any> {
+        return this.config
+    }
+
+    /**
+     * Returns the name of the extension that will be used for logging.
+     *
+     * @protected
+     * @returns name - The name of the extension.
+     */
+    public getName(): string {
+        return this.constructor.name
+    }
+
+    /**
+     * Called during the rendering of the base application on the server and the client.
+     * It is predominantly used to enhance the "base" application by wrapping it with React providers.
+     *
+     * @protected
+     * @param App - The base application component.
+     * @returns EnhancedApp - The enhanced application component.
+     */
+    public extendApp(App: Application): Application {
+        return App
+    }
+}

--- a/packages/pwa-kit-runtime/src/ssr/server/extensibility/index.ts
+++ b/packages/pwa-kit-runtime/src/ssr/server/extensibility/index.ts
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2024, Salesforce, Inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {Application} from 'express'
 
-export type {Application}
+export {default as ApplicationExtension} from './application-extension'
+export * from './types'

--- a/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/another-extension/setup-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/another-extension/setup-server.js
@@ -4,18 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {ApplicationExtension} from '../../../extensibility'
 
-class AnotherExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'AnotherExtension'
-    }
-
+class AnotherExtension extends ApplicationExtension {
     extendApp(app) {
         app.get('/another-extension', (req, res) => {
             res.send('test')

--- a/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/extension-with-bad-setup-server/setup-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/extension-with-bad-setup-server/setup-server.js
@@ -5,17 +5,9 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-class Extension {
-    options
+import {ApplicationExtension} from '../../../extensibility'
 
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'Extension'
-    }
-
+class Extension extends ApplicationExtension {
     extendApp(app) {
         throw new Error('extension will fail to initialize because of me')
     }

--- a/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/extension-with-setup-server-no-default-export/setup-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/extension-with-setup-server-no-default-export/setup-server.js
@@ -5,17 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-class AnotherExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'AnotherExtension'
-    }
-
+import {ApplicationExtension} from '../../../extensibility'
+class AnotherExtension extends ApplicationExtension {
     extendApp(app) {
         app.get('/another-extension', (req, res) => {
             res.send('test')

--- a/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/test-extension/setup-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/test_fixtures/extensions/test-extension/setup-server.js
@@ -5,18 +5,14 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-class TestExtension {
-    options
-
-    constructor(options) {
-        this.options = options
-    }
-
-    getName() {
-        return 'TestExtension'
-    }
-
+import {ApplicationExtension} from '../../../extensibility'
+class TestExtension extends ApplicationExtension {
     extendApp(app) {
+        console.log(
+            'ApplicationExtensionApplicationExtensionApplicationExtensionApplicationExtensionApplicationExtensionApplicationExtension: ',
+            ApplicationExtension
+        )
+
         app.get('/test-extension', (req, res) => {
             res.send('test')
         })

--- a/packages/pwa-kit-runtime/tsconfig.json
+++ b/packages/pwa-kit-runtime/tsconfig.json
@@ -1,103 +1,104 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
+      /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+      /* Projects */
+      // "incremental": true,                              /* Enable incremental compilation */
+      // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+      // "tsBuildInfoFile": "./",                          /* Specify the folder for .tsbuildinfo incremental compilation files. */
+      // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects */
+      // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+      // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
-    /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+      /* Language and Environment */
+      "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+      // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+      "jsx": "react-jsx" /* Specify what JSX code is generated. */,
+      // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+      // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+      // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */
+      // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+      // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx*`.` */
+      // "reactNamespace": "",                             /* Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit. */
+      // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+      // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
-    /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+      /* Modules */
+      "module": "esnext" /* Specify what module code is generated. */,
+      // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+      "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+      // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+      // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+      // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+      // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+      // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+      // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+      // "resolveJsonModule": true,                        /* Enable importing .json files */
+      // "noResolve": true,                                /* Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project. */
 
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+      /* JavaScript Support */
+      "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files. */
+      // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+      // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`. */
 
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+      /* Emit */
+      "declaration": true, /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+      "declarationMap": true, /* Create sourcemaps for d.ts files. */
+      "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+      "sourceMap": true /* Create source map files for emitted JavaScript files. */,
+      // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output. */
+      "outDir": "./dist"
+      /* Specify an output folder for all emitted files. */,
+      // "removeComments": true,                           /* Disable emitting comments. */
+      // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+      // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+      // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types */
+      // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+      // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+      // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+      // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+      // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+      // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+      // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+      // "stripInternal": true,                            /* Disable emitting declarations that have `@internal` in their JSDoc comments. */
+      // "noEmitHelpers": true,                            /* Disable generating custom helper functions like `__extends` in compiled output. */
+      // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+      // "preserveConstEnums": true,                       /* Disable erasing `const enum` declarations in generated code. */
+      // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+      // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+      /* Interop Constraints */
+      "isolatedModules": true /* Ensure that each file can be safely transpiled without relying on other imports. */,
+      // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+      "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility. */,
+      // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+      "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
-    /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+      /* Type Checking */
+      "strict": true /* Enable all strict type-checking options. */,
+      // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied `any` type.. */
+      // "strictNullChecks": true,                         /* When type checking, take into account `null` and `undefined`. */
+      // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+      // "strictBindCallApply": true,                      /* Check that the arguments for `bind`, `call`, and `apply` methods match the original function. */
+      // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+      // "noImplicitThis": true,                           /* Enable error reporting when `this` is given the type `any`. */
+      // "useUnknownInCatchVariables": true,               /* Type catch clause variables as 'unknown' instead of 'any'. */
+      // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+      // "noUnusedLocals": true,                           /* Enable error reporting when a local variables aren't read. */
+      // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read */
+      // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+      // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+      // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+      // "noUncheckedIndexedAccess": true,                 /* Include 'undefined' in index signature results */
+      // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+      // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type */
+      // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+      // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
-  }
+      /* Completeness */
+      // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+      "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.*"],
 }

--- a/packages/template-typescript-minimal/app/pages/home.tsx
+++ b/packages/template-typescript-minimal/app/pages/home.tsx
@@ -19,7 +19,6 @@ const style = `
 body {
     background: linear-gradient(-45deg, #e73c7e, #23a6d5, #ee7752);
     background-size: 400% 400%;
-    animation: gradient 10s ease 5;
     height: 100vh;
 }
 @keyframes gradient {


### PR DESCRIPTION
# Description

In this PR we are replace the use of TypeScript interface "IApplicationExtension" with an abstract class "ApplicationExtension". This allows use to hid some of the implementation for methods like `getName` and `getConfig` and also leaves the door open to adding more features in the future that all extensions will consume when upgrading their dependencies.

# Changes

- Replace IApplicationExtension with ApplicationExtension abstract class
- Update tests
- 

# How to Test-Drive This PR

- If tests are passing this is working.
- But if you want, run the dev server and check that the express endpoint `/sample` still works.

# Checklists

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
