### PR TITLE
@W-17917538 Upgrade to @tanstack/react-query v5 - Part 4 Remove query callbacks

### DIFF
--- a/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
+++ b/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
@@ -31,51 +31,51 @@ const UnavailableProductConfirmationModal = ({
 }) => {
     const unavailableProductIdsRef = useRef(null)
     const ids = productIds.length ? productIds : productItems.map((i) => i.productId)
-    
+
     const productsQuery = useProducts(
         {parameters: {ids: ids?.join(','), allImages: true}},
         {
             enabled: ids?.length > 0
         }
     )
-    
+
     useEffect(() => {
-        if (productsQuery.isSuccess && productsQuery.data) {
-            const result = productsQuery.data
-            const resProductIds = []
-            const unOrderableIds = []
-            
-            result.data?.forEach(({id, inventory}) => {
-                // when a product is unavailable, the getProducts will not return its product detail.
-                // we compare the response ids with the ones in basket to figure which product has become unavailable
-                resProductIds.push(id)
-
-                // when a product is orderable, but the quantity in the basket is more than the remaining stock
-                // we want to make sure it is removed before go to checkout page to avoid error when placing order
-                // we don't need to remove low stock/ out of stock from wishlist
-                if (productItems.length) {
-                    const productItem = productItems.find((item) => item.productId === id)
-                    // wishlist item will have the property type
-                    const isWishlist = !!productItem?.type
-                    if (
-                        !isWishlist &&
-                        (!inventory?.orderable ||
-                            (inventory?.orderable &&
-                                productItem?.quantity > inventory.stockLevel))
-                    ) {
-                        unOrderableIds.push(id)
-                    }
-                }
-            })
-
-            const unavailableProductIds = ids.filter(
-                (id) => !resProductIds.includes(id) || unOrderableIds.includes(id)
-            )
-
-            unavailableProductIdsRef.current = unavailableProductIds
+        if (!productsQuery.isSuccess || !productsQuery.data) {
+            return
         }
+        const result = productsQuery.data
+        const resProductIds = []
+        const unOrderableIds = []
+
+        result.data?.forEach(({id, inventory}) => {
+            // when a product is unavailable, the getProducts will not return its product detail.
+            // we compare the response ids with the ones in basket to figure which product has become unavailable
+            resProductIds.push(id)
+
+            // when a product is orderable, but the quantity in the basket is more than the remaining stock
+            // we want to make sure it is removed before go to checkout page to avoid error when placing order
+            // we don't need to remove low stock/ out of stock from wishlist
+            if (productItems.length) {
+                const productItem = productItems.find((item) => item.productId === id)
+                // wishlist item will have the property type
+                const isWishlist = !!productItem?.type
+                if (
+                    !isWishlist &&
+                    (!inventory?.orderable ||
+                        (inventory?.orderable && productItem?.quantity > inventory.stockLevel))
+                ) {
+                    unOrderableIds.push(id)
+                }
+            }
+        })
+
+        const unavailableProductIds = ids.filter(
+            (id) => !resProductIds.includes(id) || unOrderableIds.includes(id)
+        )
+
+        unavailableProductIdsRef.current = unavailableProductIds
     }, [productsQuery.data, productsQuery.isSuccess])
-    
+
     const unavailableProductsModalProps = useDisclosure()
     useEffect(() => {
         if (unavailableProductIdsRef.current?.length > 0) {

--- a/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
+++ b/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
@@ -31,44 +31,53 @@ const UnavailableProductConfirmationModal = ({
 }) => {
     const unavailableProductIdsRef = useRef(null)
     const ids = productIds.length ? productIds : productItems.map((i) => i.productId)
-    useProducts(
+    
+    // Updated to remove onSuccess callback
+    const productsQuery = useProducts(
         {parameters: {ids: ids?.join(','), allImages: true}},
         {
-            enabled: ids?.length > 0,
-            onSuccess: (result) => {
-                const resProductIds = []
-                const unOrderableIds = []
-                result.data?.forEach(({id, inventory}) => {
-                    // when a product is unavailable, the getProducts will not return its product detail.
-                    // we compare the response ids with the ones in basket to figure which product has become unavailable
-                    resProductIds.push(id)
-
-                    // when a product is orderable, but the quantity in the basket is more than the remaining stock
-                    // we want to make sure it is removed before go to checkout page to avoid error when placing order
-                    // we don't need to remove low stock/ out of stock from wishlist
-                    if (productItems.length) {
-                        const productItem = productItems.find((item) => item.productId === id)
-                        // wishlist item will have the property type
-                        const isWishlist = !!productItem?.type
-                        if (
-                            !isWishlist &&
-                            (!inventory?.orderable ||
-                                (inventory?.orderable &&
-                                    productItem?.quantity > inventory.stockLevel))
-                        ) {
-                            unOrderableIds.push(id)
-                        }
-                    }
-                })
-
-                const unavailableProductIds = ids.filter(
-                    (id) => !resProductIds.includes(id) || unOrderableIds.includes(id)
-                )
-
-                unavailableProductIdsRef.current = unavailableProductIds
-            }
+            enabled: ids?.length > 0
         }
     )
+    
+    // New useEffect to handle the logic previously in onSuccess
+    useEffect(() => {
+        if (productsQuery.isSuccess && productsQuery.data) {
+            const result = productsQuery.data
+            const resProductIds = []
+            const unOrderableIds = []
+            
+            result.data?.forEach(({id, inventory}) => {
+                // when a product is unavailable, the getProducts will not return its product detail.
+                // we compare the response ids with the ones in basket to figure which product has become unavailable
+                resProductIds.push(id)
+
+                // when a product is orderable, but the quantity in the basket is more than the remaining stock
+                // we want to make sure it is removed before go to checkout page to avoid error when placing order
+                // we don't need to remove low stock/ out of stock from wishlist
+                if (productItems.length) {
+                    const productItem = productItems.find((item) => item.productId === id)
+                    // wishlist item will have the property type
+                    const isWishlist = !!productItem?.type
+                    if (
+                        !isWishlist &&
+                        (!inventory?.orderable ||
+                            (inventory?.orderable &&
+                                productItem?.quantity > inventory.stockLevel))
+                    ) {
+                        unOrderableIds.push(id)
+                    }
+                }
+            })
+
+            const unavailableProductIds = ids.filter(
+                (id) => !resProductIds.includes(id) || unOrderableIds.includes(id)
+            )
+
+            unavailableProductIdsRef.current = unavailableProductIds
+        }
+    }, [productsQuery.data, productsQuery.isSuccess, ids, productItems])
+    
     const unavailableProductsModalProps = useDisclosure()
     useEffect(() => {
         if (unavailableProductIdsRef.current?.length > 0) {

--- a/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
+++ b/packages/extension-chakra-storefront/src/components/unavailable-product-confirmation-modal/index.jsx
@@ -32,7 +32,6 @@ const UnavailableProductConfirmationModal = ({
     const unavailableProductIdsRef = useRef(null)
     const ids = productIds.length ? productIds : productItems.map((i) => i.productId)
     
-    // Updated to remove onSuccess callback
     const productsQuery = useProducts(
         {parameters: {ids: ids?.join(','), allImages: true}},
         {
@@ -40,7 +39,6 @@ const UnavailableProductConfirmationModal = ({
         }
     )
     
-    // New useEffect to handle the logic previously in onSuccess
     useEffect(() => {
         if (productsQuery.isSuccess && productsQuery.data) {
             const result = productsQuery.data
@@ -76,7 +74,7 @@ const UnavailableProductConfirmationModal = ({
 
             unavailableProductIdsRef.current = unavailableProductIds
         }
-    }, [productsQuery.data, productsQuery.isSuccess, ids, productItems])
+    }, [productsQuery.data, productsQuery.isSuccess])
     
     const unavailableProductsModalProps = useDisclosure()
     useEffect(() => {

--- a/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
@@ -28,7 +28,7 @@ export const useProductViewModal = (initialProduct) => {
     const [product, setProduct] = useState(initialProduct)
     const variant = useVariant(product)
 
-    const {data: currentProduct, isFetching} = useProduct(
+    const {data: currentProduct, isFetching, isError} = useProduct(
         {parameters: {id: (variant || product)?.productId}},
         {
             placeholderData: initialProduct,
@@ -42,12 +42,6 @@ export const useProductViewModal = (initialProduct) => {
                     }
                 }
                 return data
-            },
-            onError: () => {
-                toast({
-                    title: intl.formatMessage(API_ERROR_MESSAGE),
-                    status: 'error'
-                })
             }
         }
     )
@@ -55,6 +49,15 @@ export const useProductViewModal = (initialProduct) => {
     useEffect(() => {
         if (currentProduct) setProduct(currentProduct)
     }, [currentProduct])
+
+    useEffect(() => {
+        if (isError) {
+            toast({
+                title: intl.formatMessage(API_ERROR_MESSAGE),
+                status: 'error'
+            })
+        }
+    }, [isError, toast, intl])
 
     const cleanUpVariantParams = () => {
         const paramToRemove = [...(product?.variationAttributes?.map(({id}) => id) ?? []), 'pid']

--- a/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
@@ -28,7 +28,11 @@ export const useProductViewModal = (initialProduct) => {
     const [product, setProduct] = useState(initialProduct)
     const variant = useVariant(product)
 
-    const {data: currentProduct, isFetching, isError} = useProduct(
+    const {
+        data: currentProduct,
+        isFetching,
+        isError
+    } = useProduct(
         {parameters: {id: (variant || product)?.productId}},
         {
             placeholderData: initialProduct,
@@ -51,12 +55,11 @@ export const useProductViewModal = (initialProduct) => {
     }, [currentProduct])
 
     useEffect(() => {
-        if (isError) {
-            toast({
-                title: intl.formatMessage(API_ERROR_MESSAGE),
-                status: 'error'
-            })
-        }
+        if (!isError) return
+        toast({
+            title: intl.formatMessage(API_ERROR_MESSAGE),
+            status: 'error'
+        })
     }, [isError])
 
     const cleanUpVariantParams = () => {

--- a/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-product-view-modal.js
@@ -57,7 +57,7 @@ export const useProductViewModal = (initialProduct) => {
                 status: 'error'
             })
         }
-    }, [isError, toast, intl])
+    }, [isError])
 
     const cleanUpVariantParams = () => {
         const paramToRemove = [...(product?.variationAttributes?.map(({id}) => id) ?? []), 'pid']

--- a/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
@@ -5,8 +5,10 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
+import {useEffect} from 'react'
 import {useCustomerProductLists, useShopperCustomersMutation} from '@salesforce/commerce-sdk-react'
 import {useCurrentCustomer} from './use-current-customer'
+
 const onClient = typeof window !== 'undefined'
 // TODO: remove `listId` input -> use the first list of type wish_list instead
 // (mimic the logic in the other older hook 'use-wishlist.js')
@@ -14,23 +16,26 @@ export const useWishList = ({listId = ''} = {}) => {
     const {data: customer} = useCurrentCustomer()
     const {customerId} = customer
     const createCustomerProductList = useShopperCustomersMutation('createCustomerProductList')
+    
     const {data: productLists, ...restOfQuery} = useCustomerProductLists(
         {
             parameters: {customerId}
         },
         {
-            onSuccess: (data) => {
-                if (!data.total) {
-                    createCustomerProductList.mutate({
-                        parameters: {customerId},
-                        // we only use one type of product lists for now
-                        body: {type: 'wish_list'}
-                    })
-                }
-            },
             enabled: onClient && Boolean(customerId)
         }
     )
+    
+    // Handle product list creation when no lists exist
+    useEffect(() => {
+        if (productLists && !productLists.total) {
+            createCustomerProductList.mutate({
+                parameters: {customerId},
+                // we only use one type of product lists for now
+                body: {type: 'wish_list'}
+            })
+        }
+    }, [productLists])
 
     const wishLists = productLists?.data?.filter((list) => list.type === 'wish_list') || []
     const currentWishlist = wishLists.find((list) => list.id === listId)

--- a/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
@@ -16,8 +16,12 @@ export const useWishList = ({listId = ''} = {}) => {
     const {data: customer} = useCurrentCustomer()
     const {customerId} = customer
     const createCustomerProductList = useShopperCustomersMutation('createCustomerProductList')
-    
-    const {data: productLists, isSuccess: isProductListsSuccess, ...restOfQuery} = useCustomerProductLists(
+
+    const {
+        data: productLists,
+        isSuccess: isProductListsSuccess,
+        ...restOfQuery
+    } = useCustomerProductLists(
         {
             parameters: {customerId}
         },
@@ -25,16 +29,15 @@ export const useWishList = ({listId = ''} = {}) => {
             enabled: onClient && Boolean(customerId)
         }
     )
-    
+
     // Handle product list creation when no lists exist
     useEffect(() => {
-        if (productLists && isProductListsSuccess && !productLists.total) {
-            createCustomerProductList.mutate({
-                parameters: {customerId},
-                // we only use one type of product lists for now
-                body: {type: 'wish_list'}
-            })
-        }
+        if (!productLists || !isProductListsSuccess || productLists.total) return
+        createCustomerProductList.mutate({
+            parameters: {customerId},
+            // we only use one type of product lists for now
+            body: {type: 'wish_list'}
+        })
     }, [productLists, isProductListsSuccess])
 
     const wishLists = productLists?.data?.filter((list) => list.type === 'wish_list') || []

--- a/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-wish-list.js
@@ -17,7 +17,7 @@ export const useWishList = ({listId = ''} = {}) => {
     const {customerId} = customer
     const createCustomerProductList = useShopperCustomersMutation('createCustomerProductList')
     
-    const {data: productLists, ...restOfQuery} = useCustomerProductLists(
+    const {data: productLists, isSuccess: isProductListsSuccess, ...restOfQuery} = useCustomerProductLists(
         {
             parameters: {customerId}
         },
@@ -28,14 +28,14 @@ export const useWishList = ({listId = ''} = {}) => {
     
     // Handle product list creation when no lists exist
     useEffect(() => {
-        if (productLists && !productLists.total) {
+        if (productLists && isProductListsSuccess && !productLists.total) {
             createCustomerProductList.mutate({
                 parameters: {customerId},
                 // we only use one type of product lists for now
                 body: {type: 'wish_list'}
             })
         }
-    }, [productLists])
+    }, [productLists, isProductListsSuccess])
 
     const wishLists = productLists?.data?.filter((list) => list.type === 'wish_list') || []
     const currentWishlist = wishLists.find((list) => list.id === listId)

--- a/packages/extension-chakra-storefront/src/pages/cart/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/cart/index.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React, {useState, useMemo} from 'react'
+import React, {useState, useMemo, useEffect} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 
 // Chakra Components
@@ -171,7 +171,7 @@ const Cart = () => {
     /******************* Shipping Methods for basket shipment *******************/
     // do this action only if the basket shipping method is not defined
     // we need to fetch the shippment methods to get the default value before we can add it to the basket
-    useShippingMethodsForShipment(
+    const shippingMethodsQuery = useShippingMethodsForShipment(
         {
             parameters: {
                 basketId: basket?.basketId,
@@ -183,20 +183,24 @@ const Cart = () => {
             enabled:
                 !!basket?.basketId &&
                 basket.shipments.length > 0 &&
-                !basket.shipments[0].shippingMethod,
-            onSuccess: (data) => {
-                updateShippingMethodForShipmentsMutation.mutate({
-                    parameters: {
-                        basketId: basket?.basketId,
-                        shipmentId: 'me'
-                    },
-                    body: {
-                        id: data.defaultShippingMethodId
-                    }
-                })
-            }
+                !basket.shipments[0].shippingMethod
         }
     )
+    
+    // Handle shipping method update when data is returned
+    useEffect(() => {
+        if (shippingMethodsQuery.isSuccess && shippingMethodsQuery.data) {
+            updateShippingMethodForShipmentsMutation.mutate({
+                parameters: {
+                    basketId: basket?.basketId,
+                    shipmentId: 'me'
+                },
+                body: {
+                    id: shippingMethodsQuery.data.defaultShippingMethodId
+                }
+            })
+        }
+    }, [shippingMethodsQuery.isSuccess, shippingMethodsQuery.data])
 
     /************************* Error handling ***********************/
     const showError = () => {

--- a/packages/extension-chakra-storefront/src/pages/cart/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/cart/index.jsx
@@ -186,20 +186,21 @@ const Cart = () => {
                 !basket.shipments[0].shippingMethod
         }
     )
-    
+
     // Handle shipping method update when data is returned
     useEffect(() => {
-        if (shippingMethodsQuery.isSuccess && shippingMethodsQuery.data) {
-            updateShippingMethodForShipmentsMutation.mutate({
-                parameters: {
-                    basketId: basket?.basketId,
-                    shipmentId: 'me'
-                },
-                body: {
-                    id: shippingMethodsQuery.data.defaultShippingMethodId
-                }
-            })
+        if (!shippingMethodsQuery.isSuccess || !shippingMethodsQuery.data) {
+            return
         }
+        updateShippingMethodForShipmentsMutation.mutate({
+            parameters: {
+                basketId: basket?.basketId,
+                shipmentId: 'me'
+            },
+            body: {
+                id: shippingMethodsQuery.data.defaultShippingMethodId
+            }
+        })
     }, [shippingMethodsQuery.isSuccess, shippingMethodsQuery.data])
 
     /************************* Error handling ***********************/


### PR DESCRIPTION
This PR is the part 4 of the react-query upgrade series.

This PR updates the breaking change - https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed

`useQuery` no longer support `onSuccess`, `onError` and `onSettled`. On global search in my IDE, I have found 4 instances of these usages and have converted them to `useEffect`.

`useMutation` is not affected.