### PR TITLE
[App Extensibility] Get the correct configured extensions at runtime (@W-17109413@)

### DIFF
--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -7,7 +7,6 @@
 
 // PWA-Kit Imports
 import {getApplicationExtensionInfo} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 const config = {
     sourceType: 'unambiguous',

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -6,7 +6,7 @@
  */
 
 // PWA-Kit Imports
-import {getApplicationExtensionInfo} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
+import {getPackageNamesOfInstalledExtensions} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
 
 const config = {
     sourceType: 'unambiguous',
@@ -27,7 +27,7 @@ const config = {
             require('@salesforce/pwa-kit-extension-sdk/configs/babel/plugin-application-extensions'),
             {
                 target: 'node',
-                ...getApplicationExtensionInfo()
+                installed: getPackageNamesOfInstalledExtensions()
             }
         ],
         require('@babel/plugin-transform-async-to-generator'),

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -27,8 +27,8 @@ const config = {
         [
             require('@salesforce/pwa-kit-extension-sdk/configs/babel/plugin-application-extensions'),
             {
-                target: 'node'
-                // ...getApplicationExtensionInfo(getConfig())
+                target: 'node',
+                ...getApplicationExtensionInfo()
             }
         ],
         require('@babel/plugin-transform-async-to-generator'),

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -6,7 +6,7 @@
  */
 
 // PWA-Kit Imports
-import {getPackageNamesOfInstalledExtensions} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
+import {getInstalledExtensions} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
 
 const config = {
     sourceType: 'unambiguous',
@@ -27,7 +27,7 @@ const config = {
             require('@salesforce/pwa-kit-extension-sdk/configs/babel/plugin-application-extensions'),
             {
                 target: 'node',
-                installed: getPackageNamesOfInstalledExtensions()
+                installed: getInstalledExtensions()
             }
         ],
         require('@babel/plugin-transform-async-to-generator'),

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -27,8 +27,8 @@ const config = {
         [
             require('@salesforce/pwa-kit-extension-sdk/configs/babel/plugin-application-extensions'),
             {
-                target: 'node',
-                ...getApplicationExtensionInfo(getConfig())
+                target: 'node'
+                // ...getApplicationExtensionInfo(getConfig())
             }
         ],
         require('@babel/plugin-transform-async-to-generator'),

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -186,6 +186,7 @@ const baseConfig = (target) => {
                     plugins: [
                         new OverridesResolverPlugin({
                             projectDir: process.cwd(),
+                            extensions: getConfig()?.app?.extensions,
                             fileExtensions: SUPPORTED_FILE_EXTENSIONS
                         })
                     ],

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -49,8 +49,6 @@ const DEBUG = mode !== production && process.env.DEBUG === 'true'
 const CI = process.env.CI
 const disableHMR = process.env.HMR === 'false'
 
-const {app: appConfig} = getConfig()
-
 export const EXTENIONS_NAMESPACE = '__extensions'
 
 if ([production, development].indexOf(mode) < 0) {
@@ -188,7 +186,7 @@ const baseConfig = (target) => {
                     plugins: [
                         new OverridesResolverPlugin({
                             projectDir: process.cwd(),
-                            extensions: appConfig?.extensions,
+                            // extensions: appConfig?.extensions,
                             fileExtensions: SUPPORTED_FILE_EXTENSIONS
                         })
                     ],
@@ -256,13 +254,15 @@ const baseConfig = (target) => {
                         },
                         ruleForApplicationExtensibility({
                             loaderOptions: {
-                                appConfig: getConfig(),
+                                // TODO: don't call getConfig yet
+                                // appConfig: getConfig(),
                                 target: 'web'
                             }
                         }),
                         ruleForApplicationExtensibility({
                             loaderOptions: {
-                                appConfig: getConfig(),
+                                // TODO: don't call getConfig yet
+                                // appConfig: getConfig(),
                                 target: 'node'
                             }
                         })
@@ -323,7 +323,9 @@ const staticFolderCopyPlugin = new CopyPlugin({
         {
             from: 'app/static/',
             to: 'static/'
-        },
+        }
+        // TODO: bring this back
+        /*
         ...normalizeExtensionsList(appConfig?.extensions).map((extension) => {
             const {packageName} = extension
             // Parse the extension name out.
@@ -334,6 +336,7 @@ const staticFolderCopyPlugin = new CopyPlugin({
                 noErrorOnMissing: true
             }
         })
+        */
     ]
 })
 

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -31,7 +31,12 @@ import {CLIENT, SERVER, CLIENT_OPTIONAL, SSR, REQUEST_PROCESSOR} from './config-
 
 // Utilities
 import {ruleForApplicationExtensibility} from '@salesforce/pwa-kit-extension-sdk/configs/webpack'
-import {buildAliases, expand, nameRegex} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
+import {
+    buildAliases,
+    expand,
+    getInstalledExtensions,
+    nameRegex
+} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 const projectDir = process.cwd()
@@ -310,9 +315,7 @@ const staticFolderCopyPlugin = new CopyPlugin({
             from: 'app/static/',
             to: 'static/'
         },
-        ...expand(getConfig()?.app?.extensions).map((extension) => {
-            const packageName = extension[0]
-            // Parse the extension name out.
+        ...getInstalledExtensions().map((packageName) => {
             return {
                 from: `${projectDir}/node_modules/${packageName}/static`,
                 to: `static/${EXTENIONS_NAMESPACE}/${packageName}`,

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -31,7 +31,6 @@ import {CLIENT, SERVER, CLIENT_OPTIONAL, SSR, REQUEST_PROCESSOR} from './config-
 
 // Utilities
 import {ruleForApplicationExtensibility} from '@salesforce/pwa-kit-extension-sdk/configs/webpack'
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {buildAliases, nameRegex} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
 
 const projectDir = process.cwd()

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -31,7 +31,8 @@ import {CLIENT, SERVER, CLIENT_OPTIONAL, SSR, REQUEST_PROCESSOR} from './config-
 
 // Utilities
 import {ruleForApplicationExtensibility} from '@salesforce/pwa-kit-extension-sdk/configs/webpack'
-import {buildAliases, nameRegex} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
+import {buildAliases, expand, nameRegex} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 const projectDir = process.cwd()
 const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
@@ -185,7 +186,6 @@ const baseConfig = (target) => {
                     plugins: [
                         new OverridesResolverPlugin({
                             projectDir: process.cwd(),
-                            // extensions: appConfig?.extensions,
                             fileExtensions: SUPPORTED_FILE_EXTENSIONS
                         })
                     ],
@@ -253,15 +253,11 @@ const baseConfig = (target) => {
                         },
                         ruleForApplicationExtensibility({
                             loaderOptions: {
-                                // TODO: don't call getConfig yet
-                                // appConfig: getConfig(),
                                 target: 'web'
                             }
                         }),
                         ruleForApplicationExtensibility({
                             loaderOptions: {
-                                // TODO: don't call getConfig yet
-                                // appConfig: getConfig(),
                                 target: 'node'
                             }
                         })
@@ -307,26 +303,14 @@ const withChunking = (config) => {
     }
 }
 
-// TODO: Once we create a new project for extensibility we'll have the opportunity to better move this utility
-// to a place that can be reused. This util is also used in the `extensions-loader`.
-const normalizeExtensionsList = (extensions = []) =>
-    extensions.map((extension) => {
-        return {
-            packageName: Array.isArray(extension) ? extension[0] : extension,
-            config: Array.isArray(extension) ? {enabled: true, ...extension[1]} : {enabled: true}
-        }
-    })
-
 const staticFolderCopyPlugin = new CopyPlugin({
     patterns: [
         {
             from: 'app/static/',
             to: 'static/'
-        }
-        // TODO: bring this back
-        /*
-        ...normalizeExtensionsList(appConfig?.extensions).map((extension) => {
-            const {packageName} = extension
+        },
+        ...expand(getConfig()?.app?.extensions).map((extension) => {
+            const packageName = extension[0]
             // Parse the extension name out.
             return {
                 from: `${projectDir}/node_modules/${packageName}/static`,
@@ -335,7 +319,6 @@ const staticFolderCopyPlugin = new CopyPlugin({
                 noErrorOnMissing: true
             }
         })
-        */
     ]
 })
 

--- a/packages/pwa-kit-extension-sdk/package.json
+++ b/packages/pwa-kit-extension-sdk/package.json
@@ -50,6 +50,7 @@
     "@babel/preset-env": "^7.20.2",
     "@loadable/component": "^5.15.3",
     "@salesforce/pwa-kit-dev": "4.0.0-dev",
+    "@salesforce/pwa-kit-runtime": "4.0.0-dev",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@types/babel__core": "^7.20.5",

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
@@ -41,7 +41,8 @@ module.exports = function replaceExtensionsPlaceholderContentPlugin({types: t}: 
             },
             Program(path: any, state: any) {
                 const filePath = state.file.opts.filename
-                const {installed, configured, target} = state.opts
+                // TODO
+                const {installed, target} = state.opts
 
                 // Add a marker to the state to prevent reprocessing
                 if (processedFiles.has(filePath)) {
@@ -53,7 +54,6 @@ module.exports = function replaceExtensionsPlaceholderContentPlugin({types: t}: 
                 if (filePath.endsWith(extensionsPlaceholderFile)) {
                     const newContent = renderTemplate({
                         installed,
-                        configured,
                         target
                     })
 

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
@@ -41,7 +41,6 @@ module.exports = function replaceExtensionsPlaceholderContentPlugin({types: t}: 
             },
             Program(path: any, state: any) {
                 const filePath = state.file.opts.filename
-                // TODO
                 const {installed, target} = state.opts
 
                 // Add a marker to the state to prevent reprocessing

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/plugin-application-extensions.ts
@@ -41,7 +41,6 @@ module.exports = function replaceExtensionsPlaceholderContentPlugin({types: t}: 
             },
             Program(path: any, state: any) {
                 const filePath = state.file.opts.filename
-                const {installed, target} = state.opts
 
                 // Add a marker to the state to prevent reprocessing
                 if (processedFiles.has(filePath)) {
@@ -51,10 +50,7 @@ module.exports = function replaceExtensionsPlaceholderContentPlugin({types: t}: 
 
                 // Check if the file matches one of the files we want to replace
                 if (filePath.endsWith(extensionsPlaceholderFile)) {
-                    const newContent = renderTemplate({
-                        installed,
-                        target
-                    })
+                    const newContent = renderTemplate(state.opts)
 
                     let parsedAst
 

--- a/packages/pwa-kit-extension-sdk/src/configs/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/utils.ts
@@ -25,15 +25,16 @@ Handlebars.registerHelper('getInstanceName', (aString: string) => {
 
     return kebabToUpperCamelCase(`${namespace ? `${namespace}-` : ''}${name}`)
 })
-Handlebars.registerHelper('isNotLast', (index, arrayLength) => index !== arrayLength - 1)
 Handlebars.registerHelper('isNode', (target) => target === 'node')
 Handlebars.registerHelper('isWeb', (target) => target === 'web')
-Handlebars.registerHelper('jsonStringify', (context) => JSON.stringify(context, null, 0))
 
 // NOTE: We inline this template because it's easier to bundle it in the code than load it from the file system due
 // to issues with pathing because the current working directory for the loader isn't the same as the base project.
 // We can look to resolve this in the future as it would be nice to have a independant file for the template.
 const templateString = dedent`
+    import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+    import {expand} from '../../shared/utils/helpers'
+
     {{#if (isWeb @root.target)}}
     import loadable from '@loadable/component'
     {{/if}}
@@ -46,22 +47,44 @@ const templateString = dedent`
     {{/if}}
     {{/each}}
 
+    const installedExtensions = {
+    {{#each installed}}
+    {{#if (isNode @root.target)}}
+        '{{.}}': {{getInstanceName .}},
+    {{else}}
+        '{{.}}': {{getInstanceName .}}Loader,
+    {{/if}}
+    {{/each}}
+    }
+
+    const getConfiguredExtensions = () => expand(getConfig()?.app?.extensions || [])
+
     {{#if (isNode @root.target)}}
     const getApplicationExtensions = () => {
-        {{#if configured}}
-        return [{{#each configured}}new {{getInstanceName this.[0]}}({{{jsonStringify this.[1]}}}){{#if (isNotLast @index @root.configured.length)}}, {{/if}}{{/each}}]
-        {{else}}
+        const configuredExtensions = getConfiguredExtensions()
+        if (configuredExtensions) {
+            return configuredExtensions.map((extension) => {
+                const packageName = extension[0]
+                const config = extension[1]
+                return new installedExtensions[packageName](config)
+            })
+        }
         return []
-        {{/if}}    
     }
     {{else}}
     const getApplicationExtensions = async () => {
-    	{{#if configured}}
-        const modules = await Promise.all([{{#each configured}}{{getInstanceName this.[0]}}Loader.load(){{#if (isNotLast @index @root.configured.length)}},{{/if}}{{/each}}])
-        return [{{#each configured}}new modules[{{@index}}].default({{{jsonStringify this.[1]}}}){{#if (isNotLast @index @root.configured.length)}}, {{/if}}{{/each}}]
-        {{else}}
+        const configuredExtensions = getConfiguredExtensions()
+        if (configuredExtensions) {
+            const modules = await Promise.all(configuredExtensions.map((extension) => {
+                const packageName = extension[0]
+                return installedExtensions[packageName].load()
+            }))
+            return configuredExtensions.map((extension, index) => {
+                const config = extension[1]
+                return new modules[index].default(config)
+            })
+        }
         return []
-        {{/if}}
     }
     {{/if}}
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.test.js
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.test.js
@@ -25,70 +25,96 @@ const BASE_VIRTUAL_FILES = {
     // QUIRK! These entries are required to access the files in the actual file system. The resolve method fails if
     // they don't exist. This is a sharpe edge, but it's not too bad.
     [`${path.resolve(__dirname, './application-extensions-loader.ts')}`]: '',
-    [`${path.resolve(__dirname, '../../../node_modules/@loadable/component')}`]: ''
+    [`${path.resolve(__dirname, '../../../node_modules/@loadable/component')}`]: '',
+    [`${path.resolve(
+        __dirname,
+        '../../../node_modules/@salesforce/pwa-kit-runtime/utils/ssr-config'
+    )}`]: '',
+    [`${path.resolve(
+        __dirname,
+        '../../../node_modules/@salesforce/pwa-kit-extension-sdk/shared/utils/helpers'
+    )}`]: ''
 }
 
 describe('Application Extension Loader', () => {
     const testCases = [
         {
-            description: 'Returns expected file content without empty options',
+            description: 'Without target and installed extensions, returns expected file content',
             entryPoint: './app/main.jsx',
             expects: (output) => {
-                const emptyFile = dedent`
+                const file = dedent`
+                    import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+                    import {expand} from '../../shared/utils/helpers'
+
+
+
+                    const installedExtensions = {
+                    }
+
+                    const getConfiguredExtensions = () => expand(getConfig()?.app?.extensions || [])
+
                     const getApplicationExtensions = async () => {
+                        const configuredExtensions = getConfiguredExtensions()
+                        if (configuredExtensions) {
+                            const modules = await Promise.all(configuredExtensions.map((extension) => {
+                                const packageName = extension[0]
+                                return installedExtensions[packageName].load()
+                            }))
+                            return configuredExtensions.map((extension, index) => {
+                                const config = extension[1]
+                                return new modules[index].default(config)
+                            })
+                        }
                         return []
                     }
-                    
+
                     export {
                         getApplicationExtensions
                     }
                 `
-                expect(output.modules[1].source).toBe(emptyFile)
+                expect(output.modules[1].source).toBe(file)
             },
             files: BASE_VIRTUAL_FILES
         },
         {
-            description: 'Loadable is used for web targets.',
+            description:
+                'If web target, uses loadable and certain logic for getApplicationExtensions',
             entryPoint: './app/main.jsx',
             expects: (output) => {
-                const emptyFile = dedent`
-                    import loadable from '@loadable/component'
+                const file = dedent`
+                    import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+                    import {expand} from '../../shared/utils/helpers'
 
-
-                    const getApplicationExtensions = async () => {
-                        return []
-                    }
-                    
-                    export {
-                        getApplicationExtensions
-                    }
-                `
-                expect(output.modules[1].source).toBe(emptyFile)
-            },
-            files: BASE_VIRTUAL_FILES,
-            loaderOptions: {
-                target: 'web'
-            }
-        },
-        {
-            description: 'Non-configured extensions are not exported (web)',
-            entryPoint: './app/main.jsx',
-            expects: (output) => {
-                const emptyFile = dedent`
                     import loadable from '@loadable/component'
 
                     const SalesforceSampleALoader = loadable.lib(() => import('@salesforce/extension-sample-a/setup-app'))
 
+                    const installedExtensions = {
+                        '@salesforce/extension-sample-a': SalesforceSampleALoader,
+                    }
+
+                    const getConfiguredExtensions = () => expand(getConfig()?.app?.extensions || [])
+
                     const getApplicationExtensions = async () => {
+                        const configuredExtensions = getConfiguredExtensions()
+                        if (configuredExtensions) {
+                            const modules = await Promise.all(configuredExtensions.map((extension) => {
+                                const packageName = extension[0]
+                                return installedExtensions[packageName].load()
+                            }))
+                            return configuredExtensions.map((extension, index) => {
+                                const config = extension[1]
+                                return new modules[index].default(config)
+                            })
+                        }
                         return []
                     }
-                    
+
                     export {
                         getApplicationExtensions
                     }
                 `
-
-                expect(output.modules[1].source).toBe(emptyFile)
+                expect(output.modules[1].source).toBe(file)
             },
             files: {
                 ...BASE_VIRTUAL_FILES,
@@ -103,22 +129,39 @@ describe('Application Extension Loader', () => {
             }
         },
         {
-            description: 'Non-configured extensions are not exported (node)',
+            description: 'If node target, uses certain logic for getApplicationExtensions',
             entryPoint: './app/main.jsx',
             expects: (output) => {
-                const emptyFile = dedent`
+                const file = dedent`
+                    import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+                    import {expand} from '../../shared/utils/helpers'
+
+
                     import SalesforceSampleA from '@salesforce/extension-sample-a/setup-server'
 
+                    const installedExtensions = {
+                        '@salesforce/extension-sample-a': SalesforceSampleA,
+                    }
+
+                    const getConfiguredExtensions = () => expand(getConfig()?.app?.extensions || [])
+
                     const getApplicationExtensions = () => {
+                        const configuredExtensions = getConfiguredExtensions()
+                        if (configuredExtensions) {
+                            return configuredExtensions.map((extension) => {
+                                const packageName = extension[0]
+                                const config = extension[1]
+                                return new installedExtensions[packageName](config)
+                            })
+                        }
                         return []
                     }
-                    
+
                     export {
                         getApplicationExtensions
                     }
                 `
-
-                expect(output.modules[1].source).toBe(emptyFile)
+                expect(output.modules[1].source).toBe(file)
             },
             files: {
                 ...BASE_VIRTUAL_FILES,
@@ -129,139 +172,6 @@ describe('Application Extension Loader', () => {
             },
             loaderOptions: {
                 installed: ['@salesforce/extension-sample-a'],
-                configured: [],
-                target: 'node'
-            }
-        },
-
-        {
-            description: 'Disabled extensions are still exported (web)',
-            entryPoint: './app/main.jsx',
-            expects: (output) => {
-                const emptyFile = dedent`
-                    import loadable from '@loadable/component'
-
-                    const SalesforceSampleALoader = loadable.lib(() => import('@salesforce/extension-sample-a/setup-app'))
-
-                    const getApplicationExtensions = async () => {
-                        const modules = await Promise.all([SalesforceSampleALoader.load()])
-                        return [new modules[0].default({"enabled":false})]
-                    }
-                    
-                    export {
-                        getApplicationExtensions
-                    }
-                `
-
-                expect(output.modules[1].source).toBe(emptyFile)
-            },
-            files: {
-                ...BASE_VIRTUAL_FILES,
-                [`${path.resolve(
-                    __dirname,
-                    '../../../../node_modules/@salesforce/extension-sample-a/setup-app'
-                )}`]: ''
-            },
-            loaderOptions: {
-                installed: ['@salesforce/extension-sample-a'],
-                configured: [['@salesforce/extension-sample-a', {enabled: false}]],
-                target: 'web'
-            }
-        },
-        {
-            description: 'Disabled extensions are are still exported (node)',
-            entryPoint: './app/main.jsx',
-            expects: (output) => {
-                const emptyFile = dedent`
-                    import SalesforceSampleA from '@salesforce/extension-sample-a/setup-server'
-
-                    const getApplicationExtensions = () => {
-                        return [new SalesforceSampleA({"enabled":false})]
-                    }
-                    
-                    export {
-                        getApplicationExtensions
-                    }
-                `
-
-                expect(output.modules[1].source).toBe(emptyFile)
-            },
-            files: {
-                ...BASE_VIRTUAL_FILES,
-                [`${path.resolve(
-                    __dirname,
-                    '../../../../node_modules/@salesforce/extension-sample-a/setup-server'
-                )}`]: ''
-            },
-            loaderOptions: {
-                installed: ['@salesforce/extension-sample-a'],
-                configured: [['@salesforce/extension-sample-a', {enabled: false}]],
-                target: 'node'
-            }
-        },
-
-        {
-            description: 'Loadable is used for web targets.',
-            entryPoint: './app/main.jsx',
-            expects: (output) => {
-                const emptyFile = dedent`
-                    import loadable from '@loadable/component'
-
-                    const SalesforceSampleALoader = loadable.lib(() => import('@salesforce/extension-sample-a/setup-app'))
-
-                    const getApplicationExtensions = async () => {
-                        const modules = await Promise.all([SalesforceSampleALoader.load()])
-                        return [new modules[0].default({"enabled":true})]
-                    }
-                    
-                    export {
-                        getApplicationExtensions
-                    }
-                `
-
-                expect(output.modules[1].source).toBe(emptyFile)
-            },
-            files: {
-                ...BASE_VIRTUAL_FILES,
-                [`${path.resolve(
-                    __dirname,
-                    '../../../../node_modules/@salesforce/extension-sample-a/setup-app'
-                )}`]: ''
-            },
-            loaderOptions: {
-                installed: ['@salesforce/extension-sample-a'],
-                configured: [['@salesforce/extension-sample-a', {enabled: true}]],
-                target: 'web'
-            }
-        },
-        {
-            description: 'Loadable is not used for node targets.',
-            entryPoint: './app/main.jsx',
-            expects: (output) => {
-                const emptyFile = dedent`
-                    import SalesforceSampleA from '@salesforce/extension-sample-a/setup-server'
-
-                    const getApplicationExtensions = () => {
-                        return [new SalesforceSampleA({"enabled":true})]
-                    }
-                    
-                    export {
-                        getApplicationExtensions
-                    }
-                `
-
-                expect(output.modules[1].source).toBe(emptyFile)
-            },
-            files: {
-                ...BASE_VIRTUAL_FILES,
-                [`${path.resolve(
-                    __dirname,
-                    '../../../../node_modules/@salesforce/extension-sample-a/setup-server'
-                )}`]: ''
-            },
-            loaderOptions: {
-                installed: ['@salesforce/extension-sample-a'],
-                configured: [['@salesforce/extension-sample-a', {enabled: true}]],
                 target: 'node'
             }
         }
@@ -279,6 +189,14 @@ describe('Application Extension Loader', () => {
                         '@loadable/component$': path.resolve(
                             __dirname,
                             '../../../node_modules/@loadable/component'
+                        ),
+                        '@salesforce/pwa-kit-runtime/utils/ssr-config$': path.resolve(
+                            __dirname,
+                            '../../../node_modules/@salesforce/pwa-kit-runtime/utils/ssr-config'
+                        ),
+                        '../../shared/utils/helpers$': path.resolve(
+                            __dirname,
+                            '../../../node_modules/@salesforce/pwa-kit-extension-sdk/shared/utils/helpers'
                         )
                     },
                     files,
@@ -299,6 +217,7 @@ describe('Application Extension Loader', () => {
                 // Here we are looking at the first module imported via the wildcard syntax and testing that it's right.
                 output = stats.toJson({source: true})
             } catch (e) {
+                console.error(e)
                 error = e
             }
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.test.js
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.test.js
@@ -9,6 +9,7 @@ import dedent from 'dedent'
 import path from 'path'
 
 import {runWebpackCompiler} from './test-utils'
+import {ruleForApplicationExtensibility} from './application-extensions-loader'
 
 const BASE_VIRTUAL_FILES = {
     // Virtual Project Files
@@ -223,5 +224,12 @@ describe('Application Extension Loader', () => {
 
             expects(output, error)
         })
+    })
+})
+
+describe('ruleForApplicationExtensibility', () => {
+    test('without any arguments, uses the node target', () => {
+        const result = ruleForApplicationExtensibility()
+        expect(result.use.options.target).toBe('node')
     })
 })

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -34,15 +34,11 @@ export default function ApplicationExtensibilityLoader(
 ): string {
     // TODO: Add checking for arguments.
 
-    // Get the installed and configured application extensions as well as the requested
-    // target type. For web targets the loader takes advantage of react-loadabled but node
+    // Get the installed application extensions as well as the requested target type.
+    // For web targets the loader takes advantage of react-loadabled but node
     // targets (server) do not require this optimization.
-    const data = {
-        ...this.getOptions(),
-        installed: getInstalledExtensions()
-    }
+    const data = this.getOptions()
 
-    // @ts-ignore
     return renderTemplate(data)
 }
 
@@ -69,6 +65,7 @@ export const ruleForApplicationExtensibility = (options: any = {}) => {
         use: {
             loader: '@salesforce/pwa-kit-extension-sdk/configs/webpack/application-extensions-loader',
             options: {
+                installed: getInstalledExtensions(),
                 target
             }
         }

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -37,8 +37,12 @@ export default function ApplicationExtensibilityLoader(
     // Get the installed and configured application extensions as well as the requested
     // target type. For web targets the loader takes advantage of react-loadabled but node
     // targets (server) do not require this optimization.
-    const data = this.getOptions()
+    const data = {
+        ...this.getOptions(),
+        ...getApplicationExtensionInfo()
+    }
 
+    // @ts-ignore
     return renderTemplate(data)
 }
 
@@ -50,13 +54,12 @@ export default function ApplicationExtensibilityLoader(
  * @param {Object} [options={}] - Options to customize the Webpack rule.
  * @param {Object} [options.loaderOptions={}] - Loader-specific options.
  * @param {string} [options.loaderOptions.target=DEFAULT_TARGET] - The target environment, either 'node' or 'react'.
- * @param {Object} [options.loaderOptions.appConfig] - Optional application configuration to pass to the loader.
  *
  * @returns {Object} A Webpack rule configuration object for handling application extensions.
  */
 export const ruleForApplicationExtensibility = (options: any = {}) => {
     const {loaderOptions = {}} = options
-    const {target = DEFAULT_TARGET, appConfig} = loaderOptions
+    const {target = DEFAULT_TARGET} = loaderOptions
 
     return {
         test: new RegExp(
@@ -66,7 +69,7 @@ export const ruleForApplicationExtensibility = (options: any = {}) => {
         use: {
             loader: '@salesforce/pwa-kit-extension-sdk/configs/webpack/application-extensions-loader',
             options: {
-                ...getApplicationExtensionInfo(appConfig),
+                // ...getApplicationExtensionInfo(),
                 target
             }
         }

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -7,7 +7,7 @@
 
 // Local
 import {renderTemplate} from '../utils'
-import {getPackageNamesOfInstalledExtensions} from '../../shared/utils'
+import {getInstalledExtensions} from '../../shared/utils'
 
 // Types
 import {ApplicationExtensionsLoaderContext} from './types'
@@ -39,7 +39,7 @@ export default function ApplicationExtensibilityLoader(
     // targets (server) do not require this optimization.
     const data = {
         ...this.getOptions(),
-        installed: getPackageNamesOfInstalledExtensions()
+        installed: getInstalledExtensions()
     }
 
     // @ts-ignore

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -39,8 +39,6 @@ export default function ApplicationExtensibilityLoader(
     // targets (server) do not require this optimization.
     const data = {
         ...this.getOptions(),
-
-        // TODO
         ...getApplicationExtensionInfo()
     }
 
@@ -71,7 +69,6 @@ export const ruleForApplicationExtensibility = (options: any = {}) => {
         use: {
             loader: '@salesforce/pwa-kit-extension-sdk/configs/webpack/application-extensions-loader',
             options: {
-                // ...getApplicationExtensionInfo(),
                 target
             }
         }

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -7,7 +7,7 @@
 
 // Local
 import {renderTemplate} from '../utils'
-import {getApplicationExtensionInfo} from '../../shared/utils'
+import {getPackageNamesOfInstalledExtensions} from '../../shared/utils'
 
 // Types
 import {ApplicationExtensionsLoaderContext} from './types'
@@ -39,7 +39,7 @@ export default function ApplicationExtensibilityLoader(
     // targets (server) do not require this optimization.
     const data = {
         ...this.getOptions(),
-        ...getApplicationExtensionInfo()
+        installed: getPackageNamesOfInstalledExtensions()
     }
 
     // @ts-ignore

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/application-extensions-loader.ts
@@ -39,6 +39,8 @@ export default function ApplicationExtensibilityLoader(
     // targets (server) do not require this optimization.
     const data = {
         ...this.getOptions(),
+
+        // TODO
         ...getApplicationExtensionInfo()
     }
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -15,21 +15,18 @@ import {buildCandidatePaths} from '../../shared/utils/resolver'
 import {expand} from '../../shared/utils/helpers'
 
 // Types
-import {ApplicationExtensionEntry} from '../../types'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 export const DEFAULT_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.json']
 
 interface OverridesResolverPluginOptions {
     projectDir: string
-    // extensions: ApplicationExtensionEntry[]
     fileExtensions?: string[]
     resolveOptions: any
 }
 
 const defaultOptions = {
     projectDir: process.cwd(),
-    // extensions: [],
     fileExtension: DEFAULT_FILE_EXTENSIONS,
     resolveOptions: {}
 }
@@ -80,7 +77,7 @@ export class OverridesResolverPlugin {
                         // where ALL configured extensions are listed there, and have them all enabled.
 
                         // Ensure we have the long form configuration entry.
-                        extensionEntries: expand(getConfig().extensions),
+                        extensionEntries: expand(getConfig()?.app?.extensions),
                         projectDir: this.options.projectDir
                     }),
                 ...this.options.resolveOptions

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -15,19 +15,20 @@ import {buildCandidatePaths, expand} from '../../shared/utils/resolver'
 
 // Types
 import {ApplicationExtensionEntry} from '../../types'
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 export const DEFAULT_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.json']
 
 interface OverridesResolverPluginOptions {
     projectDir: string
-    extensions: ApplicationExtensionEntry[]
+    // extensions: ApplicationExtensionEntry[]
     fileExtensions?: string[]
     resolveOptions: any
 }
 
 const defaultOptions = {
     projectDir: process.cwd(),
-    extensions: [],
+    // extensions: [],
     fileExtension: DEFAULT_FILE_EXTENSIONS,
     resolveOptions: {}
 }
@@ -47,9 +48,6 @@ export class OverridesResolverPlugin {
             ...defaultOptions,
             ...options
         }
-
-        // Ensure we have the long form configuration entry.
-        this.options.extensions = expand(this.options.extensions)
     }
 
     handleHook(
@@ -76,7 +74,8 @@ export class OverridesResolverPlugin {
                 extensions: this.options.fileExtensions,
                 packageIterator: () =>
                     buildCandidatePaths(importPath, sourcePath, {
-                        extensionEntries: this.options.extensions,
+                        // Ensure we have the long form configuration entry.
+                        extensionEntries: expand(getConfig().extensions),
                         projectDir: this.options.projectDir
                     }),
                 ...this.options.resolveOptions

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -7,7 +7,6 @@
 
 import resolve from 'resolve'
 import {Resolver} from 'webpack'
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 // Local
 // TODO: Is this a good place for this util? I seems to only be used in the plugin. Maybe we need to put it somewhere
@@ -15,16 +14,21 @@ import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {buildCandidatePaths} from '../../shared/utils/resolver'
 import {expand} from '../../shared/utils/helpers'
 
+// Types
+import {ApplicationExtensionEntry} from '../../types'
+
 export const DEFAULT_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.json']
 
 interface OverridesResolverPluginOptions {
     projectDir: string
+    extensions: ApplicationExtensionEntry[]
     fileExtensions?: string[]
     resolveOptions: any
 }
 
 const defaultOptions = {
     projectDir: process.cwd(),
+    extensions: [],
     fileExtension: DEFAULT_FILE_EXTENSIONS,
     resolveOptions: {}
 }
@@ -44,6 +48,9 @@ export class OverridesResolverPlugin {
             ...defaultOptions,
             ...options
         }
+
+        // Ensure we have the long form configuration entry.
+        this.options.extensions = expand(this.options.extensions)
     }
 
     handleHook(
@@ -70,12 +77,7 @@ export class OverridesResolverPlugin {
                 extensions: this.options.fileExtensions,
                 packageIterator: () =>
                     buildCandidatePaths(importPath, sourcePath, {
-                        // TODO: does the overrides resolver need to get the _configured_ extensions at build time?
-                        // If yes, then it looks like we'll need a convention of having at least default.json config,
-                        // where ALL configured extensions are listed there, and have them all enabled.
-
-                        // Ensure we have the long form configuration entry.
-                        extensionEntries: expand(getConfig()?.app?.extensions),
+                        extensionEntries: this.options.extensions,
                         projectDir: this.options.projectDir
                     }),
                 ...this.options.resolveOptions

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -74,6 +74,10 @@ export class OverridesResolverPlugin {
                 extensions: this.options.fileExtensions,
                 packageIterator: () =>
                     buildCandidatePaths(importPath, sourcePath, {
+                        // TODO: does the overrides resolver need to get the _configured_ extensions at build time?
+                        // If yes, then it looks like we'll need a convention of having at least default.json config,
+                        // where ALL configured extensions are listed there, and have them all enabled.
+
                         // Ensure we have the long form configuration entry.
                         extensionEntries: expand(getConfig().extensions),
                         projectDir: this.options.projectDir

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -7,15 +7,13 @@
 
 import resolve from 'resolve'
 import {Resolver} from 'webpack'
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 // Local
 // TODO: Is this a good place for this util? I seems to only be used in the plugin. Maybe we need to put it somewhere
 // else?
 import {buildCandidatePaths} from '../../shared/utils/resolver'
 import {expand} from '../../shared/utils/helpers'
-
-// Types
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 export const DEFAULT_FILE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.json']
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-plugin.ts
@@ -11,7 +11,8 @@ import {Resolver} from 'webpack'
 // Local
 // TODO: Is this a good place for this util? I seems to only be used in the plugin. Maybe we need to put it somewhere
 // else?
-import {buildCandidatePaths, expand} from '../../shared/utils/resolver'
+import {buildCandidatePaths} from '../../shared/utils/resolver'
+import {expand} from '../../shared/utils/helpers'
 
 // Types
 import {ApplicationExtensionEntry} from '../../types'

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/types.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/types.ts
@@ -10,7 +10,7 @@ import {LoaderContext} from 'webpack'
 
 export interface ApplicationExtensionsLoaderOptions {
     installed: string[]
-    configured: string[]
+    // configured: string[]
     target: 'node' | 'web'
 }
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/types.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/types.ts
@@ -10,7 +10,6 @@ import {LoaderContext} from 'webpack'
 
 export interface ApplicationExtensionsLoaderOptions {
     installed: string[]
-    // configured: string[]
     target: 'node' | 'web'
 }
 

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
@@ -160,6 +160,8 @@ describe('extensibilityUtils', () => {
         })
     })
 
+    // TODO
+    /*
     describe('getApplicationExtensionInfo', () => {
         afterEach(() => {
             jest.clearAllMocks()
@@ -219,4 +221,5 @@ describe('extensibilityUtils', () => {
             expect(result.configured).toEqual([['extension-new', {enabled: true}]])
         })
     })
+    */
 })

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
@@ -160,66 +160,31 @@ describe('extensibilityUtils', () => {
         })
     })
 
-    // TODO
-    /*
-    describe('getApplicationExtensionInfo', () => {
+    describe('getInstalledExtensions', () => {
         afterEach(() => {
             jest.clearAllMocks()
         })
 
-        it('should return empty arrays if no devDependencies or mobify config', () => {
-            mockPackageJson({})
-            const result = extensionUtils.getApplicationExtensionInfo()
-            expect(result).toEqual({installed: [], configured: []})
-        })
-
-        it('should return installed extensions based on devDependencies matching regex', () => {
+        it('should return packages that are app extensions', () => {
             const devDependencies = {
                 'extension-mock': '1.0.0',
-                'not-an-extenion': '1.0.0'
+                'not-an-extension': '1.0.0'
             }
             mockPackageJson(devDependencies)
 
-            const result = extensionUtils.getApplicationExtensionInfo()
-
-            expect(result.installed).toEqual(['extension-mock'])
-            expect(result.configured).toEqual([])
+            const result = extensionUtils.getInstalledExtensions()
+            expect(result).toEqual(['extension-mock'])
         })
 
-        it('should return configured extensions from appConfig parameter', () => {
-            const devDependencies = {}
-            const appConfig = {app: {extensions: ['extension-from-app-config']}}
+        it('should return empty list if none of packages are app extensions', () => {
+            const devDependencies = {
+                'not-an-extension': '1.0.0',
+                'not-an-extension-2': '1.0.0'
+            }
             mockPackageJson(devDependencies)
 
-            // TODO
-            // @ts-ignore
-            const result = extensionUtils.getApplicationExtensionInfo(appConfig)
-
-            expect(result.installed).toEqual([])
-            expect(result.configured).toEqual([['extension-from-app-config', {enabled: true}]])
-        })
-
-        it('should use mobify config from package.json if appConfig is not provided', () => {
-            const devDependencies = {}
-            const mobifyConfig = {app: {extensions: ['extension-from-package-json']}}
-            mockPackageJson(devDependencies, mobifyConfig)
-
-            const result = extensionUtils.getApplicationExtensionInfo()
-
-            expect(result.configured).toEqual([['extension-from-package-json', {enabled: true}]])
-        })
-
-        it('should prioritize appConfig parameter over package.json mobify config', () => {
-            const devDependencies = {}
-            const mobifyConfig = {app: {extensions: ['extension-old']}}
-            const appConfig = {app: {extensions: ['extension-new']}}
-            mockPackageJson(devDependencies, mobifyConfig)
-
-            // @ts-ignore
-            const result = extensionUtils.getApplicationExtensionInfo(appConfig)
-
-            expect(result.configured).toEqual([['extension-new', {enabled: true}]])
+            const result = extensionUtils.getInstalledExtensions()
+            expect(result).toEqual([])
         })
     })
-    */
 })

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.test.ts
@@ -189,6 +189,8 @@ describe('extensibilityUtils', () => {
             const appConfig = {app: {extensions: ['extension-from-app-config']}}
             mockPackageJson(devDependencies)
 
+            // TODO
+            // @ts-ignore
             const result = extensionUtils.getApplicationExtensionInfo(appConfig)
 
             expect(result.installed).toEqual([])
@@ -211,6 +213,7 @@ describe('extensibilityUtils', () => {
             const appConfig = {app: {extensions: ['extension-new']}}
             mockPackageJson(devDependencies, mobifyConfig)
 
+            // @ts-ignore
             const result = extensionUtils.getApplicationExtensionInfo(appConfig)
 
             expect(result.configured).toEqual([['extension-new', {enabled: true}]])

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
@@ -122,7 +122,6 @@ export const getExtensionNames = (extensions: ApplicationExtensionEntry[]) => {
  * - `installed` {string[]} - An array of installed extension names based on the project's devDependencies.
  * - `configured` {string[]} - An array of configured extension names as specified in the application configuration.
  */
-// TODO: return only `installed` ?
 export const getApplicationExtensionInfo = () => {
     const projectDir = process.cwd()
     const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
@@ -10,6 +10,8 @@ import fse from 'fs-extra'
 import path from 'path'
 import {resolve} from 'path'
 
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+
 // Types
 import {ApplicationExtensionEntry} from '../../types'
 
@@ -116,13 +118,12 @@ export const getExtensionNames = (extensions: ApplicationExtensionEntry[]) => {
  * found in the project's dependencies, and `configured`, which lists extensions configured
  * in the application settings.
  *
- * @param {object} [appConfig] - Optional application configuration object. If not provided,
- * defaults to the configuration in the project's `package.json` file under the `mobify` key.
  * @returns {Object} An object containing the following properties:
  * - `installed` {string[]} - An array of installed extension names based on the project's devDependencies.
  * - `configured` {string[]} - An array of configured extension names as specified in the application configuration.
  */
-export const getApplicationExtensionInfo = (appConfig?: any) => {
+export const getApplicationExtensionInfo = () => {
+    let appConfig = getConfig()
     const projectDir = process.cwd()
     const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
 

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
@@ -110,31 +110,11 @@ export const getExtensionNames = (extensions: ApplicationExtensionEntry[]) => {
     })
 }
 
-/**
- * Retrieves information about application extensions from the provided application configuration or,
- * if none is provided, from the default configuration in the project's `package.json`.
- *
- * This function returns an object containing two lists: `installed`, which includes extensions
- * found in the project's dependencies, and `configured`, which lists extensions configured
- * in the application settings.
- *
- * @returns {Object} An object containing the following properties:
- * - `installed` {string[]} - An array of installed extension names based on the project's devDependencies.
- * - `configured` {string[]} - An array of configured extension names as specified in the application configuration.
- */
-export const getApplicationExtensionInfo = () => {
+export const getPackageNamesOfInstalledExtensions = () => {
     const projectDir = process.cwd()
     const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
-    const appConfig = getConfig() || pkg?.mobify || {}
 
-    const installedExtensions = Object.keys(pkg?.devDependencies || {})
+    return Object.keys(pkg?.devDependencies || {})
         .map((packageName) => (packageName.match(nameRegex) !== null ? packageName : undefined))
         .filter(Boolean)
-
-    const configuredExtensions = expand(appConfig?.app?.extensions || [])
-
-    return {
-        installed: installedExtensions,
-        configured: configuredExtensions
-    }
 }

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
@@ -16,7 +16,7 @@ import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {ApplicationExtensionEntry} from '../../types'
 
 // Local
-import {expand} from './resolver'
+import {expand} from './helpers'
 
 // CONSTANTS
 // const REACT_EXTENSIBILITY_FILE = 'setup-app'
@@ -122,21 +122,16 @@ export const getExtensionNames = (extensions: ApplicationExtensionEntry[]) => {
  * - `installed` {string[]} - An array of installed extension names based on the project's devDependencies.
  * - `configured` {string[]} - An array of configured extension names as specified in the application configuration.
  */
+// TODO: return only `installed` ?
 export const getApplicationExtensionInfo = () => {
-    let appConfig = getConfig()
     const projectDir = process.cwd()
     const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
-
-    // Use the application configuration in the projects application if one isn't provided.
-    appConfig = appConfig
-        ? appConfig
-        : fse.readJsonSync(resolve(projectDir, 'package.json'))?.mobify || {}
+    const appConfig = getConfig() || pkg?.mobify || {}
 
     const installedExtensions = Object.keys(pkg?.devDependencies || {})
         .map((packageName) => (packageName.match(nameRegex) !== null ? packageName : undefined))
         .filter(Boolean)
 
-    // NOTE: Might have to get the expanded version of these.
     const configuredExtensions = expand(appConfig?.app?.extensions || [])
 
     return {

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/extensibility.ts
@@ -10,13 +10,8 @@ import fse from 'fs-extra'
 import path from 'path'
 import {resolve} from 'path'
 
-import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
-
 // Types
 import {ApplicationExtensionEntry} from '../../types'
-
-// Local
-import {expand} from './helpers'
 
 // CONSTANTS
 // const REACT_EXTENSIBILITY_FILE = 'setup-app'
@@ -110,7 +105,12 @@ export const getExtensionNames = (extensions: ApplicationExtensionEntry[]) => {
     })
 }
 
-export const getPackageNamesOfInstalledExtensions = () => {
+/**
+ * Get the _installed_ app extensions that the base project has installed via npm.
+ * They're not the same as the _configured_ extensions, which live in the project's config.
+ * @returns {string[]} An array of installed extension names based on the project's devDependencies.
+ */
+export const getInstalledExtensions = () => {
     const projectDir = process.cwd()
     const pkg = fse.readJsonSync(resolve(projectDir, 'package.json'))
 

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.test.js
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.test.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {kebabToLowerCamelCase, kebabToUpperCamelCase} from './helpers'
+import {kebabToLowerCamelCase, kebabToUpperCamelCase, expand} from './helpers'
 
 describe('kebabToLowerCamelCase', () => {
     test('converts a simple kebab-case string to lowerCamelCase', () => {
@@ -72,5 +72,36 @@ describe('kebabToUpperCamelCase', () => {
 
     test('handles strings that start or end with hyphens', () => {
         expect(kebabToUpperCamelCase('-foo-bar-')).toBe('FooBar')
+    })
+})
+
+describe('"expand" util returns correct return value when', () => {
+    ;[
+        {
+            name: 'extensions are all valid package names',
+            input: ['extension-a', 'extension-b', 'extension-c', '@salesforce/extension-d'],
+            expected: [
+                ['extension-a', {enabled: true}],
+                ['extension-b', {enabled: true}],
+                ['extension-c', {enabled: true}],
+                ['@salesforce/extension-d', {enabled: true}]
+            ]
+        },
+        {
+            name: 'extensions include falsey values',
+            input: ['extension-a', '', false],
+            expected: [['extension-a', {enabled: true}]]
+        },
+        {
+            name: 'extensions defined do not follow naming convension',
+            input: ['not-the-correct-prefix-a'],
+            expected: []
+        }
+    ].forEach((testCase) => {
+        test(`${testCase.name}`, () => {
+            const result = expand(testCase.input)
+
+            expect(result).toEqual(testCase.expected)
+        })
     })
 })

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {
+    ApplicationExtensionConfig,
+    ApplicationExtensionEntryArray,
+    ApplicationExtensionEntry
+} from '../../types'
+
+const DEFAULT_CONFIG: ApplicationExtensionConfig = {
+    enabled: true
+}
 
 /**
  * Converts a kebab-case string to UpperCamelCase (PascalCase).
@@ -50,3 +59,38 @@ export const kebabToLowerCamelCase = (str: string) =>
                 : word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
         )
         .join('')
+
+// Returns true if the entry passes is a ApplicationExtensionEntryArray type.
+// TODO: This looks like it could be done in a more generic way.
+const isApplicationExtensionEntryArray = (entry: ApplicationExtensionEntryArray): boolean => {
+    const [nameRef, config] = entry || []
+    return (
+        typeof nameRef === 'string' &&
+        typeof config === 'object' &&
+        !!nameRef.match(/^(?:@([^/]+)\/)?extension-(.+)$/)
+    )
+}
+
+/**
+ * Normalize and expand the extension configuration array so that it is easier to process.
+ * @param {{String, Object}[]} extensions - The extensions configuration value as defined in the PWA-Kit config.
+ * @returns {Object[]} extensions - The extensions array in object form.
+ *
+ * @example
+ * const result = expand(["store-finder", ["account-pages", {singlePage: true}], './extensions/local-extension']);
+ * console.log(result)
+ * // [["@salesforce/extension-store-finder", {}], ["@salesforce/extension-account-pages", {singlePage: true}], ["/home/project/extensions/local-extension", {}]]
+ */
+export const expand = (
+    extensions: ApplicationExtensionEntry[] = []
+): ApplicationExtensionEntryArray[] =>
+    extensions
+        .filter((extension) => Boolean(extension))
+        .map((extension) => {
+            const thing: [string, any] = Array.isArray(extension)
+                ? extension
+                : [extension, DEFAULT_CONFIG]
+
+            return thing
+        })
+        .filter(isApplicationExtensionEntryArray)

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/resolver.test.js
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/resolver.test.js
@@ -11,6 +11,8 @@ import * as resolverUtils from './resolver'
 const PROJECT_PATH_GOOD = '/home/user/testproject'
 const PROJECT_PATH_BAD = '/home/user/test.project'
 
+// TODO
+
 describe('resolverUtils', () => {
     describe('"isSelfReference" util returns whether or not a dollar-prefixed import is for the same module it is coming from.', () => {
         ;[
@@ -65,37 +67,6 @@ describe('resolverUtils', () => {
                     testCase.importPath,
                     testCase.sourcePath
                 )
-
-                expect(result).toEqual(testCase.expected)
-            })
-        })
-    })
-
-    describe('"expand" util returns correct return value when', () => {
-        ;[
-            {
-                name: 'extensions are all valid package names',
-                input: ['extension-a', 'extension-b', 'extension-c', '@salesforce/extension-d'],
-                expected: [
-                    ['extension-a', {enabled: true}],
-                    ['extension-b', {enabled: true}],
-                    ['extension-c', {enabled: true}],
-                    ['@salesforce/extension-d', {enabled: true}]
-                ]
-            },
-            {
-                name: 'extensions include falsey values',
-                input: ['extension-a', '', false],
-                expected: [['extension-a', {enabled: true}]]
-            },
-            {
-                name: 'extensions defined do not follow naming convension',
-                input: ['not-the-correct-prefix-a'],
-                expected: []
-            }
-        ].forEach((testCase) => {
-            test(`${testCase.name}`, () => {
-                const result = resolverUtils.expand(testCase.input)
 
                 expect(result).toEqual(testCase.expected)
             })

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/resolver.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/resolver.ts
@@ -9,12 +9,9 @@
 import path from 'path'
 
 // Types
-import {
-    ApplicationExtensionConfig,
-    ApplicationExtensionEntry,
-    ApplicationExtensionEntryArray,
-    BuildCandidatePathsOptions
-} from '../../types'
+import {ApplicationExtensionEntry, BuildCandidatePathsOptions} from '../../types'
+
+import {expand} from './helpers'
 
 // TODO: Should this be in a constants folder?
 const EXTENSION_NAMESPACE = '@salesforce'
@@ -23,9 +20,6 @@ const OVERRIDES = 'overrides'
 const APP = 'app'
 const SRC = 'src'
 const PWA_KIT_REACT_SDK = 'pwa-kit-react-sdk'
-const DEFAULT_CONFIG: ApplicationExtensionConfig = {
-    enabled: true
-}
 
 // TODO: We should determine if we want the `overrides-resolver-plugin` to handle resolution of application special
 // components like _app and _document. If so we can update this map and remove the special logic from our webpack
@@ -50,43 +44,6 @@ export const isSelfReference = (importPath: string, sourcePath: string) => {
 
     return sourcePath.endsWith(importPath)
 }
-
-// Returns true if the entry passes is a ApplicationExtensionEntryArray type.
-// TODO: This looks like it could be done in a more generic way.
-export const isApplicationExtensionEntryArray = (
-    entry: ApplicationExtensionEntryArray
-): boolean => {
-    const [nameRef, config] = entry || []
-    return (
-        typeof nameRef === 'string' &&
-        typeof config === 'object' &&
-        !!nameRef.match(/^(?:@([^/]+)\/)?extension-(.+)$/)
-    )
-}
-
-/**
- * Normalize and expand the extension configuration array so that it is easier to process.
- * @param {{String, Object}[]} extensions - The extensions configuration value as defined in the PWA-Kit config.
- * @returns {Object[]} extensions - The extensions array in object form.
- *
- * @example
- * const result = expand(["store-finder", ["account-pages", {singlePage: true}], './extensions/local-extension']);
- * console.log(result)
- * // [["@salesforce/extension-store-finder", {}], ["@salesforce/extension-account-pages", {singlePage: true}], ["/home/project/extensions/local-extension", {}]]
- */
-export const expand = (
-    extensions: ApplicationExtensionEntry[] = []
-): ApplicationExtensionEntryArray[] =>
-    extensions
-        .filter((extension) => Boolean(extension))
-        .map((extension) => {
-            const thing: [string, any] = Array.isArray(extension)
-                ? extension
-                : [extension, DEFAULT_CONFIG]
-
-            return thing
-        })
-        .filter(isApplicationExtensionEntryArray)
 
 // TODO: The extensionsEntries really isn't optional, so maybe it shouldn't exist in the opts object?
 /**


### PR DESCRIPTION
There are 2 concepts of extensions: installed and configured.  There can possibly be different configs for different environments. So we wanted to make sure that we get the correct _configured_ extensions, and the way to do that is to wait until runtime.

This PR delays as many `getConfig` call as what makes sense, in the context of App Extensibility.

- [x] Fix the tests and types

## How to test drive the PR

1. `npm ci` at the monorepo root
2. `npm start` at the typescript-minimal project
3. Verify that the project renders with a blue border around the app. That's the result of the sample extension enabled.
4. Now edit the package.json to disable the sample extension
5. Wait for the dev server to rebuild. No need to restart the server because the configured extensions are now parsed during runtime.
6. Reload your browser and verify that the homepage no longer has the blue border.