### PR TITLE
@W-18904649@ - Create a driver workflow for per-PR E2E tests

### DIFF
--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -12,6 +12,11 @@ jobs:
     test_e2e_private:
         runs-on: ubuntu-latest
         steps:
+           # Skipping the entire workflow for now until all steps are implemented.
+            - name: Skip Check
+              run: | 
+                exit 0
+
             - name: Checkout
               uses: actions/checkout@v4
 

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -1,0 +1,96 @@
+name: SalesforceCommerceCloud/pwa-kit/e2e-pr
+on:
+    workflow_dispatch:
+    pull_request: # Default: opened, reopened, synchronize (head branch updated)
+    merge_group: # Trigger GA workflow when a pull request is added to a merge queue.
+    push:
+        branches:
+            - develop
+            - 'release-*'
+
+jobs:
+    test_e2e_private:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Check PWA Kit Version
+              run: |-
+                  version=`jq -r ".version" package.json`
+                  echo "pwa_kit_version=$version" >> "$GITHUB_ENV"
+
+            # TODO: Skip the entire workflow since we don't have e2e tests for PWA Kit v2.x
+            - name: Skip if PWA Kit version older than v3.x
+              run: |
+                  major_version=$(echo "${{ env.pwa_kit_version }}" | cut -d. -f1)
+                   if [ "$major_version" -lt 3 ]; then
+                     echo "PWA Kit version is older than v3.x, skipping workflow."
+                     exit 0
+                   fi
+
+            # Only test for latest Node version supported by MRT
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 22
+                  cache: npm
+
+            # Check central resource allocation on AWS and get a lock on an available environment from the pool.
+            # Returns the MRT target ID if lock is acquired, otherwise returns an error state.
+            - name: Get MRT Target lock
+              id: get_mrt_target_lock
+              run: |
+                  echo "TODO: Implement .github/actions/get_mrt_target_lock"
+
+            - name: Create MRT target
+              id: create_mrt_target
+              if: ${{ steps.get_mrt_target_lock.outputs.status == 'ERR_NO_AVAILABLE_TARGETS' }}
+              run: |
+                  echo "TODO: Call .github/actions/create_mrt_target with correct inputs"
+
+            - name: Get Template Version
+              run: |-
+                  version=`jq -r ".version" packages/template-retail-react-app/package.json`
+                  echo "retail_app_template_version=$version" >> "$GITHUB_ENV"
+
+            - name: Generate Retail App Private Client
+              uses: ./.github/actions/e2e_generate_app
+              with:
+                  PROJECT_KEY: 'retail-app-private-client'
+                  TEMPLATE_VERSION: ${{ env.retail_app_template_version }}
+
+            - name: Validate Retail App Without Extensibility
+              uses: ./.github/actions/e2e_validate_generated_app
+              with:
+                  PROJECT_KEY: 'retail-app-no-ext'
+                  TEMPLATE_VERSION: ${{ env.retail_app_template_version }}
+
+            # TODO: Revisit the next 2 steps to see if we can use the existing .github/actions/deploy_app action.
+            - name: Create MRT credentials file
+              uses: './.github/actions/create_mrt'
+              with:
+                  mobify_user: ${{ secrets.MOBIFY_CLIENT_USER }}
+                  mobify_api_key: ${{ secrets.MOBIFY_CLIENT_API_KEY }}
+
+            - name: Push Bundle to MRT (E2E Test PWA Kit)
+              uses: './.github/actions/push_to_mrt'
+              with:
+                  CWD: '../generated-projects/retail-app-no-ext'
+                  # TODO: Use the MRT target ID from the target lock step above.
+                  TARGET: e2e-tests-pwa-kit
+                  FLAGS: --wait
+
+            - name: Install Playwright Browsers
+              run: npx playwright install --with-deps
+
+            - name: Run Playwright tests
+              run: npm run test:e2e
+
+            - name: Run Playwright a11y tests
+              run: npm run test:e2e:a11y
+
+            - name: Release MRT Target Lock
+              if: always() # Always release the target lock back to the pool even if the tests fail.
+              run: |
+                echo "TODO: Implement .github/actions/release_mrt_target_lock"

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -15,7 +15,7 @@ jobs:
            # Skipping the entire workflow for now until all steps are implemented.
             - name: Skip Check
               run: | 
-                exit 0
+                echo "SKIP_WORKFLOW=true" >> "$GITHUB_ENV"
 
             - name: Checkout
               uses: actions/checkout@v4
@@ -27,15 +27,17 @@ jobs:
 
             # TODO: Skip the entire workflow since we don't have e2e tests for PWA Kit v2.x
             - name: Skip if PWA Kit version older than v3.x
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: |
                   major_version=$(echo "${{ env.pwa_kit_version }}" | cut -d. -f1)
                    if [ "$major_version" -lt 3 ]; then
                      echo "PWA Kit version is older than v3.x, skipping workflow."
-                     exit 0
+                     echo "SKIP_WORKFLOW=true" >> "$GITHUB_ENV"
                    fi
 
             # Only test for latest Node version supported by MRT
             - name: Setup Node
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: actions/setup-node@v4
               with:
                   node-version: 22
@@ -44,28 +46,32 @@ jobs:
             # Check central resource allocation on AWS and get a lock on an available environment from the pool.
             # Returns the MRT target ID if lock is acquired, otherwise returns an error state.
             - name: Get MRT Target lock
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               id: get_mrt_target_lock
               run: |
                   echo "TODO: Implement .github/actions/get_mrt_target_lock"
 
             - name: Create MRT target
               id: create_mrt_target
