### PR TITLE
Fix a11y e2e flaky tests

### DIFF
--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -595,8 +595,8 @@ export const wishlistFlow = async ({page, registeredUserCredentials, a11y = {}})
     }
 
     // The consent form does not stick after registration
-    await page.waitForLoadState()
     await answerConsentTrackingForm(page)
+    await page.waitForLoadState()
 
     await expect(page.getByRole('heading', {name: /Account Details/i})).toBeVisible({
         timeout: 20000

--- a/e2e/tests/a11y/desktop/a11y-snapshot-test.spec.js
+++ b/e2e/tests/a11y/desktop/a11y-snapshot-test.spec.js
@@ -142,8 +142,8 @@ test.describe('Registered Account pages', () => {
             })
         }
         // The consent form does not stick after registration
-        await page.waitForLoadState()
         await answerConsentTrackingForm(page)
+        await page.waitForLoadState()
 
         await expect(page.getByRole('heading', {name: /Account Details/i})).toBeVisible({
             timeout: 20000


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
It appears that the test seems to be flaky when it runs 
- A11y for Registered shopper happy path flow
- A11y for Wishlist page flow


Root cause, the DNT banner seems to be appeared and the assertion to look for "Account Detail' timeout alot.

The fix is to add         `await page.waitForLoadState()`  to ensure the page is loaded before running the assertion for it
<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
