### PR TITLE
[App Extensibility] default configuration files have valid, working values (@W-17618701@)

### DIFF
--- a/packages/extension-chakra-store-locator/config/default.json
+++ b/packages/extension-chakra-store-locator/config/default.json
@@ -4,24 +4,28 @@
     "radius": 100,
     "radiusUnit": "km",
     "defaultPageSize": 10,
-    "defaultCountry": "<COUNTRY>",
-    "defaultCountryCode": "<COUNTRY_CODE>",
-    "defaultPostalCode": "<POSTAL_CODE>",
+    "defaultPostalCode": "10178",
+    "defaultCountry": "Germany",
+    "defaultCountryCode": "DE",
     "supportedCountries": [
         {
-            "countryName": "<COUNTRY>",
-            "countryCode": "<COUNTRY_CODE>"
+            "countryCode": "US",
+            "countryName": "United States"
+        },
+        {
+            "countryCode": "DE",
+            "countryName": "Germany"
         }
     ],
     "commerceApi": {
         "proxyPath": "/mobify/proxy/api",
         "parameters": {
-            "shortCode": "<SHORT_CODE>",
-            "clientId": "<CLIENT_ID>",
-            "organizationId": "<ORGANIZATION_ID>",
-            "siteId": "<SITE_ID>",
-            "locale": "<LOCALE>",
-            "currency": "<CURRENCY>"
+            "shortCode": "8o7m175y",
+            "clientId": "c9c45bfd-0ed3-4aa2-9971-40f88962b836",
+            "organizationId": "f_ecom_zzrf_001",
+            "siteId": "RefArchGlobal",
+            "locale": "en-GB",
+            "currency": "USD"
         }
     }
 }

--- a/packages/extension-chakra-storefront/config/default.json
+++ b/packages/extension-chakra-storefront/config/default.json
@@ -8,19 +8,19 @@
     "commerceAPI": {
         "proxyPath": "/mobify/proxy/api",
         "parameters": {
-            "clientId": "<CLIENT_ID>",
-            "organizationId": "<ORGANIZATION_ID>",
-            "shortCode": "<SHORT_CODE>",
-            "siteId": "<SITE_ID>"
+            "clientId": "c9c45bfd-0ed3-4aa2-9971-40f88962b836",
+            "organizationId": "f_ecom_zzrf_001",
+            "shortCode": "8o7m175y",
+            "siteId": "RefArchGlobal"
         }
     },
-    "defaultSite": "<SITE_ID>",
-    "defaultAppLocale": "<DEFAULT_APP_LOCALE>",
-    "defaultSiteTitle": "<DEFAULT_SITE_TITLE>",
+    "defaultSite": "RefArchGlobal",
+    "defaultAppLocale": "en-US",
+    "defaultSiteTitle": "Retail React App",
     "einsteinAPI": {
         "host": "https://api.cquotient.com",
-        "einsteinId": "<EINSTEIN_ID>",
-        "siteId": "<EINSTEIN_SITE_ID>",
+        "einsteinId": "1ea06c6e-c936-4324-bcf0-fada93f83bb1",
+        "siteId": "aaij-MobileFirst",
         "isProduction": false
     },
     "maxCacheAge": 900,
@@ -76,20 +76,77 @@
         "recentSearchLimit": 5,
         "recentSearchMinLength": 3
     },
-    "siteAliases": {},
+    "siteAliases": {
+        "RefArch": "us",
+        "RefArchGlobal": "global"
+    },
     "sites": [
         {
-            "id": "<SITE_ID>",
+            "id": "RefArch",
             "l10n": {
-                "defaultCurrency": "<CURRENCY>",
-                "defaultLocale": "<LOCALE>",
-                "supportedCurrencies": ["<CURRENCY>"],
+                "supportedCurrencies": ["USD"],
+                "defaultCurrency": "USD",
+                "defaultLocale": "en-US",
                 "supportedLocales": [
                     {
-                        "id": "<LOCALE>",
-                        "preferredCurrency": "<CURRENCY>"
+                        "id": "en-US",
+                        "preferredCurrency": "USD"
+                    },
+                    {
+                        "id": "en-CA",
+                        "preferredCurrency": "USD"
                     }
                 ]
+            }
+        },
+        {
+            "id": "RefArchGlobal",
+            "l10n": {
+                "supportedCurrencies": ["GBP", "EUR", "CNY", "JPY"],
+                "defaultCurrency": "GBP",
+                "supportedLocales": [
+                    {
+                        "id": "de-DE",
+                        "preferredCurrency": "EUR"
+                    },
+                    {
+                        "id": "en-GB",
+                        "preferredCurrency": "GBP"
+                    },
+                    {
+                        "id": "es-MX",
+                        "preferredCurrency": "MXN"
+                    },
+                    {
+                        "id": "fr-FR",
+                        "preferredCurrency": "EUR"
+                    },
+                    {
+                        "id": "it-IT",
+                        "preferredCurrency": "EUR"
+                    },
+                    {
+                        "id": "ja-JP",
+                        "preferredCurrency": "JPY"
+                    },
+                    {
+                        "id": "ko-KR",
+                        "preferredCurrency": "KRW"
+                    },
+                    {
+                        "id": "pt-BR",
+                        "preferredCurrency": "BRL"
+                    },
+                    {
+                        "id": "zh-CN",
+                        "preferredCurrency": "CNY"
+                    },
+                    {
+                        "id": "zh-TW",
+                        "preferredCurrency": "TWD"
+                    }
+                ],
+                "defaultLocale": "en-GB"
             }
         }
     ],


### PR DESCRIPTION
For now, we wanted developers to be able to generate a project with app extensions installed and then run the project with success (without any further configurations). 

Since currently there is a lack of certain features (like validating the configurations), let's make sure that the default config that comes with each extension is valid and working. There should not be any placeholder values.

## How to test-drive the PR

1. Generate a project with `node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir /tmp/foobar`
2. Then `cd /tmp/foobar`
3. `npm start` to run the project. 
4. Verify the storefront is working as expected
