### PR TITLE
@W-19078442@ Extra check to disallow trusted-system request from proxy

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.12.0-dev (Jul 28, 2025)
 - This feature introduces an AI-powered shopping assistant that integrates Salesforce Embedded Messaging Service with PWA Kit applications. The shopper agent provides real-time chat support, search assistance, and personalized shopping guidance directly within the e-commerce experience. [#2658](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2658)
+- Disallow the SLAS private client proxy from handling trusted system on behalf of requests [#3042](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3042)
 
 ## v3.11.0 (Jul 22, 2025)
 - Fix the logger so that it will now print out details of the given Error object [#2486](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2486)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -177,6 +177,9 @@ export const RemoteServerFactory = {
             `${options.slasApiPath.source}(${options.applySLASPrivateClientToEndpoints.source})`
         )
 
+        // Extra check to disallow the priate client proxy from certain endpoints
+        options.doNotApplyPrivateClientSecretToEndpoints = /\/oauth2\/trusted-system/
+
         return options
     },
 
@@ -722,14 +725,25 @@ export const RemoteServerFactory = {
                     })
 
                     // We pattern match and add client secrets only to endpoints that
-                    // match the regex specified by options.applySLASPrivateClientToEndpoints
+                    // match the regex specified by options.applySLASPrivateClientToEndpoints and are
+                    // not disallowed by doNotApplyPrivateClientSecretToEndpoints
                     // (see option defaults at the top of this file).
                     // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
                     // SLAS logout (/oauth2/logout), use the Authorization header for a different
                     // purpose so we don't want to overwrite the header for those calls.
-                    if (incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints)) {
+                    if (
+                        incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints) &&
+                        !incomingRequest.path?.match(
+                            options.doNotApplyPrivateClientSecretToEndpoints
+                        )
+                    ) {
                         proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
-                    } else if (!incomingRequest.path?.match(options.slasApiPath)) {
+                    } else if (
+                        !incomingRequest.path?.match(options.slasApiPath) ||
+                        incomingRequest.path?.match(
+                            options.doNotApplyPrivateClientSecretToEndpoints
+                        )
+                    ) {
                         const message = `Request to ${incomingRequest.path} is not allowed through the SLAS Private Client Proxy`
                         logger.error(message)
                         return res.status(403).json({

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -695,8 +695,11 @@ export const RemoteServerFactory = {
             return
         }
 
-        // We explicitly disallow the proxy from handling SLAS /oauth2/trusted-system requests
-        const trustedSystemPath = '/shopper/auth/v1/oauth2/trusted-system'
+        // This is the full path to the SLAS trusted-system endpoint
+        // We want to throw an error if the regex defined options.applySLASPrivateClientToEndpoints
+        // matches this path as an early warning to developers that they should update their regex
+        // in ssr.js to exclude this path.
+        const trustedSystemPath = '/shopper/auth/v1/oauth2/trusted-system/token'
         if (trustedSystemPath.match(options.applySLASPrivateClientToEndpoints)) {
             throw new Error(
                 'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -177,9 +177,6 @@ export const RemoteServerFactory = {
             `${options.slasApiPath.source}(${options.applySLASPrivateClientToEndpoints.source})`
         )
 
-        // Extra check to disallow the priate client proxy from certain endpoints
-        options.doNotApplyPrivateClientSecretToEndpoints = /\/oauth2\/trusted-system/
-
         return options
     },
 
@@ -698,6 +695,14 @@ export const RemoteServerFactory = {
             return
         }
 
+        // We explicitly disallow the proxy from handling SLAS /oauth2/trusted-system requests
+        const trustedSystemPath = '/shopper/auth/v1/oauth2/trusted-system'
+        if (trustedSystemPath.match(options.applySLASPrivateClientToEndpoints)) {
+            throw new Error(
+                'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'
+            )
+        }
+
         localDevLog(`Proxying ${slasPrivateProxyPath} to ${options.slasTarget}`)
 
         const clientId = options.mobify?.app?.commerceAPI?.parameters?.clientId
@@ -724,25 +729,11 @@ export const RemoteServerFactory = {
                         targetProtocol: 'https'
                     })
 
-                    // We pattern match and add client secrets only to endpoints that
-                    // match the regex specified by options.applySLASPrivateClientToEndpoints and are
-                    // not disallowed by doNotApplyPrivateClientSecretToEndpoints
-                    // (see option defaults at the top of this file).
-                    // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
-                    // SLAS logout (/oauth2/logout), use the Authorization header for a different
-                    // purpose so we don't want to overwrite the header for those calls.
+                    // We don't want the proxy to handle any non-SLAS requests
+                    // or any trusted system requests
                     if (
-                        incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints) &&
-                        !incomingRequest.path?.match(
-                            options.doNotApplyPrivateClientSecretToEndpoints
-                        )
-                    ) {
-                        proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
-                    } else if (
                         !incomingRequest.path?.match(options.slasApiPath) ||
-                        incomingRequest.path?.match(
-                            options.doNotApplyPrivateClientSecretToEndpoints
-                        )
+                        incomingRequest.path?.match(/\/oauth2\/trusted-system/)
                     ) {
                         const message = `Request to ${incomingRequest.path} is not allowed through the SLAS Private Client Proxy`
                         logger.error(message)
@@ -751,8 +742,17 @@ export const RemoteServerFactory = {
                         })
                     }
 
