### PR TITLE
@W-17554979@ Commerce-sdk-react readme updates

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v3.2.0-dev (Oct 29, 2024)
 - Allow cookies for ShopperLogin API [#2190](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2190
 - Fix refresh token TTL warning from firing when override is not provided [#2114](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2114)
+- Readme updates for private clients [#2212](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2212)
 
 - Update CacheUpdateMatrix for mergeBasket mutation [#2138](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2092)
 - Clear auth state if session has been invalidated by a password change [#2092](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2092)

--- a/packages/commerce-sdk-react/README.md
+++ b/packages/commerce-sdk-react/README.md
@@ -134,11 +134,9 @@ export default App
 
 _💡 This section assumes you have read and completed the [Authorization for Shopper APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/authorization-for-shopper-apis.html) guide._
 
-To help reduce boilerplate code for managing shopper authentication, by default, this library automatically initializes shopper session and manages the tokens for developers. Commerce-react-sdk supports both the [SLAS Public Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-public-client.html) and [SLAS Private Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html). Authorization using a private client is supported in PWA Kit 3.5 and later, and is the recommended authorization workflow.
+To help reduce boilerplate code for managing shopper authentication, by default, this library automatically initializes shopper session and manages the tokens for developers. Commerce-sdk-react supports both the [SLAS Public Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-public-client.html) and [SLAS Private Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html). Authorization using a private client is supported in PWA Kit 3.5 and later, and is the recommended authorization workflow.
 
-#### How private SLAS works
-This section assumes you read and understand how [private SLAS](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html) flow works.
-
+#### Using a private SLAS client
 To enable a private client, see [Use a SLAS Private Client](https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/use-a-slas-private-client.html).
 
 ### Shopper Session Initialization

--- a/packages/commerce-sdk-react/README.md
+++ b/packages/commerce-sdk-react/README.md
@@ -43,7 +43,7 @@ In practice, we recommend:
 npm install @salesforce/commerce-sdk-react @tanstack/react-query
 ```
 
-## ⚡️ Quickstart (PWA Kit v2.3.0+)
+## ⚡️ Quickstart (PWA Kit v3.0+)
 
 To integrate this library with your PWA Kit application you can use the `CommerceApiProvider` directly assuming that you use the `withReactQuery` higher order component to wrap your `AppConfig` component. Below is a snippet of how this is accomplished.
 
@@ -54,6 +54,10 @@ import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 
 const AppConfig = ({children}) => {
+    const headers = {
+        'correlation-id': correlationId
+    }
+
     return (
         <CommerceApiProvider
             clientId="12345678-1234-1234-1234-123412341234"
@@ -64,6 +68,11 @@ const AppConfig = ({children}) => {
             shortCode="12345678"
             locale="en-US"
             currency="USD"
+            headers={headers}
+            // Uncomment 'enablePWAKitPrivateClient' to use SLAS private client login flows.
+            // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
+            // enablePWAKitPrivateClient={true}
+            logger={createLogger({packageName: 'commerce-sdk-react'})}
         >
             {children}
         </CommerceApiProvider>
@@ -125,68 +134,12 @@ export default App
 
 _💡 This section assumes you have read and completed the [Authorization for Shopper APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/authorization-for-shopper-apis.html) guide._
 
-To help reduce boilerplate code for managing shopper authentication, by default, this library automatically initializes shopper session and manages the tokens for developers. Currently, the library supports the [Public Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-public-client.html).
-
-Commerce-react-sdk supports both public and private flow of the [Authorization for Shopper APIs](https://developer.salesforce.com/docs/commerce/commerce-api/guide/authorization-for-shopper-apis.html) guide._
-You can choose to use either public or private slas to login. By default, public flow is enabled.
+To help reduce boilerplate code for managing shopper authentication, by default, this library automatically initializes shopper session and manages the tokens for developers. Commerce-react-sdk supports both the [SLAS Public Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-public-client.html) and [SLAS Private Client login flow](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html). Authorization using a private client is supported in PWA Kit 3.5 and later, and is the recommended authorization workflow.
 
 #### How private SLAS works
-This section assumes you read and understand how [private SLAS](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html) flow works
+This section assumes you read and understand how [private SLAS](https://developer.salesforce.com/docs/commerce/commerce-api/guide/slas-private-client.html) flow works.
 
-To enable private slas flow, you need to pass your secret into the CommercerProvider via clientSecret prop.
-**Note** You should only use private slas if you know you can secure your secret since commercer-sdk-react runs isomorphically.
-
-```js
-// app/components/_app-config/index.jsx
-
-import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
-import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
-
-const AppConfig = ({children}) => {
-    return (
-        <CommerceApiProvider
-            clientId="12345678-1234-1234-1234-123412341234"
-            organizationId="f_ecom_aaaa_001"
-            proxy="localhost:3000/mobify/proxy/api"
-            redirectURI="localhost:3000/callback"
-            siteId="RefArch"
-            shortCode="12345678"
-            locale="en-US"
-            currency="USD"
-            clientSecret="<your-slas-private-secret>"
-        >
-            {children}
-        </CommerceApiProvider>
-    )
-}
-```
-#### Disable slas private warnings 
-By default, a warning as below will be displayed on client side to remind developers to always keep their secret safe and secured.
-```js
-'You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!'
-```
-You can disable this warning by using CommerceProvider prop `silenceWarnings`
-
-```js
-const AppConfig = ({children}) => {
-    return (
-        <CommerceApiProvider
-            clientId="12345678-1234-1234-1234-123412341234"
-            organizationId="f_ecom_aaaa_001"
-            proxy="localhost:3000/mobify/proxy/api"
-            redirectURI="localhost:3000/callback"
-            siteId="RefArch"
-            shortCode="12345678"
-            locale="en-US"
-            currency="USD"
-            clientSecret="<your-slas-private-secret>"
-            silenceWarnings={true}
-        >
-            {children}
-        </CommerceApiProvider>
-    )
-}
-```
+To enable a private client, see [Use a SLAS Private Client](https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/use-a-slas-private-client.html).
 
 ### Shopper Session Initialization
 


### PR DESCRIPTION
The readme is used to generate SDK docs: https://salesforcecommercecloud.github.io/pwa-kit/#:~:text=library%20supports%20the-,Public%20Client%20login%20flow.,-Shopper%20Session%20Initialization

This PR is done in collaboration with the docs team to update SLAS private client documentation.