### PR TITLE
Update BasketId sent to MIAW when one is created

### DIFF
--- a/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
@@ -122,15 +122,13 @@ function ShopperAgentWindow({commerceAgent, locale, domainUrl, basketId}) {
             window.embeddedservice_bootstrap.prechatAPI.setHiddenPrechatFields({
                 DomainURL: domainUrl,
                 SiteId: siteId,
-                BasketId: basketId,
                 Locale: locale,
                 OrganizationId: commerceOrgId,
                 UsId: usid
             })
         })
 
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        window.addEventListener('onEmbeddedMessagingWindowMaximized', (e) => {
+        window.addEventListener('onEmbeddedMessagingWindowMaximized', () => {
             const zIndex = theme.zIndices.sticky + 1
             const embeddedMessagingFrame = document.body.querySelector(
                 'div.embedded-messaging iframe'
@@ -140,6 +138,15 @@ function ShopperAgentWindow({commerceAgent, locale, domainUrl, basketId}) {
             }
         })
     }, [commerceAgent])
+
+    // whenever the basketId changes, update the hidden prechat fields
+    useEffect(() => {
+        window.addEventListener('onEmbeddedMessagingButtonClicked', function () {
+            window.embeddedservice_bootstrap.prechatAPI.setHiddenPrechatFields({
+                BasketId: basketId
+            })
+        })
+    }, [commerceAgent, basketId])
 
     // Load the embedded messaging script
     const scriptLoadStatus = useScript(scriptSourceUrl)

--- a/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
@@ -161,22 +161,34 @@ describe('ShopperAgent Component', () => {
         expect(mockEmbeddedService.init).not.toHaveBeenCalled()
     })
 
-    test('should call the preChatAPI with the correct parameters', async () => {
+    test('should set prechat fields correctly on different events', async () => {
         useScript.mockReturnValue({loaded: true, error: false})
         render(<ShopperAgent {...defaultProps} />)
 
+        // Test initial prechat fields set on ready event
         await act(async () => {
             window.dispatchEvent(new Event('onEmbeddedMessagingReady'))
         })
 
-        // Verify embedded service initialization
         expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
-            BasketId: '4a67cda5b1b9325a29207854c1',
             DomainURL: defaultProps.domainUrl,
+            SiteId: commerceAgentSettings.siteId,
             Locale: defaultProps.locale,
             OrganizationId: commerceAgentSettings.commerceOrgId,
             SiteId: commerceAgentSettings.siteId,
             UsId: 'test-usid'
+        })
+
+        // Reset mock to test button click event
+        mockEmbeddedService.prechatAPI.setHiddenPrechatFields.mockClear()
+
+        // Test BasketId update when button is clicked
+        await act(async () => {
+            window.dispatchEvent(new Event('onEmbeddedMessagingButtonClicked'))
+        })
+
+        expect(mockEmbeddedService.prechatAPI.setHiddenPrechatFields).toHaveBeenCalledWith({
+            BasketId: defaultProps.basketId
         })
     })
     test('should not render when commerce agent settings are invalid', () => {


### PR DESCRIPTION
Update BasketId sent to MIAW when one is created

# Description

This PR ensures that if a user navigates to the pwa-kit site without a basket, then creates one before calling chat, this new basket ID is sent into MIAW

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
