### PR TITLE
commerce-sdk-react v4 - Remove deprecated properties + fix private client proxy endpoint prop name

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## v3.5.0-dev (Jul 22, 2025)
 - Add support for environment level base paths on /mobify routes [#2892](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2892)
 - Update USID expiry to match SLAS refresh token expiry[#2854](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2854)
-
 - [Bugfix] Skip deleting dwsid on shopper login if hybrid auth is enabled for current site. [#3151](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3151)
+- Remove deprecated properties in commerce-sdk-react [#3177](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3177)
 
 ## v3.4.0 (Jul 22, 2025)
 

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -25,8 +25,6 @@ import {
     extractCustomParameters
 } from '../utils'
 import {
-    MOBIFY_PATH,
-    SLAS_PRIVATE_PROXY_PATH,
     SLAS_SECRET_WARNING_MSG,
     SLAS_SECRET_PLACEHOLDER,
     SLAS_SECRET_OVERRIDE_MSG,
@@ -250,16 +248,9 @@ class Auth {
     constructor(config: AuthConfig) {
         // Special proxy endpoint for injecting SLAS private client secret.
         // We prioritize config.privateClientProxyEndpoint since that allows us to use the new envBasePath feature
-        // The preexisting hard coded privateClientEndpoint is kept here for now to prevent a breaking change.
-        // TODO: We should remove this in the next major release so we do not have a hard coded proxy path inside commerce-sdk-react
-        const baseUrl = config.proxy.split(MOBIFY_PATH)[0]
-        const privateClientEndpoint = `${baseUrl}${SLAS_PRIVATE_PROXY_PATH}`
-
         this.client = new ShopperLogin({
             proxy: config.enablePWAKitPrivateClient
                 ? config.privateClientProxyEndpoint
-                    ? config.privateClientProxyEndpoint
-                    : privateClientEndpoint
                 : config.proxy,
             parameters: {
                 clientId: config.clientId,
@@ -345,13 +336,7 @@ class Auth {
         this.isPrivate = !!this.clientSecret
 
         const passwordlessLoginCallbackURI = config.passwordlessLoginCallbackURI
-        this.passwordlessLoginCallbackURI = passwordlessLoginCallbackURI
-            ? isAbsoluteUrl(passwordlessLoginCallbackURI)
-                ? passwordlessLoginCallbackURI
-                : // This fallback does not take into account the envBasePath feature
-                  // To set an env base path, config.passwordlessLoginCallbackURI must be an absolute url
-                  `${baseUrl}${passwordlessLoginCallbackURI}`
-            : ''
+        this.passwordlessLoginCallbackURI = passwordlessLoginCallbackURI || ''
 
         this.hybridAuthEnabled = config.hybridAuthEnabled || false
     }

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/utils.ts
@@ -7,7 +7,8 @@
 
 import {ApiClients} from '../../hooks/types'
 import {DEVELOPMENT_ORIGIN, getParentOrigin, isOriginTrusted} from '../../utils'
-import {LOCAL_BUNDLE_PATH} from '../../constant'
+
+const LOCAL_BUNDLE_PATH = `/mobify/bundle/development`
 
 /** Detects whether the storefront is running in an iframe as part of Storefront Preview.
  * @private

--- a/packages/commerce-sdk-react/src/constant.ts
+++ b/packages/commerce-sdk-react/src/constant.ts
@@ -14,25 +14,6 @@ export const IFRAME_HOST_ALLOW_LIST = Object.freeze([
     'https://runtime-admin-preview.mobify-storefront.com'
 ])
 
-/* Deprecating the following path constants since, outside of storefront preview,
- * the paths they are used for can be passed in via the provider. */
-/**
- * @deprecated
- */
-export const MOBIFY_PATH = '/mobify'
-/**
- * @deprecated
- */
-export const PROXY_PATH = `${MOBIFY_PATH}/proxy`
-/**
- * @deprecated
- */
-export const LOCAL_BUNDLE_PATH = `${MOBIFY_PATH}/bundle/development`
-/**
- * @deprecated
- */
-export const SLAS_PRIVATE_PROXY_PATH = `${MOBIFY_PATH}/slas/private`
-
 export const SLAS_SECRET_WARNING_MSG =
     'You are potentially exposing SLAS secret on browser. Make sure to keep it safe and secure!'
 

--- a/packages/commerce-sdk-react/src/hooks/useDNT.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/useDNT.test.ts
@@ -37,9 +37,9 @@ describe('useDNT tests', () => {
         })
     })
 
-    it('updateDNT should create dw_dnt cookie', async () => {
-        const {updateDNT} = useDNT()
-        await updateDNT(true)
+    it('updateDnt should create dw_dnt cookie', async () => {
+        const {updateDnt} = useDNT()
+        await updateDnt(true)
         expect(mockSetDnt).toHaveBeenCalledWith(true)
     })
 

--- a/packages/commerce-sdk-react/src/hooks/useDNT.ts
+++ b/packages/commerce-sdk-react/src/hooks/useDNT.ts
@@ -8,9 +8,7 @@ import useAuthContext from './useAuthContext'
 
 interface useDntReturn {
     selectedDnt: boolean | undefined
-    dntStatus: boolean | undefined
     effectiveDnt: boolean | undefined
-    updateDNT: (preference: boolean | null) => Promise<void>
     updateDnt: (preference: boolean | null) => Promise<void>
 }
 
@@ -26,8 +24,6 @@ interface useDntReturn {
  *              If defaultDnt is undefined as well, then SDK default is used.
  * @property {function} updateDnt - takes a DNT choice and creates the dw_dnt
  *              cookie and reauthorizes with SLAS
- * @property {function} updateDNT - @deprecated Deprecated since version 3.1.0. Use updateDnt instead.
- * @property {boolean} dntStatus - @deprecated Deprecated since version 3.1.0. Use selectedDnt instead.
  *
  *
  */
@@ -40,14 +36,10 @@ const useDNT = (): useDntReturn => {
     const updateDnt = async (preference: boolean | null) => {
         await auth.setDnt(preference)
     }
-    const updateDNT = updateDnt
-    const dntStatus = selectedDnt
 
     return {
         selectedDnt,
         effectiveDnt,
-        dntStatus,
-        updateDNT,
         updateDnt
     }
 }

--- a/packages/commerce-sdk-react/src/provider.test.tsx
+++ b/packages/commerce-sdk-react/src/provider.test.tsx
@@ -65,7 +65,8 @@ describe('provider', () => {
             )
         }
         const config = {
-            enablePWAKitPrivateClient: true
+            enablePWAKitPrivateClient: true,
+            privateClientProxyEndpoint: 'http://localhost:3000/mobify/slas/private'
         }
         renderWithProviders(<Component />, config)
         const element = screen.getByTestId('proxy-value')

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -8,12 +8,7 @@ import React, {ReactElement, useEffect, useMemo} from 'react'
 import Auth from './auth'
 import {ApiClientConfigParams, ApiClients, SDKClientTransformer} from './hooks/types'
 import {Logger} from './types'
-import {
-    DWSID_COOKIE_NAME,
-    MOBIFY_PATH,
-    SERVER_AFFINITY_HEADER_KEY,
-    SLAS_PRIVATE_PROXY_PATH
-} from './constant'
+import {DWSID_COOKIE_NAME, SERVER_AFFINITY_HEADER_KEY} from './constant'
 import {
     ShopperBaskets,
     ShopperContexts,
@@ -257,14 +252,6 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             fetchOptions
         }
 
-        // Special proxy endpoint for injecting SLAS private client secret.
-        // This is only used by the ShopperLogin API as that is the only one that interacts with SLAS.
-        // We prioritize config.privateClientProxyEndpoint since that allows us to use the new envBasePath feature
-        // The preexisting hard coded privateClientEndpoint is kept here for now to prevent a breaking change.
-        // TODO: We should remove this in the next major release so we do not have a hard coded proxy path inside commerce-sdk-react
-        const baseUrl = config.proxy.split(MOBIFY_PATH)[0]
-        const privateClientEndpoint = `${baseUrl}${SLAS_PRIVATE_PROXY_PATH}`
-
         return {
             shopperBaskets: new ShopperBaskets(config),
             shopperContexts: new ShopperContexts(config),
@@ -273,11 +260,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             shopperGiftCertificates: new ShopperGiftCertificates(config),
             shopperLogin: new ShopperLogin({
                 ...config,
-                proxy: enablePWAKitPrivateClient
-                    ? privateClientProxyEndpoint
-                        ? privateClientProxyEndpoint
-                        : privateClientEndpoint
-                    : config.proxy
+                proxy: enablePWAKitPrivateClient ? privateClientProxyEndpoint : config.proxy
             }),
             shopperOrders: new ShopperOrders(config),
             shopperProducts: new ShopperProducts(config),

--- a/packages/commerce-sdk-react/src/test-utils.tsx
+++ b/packages/commerce-sdk-react/src/test-utils.tsx
@@ -16,7 +16,6 @@ import {
 import nock from 'nock'
 import CommerceApiProvider, {CommerceApiProviderProps} from './provider'
 import userEvent from '@testing-library/user-event'
-import {PROXY_PATH} from './constant'
 
 // Note: this host does NOT exist
 // it is intentional b/c we can catch those unintercepted requests
@@ -24,7 +23,7 @@ import {PROXY_PATH} from './constant'
 export const DEFAULT_TEST_HOST = 'http://localhost:8888'
 
 export const DEFAULT_TEST_CONFIG = {
-    proxy: `${DEFAULT_TEST_HOST}${PROXY_PATH}/api`,
+    proxy: `${DEFAULT_TEST_HOST}/mobify/proxy/api`,
     redirectURI: `${DEFAULT_TEST_HOST}/callback`,
     clientId: '12345678-1234-1234-1234-123412341234',
     organizationId: 'f_ecom_zzrmy_orgf_001',

--- a/packages/pwa-kit-create-app/CHANGELOG.md
+++ b/packages/pwa-kit-create-app/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v3.12.0-dev (Jul 22, 2025)
 - This feature introduces an AI-powered shopping assistant that integrates Salesforce Embedded Messaging Service with PWA Kit applications. The shopper agent provides real-time chat support, search assistance, and personalized shopping guidance directly within the e-commerce experience. [#2658](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2658)
 - Add support for environment level base paths on /mobify routes [#2892](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2892)
+- Fix private client endpoint prop name in app config templates [#3177](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3177)
 - Add `--initGit` to automate git repo creation for the generated project [#2817](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2817)
 
 

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/components/_app-config/index.jsx.hbs
@@ -101,7 +101,7 @@ const AppConfig = ({children, locals = {}}) => {
             {{else}}
             enablePWAKitPrivateClient={false}
             {{/if}}
-            slasPrivateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
+            privateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
             // Uncomment 'hybridAuthEnabled' if the current site has Hybrid Auth enabled. Do NOT set this flag for hybrid storefronts using Plugin SLAS.
             // hybridAuthEnabled={true}
         >

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/components/_app-config/index.jsx.hbs
@@ -101,7 +101,7 @@ const AppConfig = ({children, locals = {}}) => {
             {{else}}
             enablePWAKitPrivateClient={false}
             {{/if}}
-            slasPrivateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
+            privateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
             // Uncomment 'hybridAuthEnabled' if the current site has Hybrid Auth enabled. Do NOT set this flag for hybrid storefronts using Plugin SLAS.
             // hybridAuthEnabled={true}
         >

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v7.1.0-dev (July 22, 2025)
 - Add support for environment level base paths on /mobify routes [#2892](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2892)
+- Fix private client endpoint prop name [#3177](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3177)
 
 - This feature introduces an AI-powered shopping assistant that integrates Salesforce Embedded Messaging Service with PWA Kit applications. The shopper agent provides real-time chat support, search assistance, and personalized shopping guidance directly within the e-commerce experience. [#2658](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/2658)
 - The feature toggle for partial hydration is now found in the config file (`config.app.partialHydrationEnabled`) [#3058](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3058)

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -105,7 +105,7 @@ const AppConfig = ({children, locals = {}}) => {
             // Set 'enablePWAKitPrivateClient' to true to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
             enablePWAKitPrivateClient={false}
-            slasPrivateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
+            privateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
             // Uncomment 'hybridAuthEnabled' if the current site has Hybrid Auth enabled. Do NOT set this flag for hybrid storefronts using Plugin SLAS.
             // hybridAuthEnabled={true}
             logger={createLogger({packageName: 'commerce-sdk-react'})}

--- a/packages/template-retail-react-app/app/components/_app/index.test.js
+++ b/packages/template-retail-react-app/app/components/_app/index.test.js
@@ -26,12 +26,12 @@ jest.mock('../../hooks/use-update-shopper-context', () => ({
 
 let windowSpy
 
-const mockUpdateDNT = jest.fn()
+const mockUpdateDnt = jest.fn()
 jest.mock('@salesforce/commerce-sdk-react', () => {
     const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
         ...originalModule,
-        useDNT: () => ({selectedDnt: undefined, updateDNT: mockUpdateDNT})
+        useDNT: () => ({selectedDnt: undefined, updateDnt: mockUpdateDnt})
     }
 })
 

--- a/packages/template-retail-react-app/app/hooks/use-dnt-notification.js
+++ b/packages/template-retail-react-app/app/hooks/use-dnt-notification.js
@@ -25,7 +25,7 @@ import {useDNT} from '@salesforce/commerce-sdk-react'
 import {useLocation} from 'react-router-dom'
 
 export const DntNotification = ({isOpen, onOpen, onClose}) => {
-    const {selectedDnt, updateDNT} = useDNT()
+    const {selectedDnt, updateDnt} = useDNT()
     const {formatMessage} = useIntl()
     const location = useLocation()
 
@@ -38,7 +38,7 @@ export const DntNotification = ({isOpen, onOpen, onClose}) => {
     }, [location, selectedDnt])
 
     const onCloseNotification = () => {
-        updateDNT(null)
+        updateDnt(null)
         onClose()
     }
 
@@ -52,7 +52,7 @@ export const DntNotification = ({isOpen, onOpen, onClose}) => {
                 borderColor="gray.100"
                 boxShadow="md"
                 onClick={() => {
-                    updateDNT(true)
+                    updateDnt(true)
                     onClose()
                 }}
                 aria-label={formatMessage({
@@ -65,7 +65,7 @@ export const DntNotification = ({isOpen, onOpen, onClose}) => {
             </Button>
             <Button
                 onClick={() => {
-                    updateDNT(false)
+                    updateDnt(false)
                     onClose()
                 }}
                 boxShadow="md"

--- a/packages/template-retail-react-app/app/hooks/use-dnt-notification.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-dnt-notification.test.js
@@ -12,12 +12,12 @@ import {
     useDntNotification
 } from '@salesforce/retail-react-app/app/hooks/use-dnt-notification'
 
-const mockUpdateDNT = jest.fn()
+const mockUpdateDnt = jest.fn()
 jest.mock('@salesforce/commerce-sdk-react', () => {
     const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
         ...originalModule,
-        useDNT: () => ({dntStatus: undefined, updateDNT: mockUpdateDNT})
+        useDNT: () => ({dntStatus: undefined, updateDnt: mockUpdateDnt})
     }
 })
 
@@ -47,7 +47,7 @@ test('Clicking out of notification does setDNT(null)', async () => {
     await user.click(closeButton)
 
     await waitFor(() => {
-        expect(mockUpdateDNT).toHaveBeenCalledWith(null)
+        expect(mockUpdateDnt).toHaveBeenCalledWith(null)
     })
 })
 
@@ -60,7 +60,7 @@ test('Clicking Accept does setDNT(false)', async () => {
     await user.click(acceptButton)
 
     await waitFor(() => {
-        expect(mockUpdateDNT).toHaveBeenCalledWith(false)
+        expect(mockUpdateDnt).toHaveBeenCalledWith(false)
     })
 })
 
@@ -73,6 +73,6 @@ test('Clicking Decline does setDNT(true)', async () => {
     await user.click(declineButton)
 
     await waitFor(() => {
-        expect(mockUpdateDNT).toHaveBeenCalledWith(true)
+        expect(mockUpdateDnt).toHaveBeenCalledWith(true)
     })
 })

--- a/packages/test-commerce-sdk-react/app/pages/use-dnt.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/use-dnt.tsx
@@ -13,7 +13,7 @@ const buttonStyle = {
 
 const UseDntHook = () => {
     const [displayButton, setDisplayButton] = useState(false)
-    const {selectedDnt, updateDNT} = useDNT()
+    const {selectedDnt, updateDnt} = useDNT()
     useEffect(() => {
         if (selectedDnt === undefined) setDisplayButton(true)
     }, [])
@@ -23,7 +23,7 @@ const UseDntHook = () => {
             style={buttonStyle}
             onClick={() => {
                 void (async () => {
-                    await updateDNT(null)
+                    await updateDnt(null)
                 })()
                 setDisplayButton(false)
             }}


### PR DESCRIPTION
This PR contains 2 small changes

1) Removes properties that have been deprecated in commerce-sdk-react since we are bumping the major version of commerce-sdk-react to v4 as part of #2879

(The removed properties are related to return properties from useDNT and /mobify constants)

2) Fix _app-config so that the correct prop name is used to set the private client proxy endpoint url
(The property cleanup removes the fallback private client proxy endpoint so it's now important that this prop name is correct)

Testing the changes:
* Set up a SLAS private client and enable private client mode
* Start the app
* In the DNT dialog box, make a selection

Verify that SLAS calls are routed to the SLAS client proxy
Verify that your DNT status is updated