### PR TITLE
Simplify useCustomMutation implementation

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 -   Add `defaultDnt` to support setting the dnt flag for SLAS. Upgrade `commerce-sdk-isomorphic` to v3.1.1 [#1979](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1979)
 -   Update logout helper to work for guest users [#1997](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1997)
 -   Update `useCustomMutation` hook to accept request body as a parameter to the mutate function [#2030](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2030)
+-  Simplify `useCustomMutation` hook implementation [#2034](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2034)
 
 ## v3.0.1 (Sep 04, 2024)
 

--- a/packages/commerce-sdk-react/src/hooks/useMutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/useMutation.test.ts
@@ -112,4 +112,38 @@ describe('useCustomMutation', () => {
         await waitAndExpectSuccess(() => result.current)
         expect(result.current.data).toEqual(mockRes)
     })
+    test('accepts headers as mutate parameter', async () => {
+        const apiName = 'hello-world'
+        mockMutationEndpoints(apiName, function () {
+            // @ts-expect-error there is no typing for nock request
+            return this.req.headers
+        })
+        const {result} = renderHookWithProviders(() => {
+            const clientConfig = {
+                parameters: {
+                    clientId: 'CLIENT_ID',
+                    siteId: 'SITE_ID',
+                    organizationId: 'ORG_ID',
+                    shortCode: 'SHORT_CODE'
+                },
+                proxy: 'http://localhost:8888/mobify/proxy/api'
+            }
+            return useCustomMutation({
+                options: {
+                    method: 'POST',
+                    customApiPathParameters: {
+                        endpointPath: 'test-hello-world',
+                        apiName
+                    }
+                },
+                clientConfig,
+                rawResponse: false
+            })
+        })
+        expect(result.current.data).toBeUndefined()
+        const mockHeaders = {test: '123'}
+        act(() => result.current.mutate({headers: mockHeaders}))
+        await waitAndExpectSuccess(() => result.current)
+        expect(result.current.data).toHaveProperty('test')
+    })
 })

--- a/packages/commerce-sdk-react/src/test-utils.tsx
+++ b/packages/commerce-sdk-react/src/test-utils.tsx
@@ -105,7 +105,7 @@ const NOCK_DELAY = 50
 /** Mocks DELETE, PATCH, POST, and PUT so we don't have to look up which verb an endpoint uses. */
 export const mockMutationEndpoints = (
     matchingPath: string,
-    response: string | object | undefined,
+    response: string | object | undefined | ((uri: string, requestBody: any) => object),
     statusCode = 200
 ) => {
     const matcher = (uri: string) => uri.includes(matchingPath)


### PR DESCRIPTION
This is a follow up for the previous PR https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2030

This PR simplifies the implementation structure to remove the if/else block that contains some duplicated code:

### Before

```js
// this is a higher order function
const callCustomEndpointWithAuth = () => {...}

// this is NOT a higher order function, this creates some inconsistencies in the code
const callCustomEndpointWithBody = () => {...}

if (!apiOptions?.options?.body) {
        return useReactQueryMutation(
            callCustomEndpointWithBody,  
            mutationOptions
        ) as UseMutationResult<TData, TError, MutationVariables>
    } else {
        return useReactQueryMutation<TData, TError, undefined, unknown>(
            callCustomEndpointWithAuth(apiOptions),
            mutationOptions
        ) as UseMutationResult<TData, TError, MutationVariables>
    }
```

### After

```js
const callCustomEndpointWithAuth = () => {...}

        return useReactQueryMutation(
            callCustomEndpointWithAuth(),
            mutationOptions
        ) as UseMutationResult<TData, TError, MutationVariables>
```