### PR TITLE
@W-18905072@ - Implement post hook action to release MRT target back to pool

### DIFF
--- a/.github/actions/e2e_release_mrt_target/action.yml
+++ b/.github/actions/e2e_release_mrt_target/action.yml
@@ -1,0 +1,20 @@
+name: e2e_release_mrt_target
+description: Release MRT Target back to pool of available targets in the MRT staging org.
+inputs:
+    SLUG:
+        description: 'MRT target slug'
+        required: true
+    MAX_RETRIES:
+        description: 'Maximum retry attempts to release MRT target'
+        required: false
+        default: '3'
+    RETRY_DELAY:
+        description: 'Delay between retries in milliseconds'
+        required: false
+        default: '10000'
+
+runs:
+    using: node22
+    main: dist/main.js
+    post: dist/post.js
+    post-if: always()

--- a/.github/actions/e2e_release_mrt_target/action.yml
+++ b/.github/actions/e2e_release_mrt_target/action.yml
@@ -14,7 +14,7 @@ inputs:
         default: '10000'
 
 runs:
-    using: node22
+    using: node20 # Only 'node12', 'node16', 'node20' or 'node24' are supported.
     main: dist/main.js
     post: dist/post.js
     post-if: always()

--- a/.github/actions/e2e_release_mrt_target/dist/main.js
+++ b/.github/actions/e2e_release_mrt_target/dist/main.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+const core = require('@actions/core')
+
+/**
+ * @file main.js
+ * @description Arms the post-release cleanup for MRT targets in CI. This step
+ * only captures inputs and persists them for the post step via core.saveState.
+ *
+ * Why:
+ * - GitHub Actions post steps execute even when a job fails or is manually cancelled,
+ *   providing best-effort cleanup of leased resources.
+ * - Keeping the actual release in post.js avoids releasing too early while the job
+ *   is still running and centralizes all teardown logic at job end.
+ *
+ * Behavior:
+ * - Reads the 'slug','maxRetries' and 'retryDelay' inputs and saves them to the Actions state for post.js.
+ * - Does not perform any release here; post.js does the release using the saved inputs.
+ *
+ * Inputs:
+ * - slug: MRT target slug to be released in the post step.
+ * - maxRetries: Maximum retry attempts to release MRT target.
+ * - retryDelay: Delay between retries in milliseconds.
+ *
+ * See also:
+ * - post.js (performs the actual release using the saved inputs)
+ */
+(async () => {
+    core.saveState('slug', core.getInput('slug', {required: true}))
+    core.saveState('maxRetries', core.getInput('maxRetries', {required: false}))
+    core.saveState('retryDelay', core.getInput('retryDelay', {required: false}))
+})().catch((e) => core.setFailed(e.message))

--- a/.github/actions/e2e_release_mrt_target/dist/main.js
+++ b/.github/actions/e2e_release_mrt_target/dist/main.js
@@ -4,33 +4,19 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-const core = require('@actions/core')
 
 /**
  * @file main.js
- * @description Arms the post-release cleanup for MRT targets in CI. This step
- * only captures inputs and persists them for the post step via core.saveState.
+ * @description Arms the post-release cleanup for MRT targets in CI. 
  *
+ * Intentionally empty. This file just needs to exist. Post step will read INPUT_DETAILS_FILE and perform release.
+ * 
  * Why:
  * - GitHub Actions post steps execute even when a job fails or is manually cancelled,
  *   providing best-effort cleanup of leased resources.
  * - Keeping the actual release in post.js avoids releasing too early while the job
  *   is still running and centralizes all teardown logic at job end.
  *
- * Behavior:
- * - Reads the 'slug','maxRetries' and 'retryDelay' inputs and saves them to the Actions state for post.js.
- * - Does not perform any release here; post.js does the release using the saved inputs.
- *
- * Inputs:
- * - slug: MRT target slug to be released in the post step.
- * - maxRetries: Maximum retry attempts to release MRT target.
- * - retryDelay: Delay between retries in milliseconds.
- *
  * See also:
  * - post.js (performs the actual release using the saved inputs)
  */
-(async () => {
-    core.saveState('slug', core.getInput('slug', {required: true}))
-    core.saveState('maxRetries', core.getInput('maxRetries', {required: false}))
-    core.saveState('retryDelay', core.getInput('retryDelay', {required: false}))
-})().catch((e) => core.setFailed(e.message))

