### PR TITLE
@W-17917586 - Upgrade to @tanstack/react-query v5 - Part 2 replace `<Hydrate>`

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -267,15 +267,13 @@ jest.mock('../universal/routes', () => {
     }
 
     const DisabledUseQueryIsntResolved = () => {
-        const {data, isLoading} = useQuery(
-            {
-                queryKey: ['use-query-resolves-object'],
-                queryFn: async () => ({
-                    prop: 'prop-value'
-                }),
-                enabled: false
-            }
-        )
+        const {data, isLoading} = useQuery({
+            queryKey: ['use-query-resolves-object'],
+            queryFn: async () => ({
+                prop: 'prop-value'
+            }),
+            enabled: false
+        })
         return <div>{isLoading ? 'loading' : data.prop}</div>
     }
 

--- a/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/server/react-rendering.test.js
@@ -257,19 +257,22 @@ jest.mock('../universal/routes', () => {
     }
 
     const UseQueryResolvesObject = () => {
-        const {data, isLoading} = useQuery(['use-query-resolves-object'], async () => ({
-            prop: 'prop-value'
-        }))
+        const {data, isLoading} = useQuery({
+            queryKey: ['use-query-resolves-object'],
+            queryFn: async () => ({
+                prop: 'prop-value'
+            })
+        })
         return <div>{isLoading ? 'loading' : data.prop}</div>
     }
 
     const DisabledUseQueryIsntResolved = () => {
         const {data, isLoading} = useQuery(
-            ['use-query-resolves-object'],
-            async () => ({
-                prop: 'prop-value'
-            }),
             {
+                queryKey: ['use-query-resolves-object'],
+                queryFn: async () => ({
+                    prop: 'prop-value'
+                }),
                 enabled: false
             }
         )

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/components/with-react-query/index.js
@@ -7,7 +7,7 @@
 import React from 'react'
 import hoistNonReactStatic from 'hoist-non-react-statics'
 import ssrPrepass from 'react-ssr-prepass'
-import {dehydrate, Hydrate, QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {dehydrate, HydrationBoundary, QueryClient, QueryClientProvider} from '@tanstack/react-query'
 import {FetchStrategy} from '../fetch-strategy'
 import {PERFORMANCE_MARKS} from '../../../../utils/performance'
 import logger from '../../../../utils/logger-instance'
@@ -54,9 +54,9 @@ export const withReactQuery = (Wrapped, options = {}) => {
 
             return (
                 <QueryClientProvider client={this.props.locals.__queryClient}>
-                    <Hydrate state={preloadedState}>
+                    <HydrationBoundary state={preloadedState}>
                         <Wrapped {...this.props} />
-                    </Hydrate>
+                    </HydrationBoundary>
                 </QueryClientProvider>
             )
         }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

This PR is the part 2 of the react-query upgrade series.

This PR updates the breaking change - https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#hydration-api-changes