### PR TITLE
Fix: a11y - Add accessibility label to edit/remove buttons on account address page (@W-12627228@)

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -24,6 +24,7 @@
 - A11y: Order Details - hide decorative image and convert some p tags as proper headings [#2026](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2026)
 - Add aria-labels for buttons in product item wishlist component to ensure they are unique and descriptive. [#2023](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2023)
 - Focus onto the `ToggleCard` title whenever the component is opened to be editted [#2029](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2029)
+- Add descriptive acccessibility label for edit/remove buttons on account addresses page [#2037](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2037)
 
 ## v4.0.1 (Sept 4, 2024)
 - Updated @salesforce/commerce-sdk-react to 3.0.1 to fix an issue with the expires attribute of cookies, ensuring it uses seconds instead of days [#1994](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1994)

--- a/packages/template-retail-react-app/app/components/action-card/index.jsx
+++ b/packages/template-retail-react-app/app/components/action-card/index.jsx
@@ -16,7 +16,15 @@ import LoadingSpinner from '@salesforce/retail-react-app/app/components/loading-
  * The provided `onRemove` callback triggers a loading spinner internally
  * if given a promise.
  */
-const ActionCard = ({children, onEdit, onRemove, editBtnRef, ...props}) => {
+const ActionCard = ({
+    children,
+    onEdit,
+    onRemove,
+    editBtnRef,
+    editBtnLabel,
+    removeBtnLabel,
+    ...props
+}) => {
     const [showLoading, setShowLoading] = useState(false)
 
     const handleRemove = async () => {
@@ -43,7 +51,13 @@ const ActionCard = ({children, onEdit, onRemove, editBtnRef, ...props}) => {
                 <Box>{children}</Box>
                 <Stack direction="row" spacing={4}>
                     {onEdit && (
-                        <Button onClick={onEdit} variant="link" size="sm" ref={editBtnRef}>
+                        <Button
+                            onClick={onEdit}
+                            variant="link"
+                            size="sm"
+                            ref={editBtnRef}
+                            aria-label={editBtnLabel}
+                        >
                             <FormattedMessage defaultMessage="Edit" id="action_card.action.edit" />
                         </Button>
                     )}
@@ -54,6 +68,7 @@ const ActionCard = ({children, onEdit, onRemove, editBtnRef, ...props}) => {
                             colorScheme="red"
                             onClick={handleRemove}
                             color="red.600"
+                            aria-label={removeBtnLabel}
                         >
                             <FormattedMessage
                                 defaultMessage="Remove"
@@ -78,7 +93,13 @@ ActionCard.propTypes = {
     children: PropTypes.node,
 
     /** Ref for the edit button so that it can be focused on for accessibility */
-    editBtnRef: PropTypes.object
+    editBtnRef: PropTypes.object,
+
+    /** Accessibility label for edit button */
+    editBtnLabel: PropTypes.string,
+
+    /** Accessibility label for remove button */
+    removeBtnLabel: PropTypes.string
 }
 
 export default ActionCard

--- a/packages/template-retail-react-app/app/pages/account/addresses.jsx
+++ b/packages/template-retail-react-app/app/pages/account/addresses.jsx
@@ -321,47 +321,67 @@ const AccountAddresses = () => {
                         </>
                     )}
 
-                    {addresses.map((address) => (
-                        <React.Fragment key={address.addressId}>
-                            <ActionCard
-                                borderColor="gray.200"
-                                key={address.addressId}
-                                editBtnRef={editBtnRefs[address.addressId]}
-                                onRemove={() => removeAddress(address.addressId)}
-                                onEdit={() => toggleEdit(address)}
-                            >
-                                {address.preferred && (
-                                    <Badge
-                                        position="absolute"
-                                        fontSize="xs"
-                                        right={4}
-                                        variant="solid"
-                                        bg="gray.100"
-                                        color="gray.900"
-                                    >
-                                        <FormattedMessage
-                                            defaultMessage="Default"
-                                            id="account_addresses.badge.default"
-                                        />
-                                    </Badge>
-                                )}
-                                <AddressDisplay address={address} />
-                                {isEditing && address.addressId === selectedAddressId && (
-                                    <BoxArrow />
-                                )}
-                            </ActionCard>
+                    {addresses.map((address) => {
+                        const editLabel = formatMessage(
+                            {
+                                defaultMessage: 'Edit {address}',
+                                id: 'account_addresses.label.edit_button'
+                            },
+                            {address: address.address1}
+                        )
 
-                            {isEditing && address.addressId === selectedAddressId && (
-                                <ShippingAddressForm
-                                    form={form}
-                                    hasAddresses={hasAddresses}
-                                    submitForm={submitForm}
-                                    selectedAddressId={selectedAddressId}
-                                    toggleEdit={toggleEdit}
-                                />
-                            )}
-                        </React.Fragment>
-                    ))}
+                        const removeLabel = formatMessage(
+                            {
+                                defaultMessage: 'Remove {address}',
+                                id: 'account_addresses.label.remove_button'
+                            },
+                            {address: address.address1}
+                        )
+
+                        return (
+                            <React.Fragment key={address.addressId}>
+                                <ActionCard
+                                    borderColor="gray.200"
+                                    key={address.addressId}
+                                    editBtnRef={editBtnRefs[address.addressId]}
+                                    onRemove={() => removeAddress(address.addressId)}
+                                    onEdit={() => toggleEdit(address)}
+                                    editBtnLabel={editLabel}
+                                    removeBtnLabel={removeLabel}
+                                >
+                                    {address.preferred && (
+                                        <Badge
+                                            position="absolute"
+                                            fontSize="xs"
+                                            right={4}
+                                            variant="solid"
+                                            bg="gray.100"
+                                            color="gray.900"
+                                        >
+                                            <FormattedMessage
+                                                defaultMessage="Default"
+                                                id="account_addresses.badge.default"
+                                            />
+                                        </Badge>
+                                    )}
+                                    <AddressDisplay address={address} />
+                                    {isEditing && address.addressId === selectedAddressId && (
+                                        <BoxArrow />
+                                    )}
+                                </ActionCard>
+
+                                {isEditing && address.addressId === selectedAddressId && (
+                                    <ShippingAddressForm
+                                        form={form}
+                                        hasAddresses={hasAddresses}
+                                        submitForm={submitForm}
+                                        selectedAddressId={selectedAddressId}
+                                        toggleEdit={toggleEdit}
+                                    />
+                                )}
+                            </React.Fragment>
+                        )
+                    })}
                 </SimpleGrid>
             )}
 

--- a/packages/template-retail-react-app/app/pages/account/addresses.test.js
+++ b/packages/template-retail-react-app/app/pages/account/addresses.test.js
@@ -174,3 +174,13 @@ test('Handles focus for cancel/save buttons in address form correctly', async ()
     await user.click(screen.getByRole('button', {name: /save/i}))
     expect(document.activeElement).toBe(editBtn)
 })
+
+test('Edit/Remove buttons have descriptive accessibility label', async () => {
+    renderWithProviders(<MockedComponent />)
+    const address = '123 Main St'
+    await waitFor(() => expect(screen.getByText(address)).toBeInTheDocument())
+    const editBtnByLabel = screen.getByLabelText(`Edit ${address}`)
+    const removeBtnByLabel = screen.getByLabelText(`Remove ${address}`)
+    expect(editBtnByLabel).toBeInTheDocument()
+    expect(removeBtnByLabel).toBeInTheDocument()
+})

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -47,6 +47,26 @@
       "value": "New address saved"
     }
   ],
+  "account_addresses.label.edit_button": [
+    {
+      "type": 0,
+      "value": "Edit "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    }
+  ],
+  "account_addresses.label.remove_button": [
+    {
+      "type": 0,
+      "value": "Remove "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    }
+  ],
   "account_addresses.page_action_placeholder.button.add_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -47,6 +47,26 @@
       "value": "New address saved"
     }
   ],
+  "account_addresses.label.edit_button": [
+    {
+      "type": 0,
+      "value": "Edit "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    }
+  ],
+  "account_addresses.label.remove_button": [
+    {
+      "type": 0,
+      "value": "Remove "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    }
+  ],
   "account_addresses.page_action_placeholder.button.add_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -111,6 +111,42 @@
       "value": "]"
     }
   ],