--- a/.github/actions/e2e_release_mrt_target/dist/post.js
+++ b/.github/actions/e2e_release_mrt_target/dist/post.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const core = require('@actions/core')
+const path = require('path')
+const {execFile} = require('child_process')
+
+function run(cmd, args, opts = {}) {
+    return new Promise((resolve, reject) => {
+        execFile(cmd, args, opts, (err, stdout, stderr) =>
+            err ? reject(err) : resolve({stdout, stderr})
+        )
+    })
+}
+
+/**
+ * @file post.js
+ * @description Performs the actual release of the MRT target back to the pool of available targets in the MRT staging org.
+ * @description This step is executed even when a job fails or is manually cancelled, providing best-effort cleanup of leased resources.
+ * @description This step is executed after the main step in the workflow.
+ */
+(async () => {
+    try {
+        const workspace = process.env.GITHUB_WORKSPACE || process.cwd()
+        const slug = core.getState('slug')
+        const maxRetries = core.getState('maxRetries')
+        const retryDelay = core.getState('retryDelay')
+        if (!slug) return
+        const cli = path.resolve(workspace, 'e2e/scripts/mrt-target-manager.js')
+        await run(
+            'node',
+            [cli, 'release', slug, '--max-retries', maxRetries, '--retry-delay', retryDelay],
+            {cwd: workspace, stdio: 'inherit'}
+        )
+        core.info(`Released MRT target: ${slug}`)
+    } catch (e) {
+        core.warning(`Release failed: ${e.message}`)
+    }
+})()

--- a/.github/actions/e2e_release_mrt_target/dist/post.js
+++ b/.github/actions/e2e_release_mrt_target/dist/post.js
@@ -5,39 +5,44 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-const core = require('@actions/core')
-const path = require('path')
-const {execFile} = require('child_process')
-
-function run(cmd, args, opts = {}) {
-    return new Promise((resolve, reject) => {
-        execFile(cmd, args, opts, (err, stdout, stderr) =>
-            err ? reject(err) : resolve({stdout, stderr})
-        )
-    })
-}
-
 /**
  * @file post.js
  * @description Performs the actual release of the MRT target back to the pool of available targets in the MRT staging org.
- * @description This step is executed even when a job fails or is manually cancelled, providing best-effort cleanup of leased resources.
- * @description This step is executed after the main step in the workflow.
+ * This step is executed even when a job fails or is manually cancelled, providing best-effort cleanup of leased resources.
+ * This step is executed after the main step in the workflow.
  */
