### PR TITLE
[App Extensibility] generated project loads its extensions (@W-17183718@)

### DIFF
--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.test.js
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.test.js
@@ -101,6 +101,19 @@ describe('"expand" util returns correct return value when', () => {
             name: 'extensions defined do not follow naming convension',
             input: ['not-the-correct-prefix-a'],
             expected: []
+        },
+        {
+            name: 'extensions have mixed formats',
+            input: [
+                '@salesforce/extension-a',
+                ['@salesforce/extension-b', {foo: 'bar'}],
+                ['@salesforce/extension-c']
+            ],
+            expected: [
+                ['@salesforce/extension-a', {enabled: true}],
+                ['@salesforce/extension-b', {enabled: true, foo: 'bar'}],
+                ['@salesforce/extension-c', {enabled: true}]
+            ]
         }
     ].forEach((testCase) => {
         test(`${testCase.name}`, () => {

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
@@ -91,11 +91,11 @@ export const expand = (extensions: unknown[] = []): ApplicationExtensionEntryArr
     extensions
         .filter((extension) => Boolean(extension))
         .map((extension) => {
-            const thing: [string, any] = Array.isArray(extension)
+            const tuple: [string, any] = Array.isArray(extension)
                 ? [extension[0], {...DEFAULT_CONFIG, ...extension[1]}]
                 : [extension, DEFAULT_CONFIG]
 
-            return thing
+            return tuple
         })
         .filter(isApplicationExtensionEntryArray)
 

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
@@ -5,11 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {
-    ApplicationExtensionEntry,
-    ApplicationExtensionEntryArray,
-    ApplicationExtensionConfig
-} from '../../types'
+import {ApplicationExtensionEntryArray, ApplicationExtensionConfig} from '../../types'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
 const DEFAULT_CONFIG: ApplicationExtensionConfig = {
@@ -64,7 +60,7 @@ export const kebabToLowerCamelCase = (str: string) =>
 
 // Returns true if the entry passes is a ApplicationExtensionEntryArray type.
 // TODO: This looks like it could be done in a more generic way.
-const isApplicationExtensionEntryArray = (entry: ApplicationExtensionEntryArray): boolean => {
+const isApplicationExtensionEntryArray = (entry: unknown[]): boolean => {
     const [nameRef, config] = entry || []
     return (
         typeof nameRef === 'string' &&
@@ -75,22 +71,28 @@ const isApplicationExtensionEntryArray = (entry: ApplicationExtensionEntryArray)
 
 /**
  * Normalize and expand the extension configuration array so that it is easier to process.
- * @param {{String, Object}[]} extensions - The extensions configuration value as defined in the PWA-Kit config.
- * @returns {Object[]} extensions - The extensions array in object form.
+ * @param extensions - The extensions configuration value as defined in the PWA-Kit config.
+ * @returns a list of extensions all in tuple format
  *
  * @example
- * const result = expand(["store-finder", ["account-pages", {singlePage: true}], './extensions/local-extension']);
+ * const result = expand([
+ *   '@salesforce/extension-a',
+ *   ['@salesforce/extension-b', {foo: 'bar'}],
+ *   ['@salesforce/extension-c']
+ * ]);
  * console.log(result)
- * // [["@salesforce/extension-store-finder", {}], ["@salesforce/extension-account-pages", {singlePage: true}], ["/home/project/extensions/local-extension", {}]]
+ * [
+ *   ['@salesforce/extension-a', {enabled: true}],
+ *   ['@salesforce/extension-b', {enabled: true, foo: 'bar'}],
+ *   ['@salesforce/extension-c', {enabled: true}]
+ * ]
  */
-export const expand = (
-    extensions: ApplicationExtensionEntry[] = []
-): ApplicationExtensionEntryArray[] =>
+export const expand = (extensions: unknown[] = []): ApplicationExtensionEntryArray[] =>
     extensions
         .filter((extension) => Boolean(extension))
         .map((extension) => {
             const thing: [string, any] = Array.isArray(extension)
-                ? extension
+                ? [extension[0], {...DEFAULT_CONFIG, ...extension[1]}]
                 : [extension, DEFAULT_CONFIG]
 
             return thing

--- a/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
+++ b/packages/pwa-kit-extension-sdk/src/shared/utils/helpers.ts
@@ -8,6 +8,9 @@
 import {ApplicationExtensionEntryArray, ApplicationExtensionConfig} from '../../types'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 
+// NOTE: please make sure that the imported modules do not include 'path'.
+// This way getConfiguredExtensions can be called from both server and client side.
+
 const DEFAULT_CONFIG: ApplicationExtensionConfig = {
     enabled: true
 }
@@ -62,11 +65,20 @@ export const kebabToLowerCamelCase = (str: string) =>
 // TODO: This looks like it could be done in a more generic way.
 const isApplicationExtensionEntryArray = (entry: unknown[]): boolean => {
     const [nameRef, config] = entry || []
-    return (
+    const isValid =
         typeof nameRef === 'string' &&
         typeof config === 'object' &&
         !!nameRef.match(/^(?:@([^/]+)\/)?extension-(.+)$/)
-    )
+
+    if (!isValid) {
+        // TODO: use our logger factory
+        console.warn(
+            'Skipping this application extension entry because it is not of valid format. Please double check your configuration.',
+            entry
+        )
+    }
+
+    return isValid
 }
 
 /**

--- a/packages/template-typescript-minimal/package.json
+++ b/packages/template-typescript-minimal/package.json
@@ -46,7 +46,7 @@
     "app":{
       "extensions": [
         [
-          "@salesforce/extension-sample", 
+          "@salesforce/extension-sample",
           {
             "enabled": true
           }


### PR DESCRIPTION
This PR fixes a regression where a generated project would no longer load its extensions. By default, the generated project configures its extensions with the tuple format, but _without_ the config → `[['extension-a']]`

Now we're correctly handling this tuple without a config.

## How to test-drive this PR

1. Run `npm ci`
2. Run the generator `node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js`  and choose these responses:
```
? What type of PWA Kit project would you like to create? PWA Kit Application
? Do you want to use Application Extensibility? Yes
? Which Application Extensions do you want to install? @salesforce/extension-sample (v1.0.0-dev)
? ⚠️ WARNING: If you choose to extract the Application Extension code,
you will NO LONGER be able to consume upgrades from NPM. All changes
made to the extracted code will be YOUR RESPONSIBILITY.

Do you want to proceed with extracting the Application Extensions code? No
? What is the name of your Project? scaffold-pwa
```
3. Start the generated project
4. Verify that there's a blue border wrapping the app. This is a sign that the sample extension works as expected.
5. Navigate to http://localhost:3000/sample and it also loads fine