### PR TITLE
@W-17830285@ Add custom parameters to SLAS authorize calls

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v3.3.0-dev (Feb 18, 2025)
 - Invalidate cache instead of removing cache when triggering logout [#2323](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2323)
 - Fix dependencies vulnerabilities [#2338](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2338)
-- Allow custom parameters/body pass to SLAS authorize/authenticate calls via commerce-sdk-react auth helpers [#2358](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2358)
+- Allow custom parameters/body to be passed to SLAS authorize/authenticate calls via commerce-sdk-react auth helpers [#2358](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2358)
 
 ## v3.2.1 (Mar 05, 2025)
 - Update PWA-Kit SDKs to v3.9.1 [#2301](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2301)

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v3.3.0-dev (Feb 18, 2025)
 - Invalidate cache instead of removing cache when triggering logout [#2323](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2323)
 - Fix dependencies vulnerabilities [#2338](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2338)
-- Add ability to send custom parameters to SLAS authorize calls via commerce-sdk-react auth helpers [#2358](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2358)
+- Allow custom parameters/body pass to SLAS authorize/authenticate calls via commerce-sdk-react auth helpers [#2358](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2358)
 
 ## v3.2.1 (Mar 05, 2025)
 - Update PWA-Kit SDKs to v3.9.1 [#2301](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2301)

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v3.3.0-dev (Feb 18, 2025)
 - Invalidate cache instead of removing cache when triggering logout [#2323](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2323)
 - Fix dependencies vulnerabilities [#2338](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2338)
+- Add ability to send custom parameters to SLAS authorize calls via commerce-sdk-react auth helpers [#2358](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2358)
 
 ## v3.2.1 (Mar 05, 2025)
 - Update PWA-Kit SDKs to v3.9.1 [#2301](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2301)

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
-        "commerce-sdk-isomorphic": "^3.2.0",
+        "commerce-sdk-isomorphic": "^3.3.0",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -845,9 +845,10 @@
       "dev": true
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-3.2.0.tgz",
-      "integrity": "sha512-eGCZ9XRTW3c+njzPzpVQIW4NNJItFxNoZB0YzxnLEMec+GP3H31t5wXz06eS0SSSh0zAWkpa7YfoH0WEcsf/CQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-3.3.0.tgz",
+      "integrity": "sha512-i+aSgVsQjh7VyODRiVB35LPQNWMoYkjrGMiw7pmYzpTsRkXv79uG8m7fGePbXjcvuVPg6H+AN+TqtebcDQukiA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",
         "node-fetch": "2.6.13",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "^3.2.0",
+    "commerce-sdk-isomorphic": "^3.3.0",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -7,7 +7,12 @@
 import Auth, {AuthData} from './'
 import {waitFor} from '@testing-library/react'
 import jwt from 'jsonwebtoken'
-import {helpers, ShopperCustomersTypes, ShopperLogin} from 'commerce-sdk-isomorphic'
+import {
+    helpers,
+    ShopperCustomersTypes,
+    ShopperCustomers,
+    ShopperLogin
+} from 'commerce-sdk-isomorphic'
 import * as utils from '../utils'
 import {SLAS_SECRET_PLACEHOLDER} from '../constant'
 import {ShopperLoginTypes} from 'commerce-sdk-isomorphic'
@@ -49,13 +54,7 @@ jest.mock('commerce-sdk-isomorphic', () => {
             authorizeIDP: jest.fn().mockResolvedValue(''),
             authorizePasswordless: jest.fn().mockResolvedValue(''),
             getPasswordLessAccessToken: jest.fn().mockResolvedValue('')
-        },
-        ShopperCustomers: jest.fn().mockImplementation(() => {
-            return {
-                updateCustomerPassword: () => {},
-                registerCustomer: () => {}
-            }
-        })
+        }
     }
 })
 
@@ -510,6 +509,9 @@ describe('Auth', () => {
     })
 
     test('register only sends custom parameters to registered login', async () => {
+        const registerCustomerSpy = jest
+            .spyOn(ShopperCustomers.prototype, 'registerCustomer')
+            .mockImplementation()
         const auth = new Auth(config)
         const inputToRegister = {
             customer: baseCustomer,
@@ -519,6 +521,11 @@ describe('Auth', () => {
         }
 
         await auth.register(inputToRegister)
+
+        // Body should only include credentials. No other parameters
+        expect(registerCustomerSpy).toHaveBeenCalledWith(
+            expect.objectContaining({body: {customer: baseCustomer, password: 'test'}})
+        )
 
         // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
         // The second argument is credentials
@@ -768,6 +775,7 @@ describe('Auth', () => {
         expect(helpers.loginGuestUser).toHaveBeenCalled()
     })
     test('updateCustomerPassword calls registered login', async () => {
+        jest.spyOn(ShopperCustomers.prototype, 'updateCustomerPassword').mockImplementation()
         const auth = new Auth(config)
         await auth.updateCustomerPassword({
             customer: baseCustomer,

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -663,7 +663,7 @@ describe('Auth', () => {
             password: 'test'
         }
         const auth = new Auth(config)
-        await auth.loginRegisteredUserB2C(credentials, options)
+        await auth.loginRegisteredUserB2C({...credentials, options})
         // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
         // The second argument is credentials, including the client secret
         // The fourth argument is custom parameters
@@ -672,7 +672,7 @@ describe('Auth', () => {
             expect.anything(),
             expect.objectContaining(credentials),
             expect.anything(),
-            {body: {c_test: 'custom parameter'}}
+            options
         )
     })
 

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -491,6 +491,18 @@ describe('Auth', () => {
         expect(helpers.loginGuestUser).toHaveBeenCalled()
     })
 
+    test('loginGuestUser can pass along custom parameters', async () => {
+        const parameters = {c_test: 'custom parameter'}
+        const auth = new Auth(config)
+        await auth.loginGuestUser(parameters)
+        // The first argument is the SLAS config, which we don't need to verify in this case
+        // We only want to see that the custom parameters were included in the second argument
+        expect(helpers.loginGuestUser).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({c_test: 'custom parameter'})
+        )
+    })
+
     test.each([
         // When user has not selected DNT pref
         [true, undefined, {dnt: true}],
@@ -614,6 +626,26 @@ describe('Auth', () => {
         })
     })
 
+    test('loginRegisteredUserB2C can pass along custom parameters', async () => {
+        const parameters = {c_test: 'custom parameter'}
+        const credentials = {
+            username: 'test',
+            password: 'test'
+        }
+        const auth = new Auth(config)
+        await auth.loginRegisteredUserB2C(credentials, parameters)
+        // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
+        // The second argument is credentials, including the client secret
+        // The fourth argument is custom parameters
+        // We only want to see that the custom parameters were included in the second argument
+        expect(helpers.loginRegisteredUserB2C).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining(credentials),
+            expect.anything(),
+            {body: {c_test: 'custom parameter'}}
+        )
+    })
+
     test('loginIDPUser calls isomorphic loginIDPUser', async () => {
         const auth = new Auth(config)
         await auth.loginIDPUser({redirectURI: 'redirectURI', code: 'test'})
@@ -634,10 +666,18 @@ describe('Auth', () => {
 
     test('authorizeIDP calls isomorphic authorizeIDP', async () => {
         const auth = new Auth(config)
-        await auth.authorizeIDP({redirectURI: 'redirectURI', hint: 'test'})
+        await auth.authorizeIDP({
+            redirectURI: 'redirectURI',
+            hint: 'test',
+            c_customParam: 'customParam'
+        })
         expect(helpers.authorizeIDP).toHaveBeenCalled()
         const functionArg = (helpers.authorizeIDP as jest.Mock).mock.calls[0][1]
-        expect(functionArg).toMatchObject({redirectURI: 'redirectURI', hint: 'test'})
+        expect(functionArg).toMatchObject({
+            redirectURI: 'redirectURI',
+            hint: 'test',
+            c_customParam: 'customParam'
+        })
     })
 
     test('authorizeIDP adds clientSecret to parameters when using private client', async () => {

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -632,13 +632,15 @@ describe('Auth', () => {
     })
 
     test('loginRegisteredUserB2C can pass along custom parameters', async () => {
-        const parameters = {c_test: 'custom parameter'}
+        const options = {
+            body: {c_test: 'custom parameter'}
+        }
         const credentials = {
             username: 'test',
             password: 'test'
         }
         const auth = new Auth(config)
-        await auth.loginRegisteredUserB2C(credentials, parameters)
+        await auth.loginRegisteredUserB2C(credentials, options)
         // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
         // The second argument is credentials, including the client secret
         // The fourth argument is custom parameters

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -58,14 +58,19 @@ jest.mock('commerce-sdk-isomorphic', () => {
     }
 })
 
-jest.mock('../utils', () => ({
-    __esModule: true,
-    onClient: () => true,
-    getParentOrigin: jest.fn().mockResolvedValue(''),
-    isOriginTrusted: () => false,
-    getDefaultCookieAttributes: () => {},
-    isAbsoluteUrl: () => true
-}))
+jest.mock('../utils', () => {
+    const originalModule = jest.requireActual('../utils')
+
+    return {
+        ...originalModule,
+        __esModule: true,
+        onClient: () => true,
+        getParentOrigin: jest.fn().mockResolvedValue(''),
+        isOriginTrusted: () => false,
+        getDefaultCookieAttributes: () => {},
+        isAbsoluteUrl: () => true
+    }
+})
 
 /** The auth data we store has a slightly different shape than what we use. */
 type StoredAuthData = Omit<AuthData, 'refresh_token'> & {refresh_token_guest?: string}
@@ -637,7 +642,7 @@ describe('Auth', () => {
         // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
         // The second argument is credentials, including the client secret
         // The fourth argument is custom parameters
-        // We only want to see that the custom parameters were included in the second argument
+        // We only want to see that the custom parameters were included in the fourth argument
         expect(helpers.loginRegisteredUserB2C).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining(credentials),

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -52,7 +52,8 @@ jest.mock('commerce-sdk-isomorphic', () => {
         },
         ShopperCustomers: jest.fn().mockImplementation(() => {
             return {
-                updateCustomerPassword: () => {}
+                updateCustomerPassword: () => {},
+                registerCustomer: () => {}
             }
         })
     }
@@ -505,6 +506,28 @@ describe('Auth', () => {
         expect(helpers.loginGuestUser).toHaveBeenCalledWith(
             expect.anything(),
             expect.objectContaining({c_test: 'custom parameter'})
+        )
+    })
+
+    test('register only sends custom parameters to registered login', async () => {
+        const auth = new Auth(config)
+        const inputToRegister = {
+            customer: baseCustomer,
+            password: 'test',
+            someOtherParameter: 'this should not be passed to login',
+            c_test: 'custom parameter'
+        }
+
+        await auth.register(inputToRegister)
+
+        // We don't need to verify the first and third parameters as they correspond to the SLAS client and mandatory parameters
+        // The second argument is credentials
+        // We want to see that only the custom parameters were included in the fourth argument and not any other parameters
+        expect(helpers.loginRegisteredUserB2C).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.anything(),
+            expect.anything(),
+            {body: {c_test: 'custom parameter'}}
         )
     })
 

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -843,7 +843,7 @@ class Auth {
         const {
             customer: {login},
             password,
-            ...parameters
+            ...customParameters
         } = body
 
         // login is optional field from isomorphic library
@@ -864,7 +864,9 @@ class Auth {
                 username: login,
                 password
             },
-            parameters
+            {
+                body: customParameters
+            }
         )
         return res
     }
@@ -875,7 +877,7 @@ class Auth {
      */
     async loginRegisteredUserB2C(
         credentials: LoginRegisteredUserB2CCredentials,
-        parameters: helpers.CustomRequestBody = {}
+        options?: {body: helpers.CustomRequestBody}
     ) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
@@ -895,9 +897,7 @@ class Auth {
                 dnt: dntPref,
                 ...(usid && {usid})
             },
-            {
-                body: parameters
-            }
+            options
         )
         this.handleTokenResponse(token, isGuest)
         if (onClient()) {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -887,7 +887,7 @@ class Auth {
      * Note: This uses the type LoginRegisteredUserCredentialsWithCustomParams rather than LoginRegisteredUserB2CCredentials
      * as a workaround to allow custom parameters through because the login.mutateAsync hook will only pass through a single
      * 'body' argument into this function.
-     * 
+     *
      * In the next major version release, we should modify this method so that it's input is a body containing credentials,
      * similar to the input for the register function.
      */

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -21,7 +21,8 @@ import {
     onClient,
     getDefaultCookieAttributes,
     isAbsoluteUrl,
-    stringToBase64
+    stringToBase64,
+    extractCustomParameters
 } from '../utils'
 import {
     MOBIFY_PATH,
@@ -742,23 +743,6 @@ class Auth {
     }
 
     /**
-     * This method extracts the custom parameters from a set of parameters.
-     *
-     * Custom parameters are defined as those whose keys are prefixed with 'c_'
-     * @Internal
-     */
-    extractCustomParameters = (
-        parameters: {[s: string]: string | number | boolean | string[] | number[]} | null
-    ): helpers.CustomQueryParameters => {
-        if (typeof parameters !== 'object' || parameters === null) {
-            throw new Error('Invalid input. Expecting an object as an input.')
-        }
-        return Object.fromEntries(
-            Object.entries(parameters).filter(([key]) => key.startsWith('c_'))
-        )
-    }
-
-    /**
      * The ready function returns a promise that resolves with valid ShopperLogin
      * token response.
      *
@@ -1095,7 +1079,7 @@ class Auth {
     async authorizeIDP(parameters: AuthorizeIDPParams) {
         const redirectURI = parameters.redirectURI || this.redirectURI
         const usid = this.get('usid')
-        const customParameters = this.extractCustomParameters(parameters)
+        const customParameters = extractCustomParameters(parameters)
         const {url, codeVerifier} = await helpers.authorizeIDP(
             this.client,
             {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -841,11 +841,11 @@ class Auth {
      */
     async register(body: ShopperCustomersTypes.CustomerRegistration) {
         const {
-            customer: {login},
+            customer,
             password,
             ...parameters
         } = body
-
+        const {login} = customer
         const customParameters = extractCustomParameters(parameters)
 
         // login is optional field from isomorphic library
@@ -855,11 +855,16 @@ class Auth {
             throw new Error('Customer registration is missing login field.')
         }
 
+        // The registerCustomer endpoint currently does not support custom parameters
+        // so we make sure not to send any custom params here
         const res = await this.shopperCustomersClient.registerCustomer({
             headers: {
                 authorization: `Bearer ${this.get('access_token')}`
             },
-            body
+            body: {
+                customer,
+                password
+            }
         })
         await this.loginRegisteredUserB2C(
             {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -73,6 +73,15 @@ type LoginPasswordlessParams = Parameters<Helpers['getPasswordLessAccessToken']>
 type LoginRegisteredUserB2CCredentials = Parameters<Helpers['loginRegisteredUserB2C']>[1]
 
 /**
+ * This is a temporary type until we can make a breaking change and modify the signature for 
+ * loginRegisteredUserB2C so that it takes in a body rather than just credentials
+ * 
+ */
+type LoginRegisteredUserCredentialsWithCustomParams = LoginRegisteredUserB2CCredentials & {
+    options?: {body: helpers.CustomRequestBody}
+}
+
+/**
  * The extended field is not from api response, we manually store the auth type,
  * so we don't need to make another API call when we already have the data.
  * Plus, the getCustomer endpoint only works for registered user, it returns a 404 for a guest user,
@@ -869,10 +878,10 @@ class Auth {
         await this.loginRegisteredUserB2C(
             {
                 username: login,
-                password
-            },
-            {
-                body: customParameters
+                password,
+                options: {
+                    body: customParameters
+                }
             }
         )
         return res
@@ -883,8 +892,7 @@ class Auth {
      *
      */
     async loginRegisteredUserB2C(
-        credentials: LoginRegisteredUserB2CCredentials,
-        options?: {body: helpers.CustomRequestBody}
+        credentials: LoginRegisteredUserCredentialsWithCustomParams
     ) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
@@ -896,7 +904,8 @@ class Auth {
         const token = await helpers.loginRegisteredUserB2C(
             this.client,
             {
-                ...credentials,
+                username: credentials.username,
+                password: credentials.password,
                 clientSecret: this.clientSecret
             },
             {
@@ -904,7 +913,7 @@ class Auth {
                 dnt: dntPref,
                 ...(usid && {usid})
             },
-            options
+            credentials.options
         )
         this.handleTokenResponse(token, isGuest)
         if (onClient()) {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -884,6 +884,12 @@ class Auth {
     /**
      * A wrapper method for commerce-sdk-isomorphic helper: loginRegisteredUserB2C.
      *
+     * Note: This uses the type LoginRegisteredUserCredentialsWithCustomParams rather than LoginRegisteredUserB2CCredentials
+     * as a workaround to allow custom parameters through because the login.mutateAsync hook will only pass through a single
+     * 'body' argument into this function.
+     * 
+     * In the next major version release, we should modify this method so that it's input is a body containing credentials,
+     * similar to the input for the register function.
      */
     async loginRegisteredUserB2C(credentials: LoginRegisteredUserCredentialsWithCustomParams) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -802,7 +802,7 @@ class Auth {
      * A wrapper method for commerce-sdk-isomorphic helper: loginGuestUser.
      *
      */
-    async loginGuestUser(parameters: helpers.CustomQueryParameters = {}) {
+    async loginGuestUser(parameters?: helpers.CustomQueryParameters) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
         }

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -843,8 +843,10 @@ class Auth {
         const {
             customer: {login},
             password,
-            ...customParameters
+            ...parameters
         } = body
+
+        const customParameters = extractCustomParameters(parameters)
 
         // login is optional field from isomorphic library
         // type CustomerRegistration

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -73,9 +73,9 @@ type LoginPasswordlessParams = Parameters<Helpers['getPasswordLessAccessToken']>
 type LoginRegisteredUserB2CCredentials = Parameters<Helpers['loginRegisteredUserB2C']>[1]
 
 /**
- * This is a temporary type until we can make a breaking change and modify the signature for 
+ * This is a temporary type until we can make a breaking change and modify the signature for
  * loginRegisteredUserB2C so that it takes in a body rather than just credentials
- * 
+ *
  */
 type LoginRegisteredUserCredentialsWithCustomParams = LoginRegisteredUserB2CCredentials & {
     options?: {body: helpers.CustomRequestBody}
@@ -849,11 +849,7 @@ class Auth {
      *
      */
     async register(body: ShopperCustomersTypes.CustomerRegistration) {
-        const {
-            customer,
-            password,
-            ...parameters
-        } = body
+        const {customer, password, ...parameters} = body
         const {login} = customer
         const customParameters = extractCustomParameters(parameters)
 
@@ -875,15 +871,13 @@ class Auth {
                 password
             }
         })
-        await this.loginRegisteredUserB2C(
-            {
-                username: login,
-                password,
-                options: {
-                    body: customParameters
-                }
+        await this.loginRegisteredUserB2C({
+            username: login,
+            password,
+            options: {
+                body: customParameters
             }
-        )
+        })
         return res
     }
 
@@ -891,9 +885,7 @@ class Auth {
      * A wrapper method for commerce-sdk-isomorphic helper: loginRegisteredUserB2C.
      *
      */
-    async loginRegisteredUserB2C(
-        credentials: LoginRegisteredUserCredentialsWithCustomParams
-    ) {
+    async loginRegisteredUserB2C(credentials: LoginRegisteredUserCredentialsWithCustomParams) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
         }

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -742,6 +742,23 @@ class Auth {
     }
 
     /**
+     * This method extracts the custom parameters from a set of parameters.
+     *
+     * Custom parameters are defined as those whose keys are prefixed with 'c_'
+     * @Internal
+     */
+    extractCustomParameters = (
+        parameters: {[s: string]: string | number | boolean | string[] | number[]} | null
+    ): helpers.CustomQueryParameters => {
+        if (typeof parameters !== 'object' || parameters === null) {
+            throw new Error('Invalid input. Expecting an object as an input.')
+        }
+        return Object.fromEntries(
+            Object.entries(parameters).filter(([key]) => key.startsWith('c_'))
+        )
+    }
+
+    /**
      * The ready function returns a promise that resolves with valid ShopperLogin
      * token response.
      *
@@ -792,7 +809,7 @@ class Auth {
      * A wrapper method for commerce-sdk-isomorphic helper: loginGuestUser.
      *
      */
-    async loginGuestUser() {
+    async loginGuestUser(parameters: helpers.CustomQueryParameters = {}) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
         }
@@ -812,7 +829,9 @@ class Auth {
             {
                 redirectURI: this.redirectURI,
                 dnt: dntPref,
-                ...(usid && {usid})
+                ...(usid && {usid}),
+                // custom parameters are sent only into the /authorize endpoint.
+                ...parameters
             }
         ] as const
         const callback = this.clientSecret
@@ -839,7 +858,8 @@ class Auth {
     async register(body: ShopperCustomersTypes.CustomerRegistration) {
         const {
             customer: {login},
-            password
+            password,
+            ...parameters
         } = body
 
         // login is optional field from isomorphic library
@@ -855,10 +875,13 @@ class Auth {
             },
             body
         })
-        await this.loginRegisteredUserB2C({
-            username: login,
-            password
-        })
+        await this.loginRegisteredUserB2C(
+            {
+                username: login,
+                password
+            },
+            parameters
+        )
         return res
     }
 
@@ -866,7 +889,10 @@ class Auth {
      * A wrapper method for commerce-sdk-isomorphic helper: loginRegisteredUserB2C.
      *
      */
-    async loginRegisteredUserB2C(credentials: LoginRegisteredUserB2CCredentials) {
+    async loginRegisteredUserB2C(
+        credentials: LoginRegisteredUserB2CCredentials,
+        parameters: helpers.CustomRequestBody = {}
+    ) {
         if (this.clientSecret && onClient() && this.clientSecret !== SLAS_SECRET_PLACEHOLDER) {
             this.logWarning(SLAS_SECRET_WARNING_MSG)
         }
@@ -884,6 +910,9 @@ class Auth {
                 redirectURI,
                 dnt: dntPref,
                 ...(usid && {usid})
+            },
+            {
+                body: parameters
             }
         )
         this.handleTokenResponse(token, isGuest)
@@ -1066,12 +1095,14 @@ class Auth {
     async authorizeIDP(parameters: AuthorizeIDPParams) {
         const redirectURI = parameters.redirectURI || this.redirectURI
         const usid = this.get('usid')
+        const customParameters = this.extractCustomParameters(parameters)
         const {url, codeVerifier} = await helpers.authorizeIDP(
             this.client,
             {
                 redirectURI,
                 hint: parameters.hint,
-                ...(usid && {usid})
+                ...(usid && {usid}),
+                ...customParameters
             },
             this.isPrivate
         )

--- a/packages/commerce-sdk-react/src/utils.test.ts
+++ b/packages/commerce-sdk-react/src/utils.test.ts
@@ -15,4 +15,20 @@ describe('Utils', () => {
         const isURL = utils.isAbsoluteUrl(url)
         expect(isURL).toBe(expected)
     })
+    test('extractCustomParameters only returns custom parameters', () => {
+        const parameters = {
+            c_param1: 'this is a custom',
+            param1: 'this is not a custom',
+            c_param2: 1,
+            param2: 2,
+            param3: false,
+            c_param3: true
+        }
+        const customParameters = utils.extractCustomParameters(parameters)
+        expect(customParameters).toEqual({
+            c_param1: 'this is a custom',
+            c_param2: 1,
+            c_param3: true
+        })
+    })
 })

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -154,7 +154,7 @@ export const stringToBase64 =
  * @returns new object containing only custom parameters
  */
 export const extractCustomParameters = (
-    parameters: {[s: string]: string | number | boolean | string[] | number[]} | null
+    parameters: {[key: string]: string | number | boolean | string[] | number[]} | null
 ): helpers.CustomQueryParameters | helpers.CustomRequestBody => {
     if (typeof parameters !== 'object' || parameters === null) {
         throw new Error('Invalid input. Expecting an object as an input.')

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -7,6 +7,7 @@
 
 import Cookies, {CookieAttributes} from 'js-cookie'
 import {IFRAME_HOST_ALLOW_LIST} from './constant'
+import {helpers} from 'commerce-sdk-isomorphic'
 
 /** Utility to determine if you are on the browser (client) or not. */
 export const onClient = (): boolean => typeof window !== 'undefined'
@@ -143,3 +144,20 @@ export const stringToBase64 =
     typeof window === 'object' && typeof window.document === 'object'
         ? btoa
         : (unencoded: string): string => Buffer.from(unencoded).toString('base64')
+
+/**
+ * Extracts custom parameters from a set of SCAPI parameters
+ *
+ * Custom parameters are identified by the 'c_' prefix before their key
+ *
+ * @param parameters object containing all parameters for a SCAPI / SLAS call
+ * @returns new object containing only custom parameters
+ */
+export const extractCustomParameters = (
+    parameters: {[s: string]: string | number | boolean | string[] | number[]} | null
+): helpers.CustomQueryParameters => {
+    if (typeof parameters !== 'object' || parameters === null) {
+        throw new Error('Invalid input. Expecting an object as an input.')
+    }
+    return Object.fromEntries(Object.entries(parameters).filter(([key]) => key.startsWith('c_')))
+}

--- a/packages/commerce-sdk-react/src/utils.ts
+++ b/packages/commerce-sdk-react/src/utils.ts
@@ -155,7 +155,7 @@ export const stringToBase64 =
  */
 export const extractCustomParameters = (
     parameters: {[s: string]: string | number | boolean | string[] | number[]} | null
-): helpers.CustomQueryParameters => {
+): helpers.CustomQueryParameters | helpers.CustomRequestBody => {
     if (typeof parameters !== 'object' || parameters === null) {
         throw new Error('Invalid input. Expecting an object as an input.')
     }


### PR DESCRIPTION
Follow up to https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/186

This PR updates the `loginGuestUser`, `loginRegisteredUserB2C`, and `authorizeIDP` so that custom parameters can be sent to SLAS `/authorize`  calls.

Testing the changes:
* New tests for sending custom parameters to the SLAS helper functions were added. Verify the commerce-sdk-react tests all pass
* Modify use-auth-modal so that custom parameters are sent when logging in or registering
  * Verify that custom parameters are not included when calling ShopperCustomers during registration
  * Verify that custom parameters are included when calling SLAS /authorize or /login