### PR TITLE
@W-18670301 - trim with code marker comments

### DIFF
--- a/packages/pwa-kit-create-app/scripts/trim-extensions.js
+++ b/packages/pwa-kit-create-app/scripts/trim-extensions.js
@@ -8,20 +8,21 @@
 const fs = require('fs')
 const parser = require('@babel/parser')
 const traverse = require('@babel/traverse').default
-const generate = require('@babel/generator').default
 const path = require('path')
 const pluginConfig = require('../assets/plugin-config')
-const {execSync} = require('child_process')
 
 const removeComponentCandidates = new Set() // List of files that are candidates for removal, as a result of trimming.
 const SEPARATOR = path.sep // Use OS-specific path separator
 const COMPONENT_SCAN_PATHS = [
-    `${SEPARATOR}src${SEPARATOR}components${SEPARATOR}`,
-    `${SEPARATOR}src${SEPARATOR}pages${SEPARATOR}`,
-    `${SEPARATOR}src${SEPARATOR}hooks${SEPARATOR}`,
-    `${SEPARATOR}src${SEPARATOR}routes.tsx`,
-    `${SEPARATOR}config${SEPARATOR}constants.js`
+    path.join(SEPARATOR, 'src', 'components', SEPARATOR),
+    path.join(SEPARATOR, 'src', 'pages', SEPARATOR),
+    path.join(SEPARATOR, 'src', 'hooks', SEPARATOR),
+    path.join(SEPARATOR, 'src', 'routes.tsx'),
+    path.join(SEPARATOR, 'config', 'constants.js')
 ]
