### PR TITLE
@W-17062545@ Add support for non-302 redirects

### DIFF
--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v3.9.0-dev (Oct 29, 2024)
-- Add support for redirects with HTTP status other than 302 [#2173](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2173)
+- Add RedirectWithStatus component, allowing finer grained control of rediriects and their status code [#2173](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2173)
 
 ## v3.8.0 (Oct 28, 2024)
 - [Server Affinity] - Attach dwsid to SCAPI request headers [#2090](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2090)

--- a/packages/pwa-kit-react-sdk/CHANGELOG.md
+++ b/packages/pwa-kit-react-sdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.9.0-dev (Oct 29, 2024)
+- Add support for redirects with HTTP status other than 302 [#2173](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2173)
 
 ## v3.8.0 (Oct 28, 2024)
 - [Server Affinity] - Attach dwsid to SCAPI request headers [#2090](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2090)

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.js
@@ -239,7 +239,7 @@ export const render = async (req, res, next) => {
     }
 
     if (redirectUrl) {
-        res.redirect(302, redirectUrl)
+        res.redirect(routerContext.status || 302, redirectUrl)
     } else {
         res.status(status).send(html)
     }

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -58,6 +58,7 @@ jest.mock('../universal/routes', () => {
     const React = require('react')
     const PropTypes = require('prop-types')
     const errors = require('../universal/errors')
+    const RedirectWithStatus = require('../universal/components/redirect-with-status').default
     const {Redirect} = require('react-router-dom')
     const {Helmet} = require('react-helmet')
     const {useQuery} = require('@tanstack/react-query')
@@ -183,6 +184,16 @@ jest.mock('../universal/routes', () => {
         }
     }
 
+    class RedirectWithStatusPage extends React.Component {
+        static getProps() {
+            return Promise.resolve()
+        }
+
+        render() {
+            return <RedirectWithStatus to="/elsewhere/" status={301} />
+        }
+    }
+
     class HelmetPage extends React.Component {
         static getProps() {
             return Promise.resolve()
@@ -304,6 +315,10 @@ jest.mock('../universal/routes', () => {
             {
                 path: '/redirect/',
                 component: RedirectPage
+            },
+            {
+                path: '/redirectWithStatus/',
+                component: RedirectWithStatusPage
             },
             {
                 path: '/init-sets-status/',
@@ -536,6 +551,13 @@ describe('The Node SSR Environment', () => {
             req: {url: '/redirect/'},
             assertions: (res) => {
                 expect(res.statusCode).toBe(302)
+            }
+        },
+        {
+            description: `can redirect with HTTP 301 status`,
+            req: {url: '/redirectWithStatus/'},
+            assertions: (res) => {
+                expect(res.statusCode).toBe(301)
             }
         },
         {

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
@@ -15,23 +15,22 @@ import PropTypes from 'prop-types'
  * The default redirect behavior when this component is not used is to set a 302 status.
  *
  * @param {number} status - The HTTP status code. Defaults to 302 if not specified
+ * @param {object} staticContext - The router context
  * @param {string} to - The redirect's target path
  */
 const RedirectWithStatus = ({status = 302, staticContext, ...props}) => {
-  // Handle server-side rendering
-  if (staticContext) {
-    staticContext.status = status
-  }
+    // Handle server-side rendering
+    if (staticContext) {
+        staticContext.status = status
+    }
 
-  return <Redirect {...props} />
+    return <Redirect {...props} />
 }
 
 RedirectWithStatus.propTypes = {
     status: PropTypes.number,
-    to: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.object
-    ])
+    staticContext: PropTypes.object,
+    to: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 }
 
 export default withRouter(RedirectWithStatus)

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
@@ -15,6 +15,7 @@ import PropTypes from 'prop-types'
  * The default redirect behavior when this component is not used is to set a 302 status.
  *
  * @param {number} status - The HTTP status code. Defaults to 302 if not specified
+ * @param {string} to - The redirect's target path 
  */
 export const RedirectWithStatus = ({status = 302, ...props}) => {
     return (

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {Redirect, Route} from 'react-router-dom'
+import PropTypes from 'prop-types'
+
+/**
+ * The `RedirectWithStatus` HOC component is used to specify a different status code when redirecting via
+ * the Redirect component.
+ * The default redirect behavior when this component is not used is to set a 302 status.
+ *
+ * @param {number} status - The HTTP status code. Defaults to 302 if not specified
+ */
+export const RedirectWithStatus = ({status = 302, ...props}) => {
+    return (
+        <Route
+            render={({staticContext}) => {
+                if (staticContext) staticContext.status = status
+                return <Redirect {...props} />
+            }}
+        />
+    )
+}
+
+RedirectWithStatus.propTypes = {
+    status: PropTypes.number,
+    to: PropTypes.string
+}

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.jsx
@@ -6,29 +6,32 @@
  */
 
 import React from 'react'
-import {Redirect, Route} from 'react-router-dom'
+import {Redirect, withRouter} from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 /**
- * The `RedirectWithStatus` HOC component is used to specify a different status code when redirecting via
+ * The `RedirectWithStatus` component is used to specify a different status code when redirecting via
  * the Redirect component.
  * The default redirect behavior when this component is not used is to set a 302 status.
  *
  * @param {number} status - The HTTP status code. Defaults to 302 if not specified
- * @param {string} to - The redirect's target path 
+ * @param {string} to - The redirect's target path
  */
-export const RedirectWithStatus = ({status = 302, ...props}) => {
-    return (
-        <Route
-            render={({staticContext}) => {
-                if (staticContext) staticContext.status = status
-                return <Redirect {...props} />
-            }}
-        />
-    )
+const RedirectWithStatus = ({status = 302, staticContext, ...props}) => {
+  // Handle server-side rendering
+  if (staticContext) {
+    staticContext.status = status
+  }
+
+  return <Redirect {...props} />
 }
 
 RedirectWithStatus.propTypes = {
     status: PropTypes.number,
-    to: PropTypes.string
+    to: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.object
+    ])
 }
+
+export default withRouter(RedirectWithStatus)

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
@@ -11,6 +11,18 @@ import {StaticRouter, Route} from 'react-router-dom'
 import {RedirectWithStatus} from './index'
 
 describe('RedirectWithStatus', () => {
+    // Dummy test needed for code coverage (the case where there is no static context)
+    test('Renders correctly', () => {
+        const targetUrl = '/target'
+        render(
+            <StaticRouter location="/redirect">
+                <Route path="/redirect">
+                    <RedirectWithStatus to={targetUrl} />
+                </Route>
+            </StaticRouter>
+        )
+    }),
+
     test('Redirect renders with correct status', async () => {
         const context = {}
         const status = 303

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {render} from '@testing-library/react'
+import {StaticRouter, Route} from 'react-router-dom'
+import {RedirectWithStatus} from './index'
+
+describe('RedirectWithStatus', () => {
+    test('Redirect renders with correct status', async () => {
+        const context = {}
+        const status = 303
+        const targetUrl = '/target'
+
+        render(
+            <StaticRouter location="/redirect" context={context}>
+                <Route path="/redirect">
+                    <RedirectWithStatus status={status} to={targetUrl} />
+                </Route>
+            </StaticRouter>
+        )
+
+        expect(context.status).toBe(status)
+        expect(context.url).toBe(targetUrl)
+    })
+})

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
@@ -16,7 +16,7 @@ describe('RedirectWithStatus', () => {
         const targetUrl = '/target'
         const history = createMemoryHistory()
         history.push('/redirect')
-       render(
+        render(
             <Router history={history}>
                 <Route path="/redirect">
                     <RedirectWithStatus to={targetUrl} />

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/redirect-with-status/index.test.js
@@ -7,22 +7,24 @@
 
 import React from 'react'
 import {render} from '@testing-library/react'
-import {StaticRouter, Route} from 'react-router-dom'
-import {RedirectWithStatus} from './index'
+import {Router, StaticRouter, Route} from 'react-router-dom'
+import {createMemoryHistory} from 'history'
+import RedirectWithStatus from './index'
 
 describe('RedirectWithStatus', () => {
-    // Dummy test needed for code coverage (the case where there is no static context)
-    test('Renders correctly', () => {
+    test('Redirects if no status or context is provided', () => {
         const targetUrl = '/target'
-        render(
-            <StaticRouter location="/redirect">
+        const history = createMemoryHistory()
+        history.push('/redirect')
+       render(
+            <Router history={history}>
                 <Route path="/redirect">
                     <RedirectWithStatus to={targetUrl} />
                 </Route>
-            </StaticRouter>
+            </Router>
         )
-    }),
-
+        expect(history.location.pathname).toBe(targetUrl)
+    })
     test('Redirect renders with correct status', async () => {
         const context = {}
         const status = 303


### PR DESCRIPTION
Addresses #2093 

This PR applies the feature suggestion in #2093 to grant developers the ability to create redirects with a different HTTP status other than 302.

Testing the changes:

1. In the app, add a new page with the following:

```
import React from 'react'
import RedirectWithStatus from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/redirect-with-status'

const RedirectTest = () => {
    return (
        <RedirectWithStatus status={301} to='/login' />
    )
}

RedirectTest.getTemplateName = () => 'redirect-test'
export default RedirectTest
```
2. Add the new page to your routes.jsx
3. Start the app
4. Navigate to your new page

In the dev console, you should see the page redirect to the login page with a HTTP 301 status code

