### PR TITLE
[🧱 MCP Server Tool] Remove `initGit` option from create-app project @@W-18909887@@

### DIFF
--- a/e2e/config.js
+++ b/e2e/config.js
@@ -13,7 +13,7 @@ module.exports = {
   GENERATED_PROJECTS_DIR: "../generated-projects",
   GENERATE_PROJECTS: ["retail-app-demo", "retail-app-ext", "retail-app-no-ext"],
   GENERATOR_CMD:
-    "node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --initGit --outputDir",
+    "node packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js --outputDir",
   CLI_RESPONSES: {
     "retail-app-demo": [
       {
@@ -112,8 +112,6 @@ module.exports = {
   },
   EXPECTED_GENERATED_ARTIFACTS: {
     "retail-app-demo": [
-      ".git",
-      ".gitignore",
       ".cursor",
       ".eslintignore",
       ".eslintrc.js",
@@ -128,8 +126,6 @@ module.exports = {
       "worker",
     ],
     "retail-app-ext": [
-      ".git",
-      ".gitignore",
       ".cursor",
       ".eslintignore",
       ".eslintrc.js",

--- a/packages/pwa-kit-create-app/CHANGELOG.md
+++ b/packages/pwa-kit-create-app/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## v3.12.0-dev (Jul 28, 2025)
-- Add `--initGit` to automate git repo creation for the generated project [#2817](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2817)
 - This feature introduces an AI-powered shopping assistant that integrates Salesforce Embedded Messaging Service with PWA Kit applications. The shopper agent provides real-time chat support, search assistance, and personalized shopping guidance directly within the e-commerce experience. [#2658](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2658)
 
 ## v3.11.0 (Jul 22, 2025)

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/.gitignore
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/.gitignore
@@ -1,8 +1,0 @@
-
-.DS_Store
-.vscode/
-node_modules/
-build/
-coverage/
-tmp/
-*.log

--- a/packages/pwa-kit-create-app/program.json
+++ b/packages/pwa-kit-create-app/program.json
@@ -727,14 +727,6 @@
             {
                 "name": "--displayProgram",
                 "description": "Display the program.json file detailing the program schema/data and exit"
-            },
-            {
-                "name": "--initGit",
-                "description": "Initializes a git repository and stages the files in the generated project",
-                "_ai": {
-                    "instruction": "CRITICAL: Before executing ANY project creation command, you MUST check if the '--initGit' flag is provided in the user's request. If NOT provided, STOP and ask: 'Would you like to initialize a Git repository for this project?' Wait for explicit yes/no answer. Only then proceed with project creation. FAILURE TO FOLLOW THIS STEP IS A CRITICAL ERROR. This check must happen AFTER preset/template selection but BEFORE command execution. DO NOT proceed with project creation until this question is answered.",
-                    "expectedUse": "Used to determine if a Git repository should be initialized in the generated project. This flag must be explicitly set by the user or confirmed via a direct question. The agent MUST wait for user confirmation before proceeding."
-                }
             }
         ],
         "examples": [

--- a/packages/pwa-kit-create-app/scripts/create-mobify-app.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app.js
@@ -329,7 +329,7 @@ const processTemplate = (relFile, inputDir, outputDir, context) => {
  * @param {*} answers
  * @param {*} param2
  */
-const runGenerator = (context, {initGit, outputDir, templateVersion, verbose}) => {
+const runGenerator = (context, {outputDir, templateVersion, verbose}) => {
     const {answers, template} = context
     const {id, source} = template
     const {extend = false} = answers.project
@@ -429,26 +429,6 @@ const runGenerator = (context, {initGit, outputDir, templateVersion, verbose}) =
         // Install dependencies for the newly minted project.
         npmInstall(outputDir, {verbose})
     }
-
-    // Initialize a git repository if the --initGit flag is provided.
-    if (initGit) {
-        initGitRepo(outputDir)
-    }
-}
-
-/**
- * Initializes a git repository in the specified directory, adds all files, and checks for git installation.
- * @param {string} outputDir - The directory in which to initialize the git repository.
- */
-const initGitRepo = (outputDir) => {
-    if (!sh.which('git')) {
-        console.error(
-            'Error: git is not installed or not found in PATH. Please install git to initialize a repository.'
-        )
-        process.exit(1)
-    }
-    sh.exec(`git init`, {cwd: outputDir})
-    sh.exec(`git add .`, {cwd: outputDir})
 }
 
 const foundNode = process.versions.node
@@ -554,7 +534,7 @@ const main = async (opts) => {
     let isPreset = false
     let answers = {}
     let selectedTemplate
-    let {outputDir, verbose, preset, templateVersion, stdio, displayProgram, initGit} = opts
+    let {outputDir, verbose, preset, templateVersion, stdio, displayProgram} = opts
     const {prompt} = inquirer
     const OUTPUT_DIR_FLAG_ACTIVE = !!outputDir
     const presetId = preset || process.env.GENERATOR_PRESET
@@ -683,7 +663,7 @@ const main = async (opts) => {
     }
 
     // Generate the project.
-    runGenerator(context, {initGit, outputDir, templateVersion, verbose})
+    runGenerator(context, {outputDir, templateVersion, verbose})
 
     // Return the folder in which the project was generated in.
     return outputDir


### PR DESCRIPTION
# Description

This PR removes the `initGit` option from the generator. It was never released so this isn't a breaking change. The changed were made in this [PR](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2817), but we are keeping the clean up work done in that PR. Just choosing to remove it for now if we aren't sure about wanting the logic in the generator.

# Changes

- Remove `initGit` from generator cli
