### PR TITLE
Create useAppOrigin hook to consume x-forwarded-host header value

### DIFF
--- a/packages/pwa-kit-create-app/CHANGELOG.md
+++ b/packages/pwa-kit-create-app/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.8.0-dev (Aug 8, 2024)
 - Update ssr.js templates to include new feature flag to encode non ASCII HTTP headers [#2048](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2048)
+- Replace getAppOrigin with useOrigin to have a better support for an app origin building. [#2050](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2050)
 
 ## v3.7.0 (Aug 7, 2024)
 

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -13,6 +13,7 @@ import 'focus-visible/dist/focus-visible'
 
 import theme from '@salesforce/retail-react-app/app/theme'
 import {MultiSiteProvider} from '@salesforce/retail-react-app/app/contexts'
+import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origin'
 import {
     resolveSiteFromUrl,
     resolveLocaleFromUrl
@@ -24,7 +25,7 @@ import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
-import {useCorrelationId, useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
+import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 /**
@@ -43,7 +44,7 @@ const AppConfig = ({children, locals = {}}) => {
 
     const commerceApiConfig = locals.appConfig.commerceAPI
 
-    const appOrigin = useOrigin()
+    const appOrigin = useAppOrigin()
 
     return (
         <CommerceApiProvider

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -24,8 +24,7 @@ import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
-import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
-import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
+import {useCorrelationId, useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 /**
@@ -44,7 +43,7 @@ const AppConfig = ({children, locals = {}}) => {
 
     const commerceApiConfig = locals.appConfig.commerceAPI
 
-    const appOrigin = getAppOrigin()
+    const appOrigin = useOrigin()
 
     return (
         <CommerceApiProvider

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.8.0-dev (Aug 08, 2024)
+- Create useOrigin hook to return an app origin that takes x-forwarded-host header into consideration. [#2050](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2050) 
 
 ## v3.7.0 (Aug 07, 2024)
 - Add `beforeHydrate` option to withReactQuery component [#1912](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1912)

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -44,6 +44,18 @@ export const useServerContext = () => {
     return serverContext
 }
 
+/**
+ * Returns the application's origin.
+ *
+ * By default, it will return the ORIGIN under which we are serving the page.
+ *
+ * If you enabled `enableXForwardedHost` in your app, it will use the value of `x-forwarded-host` header in req
+ * to build origin. (it is false by default)
+ *
+ * NOTE: this is a React hook, so it has to be used in a React rendering pipeline.
+ * @returns {string} origin string
+ *
+ */
 export const useOrigin = () => {
     if (typeof window !== 'undefined') {
         return window.location.origin

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -44,21 +44,21 @@ export const useServerContext = () => {
     return serverContext
 }
 
-export const useAppOrigin = () => {
-    const {
-        app: {useXForwardedHost}
-    } = getConfig()
+export const useOrigin = () => {
     if (typeof window !== 'undefined') {
         return window.location.origin
     }
+    const {
+        app: {enableXForwardHost}
+    } = getConfig()
+
     const {APP_ORIGIN} = process.env
 
-    const {res} = useServerContext()
-    const host = res.locals.xForwardedHost
-    console.log('host', host)
-    if (useXForwardedHost && host) {
-        console.log('--- useAppOrigin host', host)
-        return host
+    const {res, req} = useServerContext()
+    const xForwardedHost = res.locals.xForwardedHost
+    console.log('--- xForwardedHost', xForwardedHost)
+    if (enableXForwardHost && xForwardedHost) {
+        return `${req.protocol}//${xForwardedHost}`
     }
     return APP_ORIGIN
 }

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -8,7 +8,6 @@
 
 import React, {useContext} from 'react'
 import {CorrelationIdContext, ServerContext} from '../contexts'
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 /**
  * Use this hook to get the correlation id value of the closest CorrelationIdProvider component.

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -49,28 +49,25 @@ export const useServerContext = () => {
  *
  * By default, it will return the ORIGIN under which we are serving the page.
  *
- * If you enabled `enableXForwardedHost` in your app, it will use the value of `x-forwarded-host` header in req
+ * If `fromXForwardedHeader` is true, it will use the value of `x-forwarded-proto` and `x-forwarded-host` headers in req
  * to build origin. (it is false by default)
  *
  * NOTE: this is a React hook, so it has to be used in a React rendering pipeline.
  * @returns {string} origin string
  *
  */
-export const useOrigin = () => {
-    const {res, req} = useServerContext()
+export const useOrigin = ({fromXForwardedHeader = false}) => {
+    const {res} = useServerContext()
 
     if (typeof window !== 'undefined') {
         return window.location.origin
     }
-    const {
-        app: {enableXForwardedHost}
-    } = getConfig()
 
     const {APP_ORIGIN} = process.env
 
-    const xForwardedHost = res.locals.xForwardedHost
-    if (enableXForwardedHost && xForwardedHost) {
-        return `${req.protocol}://${xForwardedHost}`
+    const xForwardedOrigin = res.locals.xForwardedOrigin
+    if (fromXForwardedHeader && xForwardedOrigin) {
+        return xForwardedOrigin
     }
     return APP_ORIGIN
 }

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -49,16 +49,15 @@ export const useOrigin = () => {
         return window.location.origin
     }
     const {
-        app: {enableXForwardHost}
+        app: {enableXForwardedHost}
     } = getConfig()
 
     const {APP_ORIGIN} = process.env
 
     const {res, req} = useServerContext()
     const xForwardedHost = res.locals.xForwardedHost
-    console.log('--- xForwardedHost', xForwardedHost)
-    if (enableXForwardHost && xForwardedHost) {
-        return `${req.protocol}//${xForwardedHost}`
+    if (enableXForwardedHost && xForwardedHost) {
+        return `${req.protocol}://${xForwardedHost}`
     }
     return APP_ORIGIN
 }

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -8,6 +8,7 @@
 
 import React, {useContext} from 'react'
 import {CorrelationIdContext, ServerContext} from '../contexts'
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 /**
  * Use this hook to get the correlation id value of the closest CorrelationIdProvider component.
@@ -41,4 +42,23 @@ export const useServerContext = () => {
     const serverContext = useContext(ServerContext)
 
     return serverContext
+}
+
+export const useAppOrigin = () => {
+    const {
+        app: {useXForwardedHost}
+    } = getConfig()
+    if (typeof window !== 'undefined') {
+        return window.location.origin
+    }
+    const {APP_ORIGIN} = process.env
+
+    const {res} = useServerContext()
+    const host = res.locals.xForwardedHost
+    console.log('host', host)
+    if (useXForwardedHost && host) {
+        console.log('--- useAppOrigin host', host)
+        return host
+    }
+    return APP_ORIGIN
 }

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/hooks/index.js
@@ -57,6 +57,8 @@ export const useServerContext = () => {
  *
  */
 export const useOrigin = () => {
+    const {res, req} = useServerContext()
+
     if (typeof window !== 'undefined') {
         return window.location.origin
     }
@@ -66,7 +68,6 @@ export const useOrigin = () => {
 
     const {APP_ORIGIN} = process.env
 
-    const {res, req} = useServerContext()
     const xForwardedHost = res.locals.xForwardedHost
     if (enableXForwardedHost && xForwardedHost) {
         return `${req.protocol}://${xForwardedHost}`

--- a/packages/pwa-kit-react-sdk/src/utils/url.js
+++ b/packages/pwa-kit-react-sdk/src/utils/url.js
@@ -12,7 +12,7 @@
  * initialized using the `_createApp` method (This happens in your /app/ssr.js file).
  *
  * @function
- * @deprecated since version 3.8.0 - use `useOrigin()` instead.
+ * @deprecated use `useOrigin()` instead.
  * This function will be removed in version 4.0.0.
  * @returns {string} Returns the ORIGIN under which we are serving the page.
  * @example

--- a/packages/pwa-kit-react-sdk/src/utils/url.js
+++ b/packages/pwa-kit-react-sdk/src/utils/url.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -12,6 +12,8 @@
  * initialized using the `_createApp` method (This happens in your /app/ssr.js file).
  *
  * @function
+ * @deprecated since version 3.8.0 - use `useOrigin()` instead.
+ * This function will be removed in version 4.0.0.
  * @returns {string} Returns the ORIGIN under which we are serving the page.
  * @example
  * import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.8.0-dev (Aug 08, 2024)
 - Encode non ASCII HTTP headers when `encodeNonAsciiHttpHeaders` flag is set to true in `ssr.js` in the retail react app [#2009](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2009)
+- Add x-forwarded-host header into res locals, which can be used to build an app origin [#2050](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2050)
 
 ## v3.7.0 (Aug 07, 2024)
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -447,7 +447,7 @@ export const RemoteServerFactory = {
     },
 
     /**
-     * Set x-forward-* headers into locals
+     * Set x-forward-* headers into locals, this is primarily used to facilitate react sdk hook `useOrigin`
      * @private
      */
     _setForwardedHeaders(app, options) {

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -357,7 +357,7 @@ export const RemoteServerFactory = {
         // want request-processors applied to development views.
         this._addSDKInternalHandlers(app)
         this._setupSSRRequestProcessorMiddleware(app)
-        this._setXForwardedEnvVars(app, options)
+        this._setForwardedHeaders(app, options)
 
         this._setupLogging(app)
         this._setupMetricsFlushing(app)
@@ -447,33 +447,15 @@ export const RemoteServerFactory = {
     },
 
     /**
-     * Set up environment variables based on x-forward-* headers
+     * Set x-forward-* headers into locals
      * @private
      */
-    _setXForwardedEnvVars(app, options) {
+    _setForwardedHeaders(app, options) {
         app.use((req, res, next) => {
-            // const xForwardedHost = req.headers?.['x-forwarded-host']
-            const xForwardedHost = 'www.some-domain.org'
+            const xForwardedHost = req.headers?.['x-forwarded-host']
             if (xForwardedHost) {
-                // process.env.X_FORWARDED_HOST = `${options.protocol}://${xForwardedHost}`
                 res.locals.xForwardedHost = `${options.protocol}://${xForwardedHost}`
             }
-
-            /*
-            // since X-FORWARDED-* is attached to header on a request
-            // and process.env is a global object
-            // we only want to use the env variable when it is existing in a request
-            // once it is done, we should remove it to avoid leaking this value to other places
-            const afterResponse = () => {
-                if (process.env.X_FORWARDED_HOST) {
-                    delete process.env.X_FORWARDED_HOST
-                }
-            }
-            // Attach event listeners to the Response (we need to attach
-            // both to handle all possible cases)
-            res.on('finish', afterResponse)
-            res.on('close', afterResponse)
-            */
 
             next()
         })

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -454,7 +454,7 @@ export const RemoteServerFactory = {
         app.use((req, res, next) => {
             const xForwardedHost = req.headers?.['x-forwarded-host']
             if (xForwardedHost) {
-                res.locals.xForwardedHost = `${options.protocol}://${xForwardedHost}`
+                res.locals.xForwardedHost = xForwardedHost
             }
 
             next()

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -453,8 +453,10 @@ export const RemoteServerFactory = {
     _setForwardedHeaders(app, options) {
         app.use((req, res, next) => {
             const xForwardedHost = req.headers?.['x-forwarded-host']
+            const xForwardedProto = req.headers?.['x-forwarded-proto']
             if (xForwardedHost) {
-                res.locals.xForwardedHost = xForwardedHost
+                // prettier-ignore
+                res.locals.xForwardedOrigin = `${xForwardedProto || options.protocol}://${xForwardedHost}`
             }
 
             next()

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -452,11 +452,14 @@ export const RemoteServerFactory = {
      */
     _setXForwardedEnvVars(app, options) {
         app.use((req, res, next) => {
-            const xForwardedHost = req.headers?.['x-forwarded-host']
+            // const xForwardedHost = req.headers?.['x-forwarded-host']
+            const xForwardedHost = 'www.some-domain.org'
             if (xForwardedHost) {
-                process.env.X_FORWARDED_HOST = `${options.protocol}://${xForwardedHost}`
+                // process.env.X_FORWARDED_HOST = `${options.protocol}://${xForwardedHost}`
+                res.locals.xForwardedHost = `${options.protocol}://${xForwardedHost}`
             }
 
+            /*
             // since X-FORWARDED-* is attached to header on a request
             // and process.env is a global object
             // we only want to use the env variable when it is existing in a request
@@ -470,6 +473,8 @@ export const RemoteServerFactory = {
             // both to handle all possible cases)
             res.on('finish', afterResponse)
             res.on('close', afterResponse)
+            */
+
             next()
         })
     },

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -568,7 +568,7 @@ describe('SSRServer operation', () => {
             })
     })
 
-    test('should set xForwardedOrigin based on defined x-forwarded-host and x-forwarded-proto headers ', () => {
+    test('should set xForwardedOrigin based on defined x-forwarded-host and x-forwarded-proto headers', () => {
         process.env = {
             MRT_ALLOW_COOKIES: 'true'
         }

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -568,6 +568,31 @@ describe('SSRServer operation', () => {
             })
     })
 
+    test('SSRServer set x-forwarded-host header to locals object when it is available', () => {
+        process.env = {
+            MRT_ALLOW_COOKIES: 'true'
+        }
+        const forwardedHost = 'www.example.com'
+        const app = RemoteServerFactory._createApp(opts())
+        const route = (req, res) => {
+            expect(req.headers['x-forwarded-host']).toBe(forwardedHost)
+            expect(res.locals.xForwardedHost).toBe(forwardedHost)
+            res.sendStatus(200)
+        }
+        app.get('/*', route)
+
+        return request(app)
+            .get('/')
+            .set('x-forwarded-host', forwardedHost)
+            .then((response) => {
+                expect(response.status).toBe(200)
+            })
+            .finally(() => {
+                // Ensure that the environment variable is cleared after the response
+                expect(process.env.X_FORWARDED_HOST).toBeUndefined()
+            })
+    })
+
     test(`should reject POST requests to /`, () => {
         const app = RemoteServerFactory._createApp(opts())
         const route = (req, res) => {

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v4.1.0-dev (Aug 8, 2024)
 - Announce wishlist change in total for screen readers (a11y) [#2033](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2033)
 - Fixed a bug that incorrectly imports uninstalled package `@chakra-ui/layout` [#2047](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2047)
+- Replace getAppOrigin with useOrigin to have a better support for an app origin building. [#2050](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2050)
 
 ### Performance Improvements
 -   Remove ocapi session-bridging on phased launches [#2011](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2011)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -83,8 +83,8 @@ AppConfig.restore = (locals = {}) => {
             ? locals.originalUrl
             : `${window.location.pathname}${window.location.search}`
 
-    let site = resolveSiteFromUrl(path)
-    let locale = resolveLocaleFromUrl(path)
+    const site = resolveSiteFromUrl(path)
+    const locale = resolveLocaleFromUrl(path)
 
     const {app: appConfig} = getConfig()
     const apiConfig = {

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -22,6 +22,7 @@ import 'focus-visible/dist/focus-visible'
 
 import theme from '@salesforce/retail-react-app/app/theme'
 import {MultiSiteProvider} from '@salesforce/retail-react-app/app/contexts'
+import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origin'
 import {
     resolveSiteFromUrl,
     resolveLocaleFromUrl
@@ -32,7 +33,7 @@ import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
-import {useCorrelationId, useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
+import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 /**
@@ -50,7 +51,7 @@ const AppConfig = ({children, locals = {}}) => {
     }
 
     const commerceApiConfig = locals.appConfig.commerceAPI
-    const appOrigin = useOrigin()
+    const appOrigin = useAppOrigin()
 
     return (
         <CommerceApiProvider

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -32,7 +32,7 @@ import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
 import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
-import {useCorrelationId, useAppOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
+import {useCorrelationId, useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
 
 /**
@@ -50,7 +50,7 @@ const AppConfig = ({children, locals = {}}) => {
     }
 
     const commerceApiConfig = locals.appConfig.commerceAPI
-    const appOrigin = useAppOrigin()
+    const appOrigin = useOrigin()
 
     return (
         <CommerceApiProvider
@@ -82,18 +82,10 @@ AppConfig.restore = (locals = {}) => {
             ? locals.originalUrl
             : `${window.location.pathname}${window.location.search}`
 
-    let site
-    let locale
+    let site = resolveSiteFromUrl(path)
+    let locale = resolveLocaleFromUrl(path)
+
     const {app: appConfig} = getConfig()
-
-    if (appConfig.useXForwardedHost && locals.xForwardedHost) {
-        site = resolveSiteFromUrl(path, locals.xForwardedHost)
-        locale = resolveLocaleFromUrl(path, locals.xForwardedHost)
-    } else {
-        site = resolveSiteFromUrl(path)
-        locale = resolveLocaleFromUrl(path)
-    }
-
     const apiConfig = {
         ...appConfig.commerceAPI,
         einsteinConfig: appConfig.einsteinAPI

--- a/packages/template-retail-react-app/app/components/_app-config/index.test.js
+++ b/packages/template-retail-react-app/app/components/_app-config/index.test.js
@@ -16,6 +16,13 @@ import mockConfig from '@salesforce/retail-react-app/config/mocks/default'
 import {rest} from 'msw'
 import {registerUserToken} from '@salesforce/retail-react-app/app/utils/test-utils'
 
+jest.mock('@salesforce/pwa-kit-react-sdk/ssr/universal/hooks', () => {
+    const original = jest.requireActual('@salesforce/pwa-kit-react-sdk/ssr/universal/hooks')
+    return {
+        ...original,
+        useOrigin: jest.fn(() => 'https://www.example.com')
+    }
+})
 describe('AppConfig', () => {
     let originalFetch
     beforeAll(() => {

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -18,6 +18,8 @@ import {
     useShopperBasketsMutation
 } from '@salesforce/commerce-sdk-react'
 import logger from '@salesforce/retail-react-app/app/utils/logger-instance'
+import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origin'
+
 // Chakra
 import {
     Box,
@@ -73,7 +75,6 @@ import {
 
 import Seo from '@salesforce/retail-react-app/app/components/seo'
 import {Helmet} from 'react-helmet'
-import {useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 
 const PlaceholderComponent = () => (
     <Center p="2">
@@ -123,7 +124,7 @@ const App = (props) => {
     })
     const categories = flatten(categoriesTree || {}, 'categories')
     const {getTokenWhenReady} = useAccessToken()
-    const appOrigin = useOrigin()
+    const appOrigin = useAppOrigin()
     const activeData = useActiveData()
     const history = useHistory()
     const location = useLocation()

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -73,7 +73,7 @@ import {
 
 import Seo from '@salesforce/retail-react-app/app/components/seo'
 import {Helmet} from 'react-helmet'
-import {useAppOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
+import {useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 
 const PlaceholderComponent = () => (
     <Center p="2">
@@ -123,7 +123,7 @@ const App = (props) => {
     })
     const categories = flatten(categoriesTree || {}, 'categories')
     const {getTokenWhenReady} = useAccessToken()
-    const appOrigin = useAppOrigin()
+    const appOrigin = useOrigin()
     const activeData = useActiveData()
     const history = useHistory()
     const location = useLocation()

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -74,6 +74,7 @@ import {
 
 import Seo from '@salesforce/retail-react-app/app/components/seo'
 import {Helmet} from 'react-helmet'
+import {useAppOrigin} from '@salesforce/retail-react-app/app/components/_app-config/index'
 
 const PlaceholderComponent = () => (
     <Center p="2">
@@ -123,7 +124,7 @@ const App = (props) => {
     })
     const categories = flatten(categoriesTree || {}, 'categories')
     const {getTokenWhenReady} = useAccessToken()
-    const appOrigin = getAppOrigin()
+    const appOrigin = useAppOrigin()
     const activeData = useActiveData()
     const history = useHistory()
     const location = useLocation()

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -139,7 +139,6 @@ const App = (props) => {
         onOpen: onOpenStoreLocator,
         onClose: onCloseStoreLocator
     } = useDisclosure()
-    console.log('appOrigin', appOrigin)
 
     const targetLocale = getTargetLocale({
         getUserPreferredLocales: () => {
@@ -174,7 +173,7 @@ const App = (props) => {
                 // Otherwise, it'll continue to fetch the missing translation file again
                 return {}
             }
-            return fetchTranslations(targetLocale)
+            return fetchTranslations(targetLocale, appOrigin)
         },
         enabled: isServer
     })

--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -11,7 +11,6 @@ import {useHistory, useLocation} from 'react-router-dom'
 import {StorefrontPreview} from '@salesforce/commerce-sdk-react/components'
 import {getAssetUrl} from '@salesforce/pwa-kit-react-sdk/ssr/universal/utils'
 import useActiveData from '@salesforce/retail-react-app/app/hooks/use-active-data'
-import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
 import {useQuery} from '@tanstack/react-query'
 import {
     useAccessToken,
@@ -74,7 +73,7 @@ import {
 
 import Seo from '@salesforce/retail-react-app/app/components/seo'
 import {Helmet} from 'react-helmet'
-import {useAppOrigin} from '@salesforce/retail-react-app/app/components/_app-config/index'
+import {useAppOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 
 const PlaceholderComponent = () => (
     <Center p="2">
@@ -140,6 +139,7 @@ const App = (props) => {
         onOpen: onOpenStoreLocator,
         onClose: onCloseStoreLocator
     } = useDisclosure()
+    console.log('appOrigin', appOrigin)
 
     const targetLocale = getTargetLocale({
         getUserPreferredLocales: () => {
@@ -274,6 +274,7 @@ const App = (props) => {
 
     return (
         <Box className="sf-app" {...styles.container}>
+            AppOrigin {appOrigin}
             <StorefrontPreview getToken={getTokenWhenReady}>
                 <Helmet>
                     {ACTIVE_DATA_ENABLED && (

--- a/packages/template-retail-react-app/app/hooks/use-app-origin.js
+++ b/packages/template-retail-react-app/app/hooks/use-app-origin.js
@@ -9,7 +9,7 @@
  * Custom hook to retrieve the app's origin.
  * This hook wraps the `useOrigin` hook from the `@salesforce/pwa-kit-react-sdk/ssr/universal/hooks` package.
  * when fromXForwardedHeader: false, the x-forwarded-* headers will not be considered for app origin
- * when fromXForwardedHeader: false, the x-forwarded-* headers will be considered for app origin
+ * when fromXForwardedHeader: true, the x-forwarded-* headers will be considered for app origin
  */
 import {useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 

--- a/packages/template-retail-react-app/app/hooks/use-app-origin.js
+++ b/packages/template-retail-react-app/app/hooks/use-app-origin.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Custom hook to retrieve the app's origin.
+ * This hook wraps the `useOrigin` hook from the `@salesforce/pwa-kit-react-sdk/ssr/universal/hooks` package.
+ * when fromXForwardedHeader: false, the x-forwarded-* headers will not be considered for app origin
+ * when fromXForwardedHeader: false, the x-forwarded-* headers will be considered for app origin
+ */
+import {useOrigin} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
+
+export const useAppOrigin = () => useOrigin({fromXForwardedHeader: false})

--- a/packages/template-retail-react-app/app/utils/locale.js
+++ b/packages/template-retail-react-app/app/utils/locale.js
@@ -14,10 +14,11 @@ import fetch from 'cross-fetch'
 /**
  * Dynamically import the translations/messages for a given locale
  * @param {string} locale
+ * @param {string} origin
  * @returns {Promise<Object>} The messages (compiled in AST format) in the given locale.
  *      If the translation file is not found, return an empty object (so react-intl would fall back to the inline messages)
  */
-export const fetchTranslations = async (locale) => {
+export const fetchTranslations = async (locale, origin) => {
     const targetLocale =
         typeof window === 'undefined'
             ? process.env.USE_PSEUDOLOCALE === 'true'
@@ -26,7 +27,7 @@ export const fetchTranslations = async (locale) => {
             : locale
 
     try {
-        const file = `${getAppOrigin()}${getAssetUrl(
+        const file = `${origin || getAppOrigin()}${getAssetUrl(
             `static/translations/compiled/${targetLocale}.json`
         )}`
         const response = await fetch(file)

--- a/packages/template-retail-react-app/app/utils/site-utils.js
+++ b/packages/template-retail-react-app/app/utils/site-utils.js
@@ -12,13 +12,14 @@ import {absoluteUrl} from '@salesforce/retail-react-app/app/utils/url'
  * This functions takes an url and returns a site object,
  * an error will be thrown if no url is passed in or no site is found
  * @param {string} url
+ * @param {string} origin
  * @returns {object} site - a site object
  */
-export const resolveSiteFromUrl = (url) => {
+export const resolveSiteFromUrl = (url, origin) => {
     if (!url) {
         throw new Error('URL is required to find a site object.')
     }
-    const {pathname, search} = new URL(absoluteUrl(url))
+    const {pathname, search} = new URL(absoluteUrl(url, origin))
     const path = `${pathname}${search}`
     let site
 
@@ -195,14 +196,15 @@ export const getLocaleByReference = (site, localeRef) => {
  * and use it to find the locale object
  *
  * @param url
+ * @param origin
  * @return {Object} locale object
  */
-export const resolveLocaleFromUrl = (url) => {
+export const resolveLocaleFromUrl = (url, origin) => {
     if (!url) {
         throw new Error('URL is required to look for the locale object')
     }
     let {localeRef} = getParamsFromPath(url)
-    const site = resolveSiteFromUrl(url)
+    const site = resolveSiteFromUrl(url, origin)
     const {supportedLocales} = site.l10n
     // if no localeRef is found, use the default value of the current site
     if (!localeRef) {

--- a/packages/template-retail-react-app/app/utils/site-utils.js
+++ b/packages/template-retail-react-app/app/utils/site-utils.js
@@ -6,7 +6,6 @@
  */
 
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
-import {absoluteUrl} from '@salesforce/retail-react-app/app/utils/url'
 
 /**
  * This functions takes an url and returns a site object,
@@ -228,12 +227,7 @@ export const resolveLocaleFromUrl = (url) => {
  * @returns {{search: (string|string), pathname: string}}
  */
 function getPathnameAndSearch(url) {
-    // Clean up the URL by replacing double slashes with a single slash
-    const [baseUrl, searchString] = url.split('?')
-    const pathname = baseUrl.includes('://') ? baseUrl.split('/').slice(3).join('/') : baseUrl
-
-    return {
-        pathname: `${pathname.startsWith('/') ? '' : '/'}${pathname}`,
-        search: searchString ? `?${searchString}` : ''
-    }
+    // since url is a partial url, we pass in a dummy domain to create a validate url to pass into URL constructor
+    const {pathname, search} = new URL(url, 'https://www.some-domain.com')
+    return {pathname, search}
 }

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -15,17 +15,17 @@ import {
 import {HOME_HREF, urlPartPositions} from '@salesforce/retail-react-app/app/constants'
 
 /**
- * A function that takes a path and qualifies it with the current host and protocol.
- * This function works on the client and on the server.
+ * Constructs an absolute URL from a given path and an optional application origin.
  *
- * @example
- * absoluteUrl(/women/dresses?color=black)
- *
- * // => http(s)://www.site.com/women/dresses?color=black
- * @param path
- * @returns {string|*}
+ * @param {string} path - The relative URL path to be appended to the origin.
+ * @param {string} [appOrigin] - The optional application origin (e.g., "https://example.com").
+ *                                If not provided, the function will call `getAppOrigin()`.
+ * @returns {string} - The fully qualified URL as a string.
  */
-export const absoluteUrl = (path) => {
+export const absoluteUrl = (path, appOrigin) => {
+    if (appOrigin) {
+        return new URL(path, appOrigin).toString()
+    }
     return new URL(path, getAppOrigin()).toString()
 }
 

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -23,10 +23,7 @@ import {HOME_HREF, urlPartPositions} from '@salesforce/retail-react-app/app/cons
  * @returns {string} - The fully qualified URL as a string.
  */
 export const absoluteUrl = (path, appOrigin) => {
-    if (appOrigin) {
-        return new URL(path, appOrigin).toString()
-    }
-    return new URL(path, getAppOrigin()).toString()
+    return new URL(path, appOrigin || getAppOrigin()).toString()
 }
 
 /**

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -38,7 +38,7 @@ module.exports = {
             isProduction: false
         },
         // if this is true, useOrigin will take x-forwarded-host header into consideration
-        enableXForwardHost: false
+        enableXForwardedHost: false
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -36,9 +36,7 @@ module.exports = {
             // This differs from the siteId in commerceAPIConfig for testing purposes
             siteId: 'aaij-MobileFirst',
             isProduction: false
-        },
-        // if this is true, useOrigin will take x-forwarded-host header into consideration
-        enableXForwardedHost: false
+        }
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -37,8 +37,8 @@ module.exports = {
             siteId: 'aaij-MobileFirst',
             isProduction: false
         },
-        // getAppOrigin will take x-forwarded-host header into account if this is true
-        useXForwardedHost: false
+        // if this is true, useOrigin will take x-forwarded-host header into consideration
+        enableXForwardHost: false
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -38,7 +38,7 @@ module.exports = {
             isProduction: false
         },
         // getAppOrigin will take x-forwarded-host header into account if this is true
-        useXForwardedHost: false
+        useXForwardedHost: true
     },
     externals: [],
     pageNotFoundURL: '/page-not-found',


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
Issues: https://github.com/SalesforceCommerceCloud/pwa-kit/issues/1257

TLDR: Retail React App sometimes uses getAppOrigin to build links, on server side, it returns the value of process.env.EXTERNAL_HOSTNAME which is an MRT hostname and by pass the original host.

## Solution
When CDN is stacked in front of Pwa kit/MRT, the CDN will forward a header `x-forwarded-host` that contains the origin host. To consume this value, we pass it into `res.locals` in the server, and created a React Hook to consume it in the pwa-kit-react-sdk

To make it in a non-breaking fashion, a flag `useXForwardedHost` is introduced in the app configuration (default to false). When it is enabled, getAppOrigin will return the value of x-forwarded-host from request header. 

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

1. With useXForwardedHost enabled: 
You can't test this locally since it needs to have CDN that forwards the req headers. I've uploaded a bundle to this MRT env `https://www.phased-launch-testing.com/` that has CDN set up as intended
   - Visit https://www.phased-launch-testing.com/. Make sure it is deployed with bundle below
![image](https://github.com/user-attachments/assets/62809ac7-c403-4568-9c53-2803c4c50648)
   - Check the client and server both returns the value of origin host which is `https://www.phased-launch-testing.com` not `https://scaffold-pwa-bjnl-prd.mobify-storefront.com/`
        Client: https://www.phased-launch-testing.com/
        Server https://www.phased-launch-testing.com/?__server_only=1
        
![image](https://github.com/user-attachments/assets/3cf58d85-719f-4b95-9652-0c9b25c86285)

2. With useXForwardedHost disabled: 
Deployed to `https://www.phased-launch-testing.com/` with bundle 
![image](https://github.com/user-attachments/assets/92af7a10-591d-4813-bee2-f49c82c70723)
- After it finished deploying, Visit https://www.phased-launch-testing.com/ and https://www.phased-launch-testing.com?__server_only=1. You will notice getAppOrigin on server will return `https://scaffold-pwa-bjnl-prd.mobify-storefront.com/`



# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
