### PR TITLE
Remove incorrect usage of @chakra-ui/layout

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v4.1.0-dev (Aug 8, 2024)
 - Add useXForwardedHost (default to false) flag to allow the use of x-forwarded-host header value in building links [#2018](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2018)
-- Announce wishlist change in total for screen readers (a11y) [#2033](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2033) 
+- Announce wishlist change in total for screen readers (a11y) [#2033](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2033)
+- Fixed a bug that incorrectly imports uninstalled package `@chakra-ui/layout` [#2047](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2047)
 
 ### Performance Improvements
 -   Remove ocapi session-bridging on phased launches [#2011](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2011)

--- a/packages/template-retail-react-app/app/pages/account/wishlist/index.jsx
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/index.jsx
@@ -6,7 +6,13 @@
  */
 import React, {useState, useEffect, useRef} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
-import {Box, Flex, Skeleton, Stack, Heading} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {
+    Box,
+    Flex,
+    Skeleton,
+    Stack,
+    Heading
+} from '@salesforce/retail-react-app/app/components/shared/ui'
 import {useProducts, useShopperCustomersMutation} from '@salesforce/commerce-sdk-react'
 
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'

--- a/packages/template-retail-react-app/app/pages/account/wishlist/index.jsx
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/index.jsx
@@ -5,9 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {useState, useEffect, useRef} from 'react'
-import {Stack, Heading} from '@chakra-ui/layout'
 import {FormattedMessage, useIntl} from 'react-intl'
-import {Box, Flex, Skeleton} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {Box, Flex, Skeleton, Stack, Heading} from '@salesforce/retail-react-app/app/components/shared/ui'
 import {useProducts, useShopperCustomersMutation} from '@salesforce/commerce-sdk-react'
 
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

Remove incorrect usage of @chakra-ui/layout , this breaks generated projects.

### Why did it break NOW?

My guess is that in the `@chakra-ui/react` included the `@chakra-ui/layout` package as a transient dependencies that even if retail-react-app don't install it, it worked fine. I suspect the recent releases of `@chakra-ui/react` package removed the dependency and caused the issue.

