### PR TITLE
[App Extensibility ⚙️] Fix Babel configuration ignore `node_modules` folder adjusted for Windows (@W-17373534@)

### DIFF
--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -65,9 +65,7 @@ export default {
 
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
             if (
-                /node_modules[\\/][^/]+[\\/](@salesforce\/pwa-kit-extension-sdk|@[^/]+\/extension-[^/]+|extension-.*)/.test(
-                    normalizedPath
-                )
+                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|@[^/]+\/extension-|extension-)/.test(normalizedPath)
             ) {
                 return false
             }

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -65,9 +65,9 @@ export default {
 
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
             if (
-                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|@[^/]+\/extension-|extension-)/.test(
-                    normalizedPath
-                )
+                new RegExp(
+                    `node_modules\\${path.sep}[^\\${path.sep}]+\\${path.sep}(pwa-kit-extension-sdk|@[^\\${path.sep}]+\\${path.sep}extension-|extension-)`
+                ).test(normalizedPath)
             ) {
                 return false
             }

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -64,7 +64,7 @@ export default {
             const normalizedPath = path.normalize(filepath)
 
             const extensionRegex = new RegExp(
-                `node_modules${path.sep}[^${path.sep}]+${path.sep}(pwa-kit-extension-sdk|@[^${path.sep}]+${path.sep}extension-|extension-)`
+                `node_modules\\${path.sep}[^\\${path.sep}]+\\${path.sep}(pwa-kit-extension-sdk|@[^\\${path.sep}]+\\${path.sep}extension-|extension-)`
             )
 
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -63,12 +63,12 @@ export default {
         function (filepath) {
             const normalizedPath = path.normalize(filepath)
 
+            const extensionRegex = new RegExp(
+                `node_modules${path.sep}[^${path.sep}]+${path.sep}(pwa-kit-extension-sdk|@[^${path.sep}]+${path.sep}extension-|extension-)`
+            )
+
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
-            if (
-                new RegExp(
-                    `node_modules\\${path.sep}[^\\${path.sep}]+\\${path.sep}(pwa-kit-extension-sdk|@[^\\${path.sep}]+\\${path.sep}extension-|extension-)`
-                ).test(normalizedPath)
-            ) {
+            if (extensionRegex.test(normalizedPath)) {
                 return false
             }
 

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -65,7 +65,9 @@ export default {
 
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
             if (
-                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|@[^/]+\/extension-|extension-)/.test(normalizedPath)
+                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|@[^/]+\/extension-|extension-)/.test(
+                    normalizedPath
+                )
             ) {
                 return false
             }

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -65,7 +65,9 @@ export default {
 
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
             if (
-                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|extension-)/.test(normalizedPath)
+                /node_modules[\\/][^/]+[\\/](@salesforce\/pwa-kit-extension-sdk|@[^/]+\/extension-[^/]+|extension-.*)/.test(
+                    normalizedPath
+                )
             ) {
                 return false
             }

--- a/packages/pwa-kit-dev/src/configs/babel/babel-config.js
+++ b/packages/pwa-kit-dev/src/configs/babel/babel-config.js
@@ -8,6 +8,7 @@
 // PWA-Kit Imports
 import {getConfiguredExtensions} from '@salesforce/pwa-kit-extension-sdk/shared/utils'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+import path from 'path'
 
 export default {
     sourceType: 'unambiguous',
@@ -60,13 +61,17 @@ export default {
     },
     ignore: [
         function (filepath) {
+            const normalizedPath = path.normalize(filepath)
+
             // Return false if it's an allowed extension package @salesforce/pwa-kit-extension-sdk and extension-*
-            if (/node_modules\/@[^/]+\/(pwa-kit-extension-sdk|extension-)/.test(filepath)) {
+            if (
+                /node_modules[\\/][^/]+[\\/](pwa-kit-extension-sdk|extension-)/.test(normalizedPath)
+            ) {
                 return false
             }
 
             // Return true if it's in node_modules (excluding allowed packages handled above)
-            if (/node_modules/.test(filepath)) {
+            if (/node_modules/.test(normalizedPath)) {
                 return true
             }
 

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -341,7 +341,7 @@ const ruleForBabelLoader = (babelPlugins) => {
         test: /(\.js(x?)|\.ts(x?))$/,
         // NOTE: Because our extensions are just folders containing source code, we need to ensure that the babel-loader processes them.
         // This regex exclude everything in node_modules, but node_modules/extensions-*/ folders
-        exclude: /node_modules[\/\\](?!(@?[^/\\]+(?:[\/\\])?extension-)[^/\\]+[\/\\].*$/i,
+        exclude: /node_modules[\\/](?!(@?[^\\/]+[\\/])?extension-)[^\\/]+[\\/].*$/i,
         use: [
             {
                 loader: findDepInStack('babel-loader'),

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -342,7 +342,7 @@ const ruleForBabelLoader = (babelPlugins) => {
         // NOTE: Because our extensions are just folders containing source code, we need to ensure that the babel-loader processes them.
         // This regex exclude everything in node_modules, but node_modules/extensions-*/ folders
         exclude: new RegExp(
-            `node_modules${path.sep}(?!(@?[^${path.sep}]+${path.sep})?extension-).*`,
+            `node_modules\\${path.sep}(?!(@?[^\\${path.sep}]+\\${path.sep})?extension-).*`,
             'i'
         ),
         use: [

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -9,7 +9,7 @@
 
 // For more information on these settings, see https://webpack.js.org/configuration
 import {BundleAnalyzerPlugin} from 'webpack-bundle-analyzer'
-import {resolve} from 'path'
+import path, {resolve} from 'path'
 import fse from 'fs-extra'
 import webpack from 'webpack'
 
@@ -341,7 +341,10 @@ const ruleForBabelLoader = (babelPlugins) => {
         test: /(\.js(x?)|\.ts(x?))$/,
         // NOTE: Because our extensions are just folders containing source code, we need to ensure that the babel-loader processes them.
         // This regex exclude everything in node_modules, but node_modules/extensions-*/ folders
-        exclude: /node_modules[\\/](?!(@?[^\\/]+[\\/])?extension-)[^\\/]+[\\/].*$/i,
+        exclude: new RegExp(
+            `node_modules\\${path.sep}(?!(@?[^\\${path.sep}]+\\${path.sep})?extension-).*`,
+            'i'
+        ),
         use: [
             {
                 loader: findDepInStack('babel-loader'),

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -341,7 +341,7 @@ const ruleForBabelLoader = (babelPlugins) => {
         test: /(\.js(x?)|\.ts(x?))$/,
         // NOTE: Because our extensions are just folders containing source code, we need to ensure that the babel-loader processes them.
         // This regex exclude everything in node_modules, but node_modules/extensions-*/ folders
-        exclude: /node_modules\/(?!(@?[^/]+\/)?extension-)[^/]+\/.*$/i,
+        exclude: /node_modules[\/\\](?!(@?[^/\\]+(?:[\/\\])?extension-)[^/\\]+[\/\\].*$/i,
         use: [
             {
                 loader: findDepInStack('babel-loader'),

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -342,7 +342,7 @@ const ruleForBabelLoader = (babelPlugins) => {
         // NOTE: Because our extensions are just folders containing source code, we need to ensure that the babel-loader processes them.
         // This regex exclude everything in node_modules, but node_modules/extensions-*/ folders
         exclude: new RegExp(
-            `node_modules\\${path.sep}(?!(@?[^\\${path.sep}]+\\${path.sep})?extension-).*`,
+            `node_modules${path.sep}(?!(@?[^${path.sep}]+${path.sep})?extension-).*`,
             'i'
         ),
         use: [

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -49,22 +49,21 @@ export const buildBabelExtensibilityArgs = (config: any) => {
         const extensions = getConfiguredExtensions(config)
         const serverPath = fse.realpathSync(p.resolve(SERVER_PATH))
         const placeHolderPath = fse.realpathSync(p.resolve(PLACEHOLDER_PATH))
-        const appPath = p.join('app', '**')
 
         const extensionSrcPaths =
             extensions.length > 0
-                ? extensions.map(([packageName]) => {
-                      const realPath = fse.realpathSync(
-                          p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))
-                      )
-                      return p.join(realPath, '**')
-                  })
+                ? extensions.map(
+                      ([packageName]) =>
+                          fse.realpathSync(
+                              p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))
+                          ) + `${p.sep}**`
+                  )
                 : []
 
         const extensionsPathsStr =
             extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-        const babelArgs = `--only "${appPath},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
+        const babelArgs = `--only "${`app${p.sep}**`},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
 
         return babelArgs
     } catch (error) {

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -49,21 +49,22 @@ export const buildBabelExtensibilityArgs = (config: any) => {
         const extensions = getConfiguredExtensions(config)
         const serverPath = fse.realpathSync(p.resolve(SERVER_PATH))
         const placeHolderPath = fse.realpathSync(p.resolve(PLACEHOLDER_PATH))
+        const appPath = p.join('app', '**')
 
         const extensionSrcPaths =
             extensions.length > 0
-                ? extensions.map(
-                      ([packageName]) =>
-                          fse.realpathSync(
-                              p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))
-                          ) + '/**'
-                  )
+                ? extensions.map(([packageName]) => {
+                      const realPath = fse.realpathSync(
+                          p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))
+                      )
+                      return p.join(realPath, '**')
+                  })
                 : []
 
         const extensionsPathsStr =
             extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-        const babelArgs = `--only "app/**,${serverPath},${placeHolderPath}${extensionsPathsStr}"`
+        const babelArgs = `--only ${appPath},${serverPath},${placeHolderPath}${extensionsPathsStr}`
 
         return babelArgs
     } catch (error) {

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -64,7 +64,7 @@ export const buildBabelExtensibilityArgs = (config: any) => {
         const extensionsPathsStr =
             extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-        const babelArgs = `--only ${appPath},${serverPath},${placeHolderPath}${extensionsPathsStr}`
+        const babelArgs = `--only "${appPath},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
 
         return babelArgs
     } catch (error) {

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -21,8 +21,22 @@ import {getConfiguredExtensions} from '../../shared/utils'
  * if no actual extensions are added.
  */
 const NODE_MODULES_PATH = 'node_modules'
-const SERVER_PATH = `${NODE_MODULES_PATH}/@salesforce/pwa-kit-runtime/ssr/server/build-remote-server.js`
-const PLACEHOLDER_PATH = `${NODE_MODULES_PATH}/@salesforce/pwa-kit-extension-sdk/express/placeholders/application-extensions.js`
+const SERVER_PATH = p.join(
+    NODE_MODULES_PATH,
+    '@salesforce',
+    'pwa-kit-runtime',
+    'ssr',
+    'server',
+    'build-remote-server.js'
+)
+const PLACEHOLDER_PATH = p.join(
+    NODE_MODULES_PATH,
+    '@salesforce',
+    'pwa-kit-extension-sdk',
+    'express',
+    'placeholders',
+    'application-extensions.js'
+)
 
 /**
  * Builds Babel extensibility arguments for processing specific files and paths.
@@ -37,15 +51,17 @@ export const buildBabelExtensibilityArgs = (config: any) => {
 
     const extensionSrcPaths =
         extensions.length > 0
-            ? extensions.map(
-                  ([packageName]) =>
-                      fse.realpathSync(p.resolve(`${NODE_MODULES_PATH}/${packageName}/src`)) + '/**'
+            ? extensions.map(([packageName]) =>
+                  fse.realpathSync(p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src', '**')))
               )
             : []
 
     const extensionsPathsStr = extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-    const babelArgs = `--only "app/**,${serverPath},${placeHolderPath}${extensionsPathsStr}"`
+    const babelArgs = `--only "${p.join(
+        'app',
+        '**'
+    )},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
 
     return babelArgs
 }

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -45,23 +45,32 @@ const PLACEHOLDER_PATH = p.join(
  * or symlinked paths that Babel doesn't support by using realpathSync.
  */
 export const buildBabelExtensibilityArgs = (config: any) => {
-    const extensions = getConfiguredExtensions(config)
-    const serverPath = fse.realpathSync(p.resolve(SERVER_PATH))
-    const placeHolderPath = fse.realpathSync(p.resolve(PLACEHOLDER_PATH))
+    try {
+        const extensions = getConfiguredExtensions(config)
+        const serverPath = fse.realpathSync(p.resolve(SERVER_PATH))
+        const placeHolderPath = fse.realpathSync(p.resolve(PLACEHOLDER_PATH))
 
-    const extensionSrcPaths =
-        extensions.length > 0
-            ? extensions.map(([packageName]) =>
-                  fse.realpathSync(p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))) + '/**'
-              )
-            : []
+        const extensionSrcPaths =
+            extensions.length > 0
+                ? extensions.map(
+                      ([packageName]) =>
+                          fse.realpathSync(
+                              p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))
+                          ) + '/**'
+                  )
+                : []
 
-    const extensionsPathsStr = extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
+        const extensionsPathsStr =
+            extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-    const babelArgs = `--only "${p.join(
-        'app',
-        '**'
-    )},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
+        const babelArgs = `--only "${p.join(
+            'app',
+            '**'
+        )},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
 
-    return babelArgs
+        return babelArgs
+    } catch (error) {
+        console.error('Error building Babel extensibility arguments:', error)
+        throw error
+    }
 }

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -52,7 +52,7 @@ export const buildBabelExtensibilityArgs = (config: any) => {
     const extensionSrcPaths =
         extensions.length > 0
             ? extensions.map(([packageName]) =>
-                  fse.realpathSync(p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src', '**')))
+                  fse.realpathSync(p.resolve(p.join(NODE_MODULES_PATH, packageName, 'src'))) + '/**'
               )
             : []
 

--- a/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/babel/utils.ts
@@ -63,10 +63,7 @@ export const buildBabelExtensibilityArgs = (config: any) => {
         const extensionsPathsStr =
             extensionSrcPaths.length > 0 ? `,${extensionSrcPaths.join(',')}` : ''
 
-        const babelArgs = `--only "${p.join(
-            'app',
-            '**'
-        )},${serverPath},${placeHolderPath}${extensionsPathsStr}"`
+        const babelArgs = `--only "app/**,${serverPath},${placeHolderPath}${extensionsPathsStr}"`
 
         return babelArgs
     } catch (error) {

--- a/packages/pwa-kit-extension-sdk/src/configs/utils.test.ts
+++ b/packages/pwa-kit-extension-sdk/src/configs/utils.test.ts
@@ -30,16 +30,16 @@ describe('buildBabelExtensibilityArgs', () => {
     beforeEach(() => {
         realpathSyncMock.mockImplementation((filePath: string) => {
             if (filePath.includes('build-remote-server.js')) {
-                return '/absolute/path/to/build-remote-server.js'
+                return normalizePath('/absolute/path/to/build-remote-server.js')
             }
             if (filePath.includes('application-extensions.js')) {
-                return '/absolute/path/to/application-extensions.js'
+                return normalizePath('/absolute/path/to/application-extensions.js')
             }
             if (filePath.includes(normalizePath('@salesforce/extension-this/src'))) {
-                return '/absolute/path/to/@salesforce/extension-this/src'
+                return normalizePath('/absolute/path/to/@salesforce/extension-this/src')
             }
             if (filePath.includes(normalizePath('@salesforce/extension-that/src'))) {
-                return '/absolute/path/to/@salesforce/extension-that/src'
+                return normalizePath('/absolute/path/to/@salesforce/extension-that/src')
             }
             throw new Error(`Unexpected path: ${filePath}`)
         })
@@ -50,7 +50,7 @@ describe('buildBabelExtensibilityArgs', () => {
     })
 
     test('should return the correct Babel arguments string', () => {
-        const expectedArgs = `--only "app/**,/absolute/path/to/build-remote-server.js,/absolute/path/to/application-extensions.js,/absolute/path/to/@salesforce/extension-this/src/**,/absolute/path/to/@salesforce/extension-that/src/**"`
+        const expectedArgs = `--only "app${path.sep}**,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}build-remote-server.js,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}application-extensions.js,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}@salesforce${path.sep}extension-this${path.sep}src${path.sep}**,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}@salesforce${path.sep}extension-that${path.sep}src${path.sep}**"`
         const result = buildBabelExtensibilityArgs(CONFIG)
         expect(result).toBe(expectedArgs)
     })
@@ -78,7 +78,7 @@ describe('buildBabelExtensibilityArgs', () => {
     })
 
     test('should handle an empty list of configured extensions', () => {
-        const expectedArgs = `--only "app/**,/absolute/path/to/build-remote-server.js,/absolute/path/to/application-extensions.js"`
+        const expectedArgs = `--only "app${path.sep}**,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}build-remote-server.js,${path.sep}absolute${path.sep}path${path.sep}to${path.sep}application-extensions.js"`
         const result = buildBabelExtensibilityArgs({app: {extensions: []}})
         expect(result).toBe(expectedArgs)
         const result2 = buildBabelExtensibilityArgs({app: {}})


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

Follow up on PR https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2228 by adjusting the Babel changes to ensure compatibility with Windows.

Adjusted Babel config to support Windows using backslashes `\` and Unix-like systems using forward slashes `/` as path separators.

<img width="1136" alt="Screenshot 2025-01-30 at 1 21 20 PM" src="https://github.com/user-attachments/assets/e53a02d0-0a05-4c46-a9f1-7d8141443212" />



# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Adjusted Babel config to support Windows and Unix-like systems.

# How to Test-Drive This PR

1. Checkout this branch `W-17373534-ignore-node_modules-windows` on a Windows machine and run `npm ci`.

2. Run the generator with this configuration:
```
node .\packages\pwa-kit-create-app\scripts\create-mobify-app-dev.js
```

```
? What type of PWA Kit project would you like to create? PWA Kit Application
? Do you want to use Application Extensibility? Yes
? Which Application Extensions do you want to install? @salesforce/extension-chakra-store-locator, @salesforce/extension-chakra-storefront
? ⚠️ WARNING: If you choose to extract the Application Extension code,
you will NO LONGER be able to consume upgrades from NPM. All changes
made to the extracted code will be YOUR RESPONSIBILITY.

Do you want to proceed with extracting the Application Extensions code? No
? What is the name of your Project? test
Installing dependencies for test... This may take a few minutes.
```
2. Copy the content of `packages\extension-chakra-storefront\config\sample.json` into the `extension-chakra-storefront` inside the generated project `package.json` file.
3. Strat the project removing Babel cache.
```
rmdir /s /q node_modules\.cache
set BABEL_DISABLE_CACHE=1 
npm start
```
#### Verify
1. Observe no Babel warnings are present in the dev server logs.
2. Smoke test the extensions by navigating through the storefront


Check previous PR to test on a Mac machine: https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2228


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