-                    // /oauth2/trusted-agent/token endpoint requires a different auth header
-                    if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
+                    // We pattern match and add client secrets only to endpoints that
+                    // match the regex specified by options.applySLASPrivateClientToEndpoints.
+                    //
+                    // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
+                    // SLAS logout (/oauth2/logout), use the Authorization header for a different
+                    // purpose so we don't want to overwrite the header for those calls.
+                    if (incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints)) {
+                        proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
+                    } else if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
+                        // /oauth2/trusted-agent/token endpoint auth header comes from Account Manager
+                        // so the SLAS private client is sent via this special header
                         proxyRequest.setHeader('_sfdc_client_auth', encodedSlasCredentials)
                     }
                 }

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1263,4 +1263,29 @@ describe('SLAS private client proxy', () => {
             .get('/mobify/slas/private/shopper/auth-admin/v1/other-path')
             .expect(403)
     }, 15000)
+
+    test('returns 403 if request is for /oauth2/trusted-agent/* endpoint', async () => {
+        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
+
+        const app = RemoteServerFactory._createApp(
+            opts({
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                clientId: 'clientId',
+                                shortCode: 'shortCode'
+                            }
+                        }
+                    }
+                },
+                useSLASPrivateClient: true,
+                slasTarget: slasTarget
+            })
+        )
+
+        return await request(app)
+            .get('/mobify/slas/private/shopper/auth/v1/oauth2/trusted-system/token')
+            .expect(403)
+    }, 15000)
 })

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1264,7 +1264,7 @@ describe('SLAS private client proxy', () => {
             .expect(403)
     }, 15000)
 
