### PR TITLE
[release 3.12.0] Remove not-useful warning message

### DIFF
--- a/packages/template-retail-react-app/config/utils.js
+++ b/packages/template-retail-react-app/config/utils.js
@@ -26,7 +26,6 @@ function parseSettings(settings) {
         }
     }
 
-    console.warn('Cannot parse settings from:', settings)
     return
 }
 


### PR DESCRIPTION
The warning message `Cannot parse settings from: undefined` is not as helpful as I thought, because it can confuse other people and cause false alarm.

One use of this function is to parse an _optional_ environment variable (see [this config](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/8aa522310bcf568537397d74b5deea5b91a90497/packages/template-retail-react-app/config/default.js#L13)). So if it is not set, we constantly print out the warning message.