### PR TITLE
@W-18779406 - location based changes for v4 store-locator

### DIFF
--- a/packages/template-retail-react-app/app/components/se-input-handler/index.jsx
+++ b/packages/template-retail-react-app/app/components/se-input-handler/index.jsx
@@ -61,26 +61,13 @@ const SeInputHandler = ({onOpenStoreLocator}) => {
 
         const urlParams = new URLSearchParams(location.search)
         const hasSeParamKeys = ['lat', 'lng', 'zip', 'city', 'store', 'country']
-        const hasExternalQuery =
-            urlParams.has('q') || urlParams.has('search') || urlParams.has('query')
 
-        if (hasExternalQuery) {
-            setTimeout(onOpenStoreLocator, 1500)
-        } else {
-            onOpenStoreLocator()
-        }
-
+        onOpenStoreLocator()
         setShouldOpenModal(false)
 
         const hasSeParams = hasSeParamKeys.some((key) => urlParams.has(key))
         if (hasSeParams) {
-            const cleanParams = new URLSearchParams(location.search)
-            hasSeParamKeys.forEach((key) => cleanParams.delete(key))
-
-            const cleanSearch = cleanParams.toString()
-            const newUrl = location.pathname + (cleanSearch ? `?${cleanSearch}` : '')
-
-            history.replace(newUrl)
+            cleanURLParams(location, history, hasSeParamKeys)
         }
     }, [
         shouldOpenModal,
@@ -93,6 +80,16 @@ const SeInputHandler = ({onOpenStoreLocator}) => {
     ])
 
     return null