-              if: ${{ steps.get_mrt_target_lock.outputs.status == 'ERR_NO_AVAILABLE_TARGETS' }}
+              if: ${{ env.SKIP_WORKFLOW != 'true' && steps.get_mrt_target_lock.outputs.status == 'ERR_NO_AVAILABLE_TARGETS' }}
               run: |
                   echo "TODO: Call .github/actions/create_mrt_target with correct inputs"
 
             - name: Get Template Version
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: |-
                   version=`jq -r ".version" packages/template-retail-react-app/package.json`
                   echo "retail_app_template_version=$version" >> "$GITHUB_ENV"
 
             - name: Generate Retail App Private Client
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: ./.github/actions/e2e_generate_app
               with:
                   PROJECT_KEY: 'retail-app-private-client'
                   TEMPLATE_VERSION: ${{ env.retail_app_template_version }}
 
             - name: Validate Retail App Without Extensibility
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: ./.github/actions/e2e_validate_generated_app
               with:
                   PROJECT_KEY: 'retail-app-no-ext'
@@ -73,12 +79,14 @@ jobs:
 
             # TODO: Revisit the next 2 steps to see if we can use the existing .github/actions/deploy_app action.
             - name: Create MRT credentials file
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: './.github/actions/create_mrt'
               with:
                   mobify_user: ${{ secrets.MOBIFY_CLIENT_USER }}
                   mobify_api_key: ${{ secrets.MOBIFY_CLIENT_API_KEY }}
 
             - name: Push Bundle to MRT (E2E Test PWA Kit)
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: './.github/actions/push_to_mrt'
               with:
                   CWD: '../generated-projects/retail-app-no-ext'
@@ -87,12 +95,15 @@ jobs:
                   FLAGS: --wait
 
             - name: Install Playwright Browsers
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: npx playwright install --with-deps
 
             - name: Run Playwright tests
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: npm run test:e2e
 
             - name: Run Playwright a11y tests
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: npm run test:e2e:a11y
 
             - name: Release MRT Target Lock


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
As a PWA kit stakeholder, I'd like e2e tests to run per-PR/per-commit proactively instead of waiting overnight to know if the new code change is about to cause regressions.

This PR creates a placeholder workflow which is required to exist on the default branch to allow test runs for the workflow when implementing workflow steps on feature branches.

## How does this work ?

We checkout code for each branch that triggers this workflow, generate a new PWA Kit app, deploy the app to MRT instance and run e2e tests against the instance to catch any runtime regressions in the generated app before the branch is merged.

## How do we get an MRT instance per-PR ?
We've acquried a new MRT org on MRT stg env with 100 available targets.
We start by creating a pool of 10 MRT targets.

### Solution Overview

We need a way for GitHub Actions workflow to:
1. **Check out an available MRT environment from the pool.**
2. **Mark it as “in use”** (so other jobs don’t grab it).
3. **Deploy and run tests.**
4. **Release the environment** (mark as “available” again).

This is not natively supported by GitHub Actions, but we can implement it using a **centralized lock/state mechanism** .

#### 1. **Use a Central Lock File in a Cloud Storage Bucket**

- Store a JSON file in a shared location (i.e. AWS S3).
- The file lists the MRT target envs and their status (`available`/`in-use`/`by which PR`).
- Each workflow run:
  - **Optimistic Locking:**  
  - When you download the pool file (e.g., `mrt-env-pool.json`), also get its version or ETag.
  - When you upload your updated file (after marking an env as “in-use”), include the version/ETag in the upload request.
  - If the version/ETag has changed (someone else updated the file), your upload fails. You must retry: download the latest, try again.
 
Here’s a high-level outline for the S3 approach:

1. **Create a file** in S3, e.g., `mrt-env-pool.json`:
   ```json
   {
     "envs": [
       {"name": "env1", "status": "available"},
       {"name": "env2", "status": "available"},
       ...
     ]
   }
   ```

2. **In the GitHub Actions workflow:**
   - Download `mrt-env-pool.json` and its ETag.
   - Find an available env, mark as “in-use” by your PR.
   - Try to upload the file with the ETag as a precondition.
   - If upload fails (ETag mismatch), go back to step 1 (retry).
   - If upload succeeds, you have the lock.

3. **If no env is available:**
   - The script returns status: `ERR_NO_TARGETS_AVAILABLE`
   - The following step in the workflow will create a new target and add it to the pool for future use if this error state is returned.
   - We have 100 available targets so this should work smoothly for a while. We have follow-up work planned to manage auto-scaling(both scaling up and down) of these targets. But falling back to create a new target will work for now.

### Why is this so complex ?

We're facing  is a classic “resource pool” orchestration problem, which is a common challenge for CI/CD pipelines that need to run integration/e2e tests against limited, expensive, or slow-to-provision environments.

We considered other solutions like: 
**1. Create an MRT env per test-run and tear it down as soon as the test run completes**
Problem here is, spinning up new targets take about 20mins. So each test run or re-run by default gets delayed by 20mins.
This keeps the github actions worker waiting which adds to costs and also slows down developer productivity. 

MRT also has a 100 deploys per hour per target rate limit for it's APIs. So we need to be mindful of not exhausting the rate-limit as well.

**2. Create an MRT env per PR and tear it down once the PR merges.**
This takes care of the cold start/MRT setup issue where a github actions workflow or the developer creating the PR will need to wait for the MRT target to setup only the first time when the PR is created. For each subsequent commit to the PR/re-triggered test run the MRT target available for the PR. However, some PRs tend to eventually become stale or inactive after a while or might be created as a POC or a spike or steel thread for an experimental feature which may or may not merge into develop. This causes the MRT env tied to the PR to be blocked for as long as the PR is open requiring additional automation to scan all open PRs time-to-time and decide if the MRT env tied to the PR should be torn down and made available for new PRs.

Current proposed solution takes care of both these issues.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Created a new placeholder workflow
- Do NOT add the workflow as a required check yet!

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
