### PR TITLE
Update datacloud config (@W-18465775@)

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Other Changes
 
 - Improved the layout of product tiles in product scroll and product list [#2446](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2446)
+- Update the configuration of datacloud [#2467](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2467)
 
 ## v6.1.0-dev (Feb 18, 2025)
 

--- a/packages/template-retail-react-app/app/hooks/use-datacloud.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-datacloud.test.js
@@ -32,8 +32,8 @@ import {
 const dataCloudConfig = {
     app: {
         dataCloudAPI: {
-            appSourceId: '6ebc532a-2247-48e9-8300-d8c2b84eb463',
-            tenantId: 'mvst0mlfmrsd8zbwg8zgmytbg1'
+            appSourceId: 'f22ae831-ac03-4bf6-afc1-3a0b19f1ea8e',
+            tenantId: 'mmydmztgh04dczjzmnsw0zd0g8.pc-rnd'
         },
         defaultSite: 'test-site'
     }

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -55,8 +55,8 @@ module.exports = {
             isProduction: false
         },
         dataCloudAPI: {
-            appSourceId: 'fb81edab-24c6-4b40-8684-b67334dfdf32',
-            tenantId: 'mmyw8zrxhfsg09lfmzrd1zjqmg'
+            appSourceId: 'f22ae831-ac03-4bf6-afc1-3a0b19f1ea8e',
+            tenantId: 'mmydmztgh04dczjzmnsw0zd0g8.pc-rnd'
         }
     },
     externals: [],

--- a/packages/template-retail-react-app/config/mocks/default.js
+++ b/packages/template-retail-react-app/config/mocks/default.js
@@ -97,8 +97,8 @@ module.exports = {
             isProduction: false
         },
         dataCloudAPI: {
-            appSourceId: '23df7335-2e9d-4fbc-bc34-7e93649e69b7',
-            tenantId: '5zqheixqu9vji7spdkzxwh4hpz'
+            appSourceId: 'f22ae831-ac03-4bf6-afc1-3a0b19f1ea8e',
+            tenantId: 'mmydmztgh04dczjzmnsw0zd0g8.pc-rnd'
         }
     },
     // This list contains server-side only libraries that you don't want to be compiled by webpack


### PR DESCRIPTION
This PR makes sure that there is no longer errors when sending off datacloud events.

## How to test drive the PR

1. `npm ci` at the monorepo root
2. `npm start` to start the dev server
3. Verify that the resulting homepage sends an event to the `c360a` domain and that it returns a successful response.
4. Navigate to another page, and also verify that it fires a datacloud event too.