### PR TITLE
Fix link list to follow with a11y practise

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v5.1.0 (TBD)
+
+### Accessibility Improvements
+- [a11y] Fix LinkList component to follow a11y practise [#2098])(https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2098)
+
 ## v5.0.0 (TBD)
 
 ### New Features

--- a/packages/template-retail-react-app/app/components/links-list/index.jsx
+++ b/packages/template-retail-react-app/app/components/links-list/index.jsx
@@ -11,7 +11,6 @@ import {
     List,
     ListItem,
     Heading,
-    HStack,
     useMultiStyleConfig
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import Link from '@salesforce/retail-react-app/app/components/link'
@@ -44,41 +43,36 @@ const LinksList = ({
                     <Heading {...styles.heading}>{heading}</Heading>
                 ))}
 
-            {links && (
-                <>
-                    {variant === 'horizontal' ? (
-                        <>
-                            <List {...styles.list}>
-                                {links.map((link, i) => (
-                                    <ListItem key={i} {...styles.listItem} sx={styles.listItemSx}>
-                                        <Link
-                                            to={link.href}
-                                            onClick={onLinkClick}
-                                            {...(link.styles ? link.styles : {})}
-                                        >
-                                            {link.text}
-                                        </Link>
-                                    </ListItem>
-                                ))}
-                            </List>
-                        </>
-                    ) : (
-                        <List spacing={5} {...styles.list}>
-                            {links.map((link, i) => (
-                                <ListItem key={i}>
-                                    <Link
-                                        to={link.href}
-                                        onClick={onLinkClick}
-                                        {...(link.styles ? link.styles : {})}
-                                    >
-                                        {link.text}
-                                    </Link>
-                                </ListItem>
-                            ))}
-                        </List>
-                    )}
-                </>
-            )}
+            {links &&
+                (variant === 'horizontal' ? (
+                    <List {...styles.list} data-testid="horizontal-list">
+                        {links.map((link, i) => (
+                            <ListItem key={i} {...styles.listItem} sx={styles.listItemSx}>
+                                <Link
+                                    to={link.href}
+                                    onClick={onLinkClick}
+                                    {...(link.styles ? link.styles : {})}
+                                >
+                                    {link.text}
+                                </Link>
+                            </ListItem>
+                        ))}
+                    </List>
+                ) : (
+                    <List spacing={5} {...styles.list}>
+                        {links.map((link, i) => (
+                            <ListItem key={i}>
+                                <Link
+                                    to={link.href}
+                                    onClick={onLinkClick}
+                                    {...(link.styles ? link.styles : {})}
+                                >
+                                    {link.text}
+                                </Link>
+                            </ListItem>
+                        ))}
+                    </List>
+                ))}
         </Box>
     )
 }

--- a/packages/template-retail-react-app/app/components/links-list/index.jsx
+++ b/packages/template-retail-react-app/app/components/links-list/index.jsx
@@ -45,11 +45,27 @@ const LinksList = ({
                 ))}
 
             {links && (
-                <List spacing={5} {...styles.list}>
+                <>
                     {variant === 'horizontal' ? (
-                        <HStack>
+                        <>
+                            <List {...styles.list}>
+                                {links.map((link, i) => (
+                                    <ListItem key={i} {...styles.listItem} sx={styles.listItemSx}>
+                                        <Link
+                                            to={link.href}
+                                            onClick={onLinkClick}
+                                            {...(link.styles ? link.styles : {})}
+                                        >
+                                            {link.text}
+                                        </Link>
+                                    </ListItem>
+                                ))}
+                            </List>
+                        </>
+                    ) : (
+                        <List spacing={5} {...styles.list}>
                             {links.map((link, i) => (
-                                <ListItem key={i} {...styles.listItem} sx={styles.listItemSx}>
+                                <ListItem key={i}>
                                     <Link
                                         to={link.href}
                                         onClick={onLinkClick}
@@ -59,21 +75,9 @@ const LinksList = ({
                                     </Link>
                                 </ListItem>
                             ))}
-                        </HStack>
-                    ) : (
-                        links.map((link, i) => (
-                            <ListItem key={i}>
-                                <Link
-                                    to={link.href}
-                                    onClick={onLinkClick}
-                                    {...(link.styles ? link.styles : {})}
-                                >
-                                    {link.text}
-                                </Link>
-                            </ListItem>
-                        ))
+                        </List>
                     )}
-                </List>
+                </>
             )}
         </Box>
     )

--- a/packages/template-retail-react-app/app/components/links-list/index.test.js
+++ b/packages/template-retail-react-app/app/components/links-list/index.test.js
@@ -21,7 +21,7 @@ const links = [
         text: 'Privacy Policy'
     }
 ]
-const horizontalVariantSelector = 'ul > .chakra-stack > li'
+const horizontalVariantSelector = 'ul > li'
 
 const FooterStylesProvider = ({children}) => {
     const styles = useMultiStyleConfig('Footer')
@@ -41,7 +41,7 @@ test('renders LinksList with default arguments', () => {
     expect(screen.getAllByRole('listitem')).toHaveLength(1)
     expect(screen.getByRole('link', {name: links[0].text})).toBeInTheDocument()
     expect(screen.queryByRole('heading')).toBeNull()
-    expect(document.querySelector(horizontalVariantSelector)).toBeNull()
+    expect(screen.queryByTestId('horizontal-list')).toBeNull()
 })
 
 test('renders LinksList with heading', () => {
@@ -55,11 +55,12 @@ test('renders LinksList with heading', () => {
 })
 
 test('renders LinksList with horizontal variant', () => {
-    renderWithProviders(
+    const {container} = renderWithProviders(
         <FooterStylesProvider>
             <LinksList links={links} variant="horizontal" />
         </FooterStylesProvider>
     )
+    screen.logTestingPlaygroundURL()
 
-    expect(document.querySelector(horizontalVariantSelector)).toBeInTheDocument()
+    expect(container.querySelector(horizontalVariantSelector)).toBeInTheDocument()
 })

--- a/packages/template-retail-react-app/app/theme/components/project/links-list.js
+++ b/packages/template-retail-react-app/app/theme/components/project/links-list.js
@@ -25,6 +25,11 @@ export default {
     variants: {
         vertical: {},
         horizontal: {
+            list: {
+                display: 'flex',
+                flexDirection: 'row',
+                gap: '0.5rem'
+            },
             listItem: {
                 borderLeft: '1px solid',
                 paddingLeft: 2


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
There is an a11y error complaining on the html tag order on "horizontal" link-list. This PR addressed that

An example of where horizontal list is the footer Term Condition line
Before
![image](https://github.com/user-attachments/assets/d4d41d0e-3499-49f4-84b7-5fdeaa395e04)

After 
![image](https://github.com/user-attachments/assets/0aab8b18-c34a-446d-abb5-cf3346cf8d99)


<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Check out code
- Run Retail app
- on Homage page, run axeTools to analyze a11y
- Confirm that it is no longer complained about <li> being inside or <ul> in the footer

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
