### PR TITLE
[App Extensibility ⚙️] Update `create_mrt` GitHub Action for `-extensibility-preview.04` release (@W-17910075@)

### DIFF
--- a/.github/actions/create_mrt/action.yml
+++ b/.github/actions/create_mrt/action.yml
@@ -14,5 +14,5 @@ runs:
       working-directory: ${{ inputs.cwd }}
       run: |-
         # Add credentials file at ~/.mobify so we can upload to Mobify Cloud
-        npm run save-credentials --prefix packages/template-retail-react-app -- --user "${{inputs.mobify_user}}" --key "${{inputs.mobify_api_key}}"
+        npm run save-credentials --prefix packages/template-typescript-minimal -- --user "${{inputs.mobify_user}}" --key "${{inputs.mobify_api_key}}"
       shell: bash


### PR DESCRIPTION
The PR is updating the `create_mrt` action to use `template-typescript-minimal` folder for the release of `-extensibility-preview.4` with the latest changes merged in [feature/extensibility-v2](https://github.com/SalesforceCommerceCloud/pwa-kit/tree/feature/extensibility-v2) branch.
```
@salesforce/commerce-sdk-react             v3.3.0-extensibility-preview.4 packages/commerce-sdk-react
@salesforce/extension-chakra-store-locator v0.1.0-extensibility-preview.4 packages/extension-chakra-store-locator
@salesforce/extension-chakra-storefront    v0.1.0-extensibility-preview.4 packages/extension-chakra-storefront
@salesforce/extension-starter              v0.1.0-extensibility-preview.4 packages/extension-starter              (PRIVATE)
internal-lib-build                         v4.0.0-extensibility-preview.4 packages/internal-lib-build             (PRIVATE)
@salesforce/pwa-kit-create-app             v4.0.0-extensibility-preview.4 packages/pwa-kit-create-app
@salesforce/pwa-kit-dev                    v4.0.0-extensibility-preview.4 packages/pwa-kit-dev
@salesforce/pwa-kit-extension-sdk          v4.0.0-extensibility-preview.4 packages/pwa-kit-extension-sdk
@salesforce/pwa-kit-react-sdk              v4.0.0-extensibility-preview.4 packages/pwa-kit-react-sdk
@salesforce/pwa-kit-runtime                v4.0.0-extensibility-preview.4 packages/pwa-kit-runtime
template-express-minimal                   v4.0.0-extensibility-preview.4 packages/template-express-minimal       (PRIVATE)
template-mrt-reference-app                 v4.0.0-extensibility-preview.4 packages/template-mrt-reference-app     (PRIVATE)
typescript-minimal                         v4.0.0-extensibility-preview.4 packages/template-typescript-minimal    (PRIVATE)
test-commerce-sdk-react                    v4.0.0-extensibility-preview.4 packages/test-commerce-sdk-react        (PRIVATE)
````

