### PR TITLE
@W-18672733@ Chakra v3 - Checkout page alert follow up

### DIFF
--- a/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
@@ -6,7 +6,7 @@
  */
 import React, {useEffect, useState} from 'react'
 import {FormattedMessage, useIntl} from 'react-intl'
-import {Alert, AlertIcon, Box, Button, Container, Grid, GridItem, Stack} from '@chakra-ui/react'
+import {Alert, Box, Button, Container, Grid, GridItem, Stack} from '@chakra-ui/react'
 import useNavigation from '../../hooks/use-navigation'
 import {CheckoutProvider, useCheckout} from '../../pages/checkout/util/checkout-context'
 import ContactInfo from '../../pages/checkout/partials/contact-info'
@@ -73,10 +73,14 @@ const Checkout = () => {
                     <GridItem>
                         <Stack gap={4}>
                             {error && (
-                                <Alert status="error" variant="left-accent">
-                                    <AlertIcon />
-                                    {error}
-                                </Alert>
+                                <Alert.Root colorPalette="red">
+                                    <Alert.Indicator />
+                                      <Alert.Content>
+                                            <Text fontSize="sm">
+                                                {error}
+                                            </Text>
+                                        </Alert.Content>
+                                </Alert.Root>
                             )}
 
                             <ContactInfo

--- a/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
@@ -78,9 +78,7 @@ const Checkout = () => {
                                     <Alert.Indicator>
                                         <AlertIcon color="red.500" boxSize={4} />
                                     </Alert.Indicator>
-                                    <Alert.Description>
-                                        {error}
-                                    </Alert.Description>
+                                    <Alert.Description>{error}</Alert.Description>
                                 </Alert.Root>
                             )}
 

--- a/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
+++ b/packages/extension-chakra-storefront/src/pages/checkout/index.jsx
@@ -23,6 +23,7 @@ import {API_ERROR_MESSAGE, TOAST_MESSAGE_REMOVED_ITEM_FROM_CART} from '../../con
 import useToast from '../../hooks/use-toast'
 import {useExtensionConfig} from '../../hooks'
 import LoadingSpinner from '../../components/loading-spinner'
+import {AlertIcon} from '../../components/icons'
 
 const Checkout = () => {
     const {formatMessage} = useIntl()
@@ -73,13 +74,13 @@ const Checkout = () => {
                     <GridItem>
                         <Stack gap={4}>
                             {error && (
-                                <Alert.Root colorPalette="red">
-                                    <Alert.Indicator />
-                                      <Alert.Content>
-                                            <Text fontSize="sm">
-                                                {error}
-                                            </Text>
-                                        </Alert.Content>
+                                <Alert.Root status="error" colorPalette="red">
+                                    <Alert.Indicator>
+                                        <AlertIcon color="red.500" boxSize={4} />
+                                    </Alert.Indicator>
+                                    <Alert.Description>
+                                        {error}
+                                    </Alert.Description>
                                 </Alert.Root>
                             )}
 


### PR DESCRIPTION
Small follow up to update an alert component on the checkout page to Chakra v3.

![Screenshot 2025-07-08 at 2 21 38 PM](https://github.com/user-attachments/assets/db8c0e68-0026-4665-b039-50c6755a468e)

Testing the changes
1. On the checkout page, set the initial error state to a test value: `const [error, setError] = useState("test")`
2. Start the app
3. Navigate to the checkout page
4. Verify the error later renders
