### PR TITLE
[Chakra upgrade v3] Make sure that the desktop nav menu lazyloads its content (@W-18989161@)

### DIFF
--- a/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
+++ b/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
@@ -30,10 +30,8 @@ const ListMenuPopover = ({contentComponent, item, name, itemsKey, maxColumns}) =
             open={open}
             onOpenChange={handleOpenChange}
         >
-            <Popover.Trigger asChild>
-                <Box>
-                    <ListMenuTrigger item={item} name={name} isOpen={open} />
-                </Box>
+            <Popover.Trigger>
+                <ListMenuTrigger item={item} name={name} isOpen={open} />
             </Popover.Trigger>
             <Popover.Positioner>
                 <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>

--- a/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
+++ b/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
@@ -25,7 +25,7 @@ const ListMenuPopover = ({contentComponent, item, name, itemsKey, maxColumns}) =
             <Popover.Root
                 open={open}
                 positioning={{placement: 'bottom-start'}}
-                lazyMounted
+                lazyMount
                 unstyled
             >
                 <Popover.Trigger asChild>
@@ -39,20 +39,18 @@ const ListMenuPopover = ({contentComponent, item, name, itemsKey, maxColumns}) =
                         />
                     </Box>
                 </Popover.Trigger>
-                {open && (
-                    <Popover.Positioner>
-                        <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
-                            <Popover.Body css={styles.popoverBody}>
-                                <ContentComponent
-                                    item={item}
-                                    itemsKey={itemsKey}
-                                    onClose={onClose}
-                                    maxColumns={maxColumns}
-                                />
-                            </Popover.Body>
-                        </Popover.Content>
-                    </Popover.Positioner>
-                )}
+                <Popover.Positioner>
+                    <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
+                        <Popover.Body css={styles.popoverBody}>
+                            <ContentComponent
+                                item={item}
+                                itemsKey={itemsKey}
+                                onClose={onClose}
+                                maxColumns={maxColumns}
+                            />
+                        </Popover.Body>
+                    </Popover.Content>
+                </Popover.Positioner>
             </Popover.Root>
         </Box>
     )

--- a/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
+++ b/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
@@ -14,45 +14,35 @@ import {ListMenuTrigger} from '../../components/list-menu/list-menu-trigger'
 
 const ListMenuPopover = ({contentComponent, item, name, itemsKey, maxColumns}) => {
     const [open, setOpen] = useState(false)
-    const onOpen = () => setOpen(true)
-    const onClose = () => setOpen(false)
+    const handleOpenChange = (details) => {
+        setOpen(details.open)
+    }
+
     const ContentComponent = contentComponent || ListMenuContent
     const recipe = useSlotRecipe({key: 'listMenu'})
     const styles = recipe()
 
     return (
-        <Box onMouseLeave={onClose}>
-            <Popover.Root
-                open={open}
-                positioning={{placement: 'bottom-start'}}
-                lazyMount
-                unstyled
-            >
-                <Popover.Trigger asChild>
-                    <Box onMouseEnter={onOpen}>
-                        <ListMenuTrigger
-                            item={item}
-                            name={name}
-                            isOpen={open}
-                            onOpen={onOpen}
-                            onClose={onClose}
-                        />
-                    </Box>
-                </Popover.Trigger>
-                <Popover.Positioner>
-                    <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
-                        <Popover.Body css={styles.popoverBody}>
-                            <ContentComponent
-                                item={item}
-                                itemsKey={itemsKey}
-                                onClose={onClose}
-                                maxColumns={maxColumns}
-                            />
-                        </Popover.Body>
-                    </Popover.Content>
-                </Popover.Positioner>
-            </Popover.Root>
-        </Box>
+        <Popover.Root
+            positioning={{placement: 'bottom-start'}}
+            lazyMount
+            unstyled
+            open={open}
+            onOpenChange={handleOpenChange}
+        >
+            <Popover.Trigger asChild>
+                <Box>
+                    <ListMenuTrigger item={item} name={name} isOpen={open} />
+                </Box>
+            </Popover.Trigger>
+            <Popover.Positioner>
+                <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
+                    <Popover.Body css={styles.popoverBody}>
+                        <ContentComponent item={item} itemsKey={itemsKey} maxColumns={maxColumns} />
+                    </Popover.Body>
+                </Popover.Content>
+            </Popover.Positioner>
+        </Popover.Root>
     )
 }
 

