### PR TITLE
Override picocolors to eliminate warning when building the retail react app

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.10.0-dev (Feb 18, 2025)
+- Override picocolors to eliminate warning when building the retail react app [#2331](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2331)
 
 ## v3.9.2 (Mar 08, 2025)
 - Disable CloudWatch metrics sender retries [#2304](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2304) 

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -1042,6 +1042,7 @@
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
       "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
+      "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -2306,9 +2307,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -71,5 +71,8 @@
   },
   "publishConfig": {
     "directory": "dist"
+  },
+  "overrides": {
+    "picocolors":"^1.1.1"
   }
 }

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix hreflang alternate links [#2269](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2269)
 - PDP / PLP: Add page meta data tags that have been defined in BM [#2232](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2232)
 - Send PWA Kit events to Data Cloud [#318] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2229)
+- Override picocolors to eliminate warning when building the retail react app [#2331](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2331)
 
 ## v6.0.1 (Mar 05, 2025)
 - Update PWA-Kit SDKs to v3.9.1 [#2301](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2301)


### PR DESCRIPTION
Adds an override for picocolors to pwa-kit-runtime to get rid of the following warning when building the retail-react-app

![Screenshot 2025-03-25 at 11 11 47 AM](https://github.com/user-attachments/assets/6cb45bde-49ae-4579-9f10-a043b810c2e6)

The net change is that picocolors, which is brought in transitively by babel and other packages, is bumped from v1.0.1 to v1.1.1 ([where the warning is addressed](https://github.com/alexeyraspopov/picocolors/releases/tag/v1.1.1))