+const SINGLE_LINE_MARKER = 'sfdc-extension-line'
+const BLOCK_MARKER_START = 'sfdc-extension-block-start'
+const BLOCK_MARKER_END = 'sfdc-extension-block-end'
 
 /**
  * Trim the directory to remove unused components and unused plugins.
@@ -72,191 +73,115 @@ function trimExtensions(directory, generatedPlugins) {
 }
 
 function processFile(filePath, plugins) {
+    let modified = false // flag to indicate if the file was modified
+    let blockMarkers = [] // stack of block markers
+    let removedBlocks = [] // list of blocks that were removed
+    let skippingBlock = false // flag to indicate if we are skipping a block
+
     // Read source file
     const source = fs.readFileSync(filePath, 'utf-8')
 
     // Search file content for plugin references
-    const pluginPositions = []
     const pluginRegex = new RegExp(Object.keys(plugins).join('|'), 'g')
-    let match
-    while ((match = pluginRegex.exec(source)) !== null) {
-        pluginPositions.push({
-            start: match.index,
-            end: match.index + match[0].length,
-            name: match[0] // store which plugin was found
-        })
-    }
-    if (pluginPositions.length === 0) {
-        // No plugins found in file, return early
-        return false
-    }
-
-    // Parse into AST
-    const ast = parser.parse(source, {
-        sourceType: 'module',
-        plugins: ['jsx', 'typescript']
-    })
-
-    // Track if we made any changes
-    let modified = false
-
-    // Shared helper to evaluate boolean expressions with plugins
-    const evaluateLogicalExpression = (node) => {
-        if (node.type === 'Identifier' && Object.keys(plugins).includes(node.name)) {
-            return plugins[node.name]
-        }
-        if (node.type === 'LogicalExpression') {
-            const left = evaluateLogicalExpression(node.left)
-            const right = evaluateLogicalExpression(node.right)
-            if (node.operator === '&&') {
-                return left && right
-            }
-            if (node.operator === '||') {
-                return left || right
-            }
-        }
-        return true // Non-plugin expressions evaluate to true
-    }
-
-    const findRightmostExpression = (node) => {
-        if (node.type === 'LogicalExpression') {
-            return findRightmostExpression(node.right)
-        }
-        return node
-    }
-
-    // Helper to process plugin-guarded LogicalExpressions
-    const processPluginLogicalExpression = (path) => {
-        if (path.node.type === 'LogicalExpression') {
-            const shouldKeep = evaluateLogicalExpression(path.node)
-            if (!shouldKeep) {
-                path.parentPath.remove()
-            } else {
-                path.parentPath.replaceWith(findRightmostExpression(path.node))
-            }
-            modified = true
-        }
-    }
-
-    const nodeContainsPluginReferences = (node) => {
-        // Check if any plugin reference falls within the node's range
-        return pluginPositions.some((pos) => pos.start >= node.start && pos.start < node.end)
-    }
-
-    // Traverse AST and remove nodes guarded by plugin flags
-    traverse(ast, {
-        // Handle variable declarations like:
-        // const HelloWorld = PLUGIN_NAME && loadable(...)
-        VariableDeclaration(nodePath) {
-            if (nodeContainsPluginReferences(nodePath.node)) {
-                nodePath.node.declarations.forEach((declaration) => {
-                    if (declaration.init && declaration.init.type === 'LogicalExpression') {
-                        const shouldKeep = evaluateLogicalExpression(declaration.init)
-                        if (!shouldKeep) {
-                            // Extract import path if declaration is an import statement
-                            if (
-                                declaration.init.right &&
-                                declaration.init.right.type === 'CallExpression' &&
-                                declaration.init.right.callee &&
-                                declaration.init.right.callee.type === 'Identifier' &&
-                                declaration.init.right.callee.name === 'loadable'
-                            ) {
-                                // Extract the import path from the loadable call expression and add it to the list of candidates for removal later.
-                                const importArg = declaration.init.right.arguments[0]
-                                if (
-                                    importArg.type === 'ArrowFunctionExpression' &&
-                                    importArg.body.type === 'CallExpression' &&
-                                    importArg.body.callee.type === 'Import'
-                                ) {
-                                    const importPath = importArg.body.arguments[0].value
-                                    removeComponentCandidates.add(
-                                        path.resolve(path.join(path.dirname(filePath), importPath))
-                                    )
-                                }
-                            }
-                            nodePath.remove()
-                        } else {
-                            declaration.init = findRightmostExpression(declaration.init)
-                        }
-                        modified = true
-                    } else if (declaration?.init?.type === 'ConditionalExpression') {
-                        const testValue = evaluateLogicalExpression(declaration.init.test)
-                        if (testValue === true) {
-                            declaration.init = declaration.init.consequent
-                        } else {
-                            declaration.init = declaration.init.alternate
-                        }
-                        modified = true
-                    }
-                })
-            }
-        },
-
-        // Handle conditional expressions like:
-        // {PLUGIN_NAME && [statement]}
-        LogicalExpression(path) {
-            if (nodeContainsPluginReferences(path.node)) {
-                processPluginLogicalExpression(path)
-            }
-        },
-
-        // Handle JSX elements in return statements that are guarded by plugin flags
-        ReturnStatement(path) {
-            if (nodeContainsPluginReferences(path.node)) {
-                if (path.node.argument && path.node.argument.type === 'JSXElement') {
-                    // Find JSX children that are guarded by plugin flags
-                    const children = path.get('argument').get('children')
-                    children.forEach((child) => {
-                        if (child.node.type === 'JSXExpressionContainer') {
-                            const expr = child.node.expression
-                            if (
-                                expr.type === 'LogicalExpression' ||
-                                expr.type === 'ConditionalExpression'
-                            ) {
-                                const exprPath = child.get('expression')
-                                try {
-                                    processPluginLogicalExpression(exprPath)
-                                } catch (e) {
-                                    console.error(
-                                        `Error processing plugin logical expression: ${exprPath}`
-                                    )
-                                }
-                            }
-                        }
-                    })
-                } else if (
-                    path.node.argument &&
-                    path.node.argument.type === 'ConditionalExpression'
-                ) {
-                    // Handle top-level ternary in return statement
-                    const testValue = evaluateLogicalExpression(path.node.argument.test)
-                    if (testValue === true) {
-                        path.node.argument = path.node.argument.consequent
-                    } else {
-                        path.node.argument = path.node.argument.alternate
-                    }
+    if (pluginRegex.test(source)) {
+        const lines = source.split('\n')
+        const newLines = []
+        let i = 0
+        while (i < lines.length) {
+            const line = lines[i]
+            if (line.includes(SINGLE_LINE_MARKER)) {
+                const matchingPlugin = Object.keys(plugins).find((plugin) => line.includes(plugin))
+                if (matchingPlugin && plugins[matchingPlugin] === false) {
+                    removedBlocks.push(lines[i + 1]) // add the line that was removed to the list of removed blocks
+                    i += 2 // skip this line and the next
                     modified = true
+                    continue
+                }
+            } else if (line.includes(BLOCK_MARKER_START)) {
+                const matchingPlugin = Object.keys(plugins).find((plugin) => line.includes(plugin))
+                if (matchingPlugin) {
+                    // push a new block marker, if the plugin is false, we will start skipping the block
+                    blockMarkers.push({plugin: matchingPlugin, line: i})
+                    skippingBlock = plugins[matchingPlugin] === false
+                }
+            } else if (line.includes(BLOCK_MARKER_END)) {
+                const plugin = Object.keys(plugins).find((p) => line.includes(p))
+                // check if we have any start markers
+                if (blockMarkers.length === 0) {
+                    throw new Error(
+                        `Block marker mismatch in ${filePath}, encountered end marker ${plugin} without a matching start marker at line ${i}:\n${lines[i]}`
+                    )
+                }
+                const startMarker = blockMarkers.pop()
+                if (startMarker.plugin !== plugin) {
+                    throw new Error(
+                        `Block marker mismatch in ${filePath}, expected end marker for ${startMarker.plugin} but got ${plugin} at line ${i}:\n${lines[i]}`
+                    )
+                }
+                if (plugins[plugin] === false) {
+                    // Push the removed block (from startMarker.line to current line) into removedBlocks
+                    const removedBlock = lines.slice(startMarker.line, i + 1).join('\n')
+                    removedBlocks.push(removedBlock)
+                    modified = true
+                    skippingBlock = false
+                    i++
+                    continue
                 }
             }
+            if (!skippingBlock) {
+                newLines.push(line)
+            }
+            i++
         }
-    })
-
-    // Only write output if we made changes
-    if (modified) {
-        try {
-            // Generate code from modified AST
-            const output = generate(ast, {
-                retainLines: true,
-                compact: false
-            }).code
-            // Replace the original file with the trimmed version
-            fs.writeFileSync(filePath, output)
-            // prettify the file
-            execSync(`npx prettier --write ${filePath}`)
-            console.log(`Updated file ${filePath}`)
-        } catch (e) {
-            console.error(`Error updating file ${filePath}: ${e.message}`)
-            throw e
+        if (blockMarkers.length > 0) {
+            throw new Error(
+                `Unclosed end marker found in ${filePath}: ${
+                    blockMarkers[blockMarkers.length - 1].plugin
+                }`
+            )
+        }
+        if (modified) {
+            const newSource = newLines.join('\n')
+            try {
+                fs.writeFileSync(filePath, newSource)
+                console.log(`Updated file ${filePath}`)
+            } catch (e) {
+                console.error(`Error updating file ${filePath}: ${e.message}`)
+                throw e
+            }
+            // walk through the removed blocks, parse them into ASTs, extract the import statements, and add them to the list of candidates for removal later.
+            removedBlocks.forEach((block) => {
+                if (block.includes('import')) {
+                    const ast = parser.parse(block, {
+                        sourceType: 'module',
+                        plugins: ['jsx', 'typescript']
+                    })
+                    traverse(ast, {
+                        VariableDeclaration(nodePath) {
+                            // Extract import path from variable declarations like: const X = import('./path')
+                            nodePath.node.declarations.forEach((declaration) => {
+                                if (
+                                    declaration.init &&
+                                    declaration.init.type === 'CallExpression' &&
+                                    declaration.init.callee.type === 'Import'
+                                ) {
+                                    const importArg = declaration.init.arguments[0]
+                                    if (importArg && importArg.type === 'StringLiteral') {
+                                        const importPath = importArg.value
+                                        if (importPath.startsWith('.')) {
+                                            let absoluteImportPath = path.resolve(
+                                                path.dirname(filePath),
+                                                importPath
+                                            )
+                                            removeComponentCandidates.add(absoluteImportPath)
+                                        }
+                                    }
+                                }
+                            })
+                        }
+                    })
+                }
+            })
         }
     }
 }

--- a/packages/pwa-kit-create-app/scripts/trim-extensions.js
+++ b/packages/pwa-kit-create-app/scripts/trim-extensions.js
@@ -20,9 +20,9 @@ const COMPONENT_SCAN_PATHS = [
     path.join(SEPARATOR, 'src', 'routes.tsx'),
     path.join(SEPARATOR, 'config', 'constants.js')
 ]
-const SINGLE_LINE_MARKER = 'sfdc-extension-line'
-const BLOCK_MARKER_START = 'sfdc-extension-block-start'
-const BLOCK_MARKER_END = 'sfdc-extension-block-end'
+const SINGLE_LINE_MARKER = '@sfdc-extension-line'
+const BLOCK_MARKER_START = '@sfdc-extension-block-start'
+const BLOCK_MARKER_END = '@sfdc-extension-block-end'
 
 /**
  * Trim the directory to remove unused components and unused plugins.

--- a/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
+++ b/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
@@ -25,9 +25,9 @@ jest.mock('../assets/plugin-config', () => ({
 // Test data constants
 const TEST_CODES = {
     BASIC_COMPONENT: `
-        // sfdc-extension-line SFDC_EXT_featureA
+        // @sfdc-extension-line SFDC_EXT_featureA
         const ComponentA = import('./featureAComponent')
-        // sfdc-extension-line SFDC_EXT_featureB
+        // @sfdc-extension-line SFDC_EXT_featureB
         const ComponentB = import('./featureBComponent')
     `,
     BASIC_COMPONENT_TRIMMED: `
@@ -37,13 +37,13 @@ const TEST_CODES = {
     COMPONENT_B: `export default ComponentB`,
     FEATURE_B_PAGE: `export const FeatureBPage = 'FeatureBPage'`,
     COMPONENT_B_WITH_PAGE_REF: `
-        // sfdc-extension-line SFDC_EXT_featureB
+        // @sfdc-extension-line SFDC_EXT_featureB
         const pageB = import('../../pages/featureBPage')
         export default ComponentB
     `,
     COMPONENT_B_WITH_PAGE_REF_TRIMMED: `export default ComponentB`,
     FEATURE_B_PAGE_WITH_COMPONENT_REF: `
-        // sfdc-extension-line SFDC_EXT_featureB
+        // @sfdc-extension-line SFDC_EXT_featureB
         const ComponentB = import('../../components/featureBComponent')
         export const FeatureBPage = 'FeatureBPage'
     `,
@@ -174,7 +174,7 @@ describe('trim-extensions with nested directories', () => {
         // Create file system with nested structure
         createTestFileSystem({
             additional: {
-                '/mock/dir/src/route.jsx': `// sfdc-extension-line SFDC_EXT_featureA
+                '/mock/dir/src/route.jsx': `// @sfdc-extension-line SFDC_EXT_featureA
                 const storeLocatorPage = import('./pages/store-locator')`,
                 '/mock/dir/src/pages/store-locator/index.jsx': `import { Modal } from './partial/modal' 
                     export default StoreLocator = 'StoreLocatorModal'`,
@@ -208,7 +208,7 @@ describe('trim-extensions', () => {
     it('leaves code untouched if no plugins are referenced', () => {
         const code = `
         const test = () => {
-            // sfdc-extension-line SFDC_EXT_featureA
+            // @sfdc-extension-line SFDC_EXT_featureA
             const featureA = 'Feature A';
             const categories = flatten(categoriesTree || {}, 'categories');
             const currency = locale.preferredCurrency || l10n.defaultCurrency;
@@ -234,10 +234,10 @@ describe('trim-extensions', () => {
 
     it('removes code blocks that are guarded by plugin flags', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar1 = 'Feature A variable 1';
             const featureAVar2 = 'Feature A variable 2';
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureA
             const anotherVar = 'Another variable';
         `
         const expected = `
@@ -251,17 +251,17 @@ describe('trim-extensions', () => {
 
     it('removes nested code blocks that are guarded by plugin flags', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-block-start SFDC_EXT_featureB
+            // @sfdc-extension-block-start SFDC_EXT_featureB
             const featureBVar = 'Feature B variable 1';
-            // sfdc-extension-block-end SFDC_EXT_featureB
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureB
+            // @sfdc-extension-block-end SFDC_EXT_featureA
         `
         const expected = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureA
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
         trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
@@ -271,16 +271,16 @@ describe('trim-extensions', () => {
 
     it('removes nested line that are guarded by plugin flags', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-line SFDC_EXT_featureB
+            // @sfdc-extension-line SFDC_EXT_featureB
             const featureBVar = 'Feature B variable 2';
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureA
         `
         const expected = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureA
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
         trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
@@ -290,9 +290,9 @@ describe('trim-extensions', () => {
 
     it('fails when mismatching block markers are found', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-block-end SFDC_EXT_featureB
+            // @sfdc-extension-block-end SFDC_EXT_featureB
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
         const filePath = path.join(
@@ -312,7 +312,7 @@ describe('trim-extensions', () => {
 
     it('fails when block marker is not closed', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
@@ -331,7 +331,7 @@ describe('trim-extensions', () => {
 
     it('fails when start marker is missing', () => {
         const code = `
-            // sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureA
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
         const filePath = path.join(
@@ -349,12 +349,12 @@ describe('trim-extensions', () => {
 
     it('fails when nested block markers are not closed in the correct order', () => {
         const code = `
-            // sfdc-extension-block-start SFDC_EXT_featureA
+            // @sfdc-extension-block-start SFDC_EXT_featureA
             const featureAVar = 'Feature A variable 1';
-            // sfdc-extension-block-start SFDC_EXT_featureB
+            // @sfdc-extension-block-start SFDC_EXT_featureB
             const featureBVar = 'Feature B variable 1';
-            // sfdc-extension-block-end SFDC_EXT_featureA
-            // sfdc-extension-block-end SFDC_EXT_featureB
+            // @sfdc-extension-block-end SFDC_EXT_featureA
+            // @sfdc-extension-block-end SFDC_EXT_featureB
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
         const filePath = path.join(
@@ -377,9 +377,9 @@ describe('trim-extensions', () => {
             MyClass.PropTypes = {
                 name: PropTypes.string,
                 description: PropTypes.string,
-                // sfdc-extension-line SFDC_EXT_featureA
+                // @sfdc-extension-line SFDC_EXT_featureA
                 featureAProp: PropTypes.string,
-                // sfdc-extension-line SFDC_EXT_featureB
+                // @sfdc-extension-line SFDC_EXT_featureB
                 featureBProp: PropTypes.string,
             };
         `
@@ -392,7 +392,7 @@ describe('trim-extensions', () => {
             MyClass.PropTypes = {
                 name: PropTypes.string,
                 description: PropTypes.string,
-                // sfdc-extension-line SFDC_EXT_featureA
+                // @sfdc-extension-line SFDC_EXT_featureA
                 featureAProp: PropTypes.string,
             };
         `
@@ -406,9 +406,9 @@ describe('trim-extensions', () => {
             function test() {
                 return (
                     <div>
-                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        {/* @sfdc-extension-line SFDC_EXT_featureA */}
                         <ComponentA />
