### PR TITLE
Release `commerce-sdk-react@4.0.0-extensibility-preview.0`

### DIFF
--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/commerce-sdk-react",
-  "version": "3.2.0-extensibility-preview.4",
+  "version": "4.0.0-extensibility-preview.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/commerce-sdk-react",
-      "version": "3.2.0-extensibility-preview.4",
+      "version": "4.0.0-extensibility-preview.0",
       "license": "See license in LICENSE",
       "dependencies": {
         "commerce-sdk-isomorphic": "^3.1.1",
@@ -49,7 +49,7 @@
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "^4.28.0",
+        "@tanstack/react-query": "^5.67.1",
         "react": "^18.2.0",
         "react-helmet": "^6.1.0"
       }

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "@salesforce/commerce-sdk-react",
-  "version": "3.2.0-extensibility-preview.4",
+  "version": "4.0.0-extensibility-preview.0",
   "description": "A library that provides react hooks for fetching data from Commerce Cloud",
   "homepage": "https://github.com/SalesforceCommerceCloud/pwa-kit/tree/develop/packages/ecom-react-hooks#readme",
   "bugs": {

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "@salesforce/commerce-sdk-react",
   "version": "4.0.0-extensibility-preview.0",
   "description": "A library that provides react hooks for fetching data from Commerce Cloud",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -76,7 +76,7 @@
     "typescript": "4.9.5"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "^4.28.0",
+    "@tanstack/react-query": "^5.67.1",
     "react": "^18.2.0",
     "react-helmet": "^6.1.0"
   },

--- a/packages/extension-chakra-store-locator/package.json
+++ b/packages/extension-chakra-store-locator/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@chakra-ui/react": "2.8.2",
     "@loadable/component": "^5.15.3",
-    "@salesforce/commerce-sdk-react": "^3.2.0-extensibility-preview.4",
+    "@salesforce/commerce-sdk-react": "^4.0.0-extensibility-preview.0",
     "@salesforce/pwa-kit-dev": "^4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-extension-sdk": "^4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-react-sdk": "^4.0.0-extensibility-preview.4",

--- a/packages/extension-chakra-storefront/package.json
+++ b/packages/extension-chakra-storefront/package.json
@@ -23,7 +23,7 @@
     "@chakra-ui/skip-nav": "^2.0.15",
     "@loadable/component": "^5.15.3",
     "@peculiar/webcrypto": "^1.4.2",
-    "@salesforce/commerce-sdk-react": "^3.2.0-extensibility-preview.4",
+    "@salesforce/commerce-sdk-react": "^4.0.0-extensibility-preview.0",
     "@salesforce/pwa-kit-dev": "^4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-extension-sdk": "^4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-react-sdk": "^4.0.0-extensibility-preview.4",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -41,7 +41,7 @@
     "@lhci/cli": "^0.11.0",
     "@loadable/component": "^5.15.3",
     "@peculiar/webcrypto": "^1.4.2",
-    "@salesforce/commerce-sdk-react": "3.2.0-extensibility-preview.4",
+    "@salesforce/commerce-sdk-react": "^4.0.0-extensibility-preview.0",
     "@salesforce/pwa-kit-dev": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-react-sdk": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-runtime": "4.0.0-extensibility-preview.4",

--- a/packages/test-commerce-sdk-react/package.json
+++ b/packages/test-commerce-sdk-react/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@loadable/component": "^5.15.3",
-    "@salesforce/commerce-sdk-react": "3.2.0-extensibility-preview.4",
+    "@salesforce/commerce-sdk-react": "^4.0.0-extensibility-preview.0",
     "@salesforce/pwa-kit-dev": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-react-sdk": "4.0.0-extensibility-preview.4",
     "@salesforce/pwa-kit-runtime": "4.0.0-extensibility-preview.4",


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Releasing a new major preview version for `commerce-sdk-react`, this is required as there is a blocker for the current react-query v5 upgrade. The monorepo packages reference the `commerce-sdk-react` version on npm. We are releasing a version to unblock the peer dependency conflicts.

This version is not made to be consumed! It only updates the peerDependency version of the react query.