+}
+
+export const cleanURLParams = (location, history, hasSeParamKeys) => {
+    const cleanParams = new URLSearchParams(location.search)
+    hasSeParamKeys.forEach((key) => cleanParams.delete(key))
+
+    const cleanSearch = cleanParams.toString()
+    const newUrl = location.pathname + (cleanSearch ? `?${cleanSearch}` : '')
+
+    history.replace(newUrl)
 }
 
 SeInputHandler.propTypes = {

--- a/packages/template-retail-react-app/app/components/se-input-handler/index.jsx
+++ b/packages/template-retail-react-app/app/components/se-input-handler/index.jsx
@@ -21,60 +21,70 @@ const SeInputHandler = ({onOpenStoreLocator}) => {
         useSeStoreSelection()
 
     const {setParams} = useStoreLocatorParams()
-
-    const storeLocatorContext = useContext(StoreLocatorContext)
-    const selectedStoreId = storeLocatorContext?.state?.selectedStoreId
+    const {setState: setStoreLocatorState} = useContext(StoreLocatorContext) || {}
 
     useEffect(() => {
         const urlParams = new URLSearchParams(location.search)
         processSeParameters(urlParams)
     }, [location.search, processSeParameters])
 
+    // Handle store locator params updates
     useEffect(() => {
-        if (storeLocatorParams) {
-            setParams(storeLocatorParams)
+        if (!storeLocatorParams) return
+        setParams(storeLocatorParams)
+        const storeName = new URLSearchParams(location.search).get('store')
+        if (setStoreLocatorState && !storeName) {
+            if (storeLocatorParams.postalCode && storeLocatorParams.countryCode) {
+                setStoreLocatorState((prev) => ({
+                    ...prev,
+                    mode: 'input',
+                    formValues: {
+                        postalCode: storeLocatorParams.postalCode,
+                        countryCode: storeLocatorParams.countryCode
+                    }
+                }))
+            } else if (storeLocatorParams.latitude && storeLocatorParams.longitude) {
+                setStoreLocatorState((prev) => ({
+                    ...prev,
+                    mode: 'device',
+                    deviceCoordinates: {
+                        latitude: storeLocatorParams.latitude,
+                        longitude: storeLocatorParams.longitude
+                    }
+                }))
+            }
         }
-    }, [storeLocatorParams, setParams])
+    }, [storeLocatorParams, setParams, setStoreLocatorState])
 
     useEffect(() => {
         if (!shouldOpenModal || !storeLocatorParams) return
 
-        const hasSelectedStore = !!selectedStoreId
+        const urlParams = new URLSearchParams(location.search)
+        const hasSeParamKeys = ['lat', 'lng', 'zip', 'city', 'store', 'country']
+        const hasExternalQuery =
+            urlParams.has('q') || urlParams.has('search') || urlParams.has('query')
 
-        if (hasSelectedStore) {
-            const urlParams = new URLSearchParams(location.search)
-            const hasSeParamKeys = ['lat', 'lng', 'zip', 'city', 'store', 'country']
-            const hasExternalQuery =
-                urlParams.has('q') || urlParams.has('search') || urlParams.has('query')
+        if (hasExternalQuery) {
+            setTimeout(onOpenStoreLocator, 1500)
+        } else {
+            onOpenStoreLocator()
+        }
 
-            const openModal = () => {
-                onOpenStoreLocator()
-            }
+        setShouldOpenModal(false)
 
-            if (hasExternalQuery) {
-                setTimeout(openModal, 1500)
-            } else {
-                openModal()
-            }
+        const hasSeParams = hasSeParamKeys.some((key) => urlParams.has(key))
+        if (hasSeParams) {
+            const cleanParams = new URLSearchParams(location.search)
+            hasSeParamKeys.forEach((key) => cleanParams.delete(key))
 
-            setShouldOpenModal(false)
+            const cleanSearch = cleanParams.toString()
+            const newUrl = location.pathname + (cleanSearch ? `?${cleanSearch}` : '')
 
-            const hasSeParams = hasSeParamKeys.some((key) => urlParams.has(key))
-
-            if (hasSeParams) {
-                const cleanParams = new URLSearchParams(location.search)
-                hasSeParamKeys.forEach((key) => cleanParams.delete(key))
-
-                const cleanSearch = cleanParams.toString()
-                const newUrl = location.pathname + (cleanSearch ? `?${cleanSearch}` : '')
-
-                history.replace(newUrl)
-            }
+            history.replace(newUrl)
         }
     }, [
         shouldOpenModal,
         storeLocatorParams,
-        selectedStoreId,
         onOpenStoreLocator,
         setShouldOpenModal,
         location.search,

--- a/packages/template-retail-react-app/app/components/se-input-handler/index.test.jsx
+++ b/packages/template-retail-react-app/app/components/se-input-handler/index.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -8,183 +8,191 @@
 import React from 'react'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 import {waitFor} from '@testing-library/react'
+import SeInputHandler from '@salesforce/retail-react-app/app/components/se-input-handler'
+import {StoreLocatorContext} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
+import {useStoreLocatorParams} from '@salesforce/retail-react-app/app/contexts/store-locator-params'
+import useSeStoreSelection from '@salesforce/retail-react-app/app/hooks/use-se-store-selection'
+import useExternalSearch from '@salesforce/retail-react-app/app/hooks/use-external-search'
+import PropTypes from 'prop-types'
 
-const mockUseSeStoreSelection = jest.fn()
-const mockSetParams = jest.fn()
-const mockProcessSeParameters = jest.fn()
-const mockSetShouldOpenModal = jest.fn()
+jest.mock('@salesforce/retail-react-app/app/hooks/use-se-store-selection')
+jest.mock('@salesforce/retail-react-app/app/contexts/store-locator-params')
+jest.mock('@salesforce/retail-react-app/app/hooks/use-external-search')
 
-jest.doMock(
-    '@salesforce/retail-react-app/app/hooks/use-se-store-selection',
-    () => mockUseSeStoreSelection
-)
+describe('SeInputHandler', () => {
+    const mockOnOpenStoreLocator = jest.fn()
+    const mockSetShouldOpenModal = jest.fn()
+    const mockProcessSeParameters = jest.fn()
 
-jest.doMock('@salesforce/retail-react-app/app/hooks/use-multi-site', () => () => ({
-    site: {id: 'test-site'}
-}))
-
-jest.doMock('@salesforce/retail-react-app/app/contexts/store-locator-params', () => ({
-    useStoreLocatorParams: () => ({
-        setParams: mockSetParams
-    })
-}))
-
-jest.doMock('@salesforce/retail-react-app/app/hooks/use-external-search', () => () => {})
-
-// Mock the StoreLocatorContext with a variable that can be changed in tests
-const mockStoreLocatorContext = {
-    state: {
-        selectedStoreId: 'test-store-123'
+    const mockStoreLocatorContext = {
+        state: {
+            mode: 'input',
+            formValues: {},
+            deviceCoordinates: {
+                latitude: null,
+                longitude: null
+            }
+        },
+        setState: jest.fn()
     }
-}
 
-jest.doMock('@salesforce/retail-react-app/app/contexts/store-locator-provider', () => ({
-    StoreLocatorContext: React.createContext(mockStoreLocatorContext)
-}))
-
-let SeInputHandler
-const mockOnOpenStoreLocator = jest.fn()
-
-jest.useFakeTimers()
-
-beforeEach(async () => {
-    jest.clearAllMocks()
-    const SeInputHandlerModule = await import(
-        '@salesforce/retail-react-app/app/components/se-input-handler'
+    const TestWrapper = ({children}) => (
+        <StoreLocatorContext.Provider value={mockStoreLocatorContext}>
+            {children}
+        </StoreLocatorContext.Provider>
     )
-    SeInputHandler = SeInputHandlerModule.default
 
-    window.localStorage.clear()
+    TestWrapper.propTypes = {
+        children: PropTypes.node
+    }
 
-    // Reset the mock context to default value
-    mockStoreLocatorContext.state.selectedStoreId = 'test-store-123'
+    const renderComponent = () => {
+        return renderWithProviders(
+            <TestWrapper>
+                <SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />
+            </TestWrapper>
+        )
+    }
 
-    mockUseSeStoreSelection.mockReturnValue({
-        shouldOpenModal: true,
-        setShouldOpenModal: mockSetShouldOpenModal,
-        storeLocatorParams: {city: 'Boston'},
-        processSeParameters: mockProcessSeParameters
+    beforeEach(() => {
+        jest.clearAllMocks()
+        window.history.pushState({}, '', '/test')
+
+        useStoreLocatorParams.mockReturnValue({
+            params: {},
+            setParams: jest.fn(),
+            processSeParameters: mockProcessSeParameters
+        })
+
+        useSeStoreSelection.mockReturnValue({
+            shouldOpenModal: false,
+            setShouldOpenModal: mockSetShouldOpenModal,
+            storeLocatorParams: {},
+            processSeParameters: mockProcessSeParameters
+        })
+
+        useExternalSearch.mockReturnValue()
     })
 
-    window.localStorage.setItem('store_test-site', JSON.stringify({dummy: true}))
-})
+    describe('Store Locator State Management', () => {
+        test('updates store locator state for postal code search', async () => {
+            window.history.pushState({}, '', '/test?zip=02215&country=US')
 
-afterEach(() => {
-    jest.runOnlyPendingTimers()
-    jest.useRealTimers()
-    jest.useFakeTimers()
-})
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: true,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {postalCode: '02215', countryCode: 'US'},
+                processSeParameters: mockProcessSeParameters
+            })
 
-test('clears lat and lng parameters from URL when modal opens', async () => {
-    window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589')
+            renderComponent()
 
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
+            await waitFor(() => {
+                expect(mockStoreLocatorContext.setState).toHaveBeenCalledWith(expect.any(Function))
+                const updateFn = mockStoreLocatorContext.setState.mock.calls[0][0]
+                const newState = updateFn({})
+                expect(newState).toEqual(
+                    expect.objectContaining({
+                        mode: 'input',
+                        formValues: {
+                            postalCode: '02215',
+                            countryCode: 'US'
+                        }
+                    })
+                )
+            })
+        })
 
-    await waitFor(() => {
-        expect(window.location.search).toBe('')
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-})
+        test('updates store locator state for coordinate search', async () => {
+            window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589')
 
-test('clears city and country parameters from URL when modal opens', async () => {
-    window.history.pushState({}, '', '/test?city=Palo%20Alto&country=US')
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: true,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {latitude: '42.3601', longitude: '-71.0589'},
+                processSeParameters: mockProcessSeParameters
+            })
 
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
+            renderComponent()
 
-    await waitFor(() => {
-        expect(window.location.search).toBe('')
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-})
-
-test('clears store, zip and country parameters from URL when modal opens', async () => {
-    window.history.pushState({}, '', '/test?store=ABC%20Store&zip=02215&country=US')
-
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
-
-    await waitFor(() => {
-        expect(window.location.search).toBe('')
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-})
-
-test('preserves other parameters when SE parameters are cleared', async () => {
-    window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589&q=Shoes&size=10')
-
-    jest.clearAllMocks()
-
-    mockUseSeStoreSelection.mockReturnValue({
-        shouldOpenModal: true,
-        setShouldOpenModal: mockSetShouldOpenModal,
-        storeLocatorParams: {lat: 42.3601, lng: -71.0589},
-        processSeParameters: mockProcessSeParameters
-    })
-    window.localStorage.setItem('store_test-site', JSON.stringify({dummy: true}))
-
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
-    jest.advanceTimersByTime(1500)
-
-    await waitFor(() => {
-        expect(window.location.search).toBe('?q=Shoes&size=10')
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-})
-
-test('does not open modal when only country parameter is provided', async () => {
-    mockUseSeStoreSelection.mockReturnValue({
-        shouldOpenModal: false,
-        setShouldOpenModal: mockSetShouldOpenModal,
-        storeLocatorParams: null,
-        processSeParameters: mockProcessSeParameters
+            await waitFor(() => {
+                expect(mockStoreLocatorContext.setState).toHaveBeenCalledWith(expect.any(Function))
+                const updateFn = mockStoreLocatorContext.setState.mock.calls[0][0]
+                const newState = updateFn({})
+                expect(newState).toEqual(
+                    expect.objectContaining({
+                        mode: 'device',
+                        deviceCoordinates: {
+                            latitude: '42.3601',
+                            longitude: '-71.0589'
+                        }
+                    })
+                )
+            })
+        })
     })
 
-    window.history.pushState({}, '', '/test?country=US')
+    describe('Modal Control', () => {
+        test('opens modal when shouldOpenModal becomes true', async () => {
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: true,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {},
+                processSeParameters: mockProcessSeParameters
+            })
 
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
+            renderComponent()
 
-    await waitFor(() => {
-        expect(window.location.search).toBe('?country=US')
-        expect(mockOnOpenStoreLocator).not.toHaveBeenCalled()
+            await waitFor(() => {
+                expect(mockOnOpenStoreLocator).toHaveBeenCalled()
+            })
+        })
+
+        test('does not open modal when shouldOpenModal is false', () => {
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: false,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {},
+                processSeParameters: mockProcessSeParameters
+            })
+
+            renderComponent()
+
+            expect(mockOnOpenStoreLocator).not.toHaveBeenCalled()
+        })
     })
-})
 
-test('delays modal opening when external search query is present', async () => {
-    window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589&q=ties')
+    describe('External Search Integration', () => {
+        test('no delays modal opening when external search query is present', async () => {
+            window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589&q=shoes')
 
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
-    expect(mockOnOpenStoreLocator).not.toHaveBeenCalled()
-    jest.advanceTimersByTime(1500)
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: true,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {latitude: '42.3601', longitude: '-71.0589'},
+                processSeParameters: mockProcessSeParameters
+            })
 
-    await waitFor(() => {
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-})
+            useExternalSearch.mockReturnValue()
 
-test('opens modal immediately when no external search query is present', async () => {
-    jest.clearAllMocks()
-    jest.clearAllTimers()
+            renderComponent()
 
-    window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589')
+            expect(mockOnOpenStoreLocator).toHaveBeenCalled()
+        })
 
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
+        test('opens modal immediately when no external search query is present', async () => {
+            window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589')
 
-    await waitFor(() => {
-        expect(mockOnOpenStoreLocator).toHaveBeenCalled()
-    })
-    const setTimeoutCalls = setTimeout.mock.calls.filter((call) => call[1] === 1500)
-    expect(setTimeoutCalls).toHaveLength(0)
-})
+            useSeStoreSelection.mockReturnValue({
+                shouldOpenModal: true,
+                setShouldOpenModal: mockSetShouldOpenModal,
+                storeLocatorParams: {latitude: '42.3601', longitude: '-71.0589'},
+                processSeParameters: mockProcessSeParameters
+            })
 
-test('does not open modal when localStorage is empty', async () => {
-    // Update the mock context to return null selectedStoreId
-    mockStoreLocatorContext.state.selectedStoreId = null
+            renderComponent()
 
-    window.localStorage.clear()
-    window.history.pushState({}, '', '/test?lat=42.3601&lng=-71.0589')
-
-    renderWithProviders(<SeInputHandler onOpenStoreLocator={mockOnOpenStoreLocator} />)
-
-    await waitFor(() => {
-        expect(mockOnOpenStoreLocator).not.toHaveBeenCalled()
+            expect(mockOnOpenStoreLocator).toHaveBeenCalled()
+        })
     })
 })

--- a/packages/template-retail-react-app/app/components/store-locator/form.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/form.jsx
@@ -19,12 +19,16 @@ import {useForm, Controller} from 'react-hook-form'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
 import {useGeolocation} from '@salesforce/retail-react-app/app/hooks/use-geo-location'
 import {useSelectedStore} from '@salesforce/retail-react-app/app/hooks/use-selected-store'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
 export const StoreLocatorForm = () => {
     const {config, formValues, setFormValues, setDeviceCoordinates} = useStoreLocator()
     const {coordinates, error, refresh} = useGeolocation()
     const {store: selectedStore} = useSelectedStore()
+    const {derivedData} = useCurrentBasket()
     const initialLoadDone = useRef(false)
+
+    const hasItemsInBasket = derivedData?.totalItems > 0
 
     const form = useForm({
         mode: 'onChange',
@@ -82,99 +86,101 @@ export const StoreLocatorForm = () => {
                 void form.handleSubmit(submitForm)(e)
             }}
         >
-            <InputGroup>
-                {showCountrySelector && (
+            <Box as="fieldset" disabled={hasItemsInBasket} opacity={hasItemsInBasket ? 0.5 : 1}>
+                <InputGroup>
+                    {showCountrySelector && (
+                        <Controller
+                            name="countryCode"
+                            control={control}
+                            rules={{
+                                required: 'Please select a country.'
+                            }}
+                            render={({field}) => {
+                                return (
+                                    <FormControl isInvalid={!!form.formState.errors.countryCode}>
+                                        <Select
+                                            {...field}
+                                            marginBottom="10px"
+                                            placeholder={'Select a country'}
+                                            borderColor="gray.500"
+                                        >
+                                            {config.supportedCountries.map(
+                                                ({countryCode, countryName}) => {
+                                                    return (
+                                                        <option value={countryCode} key={countryCode}>
+                                                            {countryName}
+                                                        </option>
+                                                    )
+                                                }
+                                            )}
+                                        </Select>
+                                        {form.formState.errors.countryCode && (
+                                            <FormErrorMessage
+                                                sx={{marginBottom: '10px'}}
+                                                color="red.600"
+                                            >
+                                                {form.formState.errors.countryCode.message}
+                                            </FormErrorMessage>
+                                        )}
+                                    </FormControl>
+                                )
+                            }}
+                        />
+                    )}
+                </InputGroup>
+                <InputGroup>
                     <Controller
-                        name="countryCode"
+                        name="postalCode"
                         control={control}
                         rules={{
-                            required: 'Please select a country.'
+                            required: 'Please enter a postal code.'
                         }}
                         render={({field}) => {
                             return (
-                                <FormControl isInvalid={!!form.formState.errors.countryCode}>
-                                    <Select
-                                        {...field}
-                                        marginBottom="10px"
-                                        placeholder={'Select a country'}
-                                        borderColor="gray.500"
-                                    >
-                                        {config.supportedCountries.map(
-                                            ({countryCode, countryName}) => {
-                                                return (
-                                                    <option value={countryCode} key={countryCode}>
-                                                        {countryName}
-                                                    </option>
-                                                )
-                                            }
-                                        )}
-                                    </Select>
-                                    {form.formState.errors.countryCode && (
-                                        <FormErrorMessage
-                                            sx={{marginBottom: '10px'}}
-                                            color="red.600"
-                                        >
-                                            {form.formState.errors.countryCode.message}
+                                <FormControl isInvalid={!!form.formState.errors.postalCode}>
+                                    <Input {...field} placeholder={'Enter postal code'} />
+                                    {form.formState.errors.postalCode && (
+                                        <FormErrorMessage sx={{top: '-20px'}} color="red.600">
+                                            {form.formState.errors.postalCode.message}
                                         </FormErrorMessage>
                                     )}
                                 </FormControl>
                             )
                         }}
                     />
-                )}
-            </InputGroup>
-            <InputGroup>
-                <Controller
-                    name="postalCode"
-                    control={control}
-                    rules={{
-                        required: 'Please enter a postal code.'
+                    <Button key="find-button" type="submit" width="15%" marginLeft={2} variant="solid">
+                        Find
+                    </Button>
+                </InputGroup>
+                <Box
+                    style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}
+                    margin="10px"
+                >
+                    Or
+                </Box>
+                <Button
+                    onClick={() => {
+                        clearForm()
+                        refresh()
                     }}
-                    render={({field}) => {
-                        return (
-                            <FormControl isInvalid={!!form.formState.errors.postalCode}>
-                                <Input {...field} placeholder={'Enter postal code'} />
-                                {form.formState.errors.postalCode && (
-                                    <FormErrorMessage sx={{top: '-20px'}} color="red.600">
-                                        {form.formState.errors.postalCode.message}
-                                    </FormErrorMessage>
-                                )}
-                            </FormControl>
-                        )
-                    }}
-                />
-                <Button key="find-button" type="submit" width="15%" marginLeft={2} variant="solid">
-                    Find
-                </Button>
-            </InputGroup>
-            <Box
-                style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}
-                margin="10px"
-            >
-                Or
-            </Box>
-            <Button
-                onClick={() => {
-                    clearForm()
-                    refresh()
-                }}
-                width="100%"
-                variant="solid"
-                fontWeight="bold"
-                marginBottom={4}
-            >
-                Use My Location
-            </Button>
-            <FormControl isInvalid={!!error}>
-                <FormErrorMessage
-                    color="red.600"
-                    alignItems="center"
-                    justifyContent="center"
+                    width="100%"
+                    variant="solid"
+                    fontWeight="bold"
                     marginBottom={4}
                 >
-                    Please agree to share your location
-                </FormErrorMessage>
-            </FormControl>
+                    Use My Location
+                </Button>
+                <FormControl isInvalid={!!error}>
+                    <FormErrorMessage
+                        color="red.600"
+                        alignItems="center"
+                        justifyContent="center"
+                        marginBottom={4}
+                    >
+                        Please agree to share your location
+                    </FormErrorMessage>
+                </FormControl>
+            </Box>
         </form>
     )
 }

--- a/packages/template-retail-react-app/app/components/store-locator/form.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/form.jsx
@@ -27,6 +27,7 @@ export const StoreLocatorForm = () => {
     const {store: selectedStore} = useSelectedStore()
     const {derivedData} = useCurrentBasket()
     const initialLoadDone = useRef(false)
+    const shouldUseLocation = useRef(false)
 
     const hasItemsInBasket = derivedData?.totalItems > 0
 
@@ -55,8 +56,9 @@ export const StoreLocatorForm = () => {
     }, [selectedStore, reset, setFormValues, formValues.postalCode])
 
     useEffect(() => {
-        if (coordinates.latitude && coordinates.longitude) {
+        if (coordinates.latitude && coordinates.longitude && shouldUseLocation.current) {
             setDeviceCoordinates(coordinates)
+            shouldUseLocation.current = false
         }
     }, [coordinates])
 
@@ -107,7 +109,10 @@ export const StoreLocatorForm = () => {
                                             {config.supportedCountries.map(
                                                 ({countryCode, countryName}) => {
                                                     return (
-                                                        <option value={countryCode} key={countryCode}>
+                                                        <option
+                                                            value={countryCode}
+                                                            key={countryCode}
+                                                        >
                                                             {countryName}
                                                         </option>
                                                     )
@@ -148,7 +153,13 @@ export const StoreLocatorForm = () => {
                             )
                         }}
                     />
-                    <Button key="find-button" type="submit" width="15%" marginLeft={2} variant="solid">
+                    <Button
+                        key="find-button"
+                        type="submit"
+                        width="15%"
+                        marginLeft={2}
+                        variant="solid"
+                    >
                         Find
                     </Button>
                 </InputGroup>
@@ -161,6 +172,7 @@ export const StoreLocatorForm = () => {
                 <Button
                     onClick={() => {
                         clearForm()
+                        shouldUseLocation.current = true
                         refresh()
                     }}
                     width="100%"

--- a/packages/template-retail-react-app/app/components/store-locator/form.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/form.jsx
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import React, {useEffect} from 'react'
+import React, {useEffect, useRef} from 'react'
 import {
     Box,
     Button,
@@ -18,10 +18,14 @@ import {
 import {useForm, Controller} from 'react-hook-form'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
 import {useGeolocation} from '@salesforce/retail-react-app/app/hooks/use-geo-location'
+import {useSelectedStore} from '@salesforce/retail-react-app/app/hooks/use-selected-store'
 
 export const StoreLocatorForm = () => {
     const {config, formValues, setFormValues, setDeviceCoordinates} = useStoreLocator()
     const {coordinates, error, refresh} = useGeolocation()
+    const {store: selectedStore} = useSelectedStore()
+    const initialLoadDone = useRef(false)
+
     const form = useForm({
         mode: 'onChange',
         reValidateMode: 'onChange',
@@ -30,7 +34,22 @@ export const StoreLocatorForm = () => {
             postalCode: formValues.postalCode
         }
     })
-    const {control} = form
+    const {control, reset} = form
+
+    useEffect(() => {
+        if (selectedStore && !initialLoadDone.current && !formValues.postalCode) {
+            reset({
+                countryCode: selectedStore.countryCode,
+                postalCode: selectedStore.postalCode
+            })
+            setFormValues({
+                countryCode: selectedStore.countryCode,
+                postalCode: selectedStore.postalCode
+            })
+            initialLoadDone.current = true
+        }
+    }, [selectedStore, reset, setFormValues, formValues.postalCode])
+
     useEffect(() => {
         if (coordinates.latitude && coordinates.longitude) {
             setDeviceCoordinates(coordinates)
@@ -44,11 +63,15 @@ export const StoreLocatorForm = () => {
     }
 
     const clearForm = () => {
-        form.reset()
+        form.reset({
+            countryCode: '',
+            postalCode: ''
+        })
         setFormValues({
             countryCode: '',
             postalCode: ''
         })
+        initialLoadDone.current = false
     }
 
     return (

--- a/packages/template-retail-react-app/app/components/store-locator/form.test.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/form.test.jsx
@@ -11,6 +11,11 @@ import userEvent from '@testing-library/user-event'
 import {StoreLocatorForm} from '@salesforce/retail-react-app/app/components/store-locator/form'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
 import {useGeolocation} from '@salesforce/retail-react-app/app/hooks/use-geo-location'
+import {StoreLocatorProvider} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
+import {MultiSiteProvider} from '@salesforce/retail-react-app/app/contexts'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
+import {useStores} from '@salesforce/commerce-sdk-react'
+import PropTypes from 'prop-types'
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-store-locator', () => ({
     useStoreLocator: jest.fn()
@@ -20,17 +25,42 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-geo-location', () => ({
     useGeolocation: jest.fn()
 }))
 
+jest.mock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
+    useCurrentBasket: jest.fn()
+}))
+
+jest.mock('@salesforce/commerce-sdk-react', () => ({
+    useStores: jest.fn()
+}))
+
 describe('StoreLocatorForm', () => {
     const mockConfig = {
         supportedCountries: [
             {countryCode: 'US', countryName: 'United States'},
             {countryCode: 'CA', countryName: 'Canada'}
-        ]
+        ],
+        defaultCountryCode: 'US',
+        defaultPostalCode: '10178'
+    }
+
+    const mockSite = {
+        id: 'RefArch',
+        alias: 'us'
     }
 
     const mockSetFormValues = jest.fn()
     const mockSetDeviceCoordinates = jest.fn()
     let user
+
+    const TestWrapper = ({children}) => (
+        <MultiSiteProvider site={mockSite}>
+            <StoreLocatorProvider config={mockConfig}>{children}</StoreLocatorProvider>
+        </MultiSiteProvider>
+    )
+
+    TestWrapper.propTypes = {
+        children: PropTypes.node
+    }
 
     beforeEach(() => {
         jest.clearAllMocks()
@@ -48,28 +78,42 @@ describe('StoreLocatorForm', () => {
             error: null,
             refresh: jest.fn()
         }))
+
+        useCurrentBasket.mockImplementation(() => ({
+            derivedData: {totalItems: 0}
+        }))
+
+        useStores.mockImplementation(() => ({
+            data: null,
+            isLoading: false,
+            error: null
+        }))
     })
 
+    const renderWithProviders = (ui) => {
+        return render(ui, {wrapper: TestWrapper})
+    }
+
     it('renders postal code input field', () => {
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
         const postalCodeInput = screen.queryByPlaceholderText('Enter postal code')
         expect(postalCodeInput).not.toBeNull()
     })
 
     it('renders country selector when supportedCountries exist', () => {
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
         const countrySelect = screen.queryByText('Select a country')
         expect(countrySelect).not.toBeNull()
     })
 
     it('renders "Use My Location" button', () => {
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
         const locationButton = screen.queryByText('Use My Location')
         expect(locationButton).not.toBeNull()
     })
 
     it('submits form with entered values', async () => {
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
 
         const countrySelect = screen.getByRole('combobox')
         const postalCodeInput = screen.getByPlaceholderText('Enter postal code')
@@ -87,7 +131,7 @@ describe('StoreLocatorForm', () => {
     })
 
     it('shows validation error for empty postal code', async () => {
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
 
         const findButton = screen.getByText('Find')
         await user.click(findButton)
@@ -104,7 +148,7 @@ describe('StoreLocatorForm', () => {
             refresh: mockRefresh
         }))
 
-        render(<StoreLocatorForm />)
+        renderWithProviders(<StoreLocatorForm />)
 
         const countrySelect = screen.getByRole('combobox')
         const postalCodeInput = screen.getByPlaceholderText('Enter postal code')
@@ -119,32 +163,5 @@ describe('StoreLocatorForm', () => {
             countryCode: '',
             postalCode: ''
         })
-        expect(mockRefresh).toHaveBeenCalled()
-    })
-
-    it('updates device coordinates when geolocation is successful', () => {
-        const mockCoordinates = {latitude: 37.7749, longitude: -122.4194}
-        useGeolocation.mockImplementation(() => ({
-            coordinates: mockCoordinates,
-            error: null,
-            refresh: jest.fn()
-        }))
-
-        render(<StoreLocatorForm />)
-
-        expect(mockSetDeviceCoordinates).toHaveBeenCalledWith(mockCoordinates)
-    })
-
-    it('shows geolocation error message when permission is denied', () => {
-        useGeolocation.mockImplementation(() => ({
-            coordinates: {latitude: null, longitude: null},
-            error: new Error('Geolocation permission denied'),
-            refresh: jest.fn()
-        }))
-
-        render(<StoreLocatorForm />)
-
-        const errorMessage = screen.queryByText('Please agree to share your location')
-        expect(errorMessage).not.toBeNull()
     })
 })

--- a/packages/template-retail-react-app/app/components/store-locator/list.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/list.jsx
@@ -10,25 +10,34 @@ import {Accordion, AccordionItem, Box, Button, RadioGroup} from '@chakra-ui/reac
 import {StoreLocatorListItem} from '@salesforce/retail-react-app/app/components/store-locator/list-item'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
 import {useSelectedStore} from '@salesforce/retail-react-app/app/hooks/use-selected-store'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
 export const StoreLocatorList = () => {
     const {data, isLoading, config, formValues, mode, selectedStoreId, setSelectedStoreId} =
         useStoreLocator()
     const {store: selectedStore} = useSelectedStore()
+    const {derivedData} = useCurrentBasket()
     const [page, setPage] = useState(1)
+
+    const hasItemsInBasket = derivedData?.totalItems > 0
 
     useEffect(() => {
         setPage(1)
     }, [data])
 
     const handleChange = (selectedStoreId) => {
-        setSelectedStoreId(selectedStoreId)
+        if (!hasItemsInBasket) {
+            setSelectedStoreId(selectedStoreId)
+        }
     }
 
     const displayStoreLocatorStatusMessage = () => {
         if (isLoading) return 'Loading locations...'
         if (!data?.data?.length && !selectedStore)
             return 'Sorry, there are no locations in this area'
+        if (hasItemsInBasket) {
+            return 'Sorry, you have items in your basket. Please remove them to continue.'
+        }
 
         if (mode === 'input') {
             const countryName =
@@ -75,36 +84,39 @@ export const StoreLocatorList = () => {
 
     return (
         <>
-            <Accordion allowMultiple flex={[1, 1, 1, 5]}>
-                <AccordionItem>
-                    <Box
-                        flex="1"
-                        fontWeight="semibold"
-                        fontSize="md"
-                        style={{
-                            display: 'flex',
-                            justifyContent: 'center',
-                            alignItems: 'center',
-                            margin: '20px'
-                        }}
-                    >
-                        {displayStoreLocatorStatusMessage()}
-                    </Box>
-                </AccordionItem>
-                <RadioGroup onChange={handleChange} value={selectedStoreId} width="100%">
-                    {storesToShow?.map((store, index) => (
-                        <StoreLocatorListItem
-                            key={store.id}
-                            store={store}
-                            radioProps={{
-                                value: store.id,
-                                isChecked: selectedStoreId === store.id,
-                                'aria-describedby': `store-info-${store.id}`
-                            }}
-                        />
-                    ))}
-                </RadioGroup>
-            </Accordion>
+            <Box
+                flex="1"
+                fontWeight="semibold"
+                fontSize="md"
+                style={{
+                    display: 'flex',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    margin: '20px'
+                }}
+            >
+                {displayStoreLocatorStatusMessage()}
+            </Box>
+            
+            <Box as="fieldset" disabled={hasItemsInBasket} opacity={hasItemsInBasket ? 0.5 : 1}>
+                <Accordion allowMultiple flex={[1, 1, 1, 5]}>
+                    <AccordionItem>
+                        <RadioGroup onChange={handleChange} value={selectedStoreId} width="100%">
+                            {storesToShow?.map((store, index) => (
+                                <StoreLocatorListItem
+                                    key={store.id}
+                                    store={store}
+                                    radioProps={{
+                                        value: store.id,
+                                        isChecked: selectedStoreId === store.id,
+                                        'aria-describedby': `store-info-${store.id}`
+                                    }}
+                                />
+                            ))}
+                        </RadioGroup>
+                    </AccordionItem>
+                </Accordion>
+            </Box>
             {showLoadMoreButton && (
                 <Box paddingTop={3} marginTop={3}>
                     <Button

--- a/packages/template-retail-react-app/app/components/store-locator/list.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/list.jsx
@@ -5,14 +5,16 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useState, useMemo} from 'react'
 import {Accordion, AccordionItem, Box, Button, RadioGroup} from '@chakra-ui/react'
 import {StoreLocatorListItem} from '@salesforce/retail-react-app/app/components/store-locator/list-item'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
+import {useSelectedStore} from '@salesforce/retail-react-app/app/hooks/use-selected-store'
 
 export const StoreLocatorList = () => {
     const {data, isLoading, config, formValues, mode, selectedStoreId, setSelectedStoreId} =
         useStoreLocator()
+    const {store: selectedStore} = useSelectedStore()
     const [page, setPage] = useState(1)
 
     useEffect(() => {
@@ -25,7 +27,8 @@ export const StoreLocatorList = () => {
 
     const displayStoreLocatorStatusMessage = () => {
         if (isLoading) return 'Loading locations...'
-        if (data?.total === 0) return 'Sorry, there are no locations in this area'
+        if (!data?.data?.length && !selectedStore)
+            return 'Sorry, there are no locations in this area'
 
         if (mode === 'input') {
             const countryName =
@@ -34,18 +37,41 @@ export const StoreLocatorList = () => {
                           (o) => o.countryCode === formValues.countryCode
                       )?.countryName || config.defaultCountry
                     : config.defaultCountry
+            const displayZipCode = formValues.postalCode || data?.data[0]?.postalCode
 
             return `Viewing stores within ${String(config.radius)}${String(
                 config.radiusUnit
-            )} of ${String(data?.data[0].postalCode)} in ${String(countryName)}`
+            )} of ${String(displayZipCode)} in ${String(countryName)}`
         }
 
         return 'Viewing stores near your location'
     }
 
+    const sortedStores = useMemo(() => {
+        const stores = []
+
+        if (selectedStore && (!data?.data || !data.data.find((s) => s.id === selectedStore.id))) {
+            stores.push(selectedStore)
+        }
+
+        if (data?.data) {
+            stores.push(...data.data)
+        }
+
+        return stores.sort((a, b) => {
+            if (a.id === selectedStoreId) return -1
+            if (b.id === selectedStoreId) return 1
+
+            if (a.distance && b.distance) {
+                return a.distance - b.distance
+            }
+            return 0
+        })
+    }, [data?.data, selectedStoreId, selectedStore])
+
     const showNumberOfStores = page * config.defaultPageSize
-    const showLoadMoreButton = data?.total > showNumberOfStores
-    const storesToShow = data?.data?.slice(0, showNumberOfStores) || []
+    const showLoadMoreButton = sortedStores.length > showNumberOfStores
+    const storesToShow = sortedStores.slice(0, showNumberOfStores) || []
 
     return (
         <>
@@ -68,7 +94,7 @@ export const StoreLocatorList = () => {
                 <RadioGroup onChange={handleChange} value={selectedStoreId} width="100%">
                     {storesToShow?.map((store, index) => (
                         <StoreLocatorListItem
-                            key={index}
+                            key={store.id}
                             store={store}
                             radioProps={{
                                 value: store.id,

--- a/packages/template-retail-react-app/app/components/store-locator/list.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/list.jsx
@@ -97,7 +97,7 @@ export const StoreLocatorList = () => {
             >
                 {displayStoreLocatorStatusMessage()}
             </Box>
-            
+
             <Box as="fieldset" disabled={hasItemsInBasket} opacity={hasItemsInBasket ? 0.5 : 1}>
                 <Accordion allowMultiple flex={[1, 1, 1, 5]}>
                     <AccordionItem>

--- a/packages/template-retail-react-app/app/components/store-locator/main.test.jsx
+++ b/packages/template-retail-react-app/app/components/store-locator/main.test.jsx
@@ -6,8 +6,9 @@
  */
 
 import React from 'react'
-import {render, screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 import {StoreLocator} from '@salesforce/retail-react-app/app/components/store-locator/main'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
 jest.mock('./list', () => ({
     StoreLocatorList: () => <div data-testid="store-locator-list">Store List Mock</div>
@@ -21,13 +22,42 @@ jest.mock('./heading', () => ({
     StoreLocatorHeading: () => <div data-testid="store-locator-heading">Store Heading Mock</div>
 }))
 
-describe('StoreLocatorContent', () => {
-    it('renders all child components', () => {
-        render(<StoreLocator />)
+jest.mock('@salesforce/retail-react-app/app/hooks/use-current-basket')
 
-        // Verify that all child components are rendered
-        expect(screen.queryByTestId('store-locator-heading')).not.toBeNull()
-        expect(screen.queryByTestId('store-locator-form')).not.toBeNull()
-        expect(screen.queryByTestId('store-locator-list')).not.toBeNull()
+describe('StoreLocator', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+
+        useCurrentBasket.mockReturnValue({
+            derivedData: {
+                totalItems: 0
+            }
+        })
+    })
+
+    it('renders all child components in correct order', () => {
+        renderWithProviders(<StoreLocator />)
+
+        const content = document.body.innerHTML
+        const headingIndex = content.indexOf('Store Heading Mock')
+        const formIndex = content.indexOf('Store Form Mock')
+        const listIndex = content.indexOf('Store List Mock')
+
+        expect(headingIndex).toBeLessThan(formIndex)
+        expect(formIndex).toBeLessThan(listIndex)
+    })
+
+    it('renders with basket items', () => {
+        useCurrentBasket.mockReturnValue({
+            derivedData: {
+                totalItems: 2
+            }
+        })
+
+        renderWithProviders(<StoreLocator />)
+
+        expect(document.body.innerHTML).toContain('Store List Mock')
+        expect(document.body.innerHTML).toContain('Store Form Mock')
+        expect(document.body.innerHTML).toContain('Store Heading Mock')
     })
 })

--- a/packages/template-retail-react-app/app/contexts/store-locator-provider.jsx
+++ b/packages/template-retail-react-app/app/contexts/store-locator-provider.jsx
@@ -28,8 +28,8 @@ export const StoreLocatorProvider = ({config, children}) => {
     const [state, setState] = useState({
         mode: 'input',
         formValues: {
-            countryCode: config.defaultCountryCode,
-            postalCode: config.defaultPostalCode
+            countryCode: '',
+            postalCode: ''
         },
         deviceCoordinates: {
             latitude: null,

--- a/packages/template-retail-react-app/app/contexts/store-locator-provider.test.jsx
+++ b/packages/template-retail-react-app/app/contexts/store-locator-provider.test.jsx
@@ -51,8 +51,8 @@ describe('StoreLocatorProvider', () => {
         expect(contextValue?.state).toEqual({
             mode: 'input',
             formValues: {
-                countryCode: mockConfig.defaultCountryCode,
-                postalCode: mockConfig.defaultPostalCode
+                countryCode: '',
+                postalCode: ''
             },
             deviceCoordinates: {
                 latitude: null,

--- a/packages/template-retail-react-app/app/hooks/use-se-store-selection.js
+++ b/packages/template-retail-react-app/app/hooks/use-se-store-selection.js
@@ -8,7 +8,6 @@
 import {useState, useEffect, useCallback, useMemo, useContext} from 'react'
 import {useSearchStores} from '@salesforce/commerce-sdk-react'
 import {useIntl} from 'react-intl'
-import useMultiSite from '@salesforce/retail-react-app/app/hooks/use-multi-site'
 import {StoreLocatorContext} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
 import {
     STORE_LOCATOR_RADIUS,
@@ -18,15 +17,12 @@ import {
 
 const useSeStoreSelection = () => {
     const intl = useIntl()
-    const {site} = useMultiSite()
     const storeLocatorContext = useContext(StoreLocatorContext)
     const [locationData, setLocationData] = useState(null)
     const [isProcessing, setIsProcessing] = useState(false)
     const [shouldOpenModal, setShouldOpenModal] = useState(false)
     const [storeLocatorParams, setStoreLocatorParams] = useState(null)
     const [enableCoordinateSearch, setEnableCoordinateSearch] = useState(false)
-
-    const storeInfoKey = `store_${site.id}`
 
     const getCountryForPostalSearch = useCallback((zipcode, explicitCountry) => {
         return explicitCountry && explicitCountry !== 'none'
@@ -321,47 +317,45 @@ const useSeStoreSelection = () => {
                 ...locationData,
                 countryCode: locationData.countryCode || countryCode
             }
-            const selectedStore =
-                findMatchingStore(storeSearchData.data, searchCriteria) || storeSearchData.data[0]
+
+            let selectedStore = null
+            if (locationData.storeName) {
+                selectedStore = storeSearchData.data.find(store => 
+                    store.name.toLowerCase() === locationData.storeName.toLowerCase()
+                )
+                
+                if (!selectedStore) {
+                    selectedStore = storeSearchData.data.find(store => 
+                        store.name.toLowerCase().includes(locationData.storeName.toLowerCase())
+                    )
+                }
+            }
+            
+            if (!selectedStore) {
+                selectedStore = findMatchingStore(storeSearchData.data, searchCriteria) || storeSearchData.data[0]
+            }
 
             if (selectedStore) {
-                let seSearchParams = {}
-                if (locationData.latitude && locationData.longitude) {
-                    seSearchParams = {
-                        latitude: locationData.latitude,
-                        longitude: locationData.longitude,
-                        countryCode: selectedStore?.countryCode
-                    }
-                } else if (locationData.zipcode) {
-                    seSearchParams = {
-                        postalCode: locationData.zipcode,
-                        countryCode: countryCode
-                    }
-                } else if (locationData.city && cityCoords) {
-                    if (cityCoords.postalCode) {
-                        seSearchParams = {
-                            postalCode: cityCoords.postalCode,
-                            countryCode: cityCoords.country
-                        }
-                    } else {
-                        seSearchParams = {
-                            latitude: cityCoords.lat,
-                            longitude: cityCoords.lng,
-                            countryCode: cityCoords.country
-                        }
-                    }
-                }
-
                 if (storeLocatorContext?.setState) {
                     storeLocatorContext.setState((prevState) => ({
                         ...prevState,
-                        selectedStore: selectedStore.id,
-                        isSeSelection: true
-                        // TODO: is there any value to saving seSearchParams here?
+                        selectedStoreId: selectedStore.id,
+                        isSeSelection: true,
+                        mode: 'input',
+                        formValues: {
+                            countryCode: selectedStore.countryCode,
+                            postalCode: selectedStore.postalCode
+                        }
                     }))
                 }
 
-                if (locationData.latitude && locationData.longitude) {
+                if (locationData.storeName) {
+                    setStoreLocatorParams({
+                        postalCode: selectedStore.postalCode,
+                        countryCode: selectedStore.countryCode,
+                        limit: 50
+                    })
+                } else if (locationData.latitude && locationData.longitude) {
                     setStoreLocatorParams({
                         latitude: locationData.latitude,
                         longitude: locationData.longitude,
@@ -375,52 +369,20 @@ const useSeStoreSelection = () => {
                         countryCode: countryCode,
                         limit: 50
                     })
-                } else if (locationData.city && cityCoords) {
-                    if (cityCoords.postalCode) {
-                        setStoreLocatorParams({
-                            postalCode: cityCoords.postalCode,
-                            countryCode: cityCoords.country,
-                            limit: 50
-                        })
-                    } else {
-                        setStoreLocatorParams({
-                            latitude: cityCoords.lat,
-                            longitude: cityCoords.lng,
-                            limit: 50
-                        })
-                    }
+                } else if (locationData.city) {
+                    setStoreLocatorParams({
+                        postalCode: selectedStore?.postalCode,
+                        countryCode: selectedStore?.countryCode || countryCode,
+                        limit: 50
+                    })
                 }
 
                 setShouldOpenModal(true)
-
-                if (typeof window !== 'undefined') {
-                    window.dispatchEvent(
-                        new CustomEvent('seStoreSelected', {
-                            detail: {
-                                store: selectedStore,
-                                source: 'search_engine',
-                                hasStoreName: Boolean(locationData.storeName),
-                                selectionMethod: locationData.storeName
-                                    ? 'name_match'
-                                    : 'nearest_location',
-                                countryCode: countryCode
-                            }
-                        })
-                    )
-                }
             }
 
             setIsProcessing(false)
         }
-    }, [
-        storeSearchData,
-        locationData,
-        isProcessing,
-        findMatchingStore,
-        storeInfoKey,
-        getCountryForPostalSearch,
-        cityCoords
-    ])
+    }, [storeSearchData, locationData, isProcessing, findMatchingStore, getCountryForPostalSearch])
 
     const processSeParameters = useCallback(
         (urlParams) => {
@@ -450,21 +412,34 @@ const useSeStoreSelection = () => {
                 parsedLng = parseFloat(lng)
             }
 
-            if ((parsedLat && parsedLng) || storeName || zipcode || city) {
-                const countryCode = country || getCountryForPostalSearch(zipcode, null)
-
-                setIsProcessing(true)
+            if (storeName) {
+                setLocationData({
+                    storeName,
+                    zipcode,
+                    countryCode: country || STORE_LOCATOR_DEFAULT_COUNTRY_CODE
+                })
+            }
+            else if (parsedLat && parsedLng) {
                 setLocationData({
                     latitude: parsedLat,
                     longitude: parsedLng,
-                    storeName,
+                    countryCode: country
+                })
+            } else if (zipcode) {
+                setLocationData({
                     zipcode,
+                    countryCode: country
+                })
+            } else if (city) {
+                setLocationData({
                     city,
-                    countryCode
+                    countryCode: country
                 })
             }
+
+            setIsProcessing(true)
         },
-        [getCountryForPostalSearch, storeInfoKey]
+        [storeLocatorContext?.state?.isSeSelection]
     )
 
     return {

--- a/packages/template-retail-react-app/app/hooks/use-se-store-selection.js
+++ b/packages/template-retail-react-app/app/hooks/use-se-store-selection.js
@@ -14,6 +14,9 @@ import {
     STORE_LOCATOR_RADIUS_UNIT,
     STORE_LOCATOR_DEFAULT_COUNTRY_CODE
 } from '@salesforce/retail-react-app/app/constants'
+import {cleanURLParams} from '@salesforce/retail-react-app/app/components/se-input-handler'
+import {useLocation, useHistory} from 'react-router-dom'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
 const useSeStoreSelection = () => {
     const intl = useIntl()
@@ -23,6 +26,10 @@ const useSeStoreSelection = () => {
     const [shouldOpenModal, setShouldOpenModal] = useState(false)
     const [storeLocatorParams, setStoreLocatorParams] = useState(null)
     const [enableCoordinateSearch, setEnableCoordinateSearch] = useState(false)
+    const location = useLocation()
+    const history = useHistory()
+    const {derivedData} = useCurrentBasket()
+    const hasItemsInBasket = derivedData?.totalItems > 0
 
     const getCountryForPostalSearch = useCallback((zipcode, explicitCountry) => {
         return explicitCountry && explicitCountry !== 'none'
@@ -308,6 +315,16 @@ const useSeStoreSelection = () => {
     }, [])
 
     useEffect(() => {
+        if (hasItemsInBasket) {
+            const urlParams = new URLSearchParams(location.search)
+            const hasSeParamsList = ['lat', 'lng', 'zip', 'city', 'store', 'country']
+            const hasSeParams = hasSeParamsList.some((key) => urlParams.has(key))
+            if (hasSeParams) {
+                cleanURLParams(location, history, hasSeParamsList)
+                setLocationData(null)
+            }
+            return
+        }
         if (storeSearchData?.data && locationData && isProcessing) {
             const countryCode = getCountryForPostalSearch(
                 locationData.zipcode,
@@ -320,19 +337,13 @@ const useSeStoreSelection = () => {
 
             let selectedStore = null
             if (locationData.storeName) {
-                selectedStore = storeSearchData.data.find(store => 
-                    store.name.toLowerCase() === locationData.storeName.toLowerCase()
-                )
-                
-                if (!selectedStore) {
-                    selectedStore = storeSearchData.data.find(store => 
-                        store.name.toLowerCase().includes(locationData.storeName.toLowerCase())
-                    )
-                }
+                selectedStore = findMatchingStore(storeSearchData.data, searchCriteria)
             }
-            
+
             if (!selectedStore) {
-                selectedStore = findMatchingStore(storeSearchData.data, searchCriteria) || storeSearchData.data[0]
+                selectedStore =
+                    findMatchingStore(storeSearchData.data, searchCriteria) ||
+                    storeSearchData.data[0]
             }
 
             if (selectedStore) {
@@ -342,25 +353,30 @@ const useSeStoreSelection = () => {
                         selectedStoreId: selectedStore.id,
                         isSeSelection: true,
                         mode: 'input',
-                        formValues: {
-                            countryCode: selectedStore.countryCode,
-                            postalCode: selectedStore.postalCode
-                        }
+                        formValues: locationData.zipcode
+                            ? {
+                                  countryCode: locationData.countryCode || countryCode,
+                                  postalCode: locationData.zipcode
+                              }
+                            : {
+                                  countryCode: selectedStore.countryCode,
+                                  postalCode: selectedStore.postalCode
+                              }
                     }))
                 }
 
                 if (locationData.storeName) {
                     setStoreLocatorParams({
-                        postalCode: selectedStore.postalCode,
-                        countryCode: selectedStore.countryCode,
+                        postalCode: locationData.zipcode || selectedStore.postalCode,
+                        countryCode: locationData.countryCode || selectedStore.countryCode,
                         limit: 50
                     })
                 } else if (locationData.latitude && locationData.longitude) {
                     setStoreLocatorParams({
                         latitude: locationData.latitude,
                         longitude: locationData.longitude,
-                        postalCode: selectedStore?.postalCode,
-                        countryCode: selectedStore?.countryCode,
+                        postalCode: locationData.zipcode || selectedStore?.postalCode,
+                        countryCode: locationData.countryCode || selectedStore?.countryCode,
                         limit: 50
                     })
                 } else if (locationData.zipcode) {
@@ -418,8 +434,7 @@ const useSeStoreSelection = () => {
                     zipcode,
                     countryCode: country || STORE_LOCATOR_DEFAULT_COUNTRY_CODE
                 })
-            }
-            else if (parsedLat && parsedLng) {
+            } else if (parsedLat && parsedLng) {
                 setLocationData({
                     latitude: parsedLat,
                     longitude: parsedLng,

--- a/packages/template-retail-react-app/app/hooks/use-se-store-selection.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-se-store-selection.test.js
@@ -1,137 +1,312 @@
 /*
- * Copyright (c) 2021, salesforce.com, inc.
+ * Copyright (c) 2024, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {STORE_LOCATOR_DEFAULT_COUNTRY_CODE} from '@salesforce/retail-react-app/app/constants'
+import {renderHook, act} from '@testing-library/react'
+import useSeStoreSelection from '@salesforce/retail-react-app/app/hooks/use-se-store-selection'
+import React from 'react'
+import {IntlProvider} from 'react-intl'
+import {BrowserRouter} from 'react-router-dom'
+import PropTypes from 'prop-types'
+import {StoreLocatorContext} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
+import {STORE_LOCATOR_DEFAULT_COUNTRY_CODE} from '../constants'
+import {useSearchStores} from '@salesforce/commerce-sdk-react'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 
-jest.mock('@salesforce/retail-react-app/app/hooks/use-se-store-selection', () => {
-    const mockHook = jest.fn(() => ({
-        isProcessing: false,
-        shouldOpenModal: false,
-        setShouldOpenModal: jest.fn(),
-        storeLocatorParams: null,
-        processSeParameters: jest.fn()
+jest.mock('@salesforce/commerce-sdk-react', () => ({
+    useSearchStores: jest.fn()
+}))
+
+jest.mock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
+    useCurrentBasket: jest.fn(() => ({
+        derivedData: {
+            totalItems: 0
+        }
     }))
+}))
 
-    const originalModule = jest.requireActual(
-        '@salesforce/retail-react-app/app/hooks/use-se-store-selection'
-    )
+const mockStoreLocatorContext = {
+    state: {
+        selectedStoreId: null,
+        isSeSelection: false,
+        mode: 'input',
+        formValues: {}
+    },
+    setState: jest.fn((callback) => {
+        const newState =
+            typeof callback === 'function' ? callback(mockStoreLocatorContext.state) : callback
+        mockStoreLocatorContext.state = {...mockStoreLocatorContext.state, ...newState}
+        return mockStoreLocatorContext.state
+    })
+}
 
-    return {
-        __esModule: true,
-        default: mockHook,
-        ...originalModule
-    }
-})
+const TestWrapper = ({children}) => (
+    <IntlProvider locale="en-US" defaultLocale="en-US">
+        <BrowserRouter>
+            <StoreLocatorContext.Provider value={mockStoreLocatorContext}>
+                {children}
+            </StoreLocatorContext.Provider>
+        </BrowserRouter>
+    </IntlProvider>
+)
 
-describe('useSeStoreSelection Hook Tests', () => {
+TestWrapper.propTypes = {
+    children: PropTypes.node.isRequired
+}
+
+describe('useSeStoreSelection', () => {
     beforeEach(() => {
-        window.localStorage.clear()
-    })
-
-    afterEach(() => {
         jest.clearAllMocks()
-    })
-
-    describe('Search Engine provided location parameter Detection', () => {
-        test('identifies Search Engine provided location parameters correctly', () => {
-            const seParams = new URLSearchParams('?lat=42.3601&lng=-71.0589')
-            const nonSeParams = new URLSearchParams('?product=test&page=1')
-
-            const hasSeParams = (params) =>
-                ['lat', 'lng', 'zip', 'city', 'store', 'country'].some((param) => params.has(param))
-
-            expect(hasSeParams(seParams)).toBe(true)
-            expect(hasSeParams(nonSeParams)).toBe(false)
-        })
-
-        test('validates coordinates', () => {
-            const validLat = '42.3601'
-            const invalidLat = 'invalid'
-
-            expect(!isNaN(parseFloat(validLat))).toBe(true)
-            expect(isNaN(parseFloat(invalidLat))).toBe(true)
-        })
-
-        test('handles URL encoding', () => {
-            const params = new URLSearchParams('?city=Palo%20Alto')
-            expect(params.get('city')).toBe('Palo Alto')
-        })
-    })
-
-    describe('Country Detection', () => {
-        test('uses explicit country when provided', () => {
-            const getCountry = (country) =>
-                country && country !== 'none' ? country : STORE_LOCATOR_DEFAULT_COUNTRY_CODE
-
-            expect(getCountry('US')).toBe('US')
-            expect(getCountry(null)).toBe(STORE_LOCATOR_DEFAULT_COUNTRY_CODE)
-            expect(getCountry('none')).toBe(STORE_LOCATOR_DEFAULT_COUNTRY_CODE)
-        })
-    })
-
-    describe('Store Matching', () => {
-        const stores = [
-            {id: '001', name: 'Union Square Store', city: 'San Francisco', postalCode: '94108'},
-            {id: '002', name: 'Downtown Store', city: 'Palo Alto', postalCode: '94102'}
-        ]
-
-        test('finds store by name', () => {
-            const match = stores.find((store) => store.name.toLowerCase().includes('union square'))
-            expect(match?.id).toBe('001')
-        })
-
-        test('finds store by postal code', () => {
-            const match = stores.find((store) => store.postalCode === '94102')
-            expect(match?.id).toBe('002')
-        })
-
-        test('finds store by city', () => {
-            const match = stores.find((store) => store.city.toLowerCase().includes('palo alto'))
-            expect(match?.id).toBe('002')
-        })
-    })
-
-    describe('localStorage Handling', () => {
-        test('detects Search Engine provided parameter selection', () => {
-            const storeData = {id: '123', isSeSelection: true}
-            window.localStorage.setItem('store_RefArch', JSON.stringify(storeData))
-
-            const stored = JSON.parse(window.localStorage.getItem('store_RefArch'))
-            expect(stored.isSeSelection).toBe(true)
-        })
-
-        test('handles invalid data gracefully', () => {
-            window.localStorage.setItem('store_RefArch', 'invalid')
-
-            let isValid = false
-            try {
-                JSON.parse(window.localStorage.getItem('store_RefArch'))
-                isValid = true
-            } catch (e) {
-                isValid = false
+        mockStoreLocatorContext.setState.mockClear()
+        mockStoreLocatorContext.state = {
+            selectedStoreId: null,
+            isSeSelection: false,
+            mode: 'input',
+            formValues: {}
+        }
+        useCurrentBasket.mockImplementation(() => ({
+            derivedData: {
+                totalItems: 0
             }
+        }))
+        useSearchStores.mockImplementation(() => ({
+            data: [],
+            isLoading: false,
+            error: null
+        }))
+    })
 
-            expect(isValid).toBe(false)
+    test('initializes with default values', () => {
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        expect(result.current).toEqual({
+            isProcessing: false,
+            shouldOpenModal: false,
+            setShouldOpenModal: expect.any(Function),
+            storeLocatorParams: null,
+            processSeParameters: expect.any(Function)
         })
     })
 
-    describe('Parameter Validation', () => {
-        test('validates sufficient data', () => {
-            const data1 = {latitude: 42.3601, longitude: -71.0589}
-            const data2 = {storeName: 'Test Store'}
-            const data3 = {countryCode: 'US'}
+    test('handles coordinate-based search', async () => {
+        useSearchStores.mockImplementation(() => ({
+            data: {
+                data: [
+                    {
+                        id: 'store1',
+                        name: 'Test Store',
+                        latitude: 37.7749,
+                        longitude: -122.4194,
+                        postalCode: '94105',
+                        countryCode: 'US'
+                    }
+                ]
+            },
+            isLoading: false,
+            error: null
+        }))
 
-            const isValid = (data) =>
-                !!(data.latitude && data.longitude) ||
-                !!(data.storeName || data.zipcode || data.city)
-
-            expect(isValid(data1)).toBe(true)
-            expect(isValid(data2)).toBe(true)
-            expect(isValid(data3)).toBe(false)
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
         })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?lat=37.7749&lng=-122.4194')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(mockStoreLocatorContext.state).toEqual({
+            selectedStoreId: 'store1',
+            isSeSelection: true,
+            mode: 'input',
+            formValues: {
+                countryCode: 'US',
+                postalCode: '94105'
+            }
+        })
+    })
+
+    test('handles postal code search', async () => {
+        useSearchStores.mockImplementation(() => ({
+            data: {
+                data: [
+                    {
+                        id: 'store2',
+                        name: 'Test Store 2',
+                        postalCode: '94105',
+                        countryCode: STORE_LOCATOR_DEFAULT_COUNTRY_CODE
+                    }
+                ]
+            },
+            isLoading: false,
+            error: null
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?zip=94105')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(mockStoreLocatorContext.state).toEqual({
+            selectedStoreId: 'store2',
+            isSeSelection: true,
+            mode: 'input',
+            formValues: {
+                countryCode: STORE_LOCATOR_DEFAULT_COUNTRY_CODE,
+                postalCode: '94105'
+            }
+        })
+    })
+
+    test('handles city search', async () => {
+        useSearchStores.mockImplementation(() => ({
+            data: {
+                data: [
+                    {
+                        id: 'store3',
+                        name: 'Test Store 3',
+                        city: 'San Francisco',
+                        postalCode: '94105',
+                        countryCode: STORE_LOCATOR_DEFAULT_COUNTRY_CODE
+                    }
+                ]
+            },
+            isLoading: false,
+            error: null
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?city=San Francisco')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(mockStoreLocatorContext.state).toEqual({
+            selectedStoreId: 'store3',
+            isSeSelection: true,
+            mode: 'input',
+            formValues: {
+                countryCode: STORE_LOCATOR_DEFAULT_COUNTRY_CODE,
+                postalCode: '94105'
+            }
+        })
+    })
+
+    test('handles empty store data', async () => {
+        useSearchStores.mockImplementation(() => ({
+            data: {
+                data: []
+            },
+            isLoading: false,
+            error: null
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?zip=94105')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(mockStoreLocatorContext.state).toEqual({
+            selectedStoreId: null,
+            isSeSelection: false,
+            mode: 'input',
+            formValues: {}
+        })
+    })
+
+    test('handles loading state', async () => {
+        useSearchStores.mockImplementation(() => ({
+            data: null,
+            isLoading: true,
+            error: null
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?zip=94105')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(result.current.isProcessing).toBe(true)
+    })
+
+    test('handles error case', async () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {})
+        useSearchStores.mockImplementation(() => ({
+            data: null,
+            isLoading: false,
+            error: new Error('API Error')
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?zip=94105')
+            await result.current.processSeParameters(urlParams)
+        })
+
+        expect(mockStoreLocatorContext.state).toEqual({
+            selectedStoreId: null,
+            isSeSelection: false,
+            mode: 'input',
+            formValues: {}
+        })
+        console.error.mockRestore()
+    })
+
+    test('handles basket integration', async () => {
+        useCurrentBasket.mockImplementation(() => ({
+            derivedData: {
+                totalItems: 2
+            }
+        }))
+
+        useSearchStores.mockImplementation(() => ({
+            data: {
+                data: [
+                    {
+                        id: 'store1',
+                        name: 'Test Store',
+                        postalCode: '94105',
+                        countryCode: STORE_LOCATOR_DEFAULT_COUNTRY_CODE
+                    }
+                ]
+            },
+            isLoading: false,
+            error: null
+        }))
+
+        const {result} = renderHook(() => useSeStoreSelection(), {
+            wrapper: TestWrapper
+        })
+
+        await act(async () => {
+            const urlParams = new URLSearchParams('?zip=94105')
+            await result.current.processSeParameters(urlParams)
+            result.current.setShouldOpenModal(true)
+        })
+
+        expect(result.current.shouldOpenModal).toBe(true)
     })
 })

--- a/packages/template-retail-react-app/app/hooks/use-store-locator.js
+++ b/packages/template-retail-react-app/app/hooks/use-store-locator.js
@@ -56,7 +56,7 @@ export const useStoreLocator = () => {
     const {data, isLoading} = useStores(state)
 
     useEffect(() => {
-        if (data?.data?.length > 0 && state.mode === 'input' && !state.isSeSelection) {
+        if (data?.data?.length > 0 && !state.isSeSelection) {
             const nearestStore = data.data[0]
             setState((prev) => ({
                 ...prev,
@@ -64,7 +64,7 @@ export const useStoreLocator = () => {
                 isSeSelection: true
             }))
         }
-    }, [data?.data, state.mode, state.isSeSelection])
+    }, [data?.data, state.isSeSelection])
 
     const setFormValues = (formValues) => {
         setState((prev) => ({

--- a/packages/template-retail-react-app/app/hooks/use-store-locator.js
+++ b/packages/template-retail-react-app/app/hooks/use-store-locator.js
@@ -5,27 +5,26 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {useContext} from 'react'
+import {useContext, useEffect} from 'react'
 import {useSearchStores} from '@salesforce/commerce-sdk-react'
 import {StoreLocatorContext} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
+import {STORE_LOCATOR_NUM_STORES_PER_REQUEST_API_MAX} from '../constants'
 
 const useStores = (state) => {
-    //This is an API limit and is therefore not configurable
-    const NUM_STORES_PER_REQUEST_API_MAX = 200
     const apiParameters =
         state.mode === 'input'
             ? {
                   countryCode: state.formValues.countryCode,
                   postalCode: state.formValues.postalCode,
                   maxDistance: state.config.radius,
-                  limit: NUM_STORES_PER_REQUEST_API_MAX,
+                  limit: STORE_LOCATOR_NUM_STORES_PER_REQUEST_API_MAX,
                   distanceUnit: state.config.radiusUnit
               }
             : {
                   latitude: state.deviceCoordinates.latitude,
                   longitude: state.deviceCoordinates.longitude,
                   maxDistance: state.config.radius,
-                  limit: NUM_STORES_PER_REQUEST_API_MAX,
+                  limit: STORE_LOCATOR_NUM_STORES_PER_REQUEST_API_MAX,
                   distanceUnit: state.config.radiusUnit
               }
     const shouldFetchStores =
@@ -56,13 +55,24 @@ export const useStoreLocator = () => {
     const {state, setState} = context
     const {data, isLoading} = useStores(state)
 
-    // There are two modes, input and device.
-    // The input mode is when the user is searching for a store
-    // by entering a postal code and country code.
-    // The device mode is when the user is searching for a store by sharing their location.
-    // The mode is implicitly set by user's action.
+    useEffect(() => {
+        if (data?.data?.length > 0 && state.mode === 'input' && !state.isSeSelection) {
+            const nearestStore = data.data[0]
+            setState((prev) => ({
+                ...prev,
+                selectedStoreId: nearestStore.id,
+                isSeSelection: true
+            }))
+        }
+    }, [data?.data, state.mode, state.isSeSelection])
+
     const setFormValues = (formValues) => {
-        setState((prev) => ({...prev, formValues, mode: 'input'}))
+        setState((prev) => ({
+            ...prev,
+            formValues,
+            mode: 'input',
+            isSeSelection: false
+        }))
     }
 
     const setDeviceCoordinates = (coordinates) => {
@@ -70,12 +80,17 @@ export const useStoreLocator = () => {
             ...prev,
             deviceCoordinates: coordinates,
             mode: 'device',
-            formValues: {countryCode: '', postalCode: ''}
+            formValues: {countryCode: '', postalCode: ''},
+            isSeSelection: false
         }))
     }
 
     const setSelectedStoreId = (selectedStoreId) => {
-        setState((prev) => ({...prev, selectedStoreId}))
+        setState((prev) => ({
+            ...prev,
+            selectedStoreId,
+            isSeSelection: true // Mark manual store selection as SE selection
+        }))
     }
 
     return {

--- a/packages/template-retail-react-app/app/hooks/use-store-locator.test.jsx
+++ b/packages/template-retail-react-app/app/hooks/use-store-locator.test.jsx
@@ -8,10 +8,23 @@ import React from 'react'
 import {renderHook, act} from '@testing-library/react'
 import {useStoreLocator} from '@salesforce/retail-react-app/app/hooks/use-store-locator'
 import {StoreLocatorProvider} from '@salesforce/retail-react-app/app/contexts/store-locator-provider'
-import {MultiSiteProvider} from '@salesforce/retail-react-app/app/contexts'
 import {useSearchStores} from '@salesforce/commerce-sdk-react'
 
-// Mock the commerce-sdk-react hook
+jest.mock('@salesforce/retail-react-app/app/hooks/use-multi-site', () => ({
+    __esModule: true,
+    default: () => ({
+        site: {
+            id: 'test-site',
+            alias: 'test-site-alias'
+        },
+        locale: {
+            id: 'en-US',
+            preferredCurrency: 'USD'
+        },
+        buildUrl: (path) => path
+    })
+}))
+
 jest.mock('@salesforce/commerce-sdk-react', () => ({
     useSearchStores: jest.fn()
 }))
@@ -23,104 +36,90 @@ const config = {
     defaultPostalCode: '10178'
 }
 
-const mockSite = {
-    id: 'RefArch',
-    alias: 'us'
-}
-
 const wrapper = ({children}) => {
-    return (
-        <MultiSiteProvider site={mockSite}>
-            <StoreLocatorProvider config={config}>{children}</StoreLocatorProvider>
-        </MultiSiteProvider>
-    )
+    return <StoreLocatorProvider config={config}>{children}</StoreLocatorProvider>
 }
 
 describe('useStoreLocator', () => {
     beforeEach(() => {
         useSearchStores.mockReset()
-        // Default mock implementation
         useSearchStores.mockReturnValue({
             data: undefined,
             isLoading: false
         })
+        window.localStorage.clear()
     })
 
     it('throws error when used outside provider', () => {
-        let error
-        try {
-            renderHook(() => useStoreLocator())
-        } catch (err) {
-            error = err
-        }
-
-        expect(error).toEqual(Error('useStoreLocator must be used within a StoreLocatorProvider'))
+        const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+        expect(() => renderHook(() => useStoreLocator())).toThrow(
+            'useStoreLocator must be used within a StoreLocatorProvider'
+        )
+        consoleError.mockRestore()
     })
 
-    it('initializes with default values', () => {
+    it('initializes with default state', () => {
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         expect(result.current).toMatchObject({
             mode: 'input',
             formValues: {
-                countryCode: config.defaultCountryCode,
-                postalCode: config.defaultPostalCode
+                countryCode: '',
+                postalCode: ''
             },
-            deviceCoordinates: {latitude: null, longitude: null},
-            isLoading: false,
-            data: undefined
+            deviceCoordinates: {
+                latitude: null,
+                longitude: null
+            },
+            selectedStoreId: null,
+            isSeSelection: false,
+            config
         })
     })
 
     it('updates form values and switches to input mode', () => {
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         act(() => {
             result.current.setFormValues({
                 countryCode: 'US',
                 postalCode: '94105'
             })
         })
-
         expect(result.current.mode).toBe('input')
         expect(result.current.formValues).toEqual({
             countryCode: 'US',
             postalCode: '94105'
         })
+        expect(result.current.isSeSelection).toBe(false)
     })
 
     it('updates device coordinates and switches to device mode', () => {
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         act(() => {
             result.current.setDeviceCoordinates({
                 latitude: 37.7749,
                 longitude: -122.4194
             })
         })
-
         expect(result.current.mode).toBe('device')
         expect(result.current.deviceCoordinates).toEqual({
             latitude: 37.7749,
             longitude: -122.4194
         })
-        // Should reset form values when switching to device mode
         expect(result.current.formValues).toEqual({
             countryCode: '',
             postalCode: ''
         })
+        expect(result.current.isSeSelection).toBe(false)
     })
 
     it('calls useSearchStores with correct parameters in input mode', () => {
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         act(() => {
             result.current.setFormValues({
                 countryCode: 'US',
                 postalCode: '94105'
             })
         })
-
         expect(useSearchStores).toHaveBeenCalledWith(
             {
                 parameters: {
@@ -139,14 +138,12 @@ describe('useStoreLocator', () => {
 
     it('calls useSearchStores with correct parameters in device mode', () => {
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         act(() => {
             result.current.setDeviceCoordinates({
                 latitude: 37.7749,
                 longitude: -122.4194
             })
         })
-
         expect(useSearchStores).toHaveBeenCalledWith(
             {
                 parameters: {
@@ -163,38 +160,108 @@ describe('useStoreLocator', () => {
         )
     })
 
+    it('automatically selects nearest store when data is received in input mode', () => {
+        const mockStores = {
+            data: [
+                {id: 'store1', name: 'Store 1'},
+                {id: 'store2', name: 'Store 2'}
+            ]
+        }
+        useSearchStores.mockReturnValue({
+            data: mockStores,
+            isLoading: false
+        })
+
+        const {result} = renderHook(() => useStoreLocator(), {wrapper})
+        act(() => {
+            result.current.setFormValues({
+                countryCode: 'US',
+                postalCode: '94105'
+            })
+        })
+
+        expect(result.current.selectedStoreId).toBe('store1')
+        expect(result.current.isSeSelection).toBe(true)
+    })
+
+    it('allows manual store selection', () => {
+        const {result} = renderHook(() => useStoreLocator(), {wrapper})
+        act(() => {
+            result.current.setSelectedStoreId('store123')
+        })
+        expect(result.current.selectedStoreId).toBe('store123')
+        expect(result.current.isSeSelection).toBe(true)
+    })
+
     it('handles loading state', () => {
         useSearchStores.mockReturnValue({
             data: undefined,
             isLoading: true
         })
-
         const {result} = renderHook(() => useStoreLocator(), {wrapper})
-
         expect(result.current.isLoading).toBe(true)
     })
 
-    it('handles store data', () => {
-        const mockStoreData = [
-            {
-                id: '1',
-                name: 'Test Store',
-                address: {
-                    address1: '123 Test St',
-                    city: 'Test City',
-                    stateCode: 'CA',
-                    postalCode: '94105'
-                }
-            }
-        ]
-
-        useSearchStores.mockReturnValue({
-            data: mockStoreData,
-            isLoading: false
+    describe('useStoreLocator - localStorage behavior', () => {
+        it('initializes with stored selectedStoreId from localStorage', () => {
+            window.localStorage.setItem('selectedStore_test-site', 'store123')
+            const {result} = renderHook(() => useStoreLocator(), {wrapper})
+            expect(result.current.selectedStoreId).toBe('store123')
         })
 
-        const {result} = renderHook(() => useStoreLocator(), {wrapper})
+        it('updates localStorage when selectedStoreId changes', () => {
+            const {result} = renderHook(() => useStoreLocator(), {wrapper})
+            act(() => {
+                result.current.setSelectedStoreId('store456')
+            })
+            expect(window.localStorage.getItem('selectedStore_test-site')).toBe('store456')
+        })
 
-        expect(result.current.data).toEqual(mockStoreData)
+        it('initializes with empty values when localStorage is empty', () => {
+            const {result} = renderHook(() => useStoreLocator(), {wrapper})
+            expect(result.current.selectedStoreId).toBeNull()
+            expect(result.current.formValues).toEqual({
+                countryCode: '',
+                postalCode: ''
+            })
+            expect(useSearchStores).toHaveBeenCalledWith(
+                {
+                    parameters: {
+                        countryCode: '',
+                        postalCode: '',
+                        maxDistance: 100,
+                        limit: 200,
+                        distanceUnit: 'mi'
+                    }
+                },
+                {
+                    enabled: false
+                }
+            )
+        })
+
+        it('initializes with empty values when localStorage data is invalid', () => {
+            window.localStorage.setItem('selectedStore_test-site', 'invalid-json')
+            const {result} = renderHook(() => useStoreLocator(), {wrapper})
+            expect(result.current.selectedStoreId).toBe('invalid-json')
+            expect(result.current.formValues).toEqual({
+                countryCode: '',
+                postalCode: ''
+            })
+            expect(useSearchStores).toHaveBeenCalledWith(
+                {
+                    parameters: {
+                        countryCode: '',
+                        postalCode: '',
+                        maxDistance: 100,
+                        limit: 200,
+                        distanceUnit: 'mi'
+                    }
+                },
+                {
+                    enabled: false
+                }
+            )
+        })
     })
 })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
https://github.com/user-attachments/assets/7f2424e6-9b16-4c7f-af19-6e6877779891

https://github.com/user-attachments/assets/ff86f1b9-aeb6-463c-a638-bc8fe19fd8d7

https://github.com/user-attachments/assets/ff24f3ab-6993-480a-8164-99e5a769e737


This PR enhances the store locator functionality by introducing support for location-based parameters in the URL, including: latitude, longitude, city, zip, country, and store. These parameters allow deep-linking and pre-selection of stores when the URL is shared or accessed via search engines.

Key Enhancements:
- URL-based Store Pre-selection: Location-based fields in the URL are used to auto-select a matching store (if available from the API).

- Store Highlighting & Persistence: The selected store is sorted to the top of the list in the store locator view and persisted in localStorage, surviving page refreshes unless manually changed or cleared.

- URL Cleanup: After store selection, location-based parameters are removed from the URL while retaining others like search and language.

- PLP & PDP Integration: Works seamlessly with Product Listing Page (PLP) and Product Detail Page (PDP), ensuring that item search and store selection parameters do not conflict. Handles edge cases like multiple ? query strings in PDP URLs.

- Basket-aware Behavior: Store selection is disabled when items are present in the basket, preventing store changes mid-purchase. Functionality is re-enabled once the basket is empty.

These changes improve user experience by enabling smarter store selection and maintaining consistent behavior across different storefront entry points.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [x] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Kindly view recordings

# How to Test-Drive This PR

- Navigate to site
- Append the URL with location based params (examples listed below)
   - http://localhost:3000/?lat=42.3601&lng=-71.0589
   - http://localhost:3000/?zip=02215&country=US
   - http://localhost:3000/?city=Boston&country=US
   - http://localhost:3000/?city=San%20Francisco&country=US
   - http://localhost:3000/?store=Dedham%20Retail%20Store&zip=02215&country=US
- View the store locator component to view the selection of the store
- View cart, pdp, plp pages and select the store-locator component to ensure the persistence of the selection.

### Item based search - PLP
- Append the URL with location based params (examples listed below)
      - http://localhost:3000/?lat=42.3601&lng=-71.0589&q=shoes
      - http://localhost:3000/?zip=02215&country=US&q=ties
      - http://localhost:3000/?Store=Waltham%20Retail%20Store&zip=02215&country=US&q=gloves
      
- The PLP page for the item search opens up and the store locator component opens up with the selected store after all the components on the page are loaded.
- The location based params in the URL are cleared.

### Item based search - PDP
- Append the URL with location based params (examples listed below)
      - http://localhost:3000/global/en-GB/product/P0048M?city=San%20Francisco&country=US
      - http://localhost:3000/global/en-GB/product/82936941M?color=BDA&city=Boston&country=US
      - http://localhost:3000/global/en-GB/product/82936941M?color=BDA?city=San%20Francisco&country=US
      - http://localhost:3000/?q=ties?city=San%20Francisco&country=US
      (the last 2 URLs above should show behavior where the ? before city is converted to & to ensure that there is only 1 single query starter (?) while maintaining functionality)
      
### Store-selection restriction when basket not empty
- Ensure basket is empty.
- Select a store from the locator modal.
- Add any item to the cart.
- Try opening the store-locator modal from the homepage, PDP, PLP page, the user is unable to select/update their store selection
- Delete the items from the basket. Ensure the basket is empty.
- Open the store-locator modal to try selecting the stores, the user is able to select from the list of stores again.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [x] Changes include a UI text update in the Retail React App (which requires translation)