### PR TITLE
@W-18731707: add pwa-kit pre chat variables

### DIFF
--- a/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import React, {useEffect, useState} from 'react'
+import React, {useEffect} from 'react'
 import useScript from '@salesforce/retail-react-app/app/hooks/use-script'
 import {useUsid} from '@salesforce/commerce-sdk-react'
 import PropTypes from 'prop-types'
@@ -109,7 +109,8 @@ function ShopperAgentWindow({commerceAgentConfiguration, locale, domainUrl, bask
                 SiteId: siteId,
                 Locale: locale,
                 OrganizationId: commerceOrgId,
-                UsId: usid
+                UsId: usid,
+                PwaKit: true
             })
         }
 
@@ -186,7 +187,7 @@ ShopperAgentWindow.propTypes = {
 
 /**
  * ShopperAgent component that initializes and manages the embedded messaging service
- * @param {Object} props - Component props
+ * @param {Object} props - Component props 
  * @param {Object} props.commerceAgentConfiguration - Commerce agent settings
  * @param {string} props.domainUrl - The domain URL for the embedded messaging script
  * @param {string} props.basketId - The basket ID for the embedded messaging script

--- a/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
@@ -190,7 +190,8 @@ describe('ShopperAgent Component', () => {
             SiteId: commerceAgentSettings.siteId,
             Locale: defaultProps.locale,
             OrganizationId: commerceAgentSettings.commerceOrgId,
-            UsId: 'test-usid'
+            UsId: 'test-usid',
+            PwaKit: true
         })
 
         // Reset mock to test button click event


### PR DESCRIPTION
[W-18731707](https://gus.lightning.force.com/a07EE00002FoMFTYA3) Add PWA Kit platform identification to ShopperAgent prechat fields

**Description**

This PR enhances the ShopperAgent component to include a PwaKit: true prechat field when initializing embedded messaging. This addition enables Salesforce Service Cloud to automatically detect when conversations are originating from PWA Kit storefronts, providing better platform-specific support and analytics.

**Changes made:**
- Added PwaKit: true to the hidden prechat fields in the ShopperAgent component
- Updated test cases to validate the new prechat field
- Fixed linting warning by removing unused useState import

**Types of Changes**
  [x] New feature (non-breaking change that adds functionality)
  [ ] Bug fix (non-breaking change that fixes an issue)
  [ ] Documentation update
  [ ] Breaking change (could cause existing functionality to not work as expected)
  [ ] Other changes (non-breaking changes that does not fit any of the above)
  
**Checklists**
[x] Changes are covered by test cases
