### PR TITLE
[App Extensibility ⚙️] Fix Issues with Pushing Bundles to MRT (@W-17779391@)

### DIFF
--- a/packages/extension-chakra-store-locator/package-lock.json
+++ b/packages/extension-chakra-store-locator/package-lock.json
@@ -31,7 +31,7 @@
       "peerDependencies": {
         "@chakra-ui/react": "^2",
         "@loadable/component": "^5",
-        "@salesforce/commerce-sdk-react": "4.0.0-extensibility-preview.4",
+        "@salesforce/commerce-sdk-react": "3.2.0-extensibility-preview.4",
         "@salesforce/pwa-kit-extension-sdk": "4.0.0-extensibility-preview.4",
         "@salesforce/pwa-kit-react-sdk": "4.0.0-extensibility-preview.4",
         "@salesforce/pwa-kit-runtime": "4.0.0-extensibility-preview.4",

--- a/packages/extension-chakra-store-locator/package.json
+++ b/packages/extension-chakra-store-locator/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@chakra-ui/react": "^2",
     "@loadable/component": "^5",
-    "@salesforce/commerce-sdk-react": "4.0.0-extensibility-preview.4",
+    "@salesforce/commerce-sdk-react": "3.2.0-extensibility-preview.4",
     "@salesforce/pwa-kit-extension-sdk": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-react-sdk": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-runtime": "4.0.0-extensibility-preview.4",

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -445,7 +445,6 @@ const clientOptional = baseConfig('web')
             entry: {
                 ...optional('loader', resolve(projectDir, 'app', 'loader.js')),
                 ...optional('worker', resolve(projectDir, 'worker', 'main.js')),
-                ...optional('core-polyfill', resolve(projectDir, 'node_modules', 'core-js')),
                 ...optional('fetch-polyfill', resolve(projectDir, 'node_modules', 'whatwg-fetch'))
             },
             // use source map to make debugging easier

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -102,12 +102,13 @@ const main = (program) => {
 }
 
 /**
- * Updates the peerDependencies of monorepo packages to the specified version in all packages.
- * If updating an independent package version, only updates its references in all packages.
+ * Updates the peerDependencies of monorepo packages to the specified version.
+ * If updating a monorepo-wide version bump, updates all monorepo package peer dependencies.
+ * If updating an independent package, only updates its references in monorepo packages.
  *
- * @param {string|Object} pkgJsonOrPackageName - Package JSON object or package name to update.
+ * @param {string|Object} pkgJsonOrPackageName - A package JSON object or the package name to update.
  * @param {string} newVersion - The target version to set.
- * @param {boolean} [isIndependent=false] - Whether the update is for an independent package.
+ * @param {boolean} [isIndependent=false] - Whether the update is for an independently versioned package.
  */
 const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
     monorepoPackages.forEach(({location}) => {

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -26,7 +26,7 @@ const INDEPENDENT_PACKAGES = [
     '@salesforce/commerce-sdk-react',
     '@salesforce/extension-chakra-storefront',
     '@salesforce/extension-chakra-store-locator',
-    '@salesforce/extension-starter'
+    '@salesforce/extension-starter',
 ]
 const independentPackages = INDEPENDENT_PACKAGES.map((pkgName) =>
     monorepoPackages.find((pkg) => pkg.name === pkgName)
@@ -42,20 +42,15 @@ const main = (program) => {
     }
 
     const opts = program.opts()
-    const packageName = opts.package
-    const isIndependentBump = opts.package !== 'sdk'
-
-    if (isIndependentBump) {
+    if (opts.package !== 'sdk') {
         // Assume that we're bumping the version of package that has its own independent version
+
         const script1 = path.join(__dirname, 'independent-pkg-version.js')
-        sh.exec(`node ${script1} ${targetVersion} ${packageName}`)
+        sh.exec(`node ${script1} ${targetVersion} ${opts.package}`)
 
         const script2 = path.join(__dirname, 'pwa-kit-deps-version.js')
         const updateDepsBehaviour = opts.pwaKitDeps
-        sh.exec(`node ${script2} ${updateDepsBehaviour} ${packageName}`)
-
-        // Update peerDependencies across all packages
-        updatePeerDeps(packageName, targetVersion, true)
+        sh.exec(`node ${script2} ${updateDepsBehaviour} ${opts.package}`)
 
         // After updating the dependencies, let's update the package lock files
         sh.exec('npm install')
@@ -65,7 +60,6 @@ const main = (program) => {
         process.exit(0)
     }
 
-    // Handle non-independent package version bump
     sh.exec(`lerna version --exact --no-push --no-git-tag-version --yes ${targetVersion}`)
     // `--exact` above is for pinning the version of the pwa-kit dependencies
     // https://github.com/lerna/lerna/tree/main/libs/commands/version#--exact
@@ -76,9 +70,9 @@ const main = (program) => {
     // update versions for root package and root package lock
     setPackageVersion(newMonorepoVersion, {cwd: rootPath})
 
-    // Restore independent package versions
     independentPackages.forEach((pkg) => {
         const {location, version: oldVersion} = pkg
+        // Restore to the original version
         // TODO: is it possible to _not_ trigger the lifecycle scripts? See commerce-sdk-react/CHANGELOG.md
         setPackageVersion(oldVersion, {cwd: location})
     })
@@ -101,25 +95,14 @@ const main = (program) => {
     listAllVersions()
 }
 
-const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
-    monorepoPackages.forEach(({ location }) => {
-        const pathToPkgJson = path.join(location, 'package.json')
-        const pkgJson = JSON.parse(sh.cat(pathToPkgJson))
-        const peerDependencies = pkgJson.peerDependencies || {}
+const updatePeerDeps = (pkgJson, newMonorepoVersion) => {
+    const peerDependencies = pkgJson.peerDependencies
+    if (!peerDependencies) return
 
-        if (isIndependent) {
-            if (peerDependencies[pkgJsonOrPackageName]) {
-                console.log(`Updating ${pkgJsonOrPackageName} peerDependency in ${pkgJson.name} to ${newVersion}`)
-                peerDependencies[pkgJsonOrPackageName] = newVersion
-            saveJSONToFile(pkgJson, pathToPkgJson)
-        }
-        } else {
     Object.keys(peerDependencies).forEach((dep) => {
         if (monorepoPackageNames.includes(dep)) {
-                    console.log(`Updating ${dep} peerDependency in ${pkgJson.name} to ${newVersion}`)
-                    peerDependencies[dep] = newVersion
-                }
-            })
+            console.log(`Found lerna local package ${dep} as a peer dependency of ${pkgJson.name}.`)
+            peerDependencies[dep] = newMonorepoVersion
         }
     })
 }

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -101,8 +101,16 @@ const main = (program) => {
     listAllVersions()
 }
 
+/**
+ * Updates the peerDependencies of monorepo packages to the specified version in all packages.
+ * If updating an independent package version, only updates its references in all packages.
+ *
+ * @param {string|Object} pkgJsonOrPackageName - Package JSON object or package name to update.
+ * @param {string} newVersion - The target version to set.
+ * @param {boolean} [isIndependent=false] - Whether the update is for an independent package.
+ */
 const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
-    monorepoPackages.forEach(({ location }) => {
+    monorepoPackages.forEach(({location}) => {
         const pathToPkgJson = path.join(location, 'package.json')
         const pkgJson = JSON.parse(sh.cat(pathToPkgJson))
         const peerDependencies = pkgJson.peerDependencies || {}
@@ -111,11 +119,11 @@ const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false)
             if (peerDependencies[pkgJsonOrPackageName]) {
                 console.log(`Updating ${pkgJsonOrPackageName} peerDependency in ${pkgJson.name} to ${newVersion}`)
                 peerDependencies[pkgJsonOrPackageName] = newVersion
-            saveJSONToFile(pkgJson, pathToPkgJson)
-        }
+                saveJSONToFile(pkgJson, pathToPkgJson)
+            }
         } else {
-    Object.keys(peerDependencies).forEach((dep) => {
-        if (monorepoPackageNames.includes(dep)) {
+            Object.keys(peerDependencies).forEach((dep) => {
+                if (monorepoPackageNames.includes(dep)) {
                     console.log(`Updating ${dep} peerDependency in ${pkgJson.name} to ${newVersion}`)
                     peerDependencies[dep] = newVersion
                 }
@@ -124,6 +132,11 @@ const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false)
     })
 }
 
+/**
+ * Updates the dependencies of a package to match the versions of independent packages.
+ *
+ * @param {Object} pkgJson - The package.json object to update.
+ */
 const updateDeps = (pkgJson) => {
     independentPackages.forEach((independentPkg) => {
         const newVersion = independentPkg.version

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -101,16 +101,8 @@ const main = (program) => {
     listAllVersions()
 }
 
-/**
- * Updates the peerDependencies of monorepo packages to the specified version in all packages.
- * If updating an independent package version, only updates its references in all packages.
- *
- * @param {string|Object} pkgJsonOrPackageName - Package JSON object or package name to update.
- * @param {string} newVersion - The target version to set.
- * @param {boolean} [isIndependent=false] - Whether the update is for an independent package.
- */
 const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
-    monorepoPackages.forEach(({location}) => {
+    monorepoPackages.forEach(({ location }) => {
         const pathToPkgJson = path.join(location, 'package.json')
         const pkgJson = JSON.parse(sh.cat(pathToPkgJson))
         const peerDependencies = pkgJson.peerDependencies || {}
@@ -119,11 +111,11 @@ const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false)
             if (peerDependencies[pkgJsonOrPackageName]) {
                 console.log(`Updating ${pkgJsonOrPackageName} peerDependency in ${pkgJson.name} to ${newVersion}`)
                 peerDependencies[pkgJsonOrPackageName] = newVersion
-                saveJSONToFile(pkgJson, pathToPkgJson)
-            }
+            saveJSONToFile(pkgJson, pathToPkgJson)
+        }
         } else {
-            Object.keys(peerDependencies).forEach((dep) => {
-                if (monorepoPackageNames.includes(dep)) {
+    Object.keys(peerDependencies).forEach((dep) => {
+        if (monorepoPackageNames.includes(dep)) {
                     console.log(`Updating ${dep} peerDependency in ${pkgJson.name} to ${newVersion}`)
                     peerDependencies[dep] = newVersion
                 }
@@ -132,11 +124,6 @@ const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false)
     })
 }
 
-/**
- * Updates the dependencies of a package to match the versions of independent packages.
- *
- * @param {Object} pkgJson - The package.json object to update.
- */
 const updateDeps = (pkgJson) => {
     independentPackages.forEach((independentPkg) => {
         const newVersion = independentPkg.version

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -26,7 +26,7 @@ const INDEPENDENT_PACKAGES = [
     '@salesforce/commerce-sdk-react',
     '@salesforce/extension-chakra-storefront',
     '@salesforce/extension-chakra-store-locator',
-    '@salesforce/extension-starter',
+    '@salesforce/extension-starter'
 ]
 const independentPackages = INDEPENDENT_PACKAGES.map((pkgName) =>
     monorepoPackages.find((pkg) => pkg.name === pkgName)
@@ -42,15 +42,20 @@ const main = (program) => {
     }
 
     const opts = program.opts()
-    if (opts.package !== 'sdk') {
-        // Assume that we're bumping the version of package that has its own independent version
+    const packageName = opts.package
+    const isIndependentBump = opts.package !== 'sdk'
 
+    if (isIndependentBump) {
+        // Assume that we're bumping the version of package that has its own independent version
         const script1 = path.join(__dirname, 'independent-pkg-version.js')
-        sh.exec(`node ${script1} ${targetVersion} ${opts.package}`)
+        sh.exec(`node ${script1} ${targetVersion} ${packageName}`)
 
         const script2 = path.join(__dirname, 'pwa-kit-deps-version.js')
         const updateDepsBehaviour = opts.pwaKitDeps
-        sh.exec(`node ${script2} ${updateDepsBehaviour} ${opts.package}`)
+        sh.exec(`node ${script2} ${updateDepsBehaviour} ${packageName}`)
+
+        // Update peerDependencies across all packages
+        updatePeerDeps(packageName, targetVersion, true)
 
         // After updating the dependencies, let's update the package lock files
         sh.exec('npm install')
@@ -60,6 +65,7 @@ const main = (program) => {
         process.exit(0)
     }
 
+    // Handle non-independent package version bump
     sh.exec(`lerna version --exact --no-push --no-git-tag-version --yes ${targetVersion}`)
     // `--exact` above is for pinning the version of the pwa-kit dependencies
     // https://github.com/lerna/lerna/tree/main/libs/commands/version#--exact
@@ -70,9 +76,9 @@ const main = (program) => {
     // update versions for root package and root package lock
     setPackageVersion(newMonorepoVersion, {cwd: rootPath})
 
+    // Restore independent package versions
     independentPackages.forEach((pkg) => {
         const {location, version: oldVersion} = pkg
-        // Restore to the original version
         // TODO: is it possible to _not_ trigger the lifecycle scripts? See commerce-sdk-react/CHANGELOG.md
         setPackageVersion(oldVersion, {cwd: location})
     })
@@ -95,14 +101,25 @@ const main = (program) => {
     listAllVersions()
 }
 
-const updatePeerDeps = (pkgJson, newMonorepoVersion) => {
-    const peerDependencies = pkgJson.peerDependencies
-    if (!peerDependencies) return
+const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
+    monorepoPackages.forEach(({ location }) => {
+        const pathToPkgJson = path.join(location, 'package.json')
+        const pkgJson = JSON.parse(sh.cat(pathToPkgJson))
+        const peerDependencies = pkgJson.peerDependencies || {}
 
+        if (isIndependent) {
+            if (peerDependencies[pkgJsonOrPackageName]) {
+                console.log(`Updating ${pkgJsonOrPackageName} peerDependency in ${pkgJson.name} to ${newVersion}`)
+                peerDependencies[pkgJsonOrPackageName] = newVersion
+            saveJSONToFile(pkgJson, pathToPkgJson)
+        }
+        } else {
     Object.keys(peerDependencies).forEach((dep) => {
         if (monorepoPackageNames.includes(dep)) {
-            console.log(`Found lerna local package ${dep} as a peer dependency of ${pkgJson.name}.`)
-            peerDependencies[dep] = newMonorepoVersion
+                    console.log(`Updating ${dep} peerDependency in ${pkgJson.name} to ${newVersion}`)
+                    peerDependencies[dep] = newVersion
+                }
+            })
         }
     })
 }

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -102,13 +102,12 @@ const main = (program) => {
 }
 
 /**
- * Updates the peerDependencies of monorepo packages to the specified version.
- * If updating a monorepo-wide version bump, updates all monorepo package peer dependencies.
- * If updating an independent package, only updates its references in monorepo packages.
+ * Updates the peerDependencies of monorepo packages to the specified version in all packages.
+ * If updating an independent package version, only updates its references in all packages.
  *
- * @param {string|Object} pkgJsonOrPackageName - A package JSON object or the package name to update.
+ * @param {string|Object} pkgJsonOrPackageName - Package JSON object or package name to update.
  * @param {string} newVersion - The target version to set.
- * @param {boolean} [isIndependent=false] - Whether the update is for an independently versioned package.
+ * @param {boolean} [isIndependent=false] - Whether the update is for an independent package.
  */
 const updatePeerDeps = (pkgJsonOrPackageName, newVersion, isIndependent = false) => {
     monorepoPackages.forEach(({location}) => {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

The PR two issues when pushing bundles to MRT via the `npm run push` command on generated projects.

### Problem 1: `core-polyfill.js` file exceeds size limit  

During the build process the `core-polyfill.js` file generated via PWA Kit’s Webpack config, exceeds the recommended file size limit of **244 KB**, reaching **250 KB**. 

```
client-optional:
  WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
  This can impact web performance.
  Assets: 
    core-polyfill.js (250 KiB)
  ```
  
### Solution
Remove `core-polyfill.js` from v4.

Note: This warning was already shown when pushing PWA Kit v3 generated projects to MRT.
 

----

### Problem 2: ELSPROBLEMS Error due to incorrect `@salesforce/commerce-sdk-react` version  

An `ELSPROBLEMS` npm error occurs because the wrong version of `@salesforce/commerce-sdk-react` was being used in `@salesforce/extension-chakra-store-locator`. 

```
npm error code ELSPROBLEMS
npm error invalid: @salesforce/commerce-sdk-react@3.2.0-extensibility-preview.4 /Users/arayanavarro/git/latest-pwa-kit/test/node_modules/@salesforce/commerce-sdk-react
```


Running `npm list` confirms the wrong version being used:  
```
npm list -a @salesforce/commerce-sdk-react
test@0.0.1 /Users/arayanavarro/git/latest-pwa-kit/test
├─┬ @salesforce/extension-chakra-store-locator@0.1.0-extensibility-preview.4
│ └── @salesforce/commerce-sdk-react@3.2.0-extensibility-preview.4 invalid: "4.0.0-extensibility-preview.4" from node_modules/@salesforce/extension-chakra-store-locator
```


### Solution 

The `peerDependencies` in `@salesforce/extension-chakra-store-locator` is using the wrong version `@salesforce/commerce-sdk-react@4.0.0-extensibility-preview.4`. The solution is to use the correct version:  

```
...
"peerDependencies": {
  ...
  "@salesforce/commerce-sdk-react": "3.2.0-extensibility-preview.4"
  ...
}
```

~~Fixed bump-version script logic updating peer dependencies.~~
~~- When bumping versions on monorepo packages, updates peerDependencies only in monorepo packages (does not affect independent ones).~~
~~- When bumping versions on independent packages, updates all peerDependencies referencing it in any package.~~

We will update the bump-version script in a separate PR.


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Removed `core-polyfill.js`.
- Fix `@salesforce/commerce-sdk-react` version in `@salesforce/extension-chakra-store-locator`. 
~~- Fixed bump-version script updating peer dependencies.~~

# How to Test-Drive This PR

### Verify no issues with Pushing Bundles to MRT
- Generate a project using both extensions `@salesforce/extension-chakra-store-locator` and `@salesforce/extension-chakra-storefront`:
```
node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js
```

- Push the generated project to MRT via `npm run push`.
```
npm run push -- -m 'message' -s project -t target
```

- Observe that no warnings or errors are generated.
```
> test@0.0.1 push
> npm run build && pwa-kit-dev push -m message -s project -t target


> test@0.0.1 build
> pwa-kit-dev build

info: Validating app extensions...
info: Building...
success: Build directory is at /Users/user/git/latest-pwa-kit/test/build
info: Beginning upload to https://cloud.mobify.com
success: Bundle Uploaded
```

~~### Verify fixed bump-version script~~

~~- Run the bump-version script on monorepo packages:` npm run bump-version -- 4.0.0-extensibility-preview.5`~~
~~Check:~~
~~✅ Updates all monorepo packages to the new version.~~
~~✅ Updates peerDependencies only in monorepo packages (does not affect independent ones).~~

~~- Run the bump-version script on an independent package: `npm run bump-version:commerce-sdk-react -- 3.2.0-extensibility-preview.5`~~
~~Check:~~
~~✅ Updates only its own version.~~
~~✅ Updates all peerDependencies referencing it in any package.~~


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
