### PR TITLE
Bug Fix: TypeError: ssrGet is not a function

### DIFF
--- a/packages/template-typescript-minimal/app/ssr.js
+++ b/packages/template-typescript-minimal/app/ssr.js
@@ -45,4 +45,4 @@ const {handler} = runtime.createHandler(options, (app) => {
 
 // SSR requires that we export a single handler function called 'get', that
 // supports AWS use of the server that we created above.
-exports.get = handler
+export const get = handler


### PR DESCRIPTION
SSR for MRT was failing since the SSR.js file was combining MJS imports with CJS exports

# Description

By default, the Typescript template renders fine on localhost. However, building and pushing the Typescript template into MRT, the mobify storefront displays a 500 internal server error. 

Steps to reproduce:
1. Execute npx command to create PWA Kit TS template
```
npx '@salesforce/pwa-kit-create-app@latest' --preset <template>
```
2. Setup MRT personal API key 
3. Export MRT personal API key 
5. Execute the build script to an existing MRT environment
```
npm run push -- -m "Push" --target <env> 
```
6. Click "Visit Site" from MRT 
7. Observe the site is down due to server error
8. Enable source map 
9. Execute tail logs script to observe stack trace.
```
npm run tail-logs -- --environment <env>
```

![image](https://github.com/user-attachments/assets/66c402c7-e0bf-40a7-861b-459973fbe7b8)
![image](https://github.com/user-attachments/assets/e733d68c-3e08-45fa-aeae-5b1f8ed4390e)


# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Update "get" export from ssr.js to use cjs style export 

# How to Test-Drive This PR

- Build and push to MRT 

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

