### PR TITLE
@W-17917574 Upgrade to @tanstack/react-query v5 - Part 3 Remove server retry handling

### DIFF
--- a/packages/commerce-sdk-react/README.md
+++ b/packages/commerce-sdk-react/README.md
@@ -70,8 +70,23 @@ const AppConfig = ({children}) => {
     )
 }
 
-// You can configure the query client options by passing an options object to the withReactQuery HOC second argument.
-export default withReactQuery(AppConfig)
+// Set configuration options for react query.
+// NOTE: This configuration will be used both on the server-side and client-side.
+// retry is always disabled on server side regardless of the value from the options
+const options = {
+    queryClientConfig: {
+        defaultOptions: {
+            queries: {
+                retry: false
+            },
+            mutations: {
+                retry: false
+            }
+        }
+    }
+}
+
+export default withReactQuery(AppConfig, options)
 ```
 
 ## ⚡️ Quickstart (Generic React App)

--- a/packages/commerce-sdk-react/README.md
+++ b/packages/commerce-sdk-react/README.md
@@ -70,6 +70,7 @@ const AppConfig = ({children}) => {
     )
 }
 
+// You can configure the query client options by passing an options object to the withReactQuery HOC second argument.
 export default withReactQuery(AppConfig)
 ```
 

--- a/packages/commerce-sdk-react/README.md
+++ b/packages/commerce-sdk-react/README.md
@@ -70,23 +70,7 @@ const AppConfig = ({children}) => {
     )
 }
 