-(async () => {
+const fs = require('fs')
+const path = require('path')
+const {spawnSync} = require('child_process')
+const config = require('../../../../e2e/config.js')
+
+;(async () => {
     try {
         const workspace = process.env.GITHUB_WORKSPACE || process.cwd()
-        const slug = core.getState('slug')
-        const maxRetries = core.getState('maxRetries')
-        const retryDelay = core.getState('retryDelay')
-        if (!slug) return
+        const detailsFile = config.MRT_TARGET_DETAILS_FILE
+        const absDetails = path.resolve(workspace, detailsFile)
+        console.log(`Reading MRT target details from ${absDetails}`)
+        if (!fs.existsSync(absDetails)) {
+            console.log(`No details file at ${absDetails}. Skipping release.`)
+            return
+        }
+
+        const details = JSON.parse(fs.readFileSync(absDetails, 'utf8'))
+        console.log(`Details: ${JSON.stringify(details)}`)
+        const slug = details && details.slug
+        if (!slug) {
+            console.log('No slug found in details file. Skipping release.')
+            return
+        }
+
         const cli = path.resolve(workspace, 'e2e/scripts/mrt-target-manager.js')
-        await run(
-            'node',
-            [cli, 'release', slug, '--max-retries', maxRetries, '--retry-delay', retryDelay],
-            {cwd: workspace, stdio: 'inherit'}
-        )
-        core.info(`Released MRT target: ${slug}`)
+        console.log(`Releasing MRT target: ${slug}`)
+        const res = spawnSync('node', [cli, 'release', slug], {stdio: 'inherit', cwd: workspace})
+
+        if (res.status !== 0) {
+            console.log(`Release exited with status ${res.status}.`)
+        }
     } catch (e) {
-        core.warning(`Release failed: ${e.message}`)
+        console.log(`Release step error: ${e.message}`)
     }
 })()

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -86,7 +86,7 @@ jobs:
             # - This step is only engaged if the workflow is not skipped.
             - name: Engage Post hook to release MRT target back to the pool
               if: ${{ env.SKIP_WORKFLOW != 'true' }}
-              uses: ./.github/actions/mrt_post_release
+              uses: ./.github/actions/e2e_release_mrt_target
               with:
                   SLUG: ${{ steps.mrt_target_details.outputs.slug }}
                   MAX_RETRIES: 3

--- a/.github/workflows/e2e-pr.yml
+++ b/.github/workflows/e2e-pr.yml
@@ -53,7 +53,7 @@ jobs:
                   node ./scripts/gtime.js monorepo_install npm ci
 
             # Check central resource allocation on AWS and get a lock on an available environment from the pool.
-            # Returns the MRT target ID if lock is acquired, otherwise returns an error state.
+            # Sets the MRT target details in the workflow output.
             - name: Configure AWS Credentials
               if: ${{ env.SKIP_WORKFLOW != 'true' }}
               uses: aws-actions/configure-aws-credentials@v4
@@ -71,11 +71,31 @@ jobs:
                   RUN_ID: ${{ github.run_id }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}
 
-            # Skipping the rest of the workflow for now
-            - name: Print MRT Target Details and Skip Workflow
+            - name: Read MRT Target Details and Skip Workflow
+              id: mrt_target_details
               if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: |
-                  cat e2e/mrt-target/mrt-target-details.json
+                  jq -r 'to_entries[] | "\(.key)=\(.value // "")"' e2e/mrt-target/mrt-target-details.json >> "$GITHUB_OUTPUT"
+
+            # Engage post-run cleanup via a Node action that has a post hook.
+            # - The action defines `runs.post` so its post step runs at the
+            #   end of this job even if earlier steps fail or the job is cancelled.
+            # - This step passes the slug, maxRetries and retryDelay; the action's main saves it to state.
+            # - The actual release happens in the action's post script (post.js).
+            # - This replaces a separate cleanup job and avoids double-release.
+            # - This step is only engaged if the workflow is not skipped.
+            - name: Engage Post hook to release MRT target back to the pool
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
+              uses: ./.github/actions/mrt_post_release
+              with:
+                  SLUG: ${{ steps.mrt_target_details.outputs.slug }}
+                  MAX_RETRIES: 3
+                  RETRY_DELAY: 10000
+
+            # Skip the rest of the workflow for now.
+            - name: Skip Workflow
+              if: ${{ env.SKIP_WORKFLOW != 'true' }}
+              run: |
                   echo "SKIP_WORKFLOW=true" >> "$GITHUB_ENV"
 
             - name: Get Template Version
@@ -126,8 +146,3 @@ jobs:
             - name: Run Playwright a11y tests
               if: ${{ env.SKIP_WORKFLOW != 'true' }}
               run: npm run test:e2e:a11y
-
-            - name: Release MRT Target Lock
-              if: always() # Always release the target lock back to the pool even if the tests fail.
-              run: |
-                  echo "TODO: Implement .github/actions/release_mrt_target_lock"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ lerna-debug.log
 /playwright-report/
 /playwright/.cache/
 e2e/mrt-target/
+
+# GitHub Actions (Node.js) require built artifacts to be committed.
+# Runners do not run `npm install` for actions; `runs.main`/`runs.post` must point to files in `dist/`.
+# We generally ignore all dist directories, but allow the action’s dist so the action can execute.
+# We need this specifically to engage post run hook for the e2e_release_mrt_target action to release the MRT target back to the pool.
+!.github/actions/**/dist/

--- a/e2e/scripts/mrt-target-manager.js
+++ b/e2e/scripts/mrt-target-manager.js
@@ -241,6 +241,71 @@ class MRTTargetManager {
     }
 
     /**
+     * Releases an MRT environment back into MRT target pool with optimistic locking.
+     * @param {string} slug - The slug of the environment to release.
+     * @returns {Promise<boolean>} - True if the environment was released successfully, false otherwise.
+     * @throws {Error} - If the environment is not found or there is an error (e.g. authentication issues) releasing it.
+     */
+    async releaseEnvironment(slug) {
+        if (!process.env.CI) {
+            throw new Error(`❌ Cannot release environment in local development - Read only access`)
+        }
+
+        console.log(`🔓 Releasing environment: ${slug}`)
+
+        let retryCount = 0
+        while (retryCount < this.maxRetries) {
+            try {
+                // Step 1: Download pool file and get ETag
+                const downloadResponse = await this.downloadPoolFile()
+                const poolData = downloadResponse.poolData
+                const envToRelease = poolData.environments.find((env) => env.slug === slug)
+
+                if (!envToRelease) {
+                    throw new Error(`❌ Environment ${slug} not found`)
+                }
+
+                // Step 3: Mark environment as available
+                const updatedPoolData = this.updateMRTTargetStatus(
+                    downloadResponse.poolData,
+                    envToRelease,
+                    CI_AVAILABILITY_AVAILABLE
+                )
+
+                await this.s3Client.upload(
+                    this.bucket,
+                    this.poolDataFileKey,
+                    JSON.stringify(updatedPoolData, null, 2),
+                    poolData.etag
+                )
+
+                console.log(`✅ Successfully released environment: ${slug}`)
+                return true
+            } catch (error) {
+                retryCount++
+
+                if (error.name === AWS_S3_ERR_PRECONDITION_FAILED) {
+                    console.log(`⚠️ ETag mismatch on release attempt ${retryCount}, retrying...`)
+                    if (retryCount < this.maxRetries) {
+                        await this.sleep(this.retryDelay)
+                        continue
+                    } else {
+                        throw new Error(
+                            `❌ Failed to release environment after ${this.maxRetries} attempts`
+                        )
+                    }
+                } else {
+                    throw error
+                }
+            }
+        }
+
+        throw new Error(
+            `❌ Failed to release environment ${slug} after ${this.maxRetries} attempts`
+        )
+    }
+
+    /**
      * Utility function for delays
      */
     sleep(ms) {
@@ -347,6 +412,47 @@ async function main() {
                     error: error.message
                 })
                 process.exit(1)
+            }
+        })
+
+    program
+        .command('release')
+        .description('Release an MRT environment')
+        .argument('<slug>', 'Environment Id to release')
+        .action(async (slug) => {
+            const globalOpts = program.opts()
+
+            const mrtTargetManager = new MRTTargetManager({
+                bucket: process.env.AWS_S3_BUCKET,
+                poolDataFileKey: process.env.AWS_S3_POOL_DATA_FILE_KEY,
+                roleArn: process.env.AWS_ROLE_ARN,
+                region: process.env.AWS_REGION,
+                externalId: process.env.AWS_EXTERNAL_ID,
+                maxRetries: parseInt(globalOpts.maxRetries),
+                retryDelay: parseInt(globalOpts.retryDelay),
+                roleSessionName: process.env.CI
+                    ? GITHUB_ACTIONS_E2E_SESSION
+                    : PWA_KIT_BOT_USER_SESSION
+            })
+
+            await mrtTargetManager.initialize()
+
+            try {
+                await mrtTargetManager.releaseEnvironment(slug)
+                // Delete the target details file on successful release
+
+                await fs.remove(MRT_TARGET_DETAILS_FILE)
+                console.log(`✅ Deleted target details file: ${MRT_TARGET_DETAILS_FILE}`)
+            } catch (error) {
+                // Check if it's a file deletion error
+                if (error.code === 'ENOENT' || error.message.includes('target details file')) {
+                    console.warn(
+                        `⚠️ Warning: Could not delete target details file: ${error.message}`
+                    )
+                } else {
+                    console.error('❌ Error:', error.message)
+                    process.exit(1)
+                }
             }
         })
 

