### PR TITLE
Improve create_new_sample_component tool in the pwa-kit-mcp

### DIFF
--- a/packages/pwa-kit-mcp/src/server/server.js
+++ b/packages/pwa-kit-mcp/src/server/server.js
@@ -83,8 +83,18 @@ class PwaStorefrontMCPServerHighLevel {
             'create_new_sample_component',
             'Conversationally collect parameters and create a new sample React component.',
             {
-                sessionId: z.string().optional().describe('Session ID for the conversational flow'),
-                answer: z.string().optional().describe('User answer to the current question')
+                sessionId: z
+                    .string()
+                    .optional()
+                    .describe(
+                        'Session ID for the conversational flow. Session ID is not required for initializing the conversational flow.'
+                    ),
+                answer: z
+                    .string()
+                    .optional()
+                    .describe(
+                        'User answer to the current question. Answer is not required for initializing the conversational flow.'
+                    )
             },
             (args) => this.handleCreateNewSampleComponent(args)
         )
@@ -107,7 +117,7 @@ class PwaStorefrontMCPServerHighLevel {
             this.sessions[sessionId] = {step: 1, answers: {}}
         }
         const session = this.sessions[sessionId]
-        const {step} = session
+        const step = session?.step || 1
         const answer = args.answer?.trim()
         switch (step) {
             case 1:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

This PR addresses an issue with the `create_new_sample_component` tool in the PWA Kit MCP server, where tool calls frequently fail during initialization due to missing `sessionId` or `answer` inputs. These inputs are only relevant in the middle of a conversational flow but were not being treated as optional in practice.

To resolve this:

- Added descriptive metadata to the input schema clarifying that sessionId and answer are optional and not required for initiating the tool call.
- Introduced a null check and default fallback for accessing the session step using:

This PR is linked to the issue: https://github.com/SalesforceCommerceCloud/pwa-kit/issues/2995

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes:

- Updated tool schema to describe sessionId and answer as optional inputs.
- Added null check to default step to 1 if no session exists.

# How to Test-Drive This PR

- Run the MCP server locally.
- Invoke the `create_new_sample_component` tool without providing `sessionId` or `answer`.
- The tool should now start the conversational flow without failure.
- Test again with follow-up inputs containing `sessionId` and `answer` to ensure normal flow continues.

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
