### PR TITLE
Update Github `upload-artifact` action version @@W-17661561@@

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,9 +232,10 @@ jobs:
         uses: "./.github/actions/count_deps"
 
       - name: Store Verdaccio logfile artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          path: packages/pwa-kit-create-app/local-npm-repo/verdaccio.log
+          name: verdaccio-log-${{ matrix.template }}
+          path: packages/pwa-kit-create-app/local-npm-repo/verdaccio-${{ matrix.template }}.log
 
       # TODO: Ticket W-12425059. Revisit Snyk CLI integration to monitor manifest files on generated projects.
       # TODO: Update the SNYK_TOKEN stored in GitHub with a token generated from the proper Snyk org.
@@ -329,9 +330,10 @@ jobs:
         uses: "./.github/actions/count_deps"
 
       - name: Store Verdaccio logfile artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          path: packages/pwa-kit-create-app/local-npm-repo/verdaccio.log
+          name: verdaccio-log-${{ matrix.template }}
+          path: packages/pwa-kit-create-app/local-npm-repo/verdaccio-windows-${{ matrix.template }}.log
   lighthouse:
     needs: changelog-check
     strategy:


### PR DESCRIPTION
# Description

`actions/upload-artifact@v3` is going to be deprecated starting at the end of this month. We need to update to v4. This PR does that as well as making some small changes to what arguments are passed and the file names since errors are getting thrown (Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run) if we don't use a dynamic name.

# Types of Changes

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Update CI actions for verdaccio log upload

# How to Test-Drive This PR

- See that CI is passing for generated projects

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General
**NOT APPLICABLE**
- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