--- a/e2e/scripts/mrt-target-manager.js
+++ b/e2e/scripts/mrt-target-manager.js
@@ -256,7 +256,6 @@ class MRTTargetManager {
         let retryCount = 0
         while (retryCount < this.maxRetries) {
             try {
-                // Step 1: Download pool file and get ETag
                 const downloadResponse = await this.downloadPoolFile()
                 const poolData = downloadResponse.poolData
                 const envToRelease = poolData.environments.find((env) => env.slug === slug)
@@ -265,7 +264,6 @@ class MRTTargetManager {
                     throw new Error(`❌ Environment ${slug} not found`)
                 }
 
-                // Step 3: Mark environment as available
                 const updatedPoolData = this.updateMRTTargetStatus(
                     downloadResponse.poolData,
                     envToRelease,
@@ -276,7 +274,7 @@ class MRTTargetManager {
                     this.bucket,
                     this.poolDataFileKey,
                     JSON.stringify(updatedPoolData, null, 2),
-                    poolData.etag
+                    downloadResponse.etag
                 )
 
                 console.log(`✅ Successfully released environment: ${slug}`)

--- a/e2e/scripts/mrt-target-manager.test.js
+++ b/e2e/scripts/mrt-target-manager.test.js
@@ -604,6 +604,271 @@ describe('MRTTargetManager', () => {
         })
     })
 
+    describe('releaseEnvironment', () => {
+        beforeEach(() => {
+            manager = new MRTTargetManager({
+                bucket: 'test-bucket',
+                poolDataFileKey: 'test-key'
+            })
+        })
+
+        test('should throw error when not in CI', async () => {
+            delete process.env.CI
+
+            await expect(manager.releaseEnvironment('env1')).rejects.toThrow(
+                '❌ Cannot release environment in local development - Read only access'
+            )
+        })
+
+        test('should successfully release environment on first attempt', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE,
+                        ciRunInfo: {prNumber: '123'}
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+            mockS3Client.upload.mockResolvedValue({})
+
+            const result = await manager.releaseEnvironment('env1')
+
+            expect(result).toBe(true)
+            expect(console.log).toHaveBeenCalledWith('🔓 Releasing environment: env1')
+            expect(console.log).toHaveBeenCalledWith('✅ Successfully released environment: env1')
+            expect(mockS3Client.upload).toHaveBeenCalledWith(
+                'test-bucket',
+                'test-key',
+                expect.any(String),
+                '"test-etag"'
+            )
+
+            // Verify the uploaded data structure
+            const uploadCall = mockS3Client.upload.mock.calls[0]
+            const uploadedData = JSON.parse(uploadCall[2])
+            expect(uploadedData.environments[0].ciAvailability).toBe(CI_AVAILABILITY_AVAILABLE)
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+
+        test('should throw error when environment not found', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+
+            await expect(manager.releaseEnvironment('env2')).rejects.toThrow(
+                '❌ Environment env2 not found'
+            )
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+
+        test('should retry on ETag mismatch', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+            manager.maxRetries = 2
+            manager.retryDelay = 100 // Set a short delay for testing
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+
+            // First attempt fails with ETag mismatch
+            const etagError = new Error('Precondition failed')
+            etagError.name = AWS_S3_ERR_PRECONDITION_FAILED
+            mockS3Client.upload.mockRejectedValueOnce(etagError)
+
+            // Second attempt succeeds
+            mockS3Client.upload.mockResolvedValueOnce({})
+
+            const result = await manager.releaseEnvironment('env1')
+
+            expect(result).toBe(true)
+            expect(console.log).toHaveBeenCalledWith(
+                '⚠️ ETag mismatch on release attempt 1, retrying...'
+            )
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+
+        test('should throw error after max retries', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+            manager.maxRetries = 2
+            manager.retryDelay = 100 // Set a short delay for testing
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+
+            const etagError = new Error('Precondition failed')
+            etagError.name = AWS_S3_ERR_PRECONDITION_FAILED
+            mockS3Client.upload.mockRejectedValue(etagError)
+
+            await expect(manager.releaseEnvironment('env1')).rejects.toThrow(
+                '❌ Failed to release environment after 2 attempts'
+            )
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+
+        test('should throw non-retryable errors immediately', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+
+            const error = new Error('Upload failed')
+            mockS3Client.upload.mockRejectedValue(error)
+
+            await expect(manager.releaseEnvironment('env1')).rejects.toThrow('Upload failed')
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+
+        test('should properly update environment status to available', async () => {
+            const originalCI = process.env.CI
+            process.env.CI = 'true'
+
+            const mockPoolData = {
+                environments: [
+                    {
+                        slug: 'env1',
+                        ciAvailability: CI_AVAILABILITY_IN_USE,
+                        ciRunInfo: {
+                            prNumber: '123',
+                            branch: 'feature/test',
+                            runId: 'run-456'
+                        }
+                    }
+                ]
+            }
+
+            const mockDownloadResult = {
+                body: {
+                    [Symbol.asyncIterator]: async function* () {
+                        yield Buffer.from(JSON.stringify(mockPoolData))
+                    }
+                },
+                etag: '"test-etag"',
+                poolData: mockPoolData
+            }
+
+            mockS3Client.download.mockResolvedValue(mockDownloadResult)
+            mockS3Client.upload.mockResolvedValue({})
+
+            await manager.releaseEnvironment('env1')
+
+            // Verify the upload was called with the correct updated data
+            const uploadCall = mockS3Client.upload.mock.calls[0]
+            const uploadedData = JSON.parse(uploadCall[2]) // The JSON string passed to upload
+
+            expect(uploadedData.environments[0]).toEqual({
+                slug: 'env1',
+                ciAvailability: CI_AVAILABILITY_AVAILABLE,
+                ciLastUsed: expect.any(String)
+            })
+            expect(uploadedData.environments[0].ciRunInfo).toBeUndefined()
+
+            // Reset to original value
+            process.env.CI = originalCI
+        })
+    })
+
     describe('CLI integration', () => {
         let mockProgram
         let mockCommand
@@ -612,6 +877,7 @@ describe('MRTTargetManager', () => {
             mockCommand = {
                 description: jest.fn().mockReturnThis(),
                 option: jest.fn().mockReturnThis(),
+                argument: jest.fn().mockReturnThis(),
                 action: jest.fn().mockReturnThis(),
                 opts: jest.fn().mockReturnValue({})
             }
@@ -642,6 +908,16 @@ describe('MRTTargetManager', () => {
 
             expect(mockProgram.command).toHaveBeenCalledWith('acquire')
             expect(mockCommand.description).toHaveBeenCalledWith('Acquire an MRT environment')
+        })
+
+        test('should set up release command', async () => {
+            // Mock the main function execution
+            const {main} = require('./mrt-target-manager')
+            await main()
+
+            expect(mockProgram.command).toHaveBeenCalledWith('release')
+            expect(mockCommand.description).toHaveBeenCalledWith('Release an MRT environment')
+            expect(mockCommand.argument).toHaveBeenCalledWith('<slug>', 'Environment Id to release')
         })
     })
 })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->
This PR is the next piece of setting up per-PR e2e test runs where we generate a PWA Kit app using the code in the branch that created the PR, deploy it to a MRT target and run e2e tests against the instance.
We must then release the MRT target back to the resource pool so the next PR run can use it.

This PR implements the part where we mark a MRT target as available in the release pull.

## How is this different that other CI actions
A critical requirement for this action is that is should run irrespective of the state of the previous steps in the Github Actions workflow. We need to handle cases where the tests fail, the job runner fails or the workflow is manually cancelled.
If we add this action as a regular step in the workflow, we can set it to `if: {{ always() }}` which will handle the case where the cleanup would run even if tests fail. But if the overall workflow is cancelled manually, this step would be skipped too as the job runner itself is torn down.

So to handle all use cases we need to leverage the "post" hook in github actions.
This hook is called after the workflow completes even if it was cancelled and guarantees the cleanup will run.

Github Actions requires the following files to define a post hook implementation:
It must be a node.js or a docker implementation.
- dist/main.js: Typically used to read inputs passed in from the parent workflow. If you're not passing inputs (like in our case where we read MRT target details from a json file created when we acquire a target) you can have a no-op in main.js but Github Actions expects the file to exist.
- dist/post.js: This is the actual implementation of the target release. Since we're not using github input context, we implement reading the `mrt-target-details.json` and getting the target slug directly in this file. We then call the mrt-target-manager.js cli and pass in the slug to implement releasing the target and update our central resource manager in AWS S3
# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Added new command in mrt-target-manager.js: `release` <slug>
- Added handler for release command
- Created implementation for post hook in github actions using node.js

# How to Test-Drive This PR

- Visit the workflow run here: https://github.com/SalesforceCommerceCloud/pwa-kit/actions/runs/16835457250/job/47693706774?pr=3031
- Click "Re-Run all jobs"
- When the "Get MRT Target lock" step completes, note the Environment Slug it prints (should be stg-001 or similar)
- Visit this dashboard: https://pwa-kit-ci-production.mrt-storefront-staging.com/
- At the end of the workflow click refresh on the dashboard and you should see the acquired environment to still be marked as "available".
- Ideally when we start running playwright tests in the next steps, we'll be able to see the dashboard update to "In-Use" when the tests are running and back to "Available" but since we don't have test runs yet. The workflow moves too quickly from acquire to release to be able to notice that change on the dashboard.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
