### PR TITLE
[Multi-ship] Bump major version for retail-react-app

### DIFF
--- a/packages/template-mrt-reference-app/package.json
+++ b/packages/template-mrt-reference-app/package.json
@@ -45,7 +45,7 @@
       "node_modules/**/*.*"
     ],
     "ssrShared": [
-      "static/example.txt", 
+      "static/example.txt",
       "static/favicon.ico",
       "static/robots.txt"
     ]

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v7.1.0-dev (July 28, 2025)
+## v8.0.0-dev (August 19, 2025)
 
 - This feature introduces an AI-powered shopping assistant that integrates Salesforce Embedded Messaging Service with PWA Kit applications. The shopper agent provides real-time chat support, search assistance, and personalized shopping guidance directly within the e-commerce experience. [#2658](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2658)
 - Added support for Multi-Ship [#3056](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3056)

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "7.1.0-dev",
+  "version": "8.0.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@salesforce/retail-react-app",
-      "version": "7.1.0-dev",
+      "version": "8.0.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
         "@chakra-ui/icons": "^2.0.19",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "7.1.0-dev",
+  "version": "8.0.0-dev",
   "license": "See license in LICENSE",
   "author": "cc-pwa-kit@salesforce.com",
   "ccExtensibility": {


### PR DESCRIPTION
Bump the major version of retail-react-app to v8. For context, see related discussion here: https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3056#discussion_r2276974729