-    test('returns 403 if request is for /oauth2/trusted-agent/* endpoint', async () => {
+    test('returns 403 if request is for /oauth2/trusted-system/* endpoint', async () => {
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
 
         const app = RemoteServerFactory._createApp(

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1086,9 +1086,24 @@ describe('SLAS private client proxy', () => {
     const savedEnvironment = Object.assign({}, process.env)
 
     let proxyApp
+    let proxyServer
     const proxyPort = 12345
     const proxyPath = '/shopper/auth/responseHeaders'
     const slasTarget = `http://localhost:${proxyPort}${proxyPath}`
+    const appConfig = {
+        mobify: {
+            app: {
+                commerceAPI: {
+                    parameters: {
+                        clientId: 'clientId',
+                        shortCode: 'shortCode'
+                    }
+                }
+            }
+        },
+        useSLASPrivateClient: true,
+        slasTarget: slasTarget
+    }
 
     beforeAll(() => {
         // by setting slasTarget, rather than forwarding the request to SLAS,
@@ -1097,15 +1112,38 @@ describe('SLAS private client proxy', () => {
         proxyApp.use(proxyPath, (req, res) => {
             res.send(req.headers)
         })
-        proxyApp.listen(proxyPort)
+        proxyServer = proxyApp.listen(proxyPort)
     })
 
     afterEach(() => {
         process.env = savedEnvironment
     })
 
-    afterAll(() => {
-        proxyApp.close()
+    // There is a lot of cleanup done here to ensure the proxy server is closed
+    // after these tests.
+    afterAll(async () => {
+        if (proxyServer) {
+            // Close the server and wait for it to fully close
+            await new Promise((resolve) => {
+                proxyServer.close(() => {
+                    resolve()
+                })
+            })
+
+            // Additional cleanup to ensure all connections are closed
+            proxyServer.unref()
+
+            // Force close any remaining connections
+            if (proxyServer._handle) {
+                proxyServer._handle.close()
+            }
+
+            // Clear any remaining event listeners
+            proxyServer.removeAllListeners()
+        }
+
+        // Clear any remaining timers or intervals
+        jest.clearAllTimers()
     })
 
     test('should not create proxy by default', () => {
@@ -1121,22 +1159,7 @@ describe('SLAS private client proxy', () => {
     test('does not insert client secret if request not for /oauth2/token', async () => {
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
 
-        const app = RemoteServerFactory._createApp(
-            opts({
-                mobify: {
-                    app: {
-                        commerceAPI: {
-                            parameters: {
-                                clientId: 'clientId',
-                                shortCode: 'shortCode'
-                            }
-                        }
-                    }
-                },
-                useSLASPrivateClient: true,
-                slasTarget: slasTarget
-            })
-        )
+        const app = RemoteServerFactory._createApp(opts(appConfig))
 
         return await request(app)
             .get('/mobify/slas/private/shopper/auth/v1/somePath')
@@ -1152,22 +1175,7 @@ describe('SLAS private client proxy', () => {
 
         const encodedCredentials = Buffer.from('clientId:a secret').toString('base64')
 
-        const app = RemoteServerFactory._createApp(
-            opts({
-                mobify: {
-                    app: {
-                        commerceAPI: {
-                            parameters: {
-                                clientId: 'clientId',
-                                shortCode: 'shortCode'
-                            }
-                        }
-                    }
-                },
-                useSLASPrivateClient: true,
-                slasTarget: slasTarget
-            })
-        )
+        const app = RemoteServerFactory._createApp(opts(appConfig))
 
         return await request(app)
             .get('/mobify/slas/private/shopper/auth/v1/oauth2/token')
@@ -1181,24 +1189,7 @@ describe('SLAS private client proxy', () => {
     test('does not add _sfdc_client_auth header if request not for /oauth2/trusted-agent/token', async () => {
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
 
-        const encodedCredentials = Buffer.from('clientId:a secret').toString('base64')
-
-        const app = RemoteServerFactory._createApp(
-            opts({
-                mobify: {
-                    app: {
-                        commerceAPI: {
-                            parameters: {
-                                clientId: 'clientId',
-                                shortCode: 'shortCode'
-                            }
-                        }
-                    }
-                },
-                useSLASPrivateClient: true,
-                slasTarget: slasTarget
-            })
-        )
+        const app = RemoteServerFactory._createApp(opts(appConfig))
 
         return await request(app)
             .get('/mobify/slas/private/shopper/auth/v1/oauth2/other-path')
@@ -1242,22 +1233,7 @@ describe('SLAS private client proxy', () => {
     test('returns 403 if request is not for /shopper/auth endpoints', async () => {
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
 
-        const app = RemoteServerFactory._createApp(
-            opts({
-                mobify: {
-                    app: {
-                        commerceAPI: {
-                            parameters: {
-                                clientId: 'clientId',
-                                shortCode: 'shortCode'
-                            }
-                        }
-                    }
-                },
-                useSLASPrivateClient: true,
-                slasTarget: slasTarget
-            })
-        )
+        const app = RemoteServerFactory._createApp(opts(appConfig))
 
         return await request(app)
             .get('/mobify/slas/private/shopper/auth-admin/v1/other-path')
@@ -1267,25 +1243,36 @@ describe('SLAS private client proxy', () => {
     test('returns 403 if request is for /oauth2/trusted-system/* endpoint', async () => {
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
 
-        const app = RemoteServerFactory._createApp(
-            opts({
-                mobify: {
-                    app: {
-                        commerceAPI: {
-                            parameters: {
-                                clientId: 'clientId',
-                                shortCode: 'shortCode'
-                            }
-                        }
-                    }
-                },
-                useSLASPrivateClient: true,
-                slasTarget: slasTarget
-            })
-        )
+        const app = RemoteServerFactory._createApp(opts(appConfig))
 
         return await request(app)
             .get('/mobify/slas/private/shopper/auth/v1/oauth2/trusted-system/token')
             .expect(403)
+    }, 15000)
+
+    test('throws an error if /oauth2/trusted-system/* is included in applySLASPrivateClientToEndpoints', async () => {
+        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
+
+        expect(() => {
+            RemoteServerFactory._createApp(
+                opts({
+                    mobify: {
+                        app: {
+                            commerceAPI: {
+                                parameters: {
+                                    clientId: 'clientId',
+                                    shortCode: 'shortCode'
+                                }
+                            }
+                        }
+                    },
+                    useSLASPrivateClient: true,
+                    slasTarget: slasTarget,
+                    applySLASPrivateClientToEndpoints: /\/oauth2\/trusted-system/
+                })
+            )
+        }).toThrow(
+            'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'
+        )
     }, 15000)
 })


### PR DESCRIPTION
Currently, projects can customize the SLAS private client proxy to allow additional SLAS endpoints via ssr.js.

Because of this customizability, this PR introduces an additional condition to block the private client proxy from allowing requests to the trusted-system endpoint. 

Use of the trusted-system endpoint is gated behind several mechanisms, such as needing the scope set on a private SLAS client, and needing to configure the proxy to allow requests to the trusted-system endpoint. But we want to disallow trusted-system requests even if those gates are passed as this is not an endpoint a shopper-facing application should be using.



**Testing the changes**

Pull down this PR
Update ssr.js to allow requests to SLAS trusted system on behalf of
Update your app to use a SLAS client id that has the `sfcc.ts_ext_on_behalf_of` scope
Send a trusted system on behalf of request through the SLAS private client proxy.