### PR TITLE
Fix `getStaticAssetUrl` utility removing duplicate slash @@W-17779284@@

### DIFF
--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.client.test.js
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.client.test.js
@@ -30,13 +30,13 @@ describe('getAssetUrl (client-side)', () => {
         expect(utils.getAssetUrl()).toBe('test.com')
     })
     test('should return origin + path', () => {
-        expect(utils.getAssetUrl('/path')).toBe('test.com/path')
+        expect(utils.getAssetUrl('path')).toBe('test.com/path')
     })
 })
 
 describe('getStaticAssetUrl (client-side)', () => {
     beforeEach(() => {
-        global.Progressive = {buildOrigin: 'test.com'}
+        global.Progressive = {buildOrigin: 'test.com/'}
     })
     afterEach(() => {
         delete global.Progressive

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
@@ -38,7 +38,7 @@ export const getAssetUrl = (path: string) => {
         ? // @ts-ignore
           `${window.Progressive.buildOrigin as string}`
         : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}`
-    
+
     // Normalize the public path by removing the trailing slash
     publicPath = publicPath.replace(/\/$/, '')
 
@@ -56,16 +56,18 @@ export const getAssetUrl = (path: string) => {
  * @function
  * @returns {string} The full URL to the static asset.
  */
-export const getStaticAssetUrl = (path: string = '', opts: GetAssetUrlOptions) => {
+export const getStaticAssetUrl = (path = '', opts: GetAssetUrlOptions) => {
     const {appExtensionPackageName = ''} = opts || {}
-    const extensionPrefix =  `${appExtensionPackageName ? `/${EXTENSIONS_NAMESPACE}/${appExtensionPackageName}` : ''}`
+    const extensionPrefix = `${
+        appExtensionPackageName ? `/${EXTENSIONS_NAMESPACE}/${appExtensionPackageName}` : ''
+    }`
 
     /* istanbul ignore next */
-    let  publicPath = onClient
+    let publicPath = onClient
         ? // @ts-ignore
           `${window.Progressive.buildOrigin as string}`
         : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}`
-    
+
     // Normalize the public path by removing the trailing slash
     publicPath = publicPath.replace(/\/$/, '')
 

--- a/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
+++ b/packages/pwa-kit-react-sdk/src/ssr/universal/utils.ts
@@ -18,7 +18,7 @@ import {bundleBasePath} from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-pa
 
 const onClient = typeof window !== 'undefined'
 
-const EXTENIONS_NAMESPACE = '__extensions'
+const EXTENSIONS_NAMESPACE = '__extensions'
 const STATIC_FOLDER = 'static'
 
 type GetAssetUrlOptions = {
@@ -34,12 +34,15 @@ type GetAssetUrlOptions = {
  */
 export const getAssetUrl = (path: string) => {
     /* istanbul ignore next */
-    const publicPath = onClient
+    let publicPath = onClient
         ? // @ts-ignore
           `${window.Progressive.buildOrigin as string}`
-        : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}/`
+        : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}`
+    
+    // Normalize the public path by removing the trailing slash
+    publicPath = publicPath.replace(/\/$/, '')
 
-    return path ? `${publicPath}${path}` : publicPath
+    return path ? `${publicPath}/${path}` : publicPath
 }
 
 // TODO: Once we establish that we have a new @salesforce/pwa-kit-extensibility package, we can move this utility to
@@ -53,23 +56,29 @@ export const getAssetUrl = (path: string) => {
  * @function
  * @returns {string} The full URL to the static asset.
  */
-export const getStaticAssetUrl = (path: string, opts: GetAssetUrlOptions) => {
+export const getStaticAssetUrl = (path: string = '', opts: GetAssetUrlOptions) => {
     const {appExtensionPackageName = ''} = opts || {}
+    const extensionPrefix =  `${appExtensionPackageName ? `/${EXTENSIONS_NAMESPACE}/${appExtensionPackageName}` : ''}`
 
     /* istanbul ignore next */
-    const publicPath = onClient
+    let  publicPath = onClient
         ? // @ts-ignore
           `${window.Progressive.buildOrigin as string}`
-        : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}/`
+        : `${bundleBasePath}/${process.env.BUNDLE_ID || 'development'}`
+    
+    // Normalize the public path by removing the trailing slash
+    publicPath = publicPath.replace(/\/$/, '')
 
-    // Ensure all defined path arguments start with `/`.
-    if (path && !path.startsWith('/')) {
-        path = `/${path}`
-    }
+    // Ensure path starts with `/`.
+    path = `${path && !path.startsWith('/') ? `/${path}` : path}`
 
-    return `${publicPath}/${STATIC_FOLDER}${
-        appExtensionPackageName ? `/${EXTENIONS_NAMESPACE}/${appExtensionPackageName}` : ''
-    }${path ? path : ''}`
+    // Prepend the extension namespace and package if applicable.
+    path = `${extensionPrefix ? `${extensionPrefix}${path}` : path}`
+
+    // Prefix public assets path and static folder.
+    path = `${publicPath}/${STATIC_FOLDER}${path}`
+
+    return path
 }
 
 /**


### PR DESCRIPTION
# Description

When using the `getStaticAssetUrl` utility to get a static asset url for a given extension there was a duplicationg slash in the generated url. This PR ensures there is no duplicate slash in the result.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Re-write util to be easier to read
- Update tests knowing the `getAppOrigin` returns trailing slash

# How to Test-Drive This PR

- Install and configure the `extension-starter` in the typescript minimal project and run it. 
- Goto `/sample-page`
- Using chrome dev tools, inspect the logo image in the pages content and ensure there is no duplicate slash.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)
