### PR TITLE
[Chakra v3 upgrade] Migrate the Login, Redirect, and Registration pages (@W-18672771@)

### DIFF
--- a/packages/extension-chakra-storefront/jest.config.js
+++ b/packages/extension-chakra-storefront/jest.config.js
@@ -32,9 +32,20 @@ module.exports = {
         '<rootDir>/src/components/swatch-group/**/*.test.js',
         '<rootDir>/src/components/toaster/**/*.test.jsx',
         '<rootDir>/src/components/list-menu/**/*.test.js',
+        '<rootDir>/src/components/login/**/*.test.js',
+        '<rootDir>/src/components/register/**/*.test.js',
+        '<rootDir>/src/components/email-confirmation/**/*.test.js',
+        '<rootDir>/src/components/field/**/*.test.js',
+        '<rootDir>/src/components/reset-password/**/*.test.js',
+        '<rootDir>/src/components/with-registration/**/*.test.js',
         '<rootDir>/src/pages/home/**/*.test.js',
+        // '<rootDir>/src/pages/login/**/*.test.js',  // TODO: enable after Account page has been migrated
+        '<rootDir>/src/pages/login-redirect/**/*.test.js',
+        '<rootDir>/src/pages/social-login-redirect/**/*.test.js',
+        '<rootDir>/src/pages/registration/**/*.test.js',
         '<rootDir>/src/utils/responsive-image.test.js',
         '<rootDir>/src/hooks/use-toast.test.js'
+        // '<rootDir>/src/hooks/use-auth-modal.test.js' // TODO: enable after Account page has been migrated
     ],
     moduleNameMapper: {
         ...base.moduleNameMapper,

--- a/packages/extension-chakra-storefront/src/components/login/index.jsx
+++ b/packages/extension-chakra-storefront/src/components/login/index.jsx
@@ -48,14 +48,16 @@ const LoginForm = ({
                 data-testid="sf-auth-modal-form"
             >
                 {form.formState.errors?.global && (
-                    <Alert status="error" marginBottom={8}>
-                        <AlertIcon color="red.500" boxSize={4} />
-                        <Text fontSize="sm" ml={3}>
+                    <Alert.Root status="error" marginBottom={8}>
+                        <Alert.Indicator>
+                            <AlertIcon color="red.500" boxSize={4} />
+                        </Alert.Indicator>
+                        <Alert.Description fontSize="sm">
                             {form.formState.errors.global.message}
-                        </Text>
-                    </Alert>
+                        </Alert.Description>
+                    </Alert.Root>
                 )}
-                <Stack spacing={6}>
+                <Stack gap={6}>
                     {isPasswordlessEnabled ? (
                         <PasswordlessLogin
                             form={form}

--- a/packages/extension-chakra-storefront/src/components/register/index.jsx
+++ b/packages/extension-chakra-storefront/src/components/register/index.jsx
@@ -8,8 +8,8 @@
 import React, {Fragment} from 'react'
 import PropTypes from 'prop-types'
 import {FormattedMessage} from 'react-intl'
-import {Alert, Button, Stack, Text, Link as ChakraLink} from '@chakra-ui/react'
-import {BrandLogo} from '../../components/icons'
+import {Alert, Button, Stack, Text} from '@chakra-ui/react'
+import {AlertIcon, BrandLogo} from '../../components/icons'
 import {noop} from '../../utils/utils'
 import RegistrationFields from '../../components/forms/registration-fields'
 import Link from '../../components/link'
@@ -41,7 +41,9 @@ const RegisterForm = ({submitForm, clickSignIn = noop, form}) => {
                 <Stack paddingTop={8} gap={8} paddingLeft={4} paddingRight={4}>
                     {form.formState.errors?.global && (
                         <Alert.Root status="error">
-                            <Alert.Indicator />
+                            <Alert.Indicator>
+                                <AlertIcon color="red.500" boxSize={4} />
+                            </Alert.Indicator>
                             <Alert.Description>
                                 {form.formState.errors.global.message}
                             </Alert.Description>

--- a/packages/extension-chakra-storefront/src/pages/index.tsx
+++ b/packages/extension-chakra-storefront/src/pages/index.tsx
@@ -25,19 +25,19 @@ const Checkout = loadable(() => import('overridable!./checkout'), {
 //     fallback
 // })
 const Home = loadable(() => import('overridable!./home'), {fallback})
-// const Login = loadable(() => import('overridable!./login'), {fallback})
-// const Registration = loadable(() => import('overridable!./registration'), {
-//     fallback
-// })
+const Login = loadable(() => import('overridable!./login'), {fallback})
+const Registration = loadable(() => import('overridable!./registration'), {
+    fallback
+})
 // const ResetPassword = loadable(() => import('overridable!./reset-password'), {fallback})
-// const LoginRedirect = loadable(() => import('overridable!./login-redirect'), {fallback})
+const LoginRedirect = loadable(() => import('overridable!./login-redirect'), {fallback})
 const ProductDetail = loadable(() => import('overridable!./product-detail'), {fallback})
 const ProductList = loadable(() => import('overridable!./product-list'), {
     fallback
 })
-// const SocialLoginRedirect = loadable(() => import('overridable!./social-login-redirect'), {
-//     fallback
-// })
+const SocialLoginRedirect = loadable(() => import('overridable!./social-login-redirect'), {
+    fallback
+})
 // const Wishlist = loadable(() => import('overridable!./account/wishlist'), {
 //     fallback
 // })
@@ -50,12 +50,13 @@ const ProductList = loadable(() => import('overridable!./product-list'), {
 // Checkout.displayName = 'Checkout'
 // CheckoutConfirmation.displayName = 'CheckoutConfirmation'
 Home.displayName = 'Home'
-// Login.displayName = 'Login'
-// Registration.displayName = 'Registration'
+Login.displayName = 'Login'
+Registration.displayName = 'Registration'
 // ResetPassword.displayName = 'ResetPassword'
-// LoginRedirect.displayName = 'LoginRedirect'
+LoginRedirect.displayName = 'LoginRedirect'
 ProductDetail.displayName = 'ProductDetail'
 ProductList.displayName = 'ProductList'
+SocialLoginRedirect.displayName = 'SocialLoginRedirect'
 
 export {
     // Account,
@@ -63,11 +64,11 @@ export {
     Checkout,
     // CheckoutConfirmation,
     Home,
-    // Login,
-    // Registration,
+    Login,
+    Registration,
     // ResetPassword,
-    // LoginRedirect,
+    LoginRedirect,
     ProductDetail,
-    ProductList
-    // SocialLoginRedirect
+    ProductList,
+    SocialLoginRedirect
 }

--- a/packages/extension-chakra-storefront/src/pages/social-login-redirect/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/social-login-redirect/index.jsx
@@ -8,7 +8,6 @@
 import React, {useEffect, useState} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
 import {Alert, Box, Container, Stack, Text, Spinner} from '@chakra-ui/react'
-import {AlertIcon} from '../../components/icons'
 
 // Hooks
 import useNavigation from '../../hooks/use-navigation'
@@ -91,22 +90,22 @@ const SocialLoginRedirect = () => {
                 borderRadius="base"
             >
                 {error && (
-                    <Alert status="error" marginBottom={8}>
-                        <AlertIcon color="red.500" boxSize={4} />
+                    <Alert.Root status="error" marginBottom={8}>
+                        <Alert.Indicator color="red.500" boxSize={4} />
                         <Text fontSize="sm" ml={3}>
                             {error}
                         </Text>
-                    </Alert>
+                    </Alert.Root>
                 )}
-                <Stack justify="center" align="center" spacing={8} marginBottom={8}>
+                <Stack justify="center" align="center" gap={8} marginBottom={8}>
                     <Spinner opacity={0.85} color="blue.600" animationDuration="0.8s" size="lg" />
-                    <Text align="center" fontSize="xl" fontWeight="semibold">
+                    <Text textAlign="center" fontSize="xl" fontWeight="semibold">
                         <FormattedMessage
                             id="social_login_redirect.message.authenticating"
                             defaultMessage="Authenticating..."
                         />
                     </Text>
-                    <Text align="center" fontSize="m">
+                    <Text textAlign="center" fontSize="m">
                         <FormattedMessage
                             id="social_login_redirect.message.redirect_link"
                             defaultMessage="If you are not automatically redirected, click <link>this link</link> to proceed."

--- a/packages/extension-chakra-storefront/src/pages/social-login-redirect/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/social-login-redirect/index.jsx
@@ -18,6 +18,7 @@ import {useAppOrigin} from '../../hooks/use-app-origin'
 import {useExtensionConfig} from '../../hooks/use-extension-config'
 import {getSessionJSONItem, clearSessionJSONItem, buildRedirectURI} from '../../utils/utils'
 import {API_ERROR_MESSAGE} from '../../constants'
+import {AlertIcon} from '../../components/icons'
 
 const SocialLoginRedirect = () => {
     const {formatMessage} = useIntl()
@@ -91,7 +92,9 @@ const SocialLoginRedirect = () => {
             >
                 {error && (
                     <Alert.Root status="error" marginBottom={8}>
-                        <Alert.Indicator color="red.500" boxSize={4} />
+                        <Alert.Indicator>
+                            <AlertIcon color="red.500" boxSize={4} />
+                        </Alert.Indicator>
                         <Text fontSize="sm" ml={3}>
                             {error}
                         </Text>

--- a/packages/extension-chakra-storefront/src/setup-app.tsx
+++ b/packages/extension-chakra-storefront/src/setup-app.tsx
@@ -61,19 +61,19 @@ class ChakraStorefront extends ApplicationExtension<Config> {
                 component: Pages.Home,
                 exact: true
             },
-            // {
-            //     path: [
-            //         config.pages.Login && config.pages.Login.path,
-            //         config.login.passwordless.enabled && config.login.passwordless.landingPath
-            //     ].filter(Boolean),
-            //     component: Pages.Login,
-            //     exact: true
-            // },
-            // {
-            //     path: config.pages.Registration && config.pages.Registration.path,
-            //     component: Pages.Registration,
-            //     exact: true
-            // },
+            {
+                path: [
+                    config.pages.Login && config.pages.Login.path,
+                    config.login.passwordless.enabled && config.login.passwordless.landingPath
+                ].filter(Boolean),
+                component: Pages.Login,
+                exact: true
+            },
+            {
+                path: config.pages.Registration && config.pages.Registration.path,
+                component: Pages.Registration,
+                exact: true
+            },
             // {
             //     path: [
             //         config.pages.ResetPassword && config.pages.ResetPassword.path,
@@ -95,16 +95,16 @@ class ChakraStorefront extends ApplicationExtension<Config> {
             //     path: config.pages.CheckoutConfirmation && config.pages.CheckoutConfirmation.path,
             //     component: Pages.CheckoutConfirmation
             // },
-            // {
-            //     path: config.pages.LoginRedirect && config.pages.LoginRedirect.path,
-            //     component: Pages.LoginRedirect,
-            //     exact: true
-            // },
-            // {
-            //     path: config.login.social.enabled && config.login.social.redirectURI,
-            //     component: Pages.SocialLoginRedirect,
-            //     exact: true
-            // },
+            {
+                path: config.pages.LoginRedirect && config.pages.LoginRedirect.path,
+                component: Pages.LoginRedirect,
+                exact: true
+            },
+            {
+                path: config.login.social.enabled && config.login.social.redirectURI,
+                component: Pages.SocialLoginRedirect,
+                exact: true
+            },
             // {
             //     path: config.pages.Cart && config.pages.Cart.path,
             //     component: Pages.Cart,


### PR DESCRIPTION
In this PR, we don't need to migrate a lot of components because the work was done in previous PRs. This PR primarily re-enabled some pages and routes and made sure that visually the pages look all right.

## How to test drive the PR

0. In extension-chakra-storefront/config/default.json, configure `login.social.enabled` to `true`.
1. Run `npm start` in the template-typescript-minimal
2. Then navigate to the following pages (and compare with the corresponding pages on https://pwa-kit.mobify-storefront.com/):
	- http://localhost:3000/login
	- http://localhost:3000/registration
	- http://localhost:3000/callback
	- http://localhost:3000/social-callback

Here are some screenshots of what the pages should look like:

![Arc 2025-06-19 at 15 14 06](https://github.com/user-attachments/assets/4a2225cd-fd12-4ec5-9ce4-59f75c9d132f)
![Arc 2025-06-19 at 15 14 58](https://github.com/user-attachments/assets/57009ba5-50a0-474c-887b-a0406a47db34)
![Arc 2025-06-19 at 15 14 34](https://github.com/user-attachments/assets/878addf9-e43c-4a30-9f83-65260af5bf0d)
