### PR TITLE
@W-19275324 Modify the Product Card to support standard products

### DIFF
--- a/packages/template-chakra-storefront/src/pages/cart/partials/cart-secondary-button-group.jsx
+++ b/packages/template-chakra-storefront/src/pages/cart/partials/cart-secondary-button-group.jsx
@@ -98,6 +98,19 @@ const CartSecondaryButtonGroup = ({
         onRemoveItemClick(variant)
     }
 
+    /**
+     * Decide whether the Edit button should be displayed.
+     *
+     * - `variant.id`: avoids a brief Edit-button flicker when the variant is still being resolved.
+     * - `variant.type && !variant.type?.item`: only non-standard products can be edited
+     * - `variant.variationAttributes.length > 0`: only show Edit when there are variation attributes to edit
+     *
+     * Returns true when all conditions are satisfied, otherwise false.
+     */
+    const showEditButton = useMemo(() => {
+        return variant.id && variant.type && !variant.type?.item
+    }, [variant])
+
     return (
         <>
             <Stack
@@ -119,9 +132,12 @@ const CartSecondaryButtonGroup = ({
                             {messages.addToWishlist}
                         </Button>
                     )}
-                    <Button variant="link-blue" size="sm" onClick={() => onEditClick(variant)}>
-                        {messages.edit}
-                    </Button>
+                    {/*@sfdc-extension-block-end SFDC_EXT_WISHLIST*/}
+                    {showEditButton && (
+                        <Button variant="link-blue" size="sm" onClick={() => onEditClick(variant)}>
+                            {messages.edit}
+                        </Button>
+                    )}
                 </ButtonGroup>
                 <Flex alignItems="center">
                     <Checkbox.Root

--- a/packages/template-chakra-storefront/src/pages/cart/partials/cart-secondary-button-group.test.js
+++ b/packages/template-chakra-storefront/src/pages/cart/partials/cart-secondary-button-group.test.js
@@ -173,3 +173,71 @@ test('handles gift checkbox change', async () => {
 
     expect(giftCheckbox).toBeChecked()
 })
+
+// Helper to render with a custom variant
+const renderWithVariant = (variant, props = {}) => {
+    return renderWithProviders(
+        <ItemVariantProvider variant={variant}>
+            <CartSecondaryButtonGroup {...props} />
+        </ItemVariantProvider>
+    )
+}
+
+describe('CartSecondaryButtonGroup Edit button conditional rendering', () => {
+    test('shows Edit button for a variation product', () => {
+        const variantProduct = {
+            id: 'test-variant-123',
+            itemId: '123',
+            type: {item: false},
+            variationAttributes: [{id: 'color', values: [{value: 'red'}]}]
+        }
+        renderWithVariant(variantProduct)
+        expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument()
+    })
+
+    test('does NOT show Edit button for a bundle product without variation attributes', () => {
+        const bundleProduct = {
+            id: 'test-variant-123',
+            itemId: '456',
+            bundledProductItems: [{productId: 'bundle-item-1', quantity: 1}]
+        }
+        renderWithVariant(bundleProduct)
+        expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument()
+    })
+
+    test('shows Edit button for a product with variation attributes and bundled items', () => {
+        const bundleVariationProduct = {
+            id: 'test-variant-123',
+            itemId: '789',
+            type: {item: false},
+            variationAttributes: [{id: 'color', values: [{value: 'blue'}]}],
+            bundledProductItems: [{productId: 'bundle-item-2', quantity: 2}]
+        }
+        renderWithVariant(bundleVariationProduct)
+        expect(screen.getByRole('button', {name: /edit/i})).toBeInTheDocument()
+    })
+
+    test('does NOT show Edit button for a standard product', () => {
+        const standardProduct = {
+            id: 'test-variant-123',
+            itemId: '101',
+            type: {item: true}
+        }
+        renderWithVariant(standardProduct)
+        expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument()
+    })
+
+    test('does NOT show Edit button for a product bundle that has children, but none with variants', () => {
+        const nonVariantChildrenBundle = {
+            id: 'test-variant-124',
+            itemId: '104',
+            bundledProductItems: [
+                {productId: 'child-1', quantity: 1},
+                {productId: 'child-2', quantity: 2, variationAttributes: []},
+                {productId: 'child-3', quantity: 1, hasVariants: false}
+            ]
+        }
+        renderWithVariant(nonVariantChildrenBundle)
+        expect(screen.queryByRole('button', {name: /edit/i})).not.toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Modify the Product Card to support standard products (V4 Migration)
Reference PRs:
https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2581
https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2649

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR
https://cc-sharks-dev-emmy-test.mobify-storefront-staging.com/

- Add standard product to cart
- Confirm edit button is not shown in the product card
- Add bundle/set to cart, confirm edit button is shown

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
