### PR TITLE
[Generator] cursor rules are now copied for any type of project

### DIFF
--- a/packages/pwa-kit-create-app/CHANGELOG.md
+++ b/packages/pwa-kit-create-app/CHANGELOG.md
@@ -3,8 +3,8 @@
 - Add `program.json` + Support for Agent-Friendly CLI Input via stdio [#2662](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2662)
 - Change the default ECOM instance in the generated application [#2610](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2610)
 - Load active data scripts on demand only [#2623](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2623)
-- Introduce the cursor rules to assist storefront project developers [#2578] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2578)
-- Add `StoreLocatorProvider` to the `AppConfig` template to support BOPIS [#2753] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2753)
+- Introduce the cursor rules to assist storefront project developers [#2578](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2578) [#2754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2754)
+- Add `StoreLocatorProvider` to the `AppConfig` template to support BOPIS [#2753](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2753)
 
 ## v3.10.0 (May 22, 2025)
 - Add Data Cloud API configuration to `default.js`. [#2318](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2318)

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -352,22 +352,6 @@ const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
         assets.forEach((asset) => {
             sh.cp('-rf', p.join(packagePath, asset), outputDir)
         })
-
-        // Copy the .cursor/rules directory if it exists
-        if (sh.test('-e', CURSOR_RULES_FROM_DIR)) {
-            const outputCursorRulesDir = p.join(outputDir, '.cursor', 'rules')
-
-            // Create the directory if it doesn't exist
-            if (!sh.test('-e', outputCursorRulesDir)) {
-                fs.mkdirSync(outputCursorRulesDir, {recursive: true})
-            }
-
-            // Copy the contents of CURSOR_RULES_FROM_DIR to outputCursorRulesDir
-            const files = fs.readdirSync(CURSOR_RULES_FROM_DIR)
-            files.forEach((file) => {
-                sh.cp('-rf', p.join(CURSOR_RULES_FROM_DIR, file), outputCursorRulesDir)
-            })
-        }
     } else {
         console.log('Copying base template from package or npm: ', packagePath, outputDir)
         // Copy the base template either from the package or npm.
@@ -396,6 +380,22 @@ const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
 
         // Clean up
         sh.rm('-rf', tmp)
+    }
+
+    // Copy the .cursor/rules directory if it exists
+    if (sh.test('-e', CURSOR_RULES_FROM_DIR)) {
+        const outputCursorRulesDir = p.join(outputDir, '.cursor', 'rules')
+
+        // Create the directory if it doesn't exist
+        if (!sh.test('-e', outputCursorRulesDir)) {
+            fs.mkdirSync(outputCursorRulesDir, {recursive: true})
+        }
+
+        // Copy the contents of CURSOR_RULES_FROM_DIR to outputCursorRulesDir
+        const files = fs.readdirSync(CURSOR_RULES_FROM_DIR)
+        files.forEach((file) => {
+            sh.cp('-rf', p.join(CURSOR_RULES_FROM_DIR, file), outputCursorRulesDir)
+        })
     }
 
     // Install dependencies for the newly minted project.


### PR DESCRIPTION
It used to be that the generator would copy over the cursor rules _only if_ the user chooses extensibility for their project. Now regardless of their selection, we will still copy the cursor rules.

Related PR: #2578 

## How to test drive the PR

1. From the monorepo root, run `node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir /tmp/generated-project` to generate a new project
2. When the generator ask you questions, choose to answer: `using your own Commerce Cloud instance` and a non-extensible project.
3. Once the project is generated, verify that cursor rules exist in `/.cursor/rules`.