-// Set configuration options for react query.
-// NOTE: This configuration will be used both on the server-side and client-side.
-// retry is always disabled on server side regardless of the value from the options
-const options = {
-    queryClientConfig: {
-        defaultOptions: {
-            queries: {
-                retry: false
-            },
-            mutations: {
-                retry: false
-            }
-        }
-    }
-}
-
-export default withReactQuery(AppConfig, options)
+export default withReactQuery(AppConfig)
 ```
 
 ## ⚡️ Quickstart (Generic React App)

--- a/packages/commerce-sdk-react/src/hooks/useQuery.ts
+++ b/packages/commerce-sdk-react/src/hooks/useQuery.ts
@@ -66,12 +66,7 @@ export const useQuery = <Client extends ApiClient, Options extends ApiOptions, D
             hasAllKeys(apiOptions.parameters, hookConfig.requiredParameters),
         // End users can always completely OVERRIDE the default `enabled` check
 
-        ...queryOptions,
-        // never retry on server side because it hurts server side rendering performance
-        ...(queryOptions?.retry ? {retry: onClient() ? queryOptions?.retry : false} : {}),
-        ...(queryOptions?.retryOnMount
-            ? {retryOnMount: onClient() ? queryOptions?.retryOnMount : false}
-            : {})
+        ...queryOptions
     })
 }
 

--- a/packages/commerce-sdk-react/src/index.ts
+++ b/packages/commerce-sdk-react/src/index.ts
@@ -7,5 +7,6 @@
 import CommerceApiProvider from './provider'
 export * from './hooks/types'
 export * from './hooks'
+export * from './public-utils'
 
 export {CommerceApiProvider}

--- a/packages/commerce-sdk-react/src/public-utils.ts
+++ b/packages/commerce-sdk-react/src/public-utils.ts
@@ -16,7 +16,7 @@ import {DehydratedState} from '@tanstack/react-query'
  * @returns The updated data object with reset timestamps.
  * @since 4.0.0
  */
-export const resetQueryTimeStamp = (data: DehydratedState, timestamp?: Date) => {
+export const resetDehydratedQueryTimeStamp = (data: DehydratedState, timestamp?: Date) => {
     const time = timestamp || Date.now()
 
     const updateQueryTimeStamp = (item: any) => ({

--- a/packages/commerce-sdk-react/src/public-utils.ts
+++ b/packages/commerce-sdk-react/src/public-utils.ts
@@ -5,6 +5,8 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {DehydratedState} from '@tanstack/react-query'
+
 /**
  * Resets the dataUpdatedAt timestamp for all mutations and queries in the given data object.
  * This is typically used in conjuction with pwa-kit-react-sdk's`beforeHydrate` to ensure that
@@ -14,7 +16,7 @@
  * @returns The updated data object with reset timestamps.
  * @since 4.0.0
  */
-export const resetQueryTimeStamp = (data: {mutations: any[], queries: any[]}, timestamp: number) => {
+export const resetQueryTimeStamp = (data: DehydratedState, timestamp: number) => {
     const time = timestamp || Date.now()
 
     const updateQueryTimeStamp = (item: any) => ({

--- a/packages/commerce-sdk-react/src/public-utils.ts
+++ b/packages/commerce-sdk-react/src/public-utils.ts
@@ -16,7 +16,7 @@ import {DehydratedState} from '@tanstack/react-query'
  * @returns The updated data object with reset timestamps.
  * @since 4.0.0
  */
-export const resetDehydratedQueryTimeStamp = (data: DehydratedState, timestamp?: Date) => {
+export const resetDehydratedStateTimeStamp = (data: DehydratedState, timestamp?: Date) => {
     const time = timestamp || Date.now()
 
     const updateQueryTimeStamp = (item: any) => ({

--- a/packages/commerce-sdk-react/src/public-utils.ts
+++ b/packages/commerce-sdk-react/src/public-utils.ts
@@ -16,7 +16,7 @@ import {DehydratedState} from '@tanstack/react-query'
  * @returns The updated data object with reset timestamps.
  * @since 4.0.0
  */
-export const resetQueryTimeStamp = (data: DehydratedState, timestamp: number) => {
+export const resetQueryTimeStamp = (data: DehydratedState, timestamp?: Date) => {
     const time = timestamp || Date.now()
 
     const updateQueryTimeStamp = (item: any) => ({

--- a/packages/commerce-sdk-react/src/public-utils.ts
+++ b/packages/commerce-sdk-react/src/public-utils.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Resets the dataUpdatedAt timestamp for all mutations and queries in the given data object.
+ * This is typically used in conjuction with pwa-kit-react-sdk's`beforeHydrate` to ensure that
+ * the cached data is considered fresh on first load.
+ * @param data - The data object containing mutations and queries.
+ * @param timestamp - The timestamp to set the dataUpdatedAt to. If not provided, the current time will be used.
+ * @returns The updated data object with reset timestamps.
+ * @since 4.0.0
+ */
+export const resetQueryTimeStamp = (data: {mutations: any[], queries: any[]}, timestamp: number) => {
+    const time = timestamp || Date.now()
+
+    const updateQueryTimeStamp = (item: any) => ({
+        ...item,
+        state: {
+            ...item.state,
+            dataUpdatedAt: time
+        }
+    })
+
+    return {
+        mutations: data.mutations.map(updateQueryTimeStamp),
+        queries: data.queries.map(updateQueryTimeStamp)
+    }
+}

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -22,7 +22,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedStateTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
@@ -124,7 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetDehydratedQueryTimeStamp
+    beforeHydrate: resetDehydratedStateTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -115,8 +115,12 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
+                retry: false,
                 refetchOnWindowFocus: false,
                 staleTime: 10 * 1000
+            },
+            mutations: {
+                retry: false
             }
         }
     },

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -22,7 +22,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
@@ -124,21 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: (data) => {
-        const now = Date.now()
-
-        // Helper to reset the data timestamp to time of app load.
-        const updateQueryTimeStamp = ({state}) => {
-            state.dataUpdatedAt = now
-        }
-
-        // Update serialized mutations and queries to ensure that the cached data is
-        // considered fresh on first load.
-        data?.mutations?.forEach(updateQueryTimeStamp)
-        data?.queries?.forEach(updateQueryTimeStamp)
-
-        return data
-    }
+    beforeHydrate: resetQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -22,7 +22,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
@@ -124,7 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetQueryTimeStamp
+    beforeHydrate: resetDehydratedQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -109,24 +109,31 @@ AppConfig.propTypes = {
     locals: PropTypes.object
 }
 
-const isServerSide = typeof window === 'undefined'
-
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
-// retry is always disabled on server side regardless of the value from the options
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false,
                 refetchOnWindowFocus: false,
-                staleTime: 10 * 1000,
-                ...(isServerSide ? {retryOnMount: false} : {})
-            },
-            mutations: {
-                retry: false
+                staleTime: 10 * 1000
             }
         }
+    },
+    beforeHydrate: (data) => {
+        const now = Date.now()
+
+        // Helper to reset the data timestamp to time of app load.
+        const updateQueryTimeStamp = ({state}) => {
+            state.dataUpdatedAt = now
+        }
+
+        // Update serialized mutations and queries to ensure that the cached data is
+        // considered fresh on first load.
+        data?.mutations?.forEach(updateQueryTimeStamp)
+        data?.queries?.forEach(updateQueryTimeStamp)
+
+        return data
     }
 }
 

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -23,7 +23,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedStateTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -124,7 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetDehydratedQueryTimeStamp
+    beforeHydrate: resetDehydratedStateTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -115,8 +115,12 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
+                retry: false,
                 refetchOnWindowFocus: false,
                 staleTime: 10 * 1000
+            },
+            mutations: {
+                retry: false
             }
         }
     },

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -23,7 +23,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -124,21 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: (data) => {
-        const now = Date.now()
-
-        // Helper to reset the data timestamp to time of app load.
-        const updateQueryTimeStamp = ({state}) => {
-            state.dataUpdatedAt = now
-        }
-
-        // Update serialized mutations and queries to ensure that the cached data is
-        // considered fresh on first load.
-        data?.mutations?.forEach(updateQueryTimeStamp)
-        data?.queries?.forEach(updateQueryTimeStamp)
-
-        return data
-    }
+    beforeHydrate: resetQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -23,7 +23,7 @@ import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pat
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -124,7 +124,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetQueryTimeStamp
+    beforeHydrate: resetDehydratedQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -109,24 +109,31 @@ AppConfig.propTypes = {
     locals: PropTypes.object
 }
 
-const isServerSide = typeof window === 'undefined'
-
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
-// retry is always disabled on server side regardless of the value from the options
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false,
                 refetchOnWindowFocus: false,
-                staleTime: 10 * 1000,
-                ...(isServerSide ? {retryOnMount: false} : {})
-            },
-            mutations: {
-                retry: false
+                staleTime: 10 * 1000
             }
         }
+    },
+    beforeHydrate: (data) => {
+        const now = Date.now()
+
+        // Helper to reset the data timestamp to time of app load.
+        const updateQueryTimeStamp = ({state}) => {
+            state.dataUpdatedAt = now
+        }
+
+        // Update serialized mutations and queries to ensure that the cached data is
+        // considered fresh on first load.
+        data?.mutations?.forEach(updateQueryTimeStamp)
+        data?.queries?.forEach(updateQueryTimeStamp)
+
+        return data
     }
 }
 

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -31,7 +31,7 @@ import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -130,7 +130,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetQueryTimeStamp
+    beforeHydrate: resetDehydratedQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -121,8 +121,12 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
+                retry: false,
                 refetchOnWindowFocus: false,
                 staleTime: 10 * 1000
+            },
+            mutations: {
+                retry: false
             }
         }
     },

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -31,7 +31,7 @@ import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedStateTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -130,7 +130,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetDehydratedQueryTimeStamp
+    beforeHydrate: resetDehydratedStateTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -31,7 +31,7 @@ import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
 
-import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {ReactQueryDevtools} from '@tanstack/react-query-devtools'
@@ -130,21 +130,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: (data) => {
-        const now = Date.now()
-
-        // Helper to reset the data timestamp to time of app load.
-        const updateQueryTimeStamp = ({state}) => {
-            state.dataUpdatedAt = now
-        }
-
-        // Update serialized mutations and queries to ensure that the cached data is
-        // considered fresh on first load.
-        data?.mutations?.forEach(updateQueryTimeStamp)
-        data?.queries?.forEach(updateQueryTimeStamp)
-
-        return data
-    }
+    beforeHydrate: resetQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -115,21 +115,14 @@ AppConfig.propTypes = {
     locals: PropTypes.object
 }
 
-const isServerSide = typeof window === 'undefined'
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
-// retry is always disabled on server side regardless of the value from the options
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false,
                 refetchOnWindowFocus: false,
-                staleTime: 10 * 1000,
-                ...(isServerSide ? {retryOnMount: false} : {})
-            },
-            mutations: {
-                retry: false
+                staleTime: 10 * 1000
             }
         }
     },

--- a/packages/template-typescript-minimal/app/components/_app-config/index.js
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.js
@@ -16,8 +16,12 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
+                retry: false,
                 refetchOnWindowFocus: false,
-                staleTime: 2 * 1000,
+                staleTime: 10 * 1000
+            },
+            mutations: {
+                retry: false
             }
         }
     },

--- a/packages/template-typescript-minimal/app/components/_app-config/index.js
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.js
@@ -24,21 +24,6 @@ const options = {
                 retry: false
             }
         }
-    },
-    beforeHydrate: (data) => {
-        const now = Date.now()
-
-        // Helper to reset the data timestamp to time of app load.
-        const updateQueryTimeStamp = ({state}) => {
-            state.dataUpdatedAt = now
-        }
-
-        // Update serialized mutations and queries to ensure that the cached data is
-        // considered fresh on first load.
-        data?.mutations?.forEach(updateQueryTimeStamp)
-        data?.queries?.forEach(updateQueryTimeStamp)
-
-        return data
     }
 }
 

--- a/packages/template-typescript-minimal/app/components/_app-config/index.js
+++ b/packages/template-typescript-minimal/app/components/_app-config/index.js
@@ -16,14 +16,25 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false,
+                refetchOnWindowFocus: false,
                 staleTime: 2 * 1000,
-                ...(isServerSide ? {retryOnMount: false} : {})
-            },
-            mutations: {
-                retry: false
             }
         }
+    },
+    beforeHydrate: (data) => {
+        const now = Date.now()
+
+        // Helper to reset the data timestamp to time of app load.
+        const updateQueryTimeStamp = ({state}) => {
+            state.dataUpdatedAt = now
+        }
+
+        // Update serialized mutations and queries to ensure that the cached data is
+        // considered fresh on first load.
+        data?.mutations?.forEach(updateQueryTimeStamp)
+        data?.queries?.forEach(updateQueryTimeStamp)
+
+        return data
     }
 }
 

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -77,8 +77,12 @@ const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
+                retry: false,
                 refetchOnWindowFocus: false,
                 staleTime: 10 * 1000
+            },
+            mutations: {
+                retry: false
             }
         }
     },

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {useState, ReactElement} from 'react'
-import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-paths'
@@ -86,7 +86,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetQueryTimeStamp
+    beforeHydrate: resetDehydratedQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {useState, ReactElement} from 'react'
-import {CommerceApiProvider} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetQueryTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-paths'
@@ -86,21 +86,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: (data: any) => {
-        const now = Date.now()
-
-        // Helper to reset the data timestamp to time of app load.
-        const updateQueryTimeStamp = ({state}: {state: any}) => {
-            state.dataUpdatedAt = now
-        }
-
-        // Update serialized mutations and queries to ensure that the cached data is
-        // considered fresh on first load.
-        data?.mutations?.forEach(updateQueryTimeStamp)
-        data?.queries?.forEach(updateQueryTimeStamp)
-
-        return data
-    }
+    beforeHydrate: resetQueryTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React, {useState, ReactElement} from 'react'
-import {CommerceApiProvider, resetDehydratedQueryTimeStamp} from '@salesforce/commerce-sdk-react'
+import {CommerceApiProvider, resetDehydratedStateTimeStamp} from '@salesforce/commerce-sdk-react'
 import {withReactQuery} from '@salesforce/pwa-kit-react-sdk/ssr/universal/components/with-react-query'
 import {useCorrelationId} from '@salesforce/pwa-kit-react-sdk/ssr/universal/hooks'
 import {proxyBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-paths'
@@ -86,7 +86,7 @@ const options = {
             }
         }
     },
-    beforeHydrate: resetDehydratedQueryTimeStamp
+    beforeHydrate: resetDehydratedStateTimeStamp
 }
 
 export default withReactQuery(AppConfig, options)

--- a/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
+++ b/packages/test-commerce-sdk-react/app/components/_app-config/index.tsx
@@ -71,24 +71,31 @@ AppConfig.restore = () => {}
 AppConfig.extraGetPropsArgs = () => {}
 AppConfig.freeze = () => {}
 
-const isServerSide = typeof window === 'undefined'
-
 // Recommended settings for PWA-Kit usages.
 // NOTE: they will be applied on both server and client side.
 const options = {
     queryClientConfig: {
         defaultOptions: {
             queries: {
-                retry: false,
-                staleTime: 2 * 1000,
-                ...(isServerSide ? {retryOnMount: false} : {}),
-                // Option for debugging changes in cache with React Query Dev Tools
-                refetchOnWindowFocus: false
-            },
-            mutations: {
-                retry: false
+                refetchOnWindowFocus: false,
+                staleTime: 10 * 1000
             }
         }
+    },
+    beforeHydrate: (data: any) => {
+        const now = Date.now()
+
+        // Helper to reset the data timestamp to time of app load.
+        const updateQueryTimeStamp = ({state}: {state: any}) => {
+            state.dataUpdatedAt = now
+        }
+
+        // Update serialized mutations and queries to ensure that the cached data is
+        // considered fresh on first load.
+        data?.mutations?.forEach(updateQueryTimeStamp)
+        data?.queries?.forEach(updateQueryTimeStamp)
+
+        return data
     }
 }
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

This PR is the part 3 of the react-query upgrade series.

This PR updates the breaking change - https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#no-retries-on-the-server