### PR TITLE
@W-18725883 feat: unit test coverage for pagination

### DIFF
--- a/packages/template-retail-react-app/app/components/pagination/index.test.js
+++ b/packages/template-retail-react-app/app/components/pagination/index.test.js
@@ -5,21 +5,89 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import React from 'react'
+import {screen, fireEvent} from '@testing-library/react'
 import Pagination from '@salesforce/retail-react-app/app/components/pagination/index'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 
-const mockUrls = ['/test?offset=0', '/test?offset=25', '/test?offset=50', '/test?offset=75']
-const mockCurrentUrl = '/test?offset=25'
+// mock the useHistory
+const mockPush = jest.fn()
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useHistory: () => ({
+        push: mockPush
+    })
+}))
 
-test('Renders Breadcrum', () => {
-    const {getAllByRole} = renderWithProviders(
-        <Pagination urls={mockUrls} currentUrl={mockCurrentUrl} />
-    )
+describe('Pagination', () => {
+    const mockUrls = ['/test?offset=0', '/test?offset=25', '/test?offset=50', '/test?offset=75']
+    const defaultProps = {
+        urls: mockUrls,
+        currentURL: '/test?offset=25'
+    }
 
-    const [prev, next] = getAllByRole('link')
-    const option = getAllByRole('option')
+    beforeEach(() => {
+        mockPush.mockClear()
+    })
 
-    expect(prev).toBeDefined()
-    expect(next).toBeDefined()
-    expect(option).toHaveLength(mockUrls.length)
+    it('Renders Pagination and its elements', () => {
+        const {getAllByRole} = renderWithProviders(
+            <Pagination {...defaultProps} />
+        )
+        const [prev, next] = getAllByRole('link')
+        const option = getAllByRole('option')
+        expect(prev).toBeDefined()
+        expect(next).toBeDefined()
+        expect(option).toHaveLength(mockUrls.length)
+    })
+
+    it('shows correct number of pages', () => {
+        renderWithProviders(<Pagination {...defaultProps} />)
+        expect(screen.getByText('of 4')).toBeInTheDocument()
+    })
+
+    it('shows correct current page in select options', () => {
+        renderWithProviders(<Pagination {...defaultProps} />)
+        expect(screen.getByLabelText('Select page number').value).toBe('/test?offset=25')
+    })
+
+    it('disables disabled previous button on first page of contents', () => {
+        renderWithProviders(
+            <Pagination {...defaultProps} currentURL="/test?offset=0" />
+        )
+        const prev = screen.getByLabelText('Previous Page')
+        expect(prev).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('disables disabled next button on last page', () => {
+        renderWithProviders(
+            <Pagination {...defaultProps} currentURL="/test?offset=75" />
+        )
+        const next = screen.getByLabelText('Next Page')
+        expect(next).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('navigation buttons are enabled on middle pages', () => {
+        renderWithProviders(<Pagination {...defaultProps} />)
+        const prevButton = screen.getByLabelText('Previous Page')
+        const nextButton = screen.getByLabelText('Next Page')
+        expect(prevButton).toHaveAttribute('aria-disabled', 'false')
+        expect(nextButton).toHaveAttribute('aria-disabled', 'false')
+    })
+
+    it('navigates to selected page when using pages dropdown', () => {
+        renderWithProviders(<Pagination {...defaultProps} />)
+        const select = screen.getByLabelText('Select page number')
+        fireEvent.change(select, {target: {value: '/test?offset=50'}})
+        expect(mockPush).toHaveBeenCalledWith('/test?offset=50')
+    })
+
+    it('renders all page options in select', () => {
+        renderWithProviders(<Pagination {...defaultProps} />)
+        const select = screen.getByLabelText('Select page number')
+        expect(select.options.length).toBe(mockUrls.length)
+        mockUrls.forEach((url, index) => {
+            expect(select.options[index].value).toBe(url)
+            expect(select.options[index].text).toBe(String(index + 1))
+        })
+    })
 })

--- a/packages/template-retail-react-app/app/components/pagination/index.test.js
+++ b/packages/template-retail-react-app/app/components/pagination/index.test.js
@@ -30,9 +30,7 @@ describe('Pagination', () => {
     })
 
     it('Renders Pagination and its elements', () => {
-        const {getAllByRole} = renderWithProviders(
-            <Pagination {...defaultProps} />
-        )
+        const {getAllByRole} = renderWithProviders(<Pagination {...defaultProps} />)
         const [prev, next] = getAllByRole('link')
         const option = getAllByRole('option')
         expect(prev).toBeDefined()
@@ -51,17 +49,13 @@ describe('Pagination', () => {
     })
 
     it('disables disabled previous button on first page of contents', () => {
-        renderWithProviders(
-            <Pagination {...defaultProps} currentURL="/test?offset=0" />
-        )
+        renderWithProviders(<Pagination {...defaultProps} currentURL="/test?offset=0" />)
         const prev = screen.getByLabelText('Previous Page')
         expect(prev).toHaveAttribute('aria-disabled', 'true')
     })
 
     it('disables disabled next button on last page', () => {
-        renderWithProviders(
-            <Pagination {...defaultProps} currentURL="/test?offset=75" />
-        )
+        renderWithProviders(<Pagination {...defaultProps} currentURL="/test?offset=75" />)
         const next = screen.getByLabelText('Next Page')
         expect(next).toHaveAttribute('aria-disabled', 'true')
     })
@@ -84,7 +78,7 @@ describe('Pagination', () => {
     it('renders all page options in select', () => {
         renderWithProviders(<Pagination {...defaultProps} />)
         const select = screen.getByLabelText('Select page number')
-        expect(select.options.length).toBe(mockUrls.length)
+        expect(select.options).toHaveLength(mockUrls.length)
         mockUrls.forEach((url, index) => {
             expect(select.options[index].value).toBe(url)
             expect(select.options[index].text).toBe(String(index + 1))


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
