### PR TITLE
W-17609247 - Fix Safari bug where the same image loads several times

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Allow store to be selectable in StoreLocator [#2187](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2187)
 - [BUG] Fixed "getCheckboxProps is not a function" when rendering checkout page in generated app.[#2140](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2140)
 - Replace transfer basket call with merge basket on checkout [#2138](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2138)
+- [BUG] Fix images being fetced multiple times on Safari [#2223](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2223)
 
 ### Accessibility Improvements
 - [a11y] Fix LinkList component to follow a11y practise [#2098])(https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2098)

--- a/packages/template-retail-react-app/app/utils/responsive-image.js
+++ b/packages/template-retail-react-app/app/utils/responsive-image.js
@@ -38,6 +38,9 @@ export const getResponsiveImageAttributes = ({src, widths, breakpoints = default
     themeBreakpoints = breakpoints
     breakpointLabels = getBreakpointLabels(themeBreakpoints)
 
+    // Order of these attributes matter! If src is not last, Safari will refetch images
+    // multiple times (once when it processes src and again when it processes sizes / srcSet)
+    // See https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2223
     return {
         sizes: mapWidthsToSizes(widths),
         srcSet: mapWidthsToSrcSet(widths, src),

--- a/packages/template-retail-react-app/app/utils/responsive-image.js
+++ b/packages/template-retail-react-app/app/utils/responsive-image.js
@@ -39,9 +39,9 @@ export const getResponsiveImageAttributes = ({src, widths, breakpoints = default
     breakpointLabels = getBreakpointLabels(themeBreakpoints)
 
     return {
-        src: getSrcWithoutOptionalParams(src),
         sizes: mapWidthsToSizes(widths),
-        srcSet: mapWidthsToSrcSet(widths, src)
+        srcSet: mapWidthsToSrcSet(widths, src),
+        src: getSrcWithoutOptionalParams(src)
     }
 }
 


### PR DESCRIPTION
This PR addresses a known Safari bug seen also in other systems ([such as this from Next.js](https://github.com/vercel/next.js/pull/22902)).

The bug in Safari is that if an image has the `src` attribute before `srcSet` and `sizes`, it will fetch the image multiple times as it processes each attribute.

To ensure Safari only loads an image once, we set `src` to be the last attribute.


Reproducing the original issue:
1. In Safari, open dev tools
2. Go to https://pwa-kit.mobify-storefront.com/global/en-GB/product/Spring-look-2M (or deploy a version of the PWA without this fix onto an MRT test environment)
3. In the network tab, search for PG.10236198.JJ3KRXX.PZ
4. See that there are multiple requests to fetch this image (the first one without any query parameters and the second one with `?sw={width}&q=60`)

You can compare this result with Chrome (which only loads the image once with `?sw={width}&q=60`)


Testing the fix:
1. Deploy this fix onto MRT and in Safari navigate to the same page on your test environment (or go to https://scaffold-pwa-vincentc-test-env.mobify-storefront.com/global/en-GB/product/Spring-look-2M)
2. In the network tab, search for PG.10236198.JJ3KRXX.PZ
3. See that there is now only one request to fetch the image (the one with `?sw={width}&q=60`)
