### PR TITLE
[a11y] Order Details page @W-12627200@ @W-12627104@

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -16,11 +16,10 @@
 - [a11y] Hide log out svg from screenreader as they are decorative [#2000](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2000)
 - [a11y] Ensure heading level matches the heading's visual importance/level [#2000](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2000)
 - [a11y] Provide a descriptive dialog title for Mobile Navigation Header [#2000](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2000)
-
-### Accessibility Improvements
 - Hide breadcrumb chevrons from screen readers [#1965](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1965)
 - Add descriptive text for screen readers on product edit modal in cart page [#1965](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1965)
 - A11y: Fix search bar header element focus order [#1969](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1969)
+- A11y: Order Details - hide decorative image and convert some p tags as proper headings [#2026](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2026)
 
 ## v4.0.1 (Sept 4, 2024)
 - Updated @salesforce/commerce-sdk-react to 3.0.1 to fix an issue with the expires attribute of cookies, ensuring it uses seconds instead of days [#1994](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1994)

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -234,12 +234,12 @@ const AccountOrderDetail = () => {
                         ) : (
                             <>
                                 <Stack spacing={1}>
-                                    <Text fontWeight="bold" fontSize="sm">
+                                    <Heading as="h2" fontSize="sm" pt={1}>
                                         <FormattedMessage
                                             defaultMessage="Shipping Method"
                                             id="account_order_detail.heading.shipping_method"
                                         />
-                                    </Text>
+                                    </Heading>
                                     <Box>
                                         <Text fontSize="sm" textTransform="titlecase">
                                             {
@@ -276,12 +276,12 @@ const AccountOrderDetail = () => {
                                     </Box>
                                 </Stack>
                                 <Stack spacing={1}>
-                                    <Text fontWeight="bold" fontSize="sm">
+                                    <Heading as="h2" fontSize="sm" pt={1}>
                                         <FormattedMessage
                                             defaultMessage="Payment Method"
                                             id="account_order_detail.heading.payment_method"
                                         />
-                                    </Text>
+                                    </Heading>
                                     <Stack direction="row">
                                         {CardIcon && <CardIcon layerStyle="ccIcon" />}
                                         <Box>
@@ -300,12 +300,12 @@ const AccountOrderDetail = () => {
                                     </Stack>
                                 </Stack>
                                 <Stack spacing={1}>
-                                    <Text fontWeight="bold" fontSize="sm">
+                                    <Heading as="h2" fontSize="sm" pt={1}>
                                         <FormattedMessage
                                             defaultMessage="Shipping Address"
                                             id="account_order_detail.heading.shipping_address"
                                         />
-                                    </Text>
+                                    </Heading>
                                     <Box>
                                         <Text fontSize="sm">
                                             {shippingAddress.firstName} {shippingAddress.lastName}
@@ -318,12 +318,12 @@ const AccountOrderDetail = () => {
                                     </Box>
                                 </Stack>
                                 <Stack spacing={1}>
-                                    <Text fontWeight="bold" fontSize="sm">
+                                    <Heading as="h2" fontSize="sm" pt={1}>
                                         <FormattedMessage
                                             defaultMessage="Billing Address"
                                             id="account_order_detail.heading.billing_address"
                                         />
-                                    </Text>
+                                    </Heading>
                                     <Box>
                                         <Text fontSize="sm">
                                             {order.billingAddress.firstName}{' '}

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -283,7 +283,9 @@ const AccountOrderDetail = () => {
                                         />
                                     </Heading>
                                     <Stack direction="row">
-                                        {CardIcon && <CardIcon layerStyle="ccIcon" />}
+                                        {CardIcon && (
+                                            <CardIcon layerStyle="ccIcon" aria-hidden="true" />
+                                        )}
                                         <Box>
                                             <Text fontSize="sm">{paymentCard?.cardType}</Text>
                                             <Stack direction="row">


### PR DESCRIPTION
Fixes 2 accessibility issues by:
- hiding a decorative image as aria-hidden
- converting some `p` tags into proper headings 

![Arc 2024-09-25 at 11 17 03](https://github.com/user-attachments/assets/251eb53b-820e-4b97-b785-61a6a8e0ee0f)

![Arc 2024-09-25 at 11 06 09](https://github.com/user-attachments/assets/aeb5ce1e-98ed-4dcf-84b8-5e1bf6509fa6)


# How to Test-Drive This PR

1. http://localhost:3000
2. Log in and then navigate to http://localhost:3000/global/en-GB/account/orders
4. Navigate to one of the orders to see the Order Details page
5. Then verify the changes as described in the screenshots above
