### PR TITLE
@W-17917565 Upgrade to @tanstack/react-query v5 - Part 5 replace `keepPreviousData`

### DIFF
--- a/packages/extension-chakra-storefront/src/components/product-view-modal/bundle.jsx
+++ b/packages/extension-chakra-storefront/src/components/product-view-modal/bundle.jsx
@@ -51,7 +51,7 @@ const BundleProductViewModal = ({product: bundle, isOpen, onClose, updateCart, .
         {parameters: {ids: childProductIds, allImages: true}},
         {
             enabled: Boolean(childProductIds),
-            keepPreviousData: true
+            placeholderData: (previousData) => previousData
         }
     )
 

--- a/packages/extension-chakra-storefront/src/components/product-view-modal/bundle.jsx
+++ b/packages/extension-chakra-storefront/src/components/product-view-modal/bundle.jsx
@@ -18,6 +18,7 @@ import {
     VStack,
     useBreakpointValue
 } from '@chakra-ui/react'
+import {keepPreviousData} from '@tanstack/react-query'
 import ProductView from '../../components/product-view'
 import {useProductViewModal} from '../../hooks/use-product-view-modal'
 import {useProducts} from '@salesforce/commerce-sdk-react'
@@ -51,7 +52,7 @@ const BundleProductViewModal = ({product: bundle, isOpen, onClose, updateCart, .
         {parameters: {ids: childProductIds, allImages: true}},
         {
             enabled: Boolean(childProductIds),
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
 

--- a/packages/extension-chakra-storefront/src/hooks/use-auth-modal.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-auth-modal.js
@@ -82,7 +82,10 @@ export const AuthModal = ({
 
     const {data: baskets} = useCustomerBaskets(
         {parameters: {customerId}},
-        {enabled: !!customerId && !isServer, keepPreviousData: true}
+        {
+            enabled: !!customerId && !isServer,
+            placeholderData: (previousData) => previousData
+        }
     )
     const mergeBasket = useShopperBasketsMutation('mergeBasket')
 

--- a/packages/extension-chakra-storefront/src/hooks/use-auth-modal.js
+++ b/packages/extension-chakra-storefront/src/hooks/use-auth-modal.js
@@ -20,6 +20,7 @@ import {
     useDisclosure,
     useToast
 } from '@chakra-ui/react'
+import {keepPreviousData} from '@tanstack/react-query'
 import {
     AuthHelpers,
     useAuthHelper,
@@ -84,7 +85,7 @@ export const AuthModal = ({
         {parameters: {customerId}},
         {
             enabled: !!customerId && !isServer,
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
     const mergeBasket = useShopperBasketsMutation('mergeBasket')

--- a/packages/extension-chakra-storefront/src/pages/cart/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/cart/index.jsx
@@ -98,7 +98,7 @@ const Cart = () => {
         },
         {
             enabled: bundleChildVariantIds?.length > 0,
-            keepPreviousData: true,
+            placeholderData: (previousData) => previousData,
             select: (result) => {
                 return result?.data?.reduce((result, item) => {
                     const key = item.id

--- a/packages/extension-chakra-storefront/src/pages/cart/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/cart/index.jsx
@@ -6,6 +6,7 @@
  */
 import React, {useState, useMemo} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
+import {keepPreviousData} from '@tanstack/react-query'
 
 // Chakra Components
 import {Box, Stack, Grid, GridItem, Container, useDisclosure, Button} from '@chakra-ui/react'
@@ -98,7 +99,7 @@ const Cart = () => {
         },
         {
             enabled: bundleChildVariantIds?.length > 0,
-            placeholderData: (previousData) => previousData,
+            placeholderData: keepPreviousData,
             select: (result) => {
                 return result?.data?.reduce((result, item) => {
                     const key = item.id

--- a/packages/extension-chakra-storefront/src/pages/login/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/login/index.jsx
@@ -43,7 +43,10 @@ const Login = () => {
     const prevAuthType = usePrevious(customerType)
     const {data: baskets} = useCustomerBaskets(
         {parameters: {customerId}},
-        {enabled: !!customerId && !isServer, keepPreviousData: true}
+        {
+            enabled: !!customerId && !isServer,
+            placeholderData: (previousData) => previousData
+        }
     )
     const mergeBasket = useShopperBasketsMutation('mergeBasket')
 

--- a/packages/extension-chakra-storefront/src/pages/login/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/login/index.jsx
@@ -45,7 +45,7 @@ const Login = () => {
         {parameters: {customerId}},
         {
             enabled: !!customerId && !isServer,
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
     const mergeBasket = useShopperBasketsMutation('mergeBasket')

--- a/packages/extension-chakra-storefront/src/pages/login/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/login/index.jsx
@@ -8,6 +8,7 @@
 import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {useIntl, defineMessage} from 'react-intl'
+import {keepPreviousData} from '@tanstack/react-query'
 import {Box, Container} from '@chakra-ui/react'
 import {
     AuthHelpers,

--- a/packages/extension-chakra-storefront/src/pages/product-detail/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/product-detail/index.jsx
@@ -103,7 +103,7 @@ const ProductDetail = () => {
         {
             // When shoppers select a different variant (and the app fetches the new data),
             // the old data is still rendered (and not the skeletons).
-            keepPreviousData: true
+            placeholderData: (previousData) => previousData
         }
     )
 
@@ -145,7 +145,7 @@ const ProductDetail = () => {
         },
         {
             enabled: bundleChildVariantIds?.length > 0,
-            keepPreviousData: true
+            placeholderData: (previousData) => previousData
         }
     )
 

--- a/packages/extension-chakra-storefront/src/pages/product-detail/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/product-detail/index.jsx
@@ -9,6 +9,7 @@ import React, {Fragment, useCallback, useEffect, useState} from 'react'
 import PropTypes from 'prop-types'
 import {Helmet} from 'react-helmet'
 import {FormattedMessage, useIntl} from 'react-intl'
+import {keepPreviousData} from '@tanstack/react-query'
 import {normalizeSetBundleProduct, getUpdateBundleChildArray} from '../../utils/product-utils'
 
 // Components
@@ -103,7 +104,7 @@ const ProductDetail = () => {
         {
             // When shoppers select a different variant (and the app fetches the new data),
             // the old data is still rendered (and not the skeletons).
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
 
@@ -145,7 +146,7 @@ const ProductDetail = () => {
         },
         {
             enabled: bundleChildVariantIds?.length > 0,
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
 

--- a/packages/extension-chakra-storefront/src/pages/product-list/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/product-list/index.jsx
@@ -160,7 +160,7 @@ const ProductList = (props) => {
             }
         },
         {
-            keepPreviousData: true
+            placeholderData: (previousData) => previousData
         }
     )
 

--- a/packages/extension-chakra-storefront/src/pages/product-list/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/product-list/index.jsx
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types'
 import {useHistory, useLocation, useParams} from 'react-router-dom'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {Helmet} from 'react-helmet'
+import {keepPreviousData} from '@tanstack/react-query'
 import {
     useCategory,
     useCustomerId,
@@ -160,7 +161,7 @@ const ProductList = (props) => {
             }
         },
         {
-            placeholderData: (previousData) => previousData
+            placeholderData: keepPreviousData
         }
     )
 


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

This PR is the part 5 of the react-query upgrade series.

This PR updates the breaking change - https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#removed-keeppreviousdata-in-favor-of-placeholderdata-identity-function