--- a/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
+++ b/packages/extension-chakra-storefront/src/components/list-menu/list-menu-popover.jsx
@@ -39,18 +39,20 @@ const ListMenuPopover = ({contentComponent, item, name, itemsKey, maxColumns}) =
                         />
                     </Box>
                 </Popover.Trigger>
-                <Popover.Positioner>
-                    <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
-                        <Popover.Body css={styles.popoverBody}>
-                            <ContentComponent
-                                item={item}
-                                itemsKey={itemsKey}
-                                onClose={onClose}
-                                maxColumns={maxColumns}
-                            />
-                        </Popover.Body>
-                    </Popover.Content>
-                </Popover.Positioner>
+                {open && (
+                    <Popover.Positioner>
+                        <Popover.Content data-testid="popover-menu" css={styles.popoverContent}>
+                            <Popover.Body css={styles.popoverBody}>
+                                <ContentComponent
+                                    item={item}
+                                    itemsKey={itemsKey}
+                                    onClose={onClose}
+                                    maxColumns={maxColumns}
+                                />
+                            </Popover.Body>
+                        </Popover.Content>
+                    </Popover.Positioner>
+                )}
             </Popover.Root>
         </Box>
     )

--- a/packages/extension-chakra-storefront/src/components/list-menu/list-menu-trigger.jsx
+++ b/packages/extension-chakra-storefront/src/components/list-menu/list-menu-trigger.jsx
@@ -9,28 +9,22 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {Link as RouteLink} from 'react-router-dom'
 
-import {Box, useSlotRecipe} from '@chakra-ui/react'
+import {Box, Button, useSlotRecipe} from '@chakra-ui/react'
 
 import Link from '../../components/link'
 import {ChevronDownIcon} from '../../components/icons'
 
 import {categoryUrlBuilder} from '../../utils/url'
 
-const ListMenuTrigger = ({item, name, isOpen, onOpen, onClose}) => {
+const ListMenuTrigger = ({item, name, isOpen}) => {
     const recipe = useSlotRecipe({key: 'listMenu'})
     const styles = recipe()
-
-    const keyMap = {
-        Escape: () => onClose(),
-        Enter: () => onOpen()
-    }
 
     return (
         <Box css={styles.listMenuTriggerContainer}>
             <Link
                 as={RouteLink}
                 to={categoryUrlBuilder(item)}
-                onMouseOver={onOpen}
                 css={styles.listMenuTriggerLink}
                 {...{name: name + ' __'}}
                 {...(isOpen ? {css: styles.listMenuTriggerLinkActive} : {})}
@@ -38,17 +32,9 @@ const ListMenuTrigger = ({item, name, isOpen, onOpen, onClose}) => {
                 {name}
             </Link>
 
-            <Link
-                as={RouteLink}
-                to={'#'}
-                onMouseOver={onOpen}
-                onKeyDown={(e) => {
-                    keyMap[e.key]?.(e)
-                }}
-                css={styles.listMenuTriggerLinkIcon}
-            >
+            <Button unstyled css={styles.listMenuTriggerLinkIcon}>
                 <ChevronDownIcon />
-            </Link>
+            </Button>
         </Box>
     )
 }
@@ -56,9 +42,7 @@ const ListMenuTrigger = ({item, name, isOpen, onOpen, onClose}) => {
 ListMenuTrigger.propTypes = {
     item: PropTypes.object,
     name: PropTypes.string,
-    isOpen: PropTypes.bool,
-    onOpen: PropTypes.func,
-    onClose: PropTypes.func
+    isOpen: PropTypes.bool
 }
 
 export {ListMenuTrigger}

--- a/packages/extension-chakra-storefront/src/theme/components/project/list-menu.js
+++ b/packages/extension-chakra-storefront/src/theme/components/project/list-menu.js
@@ -120,7 +120,8 @@ export default defineSlotRecipe({
             marginLeft: 0,
             _hover: {
                 textDecoration: 'none'
-            }
+            },
+            cursor: 'pointer'
         }
     }
 })


### PR DESCRIPTION
This PR makes sure to preserve the original behaviour, which is the initially-hidden content of the nav menu is lazyloaded. When the shoppers open the menu, that is when the app would fetch the menu content.

TODOs
- [x] open menu on click (not on hover)

## How to test-drive the PR

The issue was happening on desktop only.
1. Navigate to http://localhost:3000/ on desktop
2. Click on the New Arrivals category
3. A loading spinner would appear, as the subcategories are being fetched
4. Click on another top-level category, say, Womens
5. Expect to see another loading spinner too