-                        {/* sfdc-extension-line SFDC_EXT_featureB */}
+                        {/* @sfdc-extension-line SFDC_EXT_featureB */}
                         <ComponentB />
                     </div>
                 );
@@ -423,7 +423,7 @@ describe('trim-extensions', () => {
             function test() {
                 return (
                     <div>
-                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        {/* @sfdc-extension-line SFDC_EXT_featureA */}
                         <ComponentA />
                     </div>
                 );
@@ -439,10 +439,10 @@ describe('trim-extensions', () => {
             function test() {
                 return (
                     <div>
-                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        {/* @sfdc-extension-line SFDC_EXT_featureA */}
                         <ComponentA>
                             <ChildComponent />
-                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        {/* @sfdc-extension-line SFDC_EXT_featureA */}
                         </ComponentA>
                     </div>
                 );
@@ -500,7 +500,7 @@ describe('trim-extensions', () => {
         // Create a read-only file to simulate write failure
         vol.writeFileSync(
             '/mock/dir/src/components/featureComponent.jsx',
-            `// sfdc-extension-line SFDC_EXT_featureA
+            `// @sfdc-extension-line SFDC_EXT_featureA
             const feature = Feature_A;`
         )
         vol.writeFileSync = (...args) => {

--- a/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
+++ b/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
@@ -6,7 +6,6 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const {Volume} = require('memfs')
-const {execSync} = require('child_process')
 
 // Mock plugin config to simulate different plugin states
 let mockedPluginConfig = {
@@ -22,29 +21,29 @@ jest.mock('../assets/plugin-config', () => ({
     plugins: mockedPluginConfig
 }))
 
-jest.mock('child_process')
-
 // Test data constants
 const TEST_CODES = {
     BASIC_COMPONENT: `
-        import loadable from '@loadable/component'
-        const ComponentA = SFDC_EXT_featureA && loadable(() => import('./featureAComponent'))
-        const ComponentB = SFDC_EXT_featureB && loadable(() => import('./featureBComponent'))
+        // sfdc-extension-line SFDC_EXT_featureA
+        const ComponentA = import('./featureAComponent')
+        // sfdc-extension-line SFDC_EXT_featureB
+        const ComponentB = import('./featureBComponent')
     `,
     BASIC_COMPONENT_TRIMMED: `
-        import loadable from '@loadable/component'
-        const ComponentA = loadable(() => import('./featureAComponent'))
+        const ComponentA = import('./featureAComponent')
     `,
     COMPONENT_A: `export default ComponentA`,
     COMPONENT_B: `export default ComponentB`,
     FEATURE_B_PAGE: `export const FeatureBPage = 'FeatureBPage'`,
     COMPONENT_B_WITH_PAGE_REF: `
-        const pageB = SFDC_EXT_featureB && loadable(() => import('../../pages/featureBPage'))
+        // sfdc-extension-line SFDC_EXT_featureB
+        const pageB = import('../../pages/featureBPage')
         export default ComponentB
     `,
     COMPONENT_B_WITH_PAGE_REF_TRIMMED: `export default ComponentB`,
     FEATURE_B_PAGE_WITH_COMPONENT_REF: `
-        const ComponentB = SFDC_EXT_featureB && loadable(() => import('../../components/featureBComponent'))
+        // sfdc-extension-line SFDC_EXT_featureB
+        const ComponentB = import('../../components/featureBComponent')
         export const FeatureBPage = 'FeatureBPage'
     `,
     FEATURE_B_PAGE_WITH_COMPONENT_REF_TRIMMED: `export const FeatureBPage = 'FeatureBPage'`
@@ -174,7 +173,8 @@ describe('trim-extensions with nested directories', () => {
         // Create file system with nested structure
         createTestFileSystem({
             additional: {
-                '/mock/dir/src/route.jsx': `const storeLocatorPage = SFDC_EXT_featureA && loadable(() => import('./pages/store-locator'))`,
+                '/mock/dir/src/route.jsx': `// sfdc-extension-line SFDC_EXT_featureA
+                const storeLocatorPage = import('./pages/store-locator')`,
                 '/mock/dir/src/pages/store-locator/index.jsx': `import { Modal } from './partial/modal' 
                     export default StoreLocator = 'StoreLocatorModal'`,
                 '/mock/dir/src/pages/store-locator/partial/modal.jsx': `export const StoreLocator = 'StoreLocatorModal'`
@@ -182,7 +182,6 @@ describe('trim-extensions with nested directories', () => {
         })
 
         trimExtensions = require('./trim-extensions')
-        execSync.mockReturnValue(true)
     })
 
     it('recursively removes unused directories', () => {
@@ -203,13 +202,13 @@ describe('trim-extensions', () => {
         jest.resetAllMocks()
         createTestFileSystem()
         trimExtensions = require('./trim-extensions')
-        execSync.mockReturnValue(true)
     })
 
     it('leaves code untouched if no plugins are referenced', () => {
         const code = `
         const test = () => {
-            const featureA = SFDC_EXT_featureA && 'Feature A';
+            // sfdc-extension-line SFDC_EXT_featureA
+            const featureA = 'Feature A';
             const categories = flatten(categoriesTree || {}, 'categories');
             const currency = locale.preferredCurrency || l10n.defaultCurrency;
             return [locale?.id || appConfig.defaultAppLocale];
@@ -232,89 +231,124 @@ describe('trim-extensions', () => {
         expect(result).toEqualTrimmedLines(expected)
     })
 
-    it('handles OR operator correctly', () => {
-        const code = `const feature = (SFDC_EXT_featureA || SFDC_EXT_featureB) && 'Feature Enabled';`
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
-
-        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
-        expect(result).toEqualTrimmedLines("const feature = 'Feature Enabled';")
-    })
-
-    it('handles variable declarations correctly', () => {
-        const code = `const featureAFunc = SFDC_EXT_featureA && (() => 'Feature A');
-            const featureBFunc = SFDC_EXT_featureB && (() => 'Feature B');
-        `
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
-
-        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
-        expect(result).toEqualTrimmedLines("const featureAFunc = () => 'Feature A';")
-        expect(result).not.toContain("const featureBFunc = () => 'Feature B';")
-    })
-
-    it('handles variable with ternary expressions correctly when true', () => {
-        const code = `const showFeature = SFDC_EXT_featureA ? Feature_A : Feature_B;`
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true})
-
-        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
-        expect(result).toEqualTrimmedLines('const showFeature = Feature_A;')
-        expect(result).not.toContain('Feature_B')
-    })
-
-    it('handles variable with ternary expressions correctly when false', () => {
-        const code = `const showFeature = SFDC_EXT_featureA ? Feature_A : Feature_B;`
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})
-
-        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
-        expect(result).toEqualTrimmedLines('const showFeature = Feature_B;')
-        expect(result).not.toContain('Feature_A')
-    })
-
-    it('handles return with ternary expressions correctly', () => {
+    it('removes code blocks that are guarded by plugin flags', () => {
         const code = `
-            function test() {
-                return SFDC_EXT_featureA ? Feature_A : Feature_B;
-            }
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar1 = 'Feature A variable 1';
+            const featureAVar2 = 'Feature A variable 2';
+            // sfdc-extension-block-end SFDC_EXT_featureA
+            const anotherVar = 'Another variable';
         `
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true})
-
         const expected = `
-            function test() {
-                return Feature_A;
-            }
+            const anotherVar = 'Another variable';
         `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})
         const result = readFile('/mock/dir/src/components/featureComponent.jsx')
         expect(result).toEqualTrimmedLines(expected)
+    })
+
+    it('removes nested code blocks that are guarded by plugin flags', () => {
+        const code = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-block-start SFDC_EXT_featureB
+            const featureBVar = 'Feature B variable 1';
+            // sfdc-extension-block-end SFDC_EXT_featureB
+            // sfdc-extension-block-end SFDC_EXT_featureA
+        `
+        const expected = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-block-end SFDC_EXT_featureA
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
+        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
+        expect(result).toEqualTrimmedLines(expected)
+    })
+
+    it('removes nested line that are guarded by plugin flags', () => {
+        const code = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-line SFDC_EXT_featureB
+            const featureBVar = 'Feature B variable 2';
+            // sfdc-extension-block-end SFDC_EXT_featureA
+        `
+        const expected = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-block-end SFDC_EXT_featureA
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
+        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
+        expect(result).toEqualTrimmedLines(expected)
+    })
+
+    it('fails when mismatching block markers are found', () => {
+        const code = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-block-end SFDC_EXT_featureB
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        expect(() =>
+            trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
+        ).toThrow(
+            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, expected end marker for SFDC_EXT_featureA but got SFDC_EXT_featureB at line 3'
+        )
+    })
+
+    it('fails when block marker is not closed', () => {
+        const code = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        expect(() => trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})).toThrow(
+            'Unclosed end marker found in /mock/dir/src/components/featureComponent.jsx: SFDC_EXT_featureA'
+        )
+    })
+
+    it('fails when start marker is missing', () => {
+        const code = `
+            // sfdc-extension-block-end SFDC_EXT_featureA
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        expect(() => trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})).toThrow(
+            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, encountered end marker SFDC_EXT_featureA without a matching start marker at line 1'
+        )
+    })
+
+    it('fails when nested block markers are not closed in the correct order', () => {
+        const code = `
+            // sfdc-extension-block-start SFDC_EXT_featureA
+            const featureAVar = 'Feature A variable 1';
+            // sfdc-extension-block-start SFDC_EXT_featureB
+            const featureBVar = 'Feature B variable 1';
+            // sfdc-extension-block-end SFDC_EXT_featureA
+            // sfdc-extension-block-end SFDC_EXT_featureB
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        expect(() =>
+            trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
+        ).toThrow(
+            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, expected end marker for SFDC_EXT_featureB but got SFDC_EXT_featureA at line 5:'
+        )
     })
 
     it('handles PropTypes declarations correctly', () => {
         const code = `
             MyClass.PropTypes = {
                 name: PropTypes.string,
-                description: PropTypes.string
+                description: PropTypes.string,
+                // sfdc-extension-line SFDC_EXT_featureA
+                featureAProp: PropTypes.string,
+                // sfdc-extension-line SFDC_EXT_featureB
+                featureBProp: PropTypes.string,
             };
-            SFDC_EXT_featureA && (MyClass.PropType = {
-                ...MyClass.PropType,
-                featureAProp: PropTypes.string
-            });
-            SFDC_EXT_featureB && (MyClass.PropType = {
-                ...MyClass.PropType,
-                featureBProp: PropTypes.string
-            });
         `
 
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
@@ -324,11 +358,9 @@ describe('trim-extensions', () => {
         const expected = `
             MyClass.PropTypes = {
                 name: PropTypes.string,
-                description: PropTypes.string
-            };
-            MyClass.PropType = {
-                ...MyClass.PropType,
-                featureAProp: PropTypes.string
+                description: PropTypes.string,
+                // sfdc-extension-line SFDC_EXT_featureA
+                featureAProp: PropTypes.string,
             };
         `
         const result = readFile('/mock/dir/src/components/featureComponent.jsx')
@@ -336,34 +368,15 @@ describe('trim-extensions', () => {
         expect(result).not.toContain('featureBProp: PropTypes.string')
     })
 
-    it('handles ternary expressions in return statements correctly', () => {
-        const code = `
-            function test() {
-                return SFDC_EXT_featureA ? "componentA" : "componentB";
-            }
-        `
-
-        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
-
-        trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})
-
-        const expected = `
-            function test() {
-                return "componentB";
-            }
-        `
-        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
-        expect(result).toEqualTrimmedLines(expected)
-        expect(result).not.toContain('componentA')
-    })
-
     it('handles JSX elements in return statements correctly', () => {
         const code = `
             function test() {
                 return (
                     <div>
-                        {SFDC_EXT_featureA && <ComponentA />}
-                        {SFDC_EXT_featureB && <ComponentB />}
+                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        <ComponentA />
+                        {/* sfdc-extension-line SFDC_EXT_featureB */}
+                        <ComponentB />
                     </div>
                 );
             }
@@ -377,8 +390,42 @@ describe('trim-extensions', () => {
             function test() {
                 return (
                     <div>
+                        {/* sfdc-extension-line SFDC_EXT_featureA */}
                         <ComponentA />
-                    </div>);
+                    </div>
+                );
+            }
+        `
+        const result = readFile('/mock/dir/src/components/featureComponent.jsx')
+        expect(result).toEqualTrimmedLines(expected)
+        expect(result).not.toContain('<ComponentB />')
+    })
+
+    it('handles nested JSX elements in return statements correctly', () => {
+        const code = `
+            function test() {
+                return (
+                    <div>
+                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        <ComponentA>
+                            <ChildComponent />
+                        {/* sfdc-extension-line SFDC_EXT_featureA */}
+                        </ComponentA>
+                    </div>
+                );
+            }
+        `
+        vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+
+        trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})
+
+        const expected = `
+            function test() {
+                return (
+                    <div>
+                        <ChildComponent />
+                    </div>
+                );
             }
         `
         const result = readFile('/mock/dir/src/components/featureComponent.jsx')
@@ -420,14 +467,15 @@ describe('trim-extensions', () => {
         // Create a read-only file to simulate write failure
         vol.writeFileSync(
             '/mock/dir/src/components/featureComponent.jsx',
-            `const feature = SFDC_EXT_featureA ? Feature_A : Feature_B;`
+            `// sfdc-extension-line SFDC_EXT_featureA
+            const feature = Feature_A;`
         )
         vol.writeFileSync = (...args) => {
             throw new Error('Simulated write error')
         }
 
         try {
-            trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
+            trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})
         } catch (error) {
             // Expected to fail
         }

--- a/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
+++ b/packages/pwa-kit-create-app/scripts/trim-extensions.test.js
@@ -6,6 +6,7 @@
  */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const {Volume} = require('memfs')
+const path = require('path')
 
 // Mock plugin config to simulate different plugin states
 let mockedPluginConfig = {
@@ -294,10 +295,18 @@ describe('trim-extensions', () => {
             // sfdc-extension-block-end SFDC_EXT_featureB
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        const filePath = path.join(
+            path.sep,
+            'mock',
+            'dir',
+            'src',
+            'components',
+            'featureComponent.jsx'
+        )
         expect(() =>
             trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
         ).toThrow(
-            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, expected end marker for SFDC_EXT_featureA but got SFDC_EXT_featureB at line 3'
+            `Block marker mismatch in ${filePath}, expected end marker for SFDC_EXT_featureA but got SFDC_EXT_featureB at line 3`
         )
     })
 
@@ -307,8 +316,16 @@ describe('trim-extensions', () => {
             const featureAVar = 'Feature A variable 1';
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        const filePath = path.join(
+            path.sep,
+            'mock',
+            'dir',
+            'src',
+            'components',
+            'featureComponent.jsx'
+        )
         expect(() => trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})).toThrow(
-            'Unclosed end marker found in /mock/dir/src/components/featureComponent.jsx: SFDC_EXT_featureA'
+            `Unclosed end marker found in ${filePath}: SFDC_EXT_featureA`
         )
     })
 
@@ -317,8 +334,16 @@ describe('trim-extensions', () => {
             // sfdc-extension-block-end SFDC_EXT_featureA
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        const filePath = path.join(
+            path.sep,
+            'mock',
+            'dir',
+            'src',
+            'components',
+            'featureComponent.jsx'
+        )
         expect(() => trimExtensions('/mock/dir', {SFDC_EXT_featureA: false})).toThrow(
-            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, encountered end marker SFDC_EXT_featureA without a matching start marker at line 1'
+            `Block marker mismatch in ${filePath}, encountered end marker SFDC_EXT_featureA without a matching start marker at line 1`
         )
     })
 
@@ -332,10 +357,18 @@ describe('trim-extensions', () => {
             // sfdc-extension-block-end SFDC_EXT_featureB
         `
         vol.writeFileSync('/mock/dir/src/components/featureComponent.jsx', code)
+        const filePath = path.join(
+            path.sep,
+            'mock',
+            'dir',
+            'src',
+            'components',
+            'featureComponent.jsx'
+        )
         expect(() =>
             trimExtensions('/mock/dir', {SFDC_EXT_featureA: true, SFDC_EXT_featureB: false})
         ).toThrow(
-            'Block marker mismatch in /mock/dir/src/components/featureComponent.jsx, expected end marker for SFDC_EXT_featureB but got SFDC_EXT_featureA at line 5:'
+            `Block marker mismatch in ${filePath}, expected end marker for SFDC_EXT_featureB but got SFDC_EXT_featureA at line 5:`
         )
     })
 

--- a/packages/pwa-kit-dev/src/configs/webpack/config.js
+++ b/packages/pwa-kit-dev/src/configs/webpack/config.js
@@ -182,14 +182,6 @@ const baseConfig = (target) => {
                     },
                     ...(target === 'web' ? {fallback: {crypto: false}} : {})
                 },
-                // To add a new config for an extension, you can add a new element to the plugins array with the key and value as follows:
-                // The key should be the name of the plugin, and the value should be a boolean.
-                // The value should be true if the plugin is enabled, and false if it is disabled.
-                // The key should start with SFDC_EXT_, so that it's clear that it is an extension and not part of the core PWA Kit.
-                // For example, to add a new config for the Hello World extension, you can add the following:
-                // new webpack.DefinePlugin({
-                //     SFDC_EXT_HELLO_WORLD_ENABLED: true
-                // })
                 plugins: [
                     new webpack.DefinePlugin({
                         DEBUG,


### PR DESCRIPTION
Replaced the trim-extension logic from using plugin flag to using code marker comment

# Description

When converting store-locator to an extension, I ran into a few issues:
- eslint doesn't recognize the plugin flag (additional config required)
- ts type doesn't recognize the flag (additional config required)
- code blocks such as route arrays, prop types etc have to be split up
- there's no easy way of guarding wrapper component such as StoreLocatorProvider, which contains child components that we don't want to remove
- lastly, AST is rather tricky

So I decided that we should switch to a code comment-based mechanism, in which a special comment line precedes the line being guarded, or a pair of comment start/end markers surround the code block to be guarded. Nested blocks are also supported. 

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
