### PR TITLE
Revert "@W-17643479@ Add page meta data to search results and product…

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -12,8 +12,7 @@
 - Replace transfer basket call with merge basket on checkout [#2138](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2138)
 - [BUG] Fix images being fetced multiple times on Safari [#2223](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2223)
 - Support Node 22 [#2218](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2218)
-tags
-- PDP / PLP: Add page meta data tags that have been defined in BM [#2232](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2232)
+
 
 ### Accessibility Improvements
 - [a11y] Fix LinkList component to follow a11y practise [#2098])(https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2098)

--- a/packages/template-retail-react-app/app/pages/product-detail/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-detail/index.jsx
@@ -99,8 +99,7 @@ const ProductDetail = () => {
                     'prices',
                     'variations',
                     'set_products',
-                    'bundled_products',
-                    'page_meta_tags'
+                    'bundled_products'
                 ],
                 allImages: true
             }
@@ -456,15 +455,7 @@ const ProductDetail = () => {
         >
             <Helmet>
                 <title>{product?.pageTitle}</title>
-                {product?.pageMetaTags?.length > 0 &&
-                    product.pageMetaTags.map(({id, value}) => (
-                        <meta name={id} content={value} key={id} />
-                    ))}
-                {/* Fallback for description if not included in pageMetaTags */}
-                {!product?.pageMetaTags?.some((tag) => tag.id === 'description') &&
-                    product?.pageDescription && (
-                        <meta name="description" content={product.pageDescription} />
-                    )}
+                <meta name="description" content={product?.pageDescription} />
             </Helmet>
 
             <Stack spacing={16}>

--- a/packages/template-retail-react-app/app/pages/product-list/index.jsx
+++ b/packages/template-retail-react-app/app/pages/product-list/index.jsx
@@ -159,14 +159,7 @@ const ProductList = (props) => {
                 perPricebook: true,
                 allVariationProperties: true,
                 allImages: true,
-                expand: [
-                    'promotions',
-                    'variations',
-                    'prices',
-                    'images',
-                    'page_meta_tags',
-                    'custom_properties'
-                ],
+                expand: ['promotions', 'variations', 'prices', 'images', 'custom_properties'],
                 refine: _refine
             }
         },
@@ -418,9 +411,6 @@ const ProductList = (props) => {
                 <title>{category?.pageTitle ?? searchQuery}</title>
                 <meta name="description" content={category?.pageDescription ?? searchQuery} />
                 <meta name="keywords" content={category?.pageKeywords} />
-                {productSearchResult?.pageMetaTags?.map(({id, value}) => {
-                    return <meta name={id} content={value} key={id} />
-                })}
             </Helmet>
             {showNoResults ? (
                 <EmptySearchResults searchQuery={searchQuery} category={category} />


### PR DESCRIPTION
Revert #2232 since prod ECOM pods and prod SCAPI are still on 25.1 until Feb 20 2025

We will re-apply this PR once prod pods and SCAPI are updated to 25.2 and page meta tags from the API are GA