+  "account_addresses.label.edit_button": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḗḓīŧ "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_addresses.label.remove_button": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Řḗḗḿǿǿṽḗḗ "
+    },
+    {
+      "type": 1,
+      "value": "address"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_addresses.page_action_placeholder.button.add_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -23,6 +23,12 @@
   "account_addresses.info.new_address_saved": {
     "defaultMessage": "New address saved"
   },
+  "account_addresses.label.edit_button": {
+    "defaultMessage": "Edit {address}"
+  },
+  "account_addresses.label.remove_button": {
+    "defaultMessage": "Remove {address}"
+  },
   "account_addresses.page_action_placeholder.button.add_address": {
     "defaultMessage": "Add Address"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -23,6 +23,12 @@
   "account_addresses.info.new_address_saved": {
     "defaultMessage": "New address saved"
   },
+  "account_addresses.label.edit_button": {
+    "defaultMessage": "Edit {address}"
+  },
+  "account_addresses.label.remove_button": {
+    "defaultMessage": "Remove {address}"
+  },
   "account_addresses.page_action_placeholder.button.add_address": {
     "defaultMessage": "Add Address"
   },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

This PR adds descriptive accessibility label to the edit/remove buttons on the Account page, specifically within the addresses section so you know which edit/remove button is associated to which address.

![Screenshot 2024-10-01 at 4 13 10 AM](https://github.com/user-attachments/assets/bb94155d-c4e9-49b7-8c4c-5c8cc8472ade)

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

1. `git checkout ju/a11y-btn-label`
2. start the retail react app
3. navigate to account page and addresses section
4. use screen reader to read edit/remove button
5. Observe that the screen reader reads out the accessibility label: `Edit {address}` or `Remove {address}` 

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
