### PR TITLE
[App Extensibility ⚙️] 🐞 Fix `overrides-resolver-loader` (@@17484905 @@)

### DIFF
--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.test.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.test.ts
@@ -189,6 +189,56 @@ describe('Overrides Resolver Loader', () => {
             expects: (_: any, err: any) => {
                 expect(err).toBeDefined()
             }
+        },
+        {
+            bypassWindows: true,
+            description:
+                'imports can be overridden from extensions and the override can use relative paths',
+            entryPoint: '/node_modules/@salesforce/extension-this/src/setup-app.js',
+            loaderTest: /node_modules\/@salesforce\/extension-this\/src\/pages\/sample-page/i,
+            // Compiler configuration.
+            compilerConfig: {
+                extensions: [
+                    ['@salesforce/extension-this', {enabled: true}],
+                    ['@salesforce/extension-that', {enabled: true}]
+                ],
+                files: {
+                    // Virtual Project Files
+
+                    // Overrides
+
+                    // Extensions with overrides
+                    '/node_modules/@salesforce/extension-that/src/overrides/@salesforce/extension-this/pages/sample-page.jsx': `
+                            // @salesforce/extension-that
+                            import Test from './sample-page-dependency'
+                        `,
+                    '/node_modules/@salesforce/extension-that/src/overrides/@salesforce/extension-this/pages/sample-page-dependency.js': `
+                            // Should Be Referenced
+                            export default {} 
+                        `,
+
+                    // Extension using overridable import
+                    '/node_modules/@salesforce/extension-this/src/pages/sample-page.jsx': `
+                            // @salesforce/extension-this
+                            import Test from './sample-page-dependency'
+                        `,
+                    '/node_modules/@salesforce/extension-this/src/pages/sample-page-dependency.js': `
+                            // Should Not Be Referenced
+                            export default {} 
+                        `,
+                    '/node_modules/@salesforce/extension-this/package.json':
+                        '{"name": "@salesforce/extension-this"}',
+                    '/node_modules/@salesforce/extension-this/src/setup-app.js':
+                        'import Page from "./pages/sample-page"',
+
+                    // QUIRK! These entries are required to access the files in the actual file system. The resolve method fails if
+                    // they don't exist. This is a sharpe edge, but it's not too bad.
+                    [`${path.resolve(__dirname, './overrides-resolver-loader.ts')}`]: ''
+                }
+            },
+            expects: (output: any) => {
+                expect(output.modules[2].source).toContain('// Should Be Referenced')
+            }
         }
     ]
 

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.ts
@@ -96,8 +96,6 @@ const OverrideResolverLoader = function (this: LoaderContext<any>) {
 
         // NOTE: Convert all relative path imports to absolute path imports. This solves the problem of the wrong
         // basedir being used when imports are resolved by webpack.
-        // NOTE: This only supports "import" statements and should be adjusted to work with "require"
-        // statements as well.
         const adjustedSource = newSource
             ?.toString()
             .replace(IMPORT_REGEX, convertRelativePaths) // Update relative imports

--- a/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/webpack/overrides-resolver-loader.ts
@@ -15,6 +15,8 @@ import {buildCandidatePaths, getPackageName} from '../../shared/utils'
 import type {ExtendedCompiler} from './types'
 
 // Constants
+const IMPORT_REGEX = /import\s+(?:(?:[\w*\s{},]*)\s+from\s+)?['"](\..*?)['"]/g
+const REQUIRES_REGEX = /require\(['"](\..*?)['"]\)/g
 const SRC = 'src'
 
 /**
@@ -22,7 +24,7 @@ const SRC = 'src'
  * extension configuration.
  *
  * This loader resolves a new resource path by evaluating possible overrides in other
- * extensions, transpilubg the file with the same loaders/plugins as the original file.
+ * extensions, transpiling the file with the same loaders/plugins as the original file.
  *
  * @param {LoaderContext<any>} this - The Webpack loader context, which provides information
  * about the module being processed and the current Webpack compiler.
@@ -32,6 +34,7 @@ const OverrideResolverLoader = function (this: LoaderContext<any>) {
     // NOTE: We intensionally exclude any path prefixes like "/" or "./" so that we can
     // use `packageIterator` in the "resolve" function used later on.
     const {resourcePath, _compiler} = this
+
     const compiler = _compiler as ExtendedCompiler
     const projectRelPath = resourcePath.split(`${SRC}${path.sep}`)[1].split('.')[0] // File path relative to the project directory without file extension
     const projectPath = resourcePath.split(SRC)[0]
@@ -71,19 +74,40 @@ const OverrideResolverLoader = function (this: LoaderContext<any>) {
     })
 
     // Tell Webpack to treat this new resource as a dependency of the original module in order to have the dependency
-    // transpiled with all the same loaders/plugins that the orginal file was.
+    // transpiled with all the same loaders/plugins that the original file was.
     this.addDependency(resolvedResourcePath)
 
     // Use Webpack's `loadModule` function to load, process, and transpile the alternative module
     const callback = this.async()
+
+    // Adjust the `basedir` dynamically for resolving relative imports in the new file
+    const newBasedir = path.dirname(resolvedResourcePath)
+
+    // Provided a match and group representing a relative path, replace it with an absolute path using the new base directory.
+    const convertRelativePaths = (match: string, relativePath: string) => {
+        const absolutePath = path.resolve(newBasedir, relativePath)
+        return match.replace(relativePath, absolutePath)
+    }
 
     // Load the replacement module adding a `noHMR=true` query so we can prevent the HMR plugin from trying
     // to define its globals again.
     this.loadModule(`${resolvedResourcePath}?noHMR=true`, (err, newSource) => {
         if (err) return callback(err)
 
-        // Return the loaded and transpiled content of the alternative module
-        callback(null, newSource)
+        // NOTE: Convert all relative path imports to absolute path imports. This solves the problem of the wrong
+        // basedir being used when imports are resolved by webpack.
+        // NOTE: This only supports "import" statements and should be adjusted to work with "require"
+        // statements as well.
+        const adjustedSource = newSource
+            ?.toString()
+            .replace(IMPORT_REGEX, convertRelativePaths) // Update relative imports
+            .replace(REQUIRES_REGEX, convertRelativePaths) // Update relative requires
+
+        // Return the loaded and transpiled content of the alternative module.
+        // NOTE: The third argument to the `callback` function is `sourceMap`. The fact that we aren't using
+        // that argument might be a point of debugging limitations in the future. Leaving this note here to tell
+        // future dev's this might be a place that needs to be adjusted.
+        callback(null, adjustedSource)
     })
 }
 


### PR DESCRIPTION
# Description

When using overrides if the overriding file includes relative path imports (or requires) it would mistakenly import those modules using the base path as if the file was located in the project that is being overridden. 

For example. If extension A has a page that is overridable, lets called it page A. You then override that page in your projects `/overrides` folder, lets call this new page, page B. Page B imports a component called "component B" that is also located in the same project as page B.

Prior to this fix, then resolving for component B, webpack would look in the extension A project folder for this module and not in the base project where the override was defined.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Update the loader to replace relative paths in overrider files so that the module is correctly targeted.
- Added unit tests.

# How to Test-Drive This PR

- Verify that this site --> https://scaffold-pwa-app-extensibility.mobify-storefront.com/ has all grey background.
- Explanation: The above site is a version of typescript minimal that is using the storefront extension as well as a new "dark theme" extension. It does this by overriding the "theme.js" file. Because the theme file has additional relative imports in it, I ran into this issue with the loader. Meaning that changes to the App theme module wasn't getting applied because it wasn't be resolved correctly. With this fix, it does.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
