### PR TITLE
@W-12627162@ A11y - PLP page filter: change p tags to header tags

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -2,7 +2,6 @@
 - Announce wishlist change in total for screen readers (a11y) [#2033](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2033)
 - Fixed a bug that incorrectly imports uninstalled package `@chakra-ui/layout` [#2047](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2047)
 - Replace getAppOrigin with useOrigin to have a better support for an app origin building. [#2050](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2050)
-- [a11y] Mobile view account menu a11y adjustments [#1059](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2059)
 
 ### Performance Improvements
 -   Remove ocapi session-bridging on phased launches [#2011](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2011)
@@ -27,6 +26,8 @@
 - Add aria-labels for buttons in product item wishlist component to ensure they are unique and descriptive. [#2023](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2023)
 - Focus onto the `ToggleCard` title whenever the component is opened to be editted [#2029](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2029)
 - Add descriptive acccessibility label for edit/remove buttons on account addresses and checkout pages [#2037](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2037)
+- [a11y] Mobile view account menu a11y adjustments [#2059](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2059)
+- [a11y] PLP - Use header tags for filter options [#2065](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2065)
 
 ## v4.0.1 (Sept 4, 2024)
 - Updated @salesforce/commerce-sdk-react to 3.0.1 to fix an issue with the expires attribute of cookies, ensuring it uses seconds instead of days [#1994](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/1994)

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -25,6 +25,7 @@ import {
     SimpleGrid,
     Grid,
     Select,
+    Heading,
     Text,
     FormControl,
     Stack,
@@ -449,6 +450,7 @@ const ProductList = (props) => {
                         </Box>
                     </Stack>
 
+                    {/* Filter Button for Mobile */}
                     <HideOnDesktop>
                         <Stack spacing={6}>
                             <PageHeader
@@ -634,12 +636,12 @@ const ProductList = (props) => {
                 <ModalOverlay />
                 <ModalContent top={0} marginTop={0}>
                     <ModalHeader>
-                        <Text fontWeight="bold" fontSize="2xl">
+                        <Heading as="h1" fontWeight="bold" fontSize="2xl">
                             <FormattedMessage
                                 defaultMessage="Filter"
                                 id="product_list.modal.title.filter"
                             />
-                        </Text>
+                        </Heading>
                     </ModalHeader>
                     <ModalCloseButton />
                     <ModalBody py={4}>

--- a/packages/template-retail-react-app/app/pages/product-list/partials/category-links.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/category-links.jsx
@@ -16,7 +16,8 @@ import {
     AccordionPanel,
     AccordionIcon,
     Stack,
-    Text
+    Text,
+    Heading
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import Link from '@salesforce/retail-react-app/app/components/link'
 
@@ -29,9 +30,9 @@ const CategoryLinks = ({category = {}, onSelect = noop}) => {
     return (
         <AccordionItem paddingBottom={6} borderTop="none" key="show-all">
             <AccordionButton>
-                <Text flex="1" textAlign="left" fontSize="md" fontWeight={600}>
+                <Heading as="h2" flex="1" textAlign="left" fontSize="md" fontWeight={600}>
                     <FormattedMessage defaultMessage="Categories" id="category_links.button_text" />
-                </Text>
+                </Heading>
                 <AccordionIcon />
             </AccordionButton>
             <AccordionPanel>

--- a/packages/template-retail-react-app/app/pages/product-list/partials/refinements.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/partials/refinements.jsx
@@ -7,7 +7,7 @@
 
 import React from 'react'
 import {
-    Text,
+    Heading,
     Stack,
     Divider,
     Accordion,
@@ -79,7 +79,7 @@ const Refinements = ({
 
     return (
         <Stack spacing={8}>
-            {/* Wait to have filters before rendering the Accordion to allow the deafult indexes to be accurate */}
+            {/* Wait to have filters before rendering the Accordion to allow the default indexes to be accurate */}
             {filtersIndexes && (
                 <Accordion
                     pointerEvents={isLoading ? 'none' : 'auto'}
@@ -124,14 +124,15 @@ const Refinements = ({
                                                     paddingTop={0}
                                                     paddingBottom={isExpanded ? 2 : 0}
                                                 >
-                                                    <Text
+                                                    <Heading
+                                                        as="h2"
                                                         flex="1"
                                                         textAlign="left"
                                                         fontSize="md"
                                                         fontWeight={600}
                                                     >
                                                         {filter.label}
-                                                    </Text>
+                                                    </Heading>
                                                     <AccordionIcon />
                                                 </AccordionButton>
                                                 <AccordionPanel paddingLeft={0}>


### PR DESCRIPTION
Small PR to change some `<p>` tags in the plp filter to `<h1>` and `<h2>` tags to aid screen readers in sectioning the plp.

Desktop:
<img width="870" alt="Screenshot 2024-10-09 at 2 48 44 PM" src="https://github.com/user-attachments/assets/364c118f-cf39-4111-8297-c4e5ec3305e8">

Mobile:
<img width="483" alt="Screenshot 2024-10-09 at 2 55 57 PM" src="https://github.com/user-attachments/assets/db3b1b47-03e5-47ec-bdb2-f56f156bbc53">

Testing the changes:
- Start the app and go to the PLP
- Verify the filter dropdown options are in `<h2>` rather than `<p>` tags
- Resize the screen so you can see mobile view
- Open the filter modal 
- Verify the filter dropdown options are in `<h2>` rather than `<p>` tags. Verify the top 'Filter' heading is in `<h1>`
