### PR TITLE
[Social Login] Update default value of `applySLASPrivateClientToEndpoints`

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -136,7 +136,7 @@ export const RemoteServerFactory = {
             // To allow additional SLAS endpoints, users can override this value in
             // their project's ssr.js.
             applySLASPrivateClientToEndpoints:
-                /oauth2\/(token|authorize|passwordless\/(login|token)|password\/(reset|action))/
+/\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/
         }
 
         options = Object.assign({}, defaults, options)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -133,9 +133,10 @@ export const RemoteServerFactory = {
 
             // A regex for identifying which SLAS endpoints the custom SLAS private
             // client secret handler will inject an Authorization header.
-            // Do not modify unless a project wants to customize additional SLAS
-            // endpoints that we currently do not support (ie. /oauth2/passwordless/token)
-            applySLASPrivateClientToEndpoints: /\/oauth2\/token/
+            // To allow additional SLAS endpoints, users can override this value in
+            // their project's ssr.js.
+            applySLASPrivateClientToEndpoints:
+                /oauth2\/(token|authorize|passwordless\/(login|token)|password\/(reset|action))/
         }
 
         options = Object.assign({}, defaults, options)
@@ -713,8 +714,7 @@ export const RemoteServerFactory = {
                     })
 
                     // We pattern match and add client secrets only to endpoints that
-                    // match the regex specified by options.applySLASPrivateClientToEndpoints.
-                    // By default, this regex matches only calls to SLAS /oauth2/token
+                    // match the regex specified by options.applySLASPrivateClientToEndpoints
                     // (see option defaults at the top of this file).
                     // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
                     // SLAS logout (/oauth2/logout), use the Authorization header for a different

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -136,7 +136,7 @@ export const RemoteServerFactory = {
             // To allow additional SLAS endpoints, users can override this value in
             // their project's ssr.js.
             applySLASPrivateClientToEndpoints:
-/\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/
+                /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/
         }
 
         options = Object.assign({}, defaults, options)

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -59,8 +59,13 @@ const options = {
     // When setting this to true, make sure to also set the PWA_KIT_SLAS_CLIENT_SECRET
     // environment variable as this endpoint will return HTTP 501 if it is not set
     useSLASPrivateClient: false,
-    applySLASPrivateClientToEndpoints:
-        /oauth2\/(token|authorize|passwordless\/(login|token)|password\/(reset|action))/,
+
+    // If you wish to use additional SLAS endpoints that require private clients,
+    // customize this regex to include the additional endpoints the custom SLAS
+    // private client secret handler will inject an Authorization header.
+    // The default regex is defined in this file: https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+    // applySLASPrivateClientToEndpoints:
+    //     /oauth2\/(token|authorize|passwordless\/(login|token)|password\/(reset|action))/,
 
     // If this is enabled, any HTTP header that has a non ASCII value will be URI encoded
     // If there any HTTP headers that have been encoded, an additional header will be

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -65,7 +65,7 @@ const options = {
     // private client secret handler will inject an Authorization header.
     // The default regex is defined in this file: https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
     // applySLASPrivateClientToEndpoints:
-    //     /oauth2\/(token|authorize|passwordless\/(login|token)|password\/(reset|action))/,
+    //     /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/,
 
     // If this is enabled, any HTTP header that has a non ASCII value will be URI encoded
     // If there any HTTP headers that have been encoded, an additional header will be


### PR DESCRIPTION
Previously, the value of `applySLASPrivateClientToEndpoints` was customized in the retail-react-app template (see [comment](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2079#discussion_r1945777812)). But for easier consumption, let's move it back to the SDK (pwa-kit-runtime specifically).

## How to test-drive this PR

_Public_ client flow (which is not that helpful, but shows that it still works):
1. Configure your copy of retail-react-app such that `app.login.social.enabled` is set to `true
2. Run `npm start` in template-retail-react-app folder
3. Navigate to log in with your Google account
4. Verify that you have logged in successfully

Thanks to @yunakim714 for providing this test environment that has the _private_ client enabled:
https://wasatch-mrt-feature-private.mrt-storefront-staging.com/