### PR TITLE
@W-19398300 fix modal position, add header title, back to seletion on close

### DIFF
--- a/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
@@ -99,6 +99,10 @@ const BonusProductViewModal = ({
             viewCart: formatMessage({
                 id: 'bonus_product_view_modal.button.view_cart',
                 defaultMessage: 'View Cart'
+            }),
+            backToSelection: formatMessage({
+                id: 'bonus_product_view_modal.button.back_to_selection',
+                defaultMessage: 'Back to Selection'
             })
         }),
         [intl]
@@ -255,9 +259,12 @@ const BonusProductViewModal = ({
         () => [
             <Button key="view-cart" variant="outline" onClick={handleViewCart}>
                 {messages.viewCart}
+            </Button>,
+            <Button key="back-to-selection" variant="outline" onClick={onReturnToSelection}>
+                {messages.backToSelection}
             </Button>
         ],
-        [messages.viewCart, handleViewCart]
+        [messages.viewCart, messages.backToSelection, handleViewCart, onReturnToSelection]
     )
 
     // Clean product data but preserve variation attributes for size/color selectors
@@ -292,7 +299,7 @@ const BonusProductViewModal = ({
     return (
         <Modal
             isOpen={isOpen}
-            onClose={onReturnToSelection || onClose}
+            onClose={onClose}
             size={productViewModalTheme.modal.size}
             closeOnOverlayClick={true}
             closeOnEsc={true}

--- a/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
@@ -26,7 +26,8 @@ import {useShopperBasketsMutationHelper} from '@salesforce/commerce-sdk-react'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import {
     findAvailableBonusDiscountLineItemId,
-    getRemainingAvailableBonusProductsForProduct
+    getRemainingAvailableBonusProductsForProduct,
+    getBonusProductCountsForPromotion
 } from '@salesforce/retail-react-app/app/utils/bonus-product-utils'
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'
 import {productViewModalTheme} from '@salesforce/retail-react-app/app/theme/components/project/product-view-modal'
@@ -69,23 +70,10 @@ const BonusProductViewModal = ({
     const {formatMessage} = intl
     const showToast = useToast()
 
-    // Calculate bonus items count for header
-    const {selectedBonusItems, maxBonusItems} = useMemo(() => {
-        if (!basket?.bonusDiscountLineItems) {
-            return {selectedBonusItems: 0, maxBonusItems: 0}
-        }
-
-        const maxItems = basket.bonusDiscountLineItems.reduce(
-            (sum, bli) => sum + (bli.maxBonusItems || 0), 
-            0
-        )
-        
-        const selectedItems = (basket.productItems || [])
-            .filter(item => item.bonusProductLineItem)
-            .reduce((sum, item) => sum + (item.quantity || 0), 0)
-
-        return {selectedBonusItems: selectedItems, maxBonusItems: maxItems}
-    }, [basket])
+    // Calculate bonus counts using promotionId and utility method
+    const {selectedBonusItems: finalSelectedBonusItems, maxBonusItems: finalMaxBonusItems} = useMemo(() => {
+        return getBonusProductCountsForPromotion(basket, promotionId)
+    }, [basket, promotionId])
 
     const messages = useMemo(
         () => ({
@@ -100,9 +88,9 @@ const BonusProductViewModal = ({
                 id: 'bonus_product_view_modal.button.view_cart',
                 defaultMessage: 'View Cart'
             }),
-            backToSelection: formatMessage({
-                id: 'bonus_product_view_modal.button.back_to_selection',
-                defaultMessage: 'Back to Selection'
+            cancel: formatMessage({
+                id: 'form_action_buttons.button.cancel',
+                defaultMessage: 'Cancel'
             })
         }),
         [intl]
@@ -261,10 +249,10 @@ const BonusProductViewModal = ({
                 {messages.viewCart}
             </Button>,
             <Button key="back-to-selection" variant="outline" onClick={onReturnToSelection}>
-                {messages.backToSelection}
+                {messages.cancel}
             </Button>
         ],
-        [messages.viewCart, messages.backToSelection, handleViewCart, onReturnToSelection]
+        [messages.viewCart, messages.cancel, handleViewCart, onReturnToSelection]
     )
 
     // Clean product data but preserve variation attributes for size/color selectors
@@ -325,9 +313,9 @@ const BonusProductViewModal = ({
                             {
                                 id: 'bonus_product_view_modal.title',
                                 defaultMessage: 'Select Bonus Product ({selected} of {max} selected)'
-                            },
-                            {selected: selectedBonusItems, max: maxBonusItems}
-                        )}
+                    },
+                    {selected: finalSelectedBonusItems, max: finalMaxBonusItems}
+                )}
                     </Heading>
                 </ModalHeader>
 

--- a/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.jsx
@@ -11,11 +11,13 @@ import {
     Modal,
     ModalOverlay,
     ModalContent,
+    ModalHeader,
     ModalBody,
     ModalCloseButton,
     Button,
     Box,
-    Text
+    Text,
+    Heading
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import ProductView from '@salesforce/retail-react-app/app/components/product-view'
 import {useProductViewModal} from '@salesforce/retail-react-app/app/hooks/use-product-view-modal'
@@ -66,6 +68,24 @@ const BonusProductViewModal = ({
     const intl = useIntl()
     const {formatMessage} = intl
     const showToast = useToast()
+
+    // Calculate bonus items count for header
+    const {selectedBonusItems, maxBonusItems} = useMemo(() => {
+        if (!basket?.bonusDiscountLineItems) {
+            return {selectedBonusItems: 0, maxBonusItems: 0}
+        }
+
+        const maxItems = basket.bonusDiscountLineItems.reduce(
+            (sum, bli) => sum + (bli.maxBonusItems || 0), 
+            0
+        )
+        
+        const selectedItems = (basket.productItems || [])
+            .filter(item => item.bonusProductLineItem)
+            .reduce((sum, item) => sum + (item.quantity || 0), 0)
+
+        return {selectedBonusItems: selectedItems, maxBonusItems: maxItems}
+    }, [basket])
 
     const messages = useMemo(
         () => ({
@@ -240,16 +260,16 @@ const BonusProductViewModal = ({
         [messages.viewCart, handleViewCart]
     )
 
-    // Aggressively clean product data to prevent SwatchGroup errors while preserving essential fields
+    // Clean product data but preserve variation attributes for size/color selectors
     const productToRender = useMemo(() => {
         const baseProduct = productViewModalData.product || safeProduct
         return {
             ...baseProduct,
-            variationAttributes: [], // Force empty array
-            variants: [], // Also remove variants to be safe
-            variationParams: {},
-            selectedVariationAttributes: {},
-            type: {...baseProduct.type, variant: false, master: false},
+            variationAttributes: baseProduct.variationAttributes,
+            variants: baseProduct.variants,
+            variationParams: baseProduct.variationParams,
+            selectedVariationAttributes: baseProduct.selectedVariationAttributes,
+            type: baseProduct.type,
             // Ensure proper inventory and quantity defaults for bonus products
             inventory: {
                 ...baseProduct.inventory,
@@ -259,7 +279,10 @@ const BonusProductViewModal = ({
             minOrderQuantity: 1,
             stepQuantity: 1,
             // Ensure the product is orderable
-            orderable: true
+            orderable: true,
+            // Add review data for display
+            rating: baseProduct.rating,
+            reviewCount: baseProduct.reviewCount
         }
     }, [productViewModalData.product, safeProduct])
 
@@ -269,10 +292,11 @@ const BonusProductViewModal = ({
     return (
         <Modal
             isOpen={isOpen}
-            onClose={onClose}
+            onClose={onReturnToSelection || onClose}
             size={productViewModalTheme.modal.size}
             closeOnOverlayClick={true}
             closeOnEsc={true}
+            isCentered
             motionPreset="slideInBottom"
             preserveScrollBarGap={true}
         >
@@ -286,11 +310,24 @@ const BonusProductViewModal = ({
                 maxHeight={productViewModalTheme.layout.content.maxHeight}
                 overflowY={productViewModalTheme.layout.content.overflowY}
             >
+                <ModalHeader
+                    bg={productViewModalTheme.colors.contentBackground}
+                >
+                    <Heading size="md">
+                        {formatMessage(
+                            {
+                                id: 'bonus_product_view_modal.title',
+                                defaultMessage: 'Select Bonus Product ({selected} of {max} selected)'
+                            },
+                            {selected: selectedBonusItems, max: maxBonusItems}
+                        )}
+                    </Heading>
+                </ModalHeader>
+
                 <ModalBody
                     bg={productViewModalTheme.layout.body.background}
                     p={productViewModalTheme.layout.body.padding}
                     pb={productViewModalTheme.layout.body.paddingBottom}
-                    mt={productViewModalTheme.layout.body.marginTop}
                 >
                     {productViewModalData.isFetching && !productViewModalData.product ? (
                         <Box p={8} textAlign="center">
@@ -308,6 +345,8 @@ const BonusProductViewModal = ({
                             customButtons={customButtons}
                             promotionId={promotionId}
                             maxOrderQuantity={maxOrderQuantity}
+                            showReviews={true}
+                            showVariationAttributes={true}
                             {...props}
                         />
                     )}

--- a/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.test.js
+++ b/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.test.js
@@ -14,7 +14,8 @@ import mockProductDetail from '@salesforce/retail-react-app/app/mocks/variant-75
 import {prependHandlersToServer} from '@salesforce/retail-react-app/jest-setup'
 import {
     getRemainingAvailableBonusProductsForProduct,
-    findAvailableBonusDiscountLineItemId
+    findAvailableBonusDiscountLineItemId,
+    getBonusProductCountsForPromotion
 } from '@salesforce/retail-react-app/app/utils/bonus-product-utils'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import {useShopperBasketsMutationHelper} from '@salesforce/commerce-sdk-react'
@@ -82,7 +83,8 @@ jest.mock(
 // Mock bonus product utils
 jest.mock('@salesforce/retail-react-app/app/utils/bonus-product-utils', () => ({
     getRemainingAvailableBonusProductsForProduct: jest.fn(),
-    findAvailableBonusDiscountLineItemId: jest.fn()
+    findAvailableBonusDiscountLineItemId: jest.fn(),
+    getBonusProductCountsForPromotion: jest.fn()
 }))
 
 // Mock current basket hook
@@ -122,6 +124,12 @@ beforeEach(() => {
     getRemainingAvailableBonusProductsForProduct.mockReturnValue({
         aggregatedMaxBonusItems: 5,
         aggregatedSelectedItems: 2
+    })
+
+    // Mock getBonusProductCountsForPromotion to return default values
+    getBonusProductCountsForPromotion.mockReturnValue({
+        selectedBonusItems: 2,
+        maxBonusItems: 5
     })
 
     // Mock findAvailableBonusDiscountLineItemId to return a valid ID
@@ -165,14 +173,17 @@ describe('BonusProductViewModal - getRemainingBonusQuantity', () => {
 })
 
 describe('BonusProductViewModal - Header Count Display', () => {
-    const testHeaderCount = (description, bonusItems, productItems, expectedText) => {
+    const testHeaderCount = (description, maxBonusItems, selectedBonusItems, expectedText) => {
         test(description, () => {
-            const mockBasket = bonusItems ? {
-                bonusDiscountLineItems: bonusItems,
-                productItems: productItems || []
-            } : null
+            const mockBasket = {basketId: 'test-basket'}
             
             useCurrentBasket.mockReturnValue({data: mockBasket})
+            
+            // Mock getBonusProductCountsForPromotion to return specific test values
+            getBonusProductCountsForPromotion.mockReturnValue({
+                selectedBonusItems,
+                maxBonusItems
+            })
 
             renderWithProviders(
                 <BonusProductViewModal
@@ -190,25 +201,22 @@ describe('BonusProductViewModal - Header Count Display', () => {
 
     testHeaderCount(
         'displays "0 of 2 selected" when no bonus items are selected',
-        [{id: 'bonus-1', maxBonusItems: 2}],
-        [],
+        2, // maxBonusItems
+        0, // selectedBonusItems
         'Select Bonus Product (0 of 2 selected)'
     )
 
     testHeaderCount(
         'displays "1 of 4 selected" when one bonus item is selected',
-        [{id: 'bonus-1', maxBonusItems: 2}, {id: 'bonus-2', maxBonusItems: 2}],
-        [{bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-1', quantity: 1}],
+        4, // maxBonusItems
+        1, // selectedBonusItems
         'Select Bonus Product (1 of 4 selected)'
     )
 
     testHeaderCount(
         'displays "5 of 6 selected" when most bonus items are selected',
-        [{id: 'bonus-1', maxBonusItems: 3}, {id: 'bonus-2', maxBonusItems: 3}],
-        [
-            {bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-1', quantity: 3},
-            {bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-2', quantity: 2}
-        ],
+        6, // maxBonusItems
+        5, // selectedBonusItems
         'Select Bonus Product (5 of 6 selected)'
     )
 })

--- a/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.test.js
+++ b/packages/template-retail-react-app/app/components/bonus-product-view-modal/index.test.js
@@ -164,6 +164,55 @@ describe('BonusProductViewModal - getRemainingBonusQuantity', () => {
     })
 })
 
+describe('BonusProductViewModal - Header Count Display', () => {
+    const testHeaderCount = (description, bonusItems, productItems, expectedText) => {
+        test(description, () => {
+            const mockBasket = bonusItems ? {
+                bonusDiscountLineItems: bonusItems,
+                productItems: productItems || []
+            } : null
+            
+            useCurrentBasket.mockReturnValue({data: mockBasket})
+
+            renderWithProviders(
+                <BonusProductViewModal
+                    product={mockProductDetail}
+                    isOpen={true}
+                    onClose={() => {}}
+                    bonusDiscountLineItemId="bonus-1"
+                    promotionId="test-promo"
+                />
+            )
+
+            expect(screen.getByRole('heading')).toHaveTextContent(expectedText)
+        })
+    }
+
+    testHeaderCount(
+        'displays "0 of 2 selected" when no bonus items are selected',
+        [{id: 'bonus-1', maxBonusItems: 2}],
+        [],
+        'Select Bonus Product (0 of 2 selected)'
+    )
+
+    testHeaderCount(
+        'displays "1 of 4 selected" when one bonus item is selected',
+        [{id: 'bonus-1', maxBonusItems: 2}, {id: 'bonus-2', maxBonusItems: 2}],
+        [{bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-1', quantity: 1}],
+        'Select Bonus Product (1 of 4 selected)'
+    )
+
+    testHeaderCount(
+        'displays "5 of 6 selected" when most bonus items are selected',
+        [{id: 'bonus-1', maxBonusItems: 3}, {id: 'bonus-2', maxBonusItems: 3}],
+        [
+            {bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-1', quantity: 3},
+            {bonusProductLineItem: true, bonusDiscountLineItemId: 'bonus-2', quantity: 2}
+        ],
+        'Select Bonus Product (5 of 6 selected)'
+    )
+})
+
 describe('BonusProductViewModal - Return to Selection Flow', () => {
     beforeEach(() => {
         // Setup default mocks - using global mock functions

--- a/packages/template-retail-react-app/app/components/swatch-group/index.jsx
+++ b/packages/template-retail-react-app/app/components/swatch-group/index.jsx
@@ -83,9 +83,10 @@ const SwatchGroup = (props) => {
     // Whenever the selected index changes ensure that we call the change handler.
     useEffect(() => {
         const childrenArray = Children.toArray(children)
-        const newValue = childrenArray[selectedIndex].props.value
-
-        handleChange(newValue)
+        if (childrenArray[selectedIndex]) {
+            const newValue = childrenArray[selectedIndex].props.value
+            handleChange(newValue)
+        }
     }, [selectedIndex])
 
     return (

--- a/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal.js
@@ -349,7 +349,7 @@ export const BonusProductSelectionModal = () => {
                             borderBottom={addToCartModalTheme.layout.header.borderBottom}
                             borderColor={addToCartModalTheme.layout.header.borderColor}
                         >
-                            <Heading as="h3" fontSize={24} fontWeight="700">
+                            <Heading as="h3" size="md">
                                 {intl.formatMessage(
                                     {
                                         id: 'bonus_product_modal.title',

--- a/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal.js
+++ b/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal.js
@@ -31,7 +31,7 @@ import {filterImageGroups} from '@salesforce/retail-react-app/app/utils/product-
 import {useModalState} from '@salesforce/retail-react-app/app/hooks/use-modal-state'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import BonusProductViewModal from '@salesforce/retail-react-app/app/components/bonus-product-view-modal'
-import {findAvailableBonusDiscountLineItemId} from '@salesforce/retail-react-app/app/utils/bonus-product-utils'
+import {findAvailableBonusDiscountLineItemId, getBonusProductCountsForPromotion} from '@salesforce/retail-react-app/app/utils/bonus-product-utils'
 import {addToCartModalTheme} from '@salesforce/retail-react-app/app/theme/components/project/add-to-cart-modal'
 
 // Import AddToCartModal to render it within this provider
@@ -179,27 +179,18 @@ export const BonusProductSelectionModal = () => {
     })
     const intl = useIntl()
 
-    // Extract bonus products and basket for selection counts
+    // Extract bonus products from modal data and derive promotionId using same logic as products card
     const bonusProducts = data?.bonusDiscountLineItems || []
     const {data: basket} = useCurrentBasket()
-    const bonusLineItemIds = useMemo(
-        () => bonusProducts.map((bli) => bli.id).filter(Boolean),
-        [bonusProducts]
-    )
-    const maxBonusItems = useMemo(
-        () => bonusProducts.reduce((sum, bli) => sum + (bli.maxBonusItems || 0), 0),
-        [bonusProducts]
-    )
-    const selectedBonusItems = useMemo(() => {
-        const items = basket?.productItems || []
-        return items
-            .filter(
-                (it) =>
-                    it?.bonusProductLineItem &&
-                    bonusLineItemIds.includes(it?.bonusDiscountLineItemId)
-            )
-            .reduce((acc, it) => acc + (it?.quantity || 0), 0)
-    }, [basket, bonusLineItemIds])
+    
+    // Get promotionId from bonus products - all items have the same promotionId since they're 
+    // pre-filtered in select-bonus-products-card.jsx (line 143: bli.promotionId === promotionId)
+    const promotionId = bonusProducts.length > 0 ? bonusProducts[0]?.promotionId : null
+    
+    // Calculate promotion-specific bonus counts using utility method
+    const {selectedBonusItems, maxBonusItems} = useMemo(() => {
+        return getBonusProductCountsForPromotion(basket, promotionId)
+    }, [basket, promotionId])
 
     // Get product IDs for fetching product data, deduplicating by productId
     const uniqueBonusProducts = bonusProducts

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -509,12 +509,6 @@
       "value": " selected)"
     }
   ],
-  "bonus_product_view_modal.button.back_to_selection": [
-    {
-      "type": 0,
-      "value": "Back to Selection"
-    }
-  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -509,6 +509,12 @@
       "value": " selected)"
     }
   ],
+  "bonus_product_view_modal.button.back_to_selection": [
+    {
+      "type": 0,
+      "value": "Back to Selection"
+    }
+  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -525,6 +525,28 @@
       "value": "productName"
     }
   ],
+  "bonus_product_view_modal.title": [
+    {
+      "type": 0,
+      "value": "Select Bonus Product ("
+    },
+    {
+      "type": 1,
+      "value": "selected"
+    },
+    {
+      "type": 0,
+      "value": " of "
+    },
+    {
+      "type": 1,
+      "value": "max"
+    },
+    {
+      "type": 0,
+      "value": " selected)"
+    }
+  ],
   "bonus_product_view_modal.toast.item_added": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -509,12 +509,6 @@
       "value": " selected)"
     }
   ],
-  "bonus_product_view_modal.button.back_to_selection": [
-    {
-      "type": 0,
-      "value": "Back to Selection"
-    }
-  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -509,6 +509,12 @@
       "value": " selected)"
     }
   ],
+  "bonus_product_view_modal.button.back_to_selection": [
+    {
+      "type": 0,
+      "value": "Back to Selection"
+    }
+  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -525,6 +525,28 @@
       "value": "productName"
     }
   ],
+  "bonus_product_view_modal.title": [
+    {
+      "type": 0,
+      "value": "Select Bonus Product ("
+    },
+    {
+      "type": 1,
+      "value": "selected"
+    },
+    {
+      "type": 0,
+      "value": " of "
+    },
+    {
+      "type": 1,
+      "value": "max"
+    },
+    {
+      "type": 0,
+      "value": " selected)"
+    }
+  ],
   "bonus_product_view_modal.toast.item_added": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1061,6 +1061,36 @@
       "value": "]"
     }
   ],
+  "bonus_product_view_modal.title": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Şḗḗŀḗḗƈŧ Ɓǿǿƞŭŭş Ƥřǿǿḓŭŭƈŧ ("
+    },
+    {
+      "type": 1,
+      "value": "selected"
+    },
+    {
+      "type": 0,
+      "value": " ǿǿƒ "
+    },
+    {
+      "type": 1,
+      "value": "max"
+    },
+    {
+      "type": 0,
+      "value": " şḗḗŀḗḗƈŧḗḗḓ)"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "bonus_product_view_modal.toast.item_added": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1029,20 +1029,6 @@
       "value": "]"
     }
   ],
-  "bonus_product_view_modal.button.back_to_selection": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ɓȧȧƈķ ŧǿǿ Şḗḗŀḗḗƈŧīǿǿƞ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1029,6 +1029,20 @@
       "value": "]"
     }
   ],
+  "bonus_product_view_modal.button.back_to_selection": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓȧȧƈķ ŧǿǿ Şḗḗŀḗḗƈŧīǿǿƞ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "bonus_product_view_modal.button.view_cart": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/utils/bonus-product-utils.js
+++ b/packages/template-retail-react-app/app/utils/bonus-product-utils.js
@@ -600,3 +600,38 @@ export const useRemainingAvailableBonusProductsForProduct = (productId) => {
         hasPromotionData: Object.keys(productsWithPromotions || {}).length > 0
     }
 }
+
+/**
+ * Calculate bonus product counts for a specific promotion from basket data.
+ * 
+ * @param {Object} basket - The current basket/cart object
+ * @param {string} promotionId - The promotion ID to calculate counts for
+ * @returns {Object} Object with selectedBonusItems and maxBonusItems counts
+ */
+export const getBonusProductCountsForPromotion = (basket, promotionId) => {
+    if (!basket || !promotionId) {
+        return {selectedBonusItems: 0, maxBonusItems: 0}
+    }
+    
+    // Find all bonus discount line items for this promotion
+    const promotionBonusItems = basket.bonusDiscountLineItems?.filter(
+        item => item.promotionId === promotionId
+    ) || []
+    
+    // Sum up max items for this promotion
+    const maxBonusItems = promotionBonusItems.reduce(
+        (sum, item) => sum + (item.maxBonusItems || 0), 
+        0
+    )
+    
+    // Count selected items for this promotion (all bonus items with this promotion's bonusDiscountLineItemIds)
+    const promotionBonusLineItemIds = promotionBonusItems.map(item => item.id).filter(Boolean)
+    const selectedBonusItems = (basket.productItems || [])
+        .filter(item => 
+            item.bonusProductLineItem && 
+            promotionBonusLineItemIds.includes(item.bonusDiscountLineItemId)
+        )
+        .reduce((sum, item) => sum + (item.quantity || 0), 0)
+    
+    return {selectedBonusItems, maxBonusItems}
+}

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -201,6 +201,9 @@
   "bonus_product_view_modal.modal_label": {
     "defaultMessage": "Bonus product selection modal for {productName}"
   },
+  "bonus_product_view_modal.title": {
+    "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
+  },
   "bonus_product_view_modal.toast.item_added": {
     "defaultMessage": "Bonus item added to cart"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -195,6 +195,9 @@
   "bonus_product_modal.title": {
     "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
   },
+  "bonus_product_view_modal.button.back_to_selection": {
+    "defaultMessage": "Back to Selection"
+  },
   "bonus_product_view_modal.button.view_cart": {
     "defaultMessage": "View Cart"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -195,9 +195,6 @@
   "bonus_product_modal.title": {
     "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
   },
-  "bonus_product_view_modal.button.back_to_selection": {
-    "defaultMessage": "Back to Selection"
-  },
   "bonus_product_view_modal.button.view_cart": {
     "defaultMessage": "View Cart"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -201,6 +201,9 @@
   "bonus_product_view_modal.modal_label": {
     "defaultMessage": "Bonus product selection modal for {productName}"
   },
+  "bonus_product_view_modal.title": {
+    "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
+  },
   "bonus_product_view_modal.toast.item_added": {
     "defaultMessage": "Bonus item added to cart"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -195,6 +195,9 @@
   "bonus_product_modal.title": {
     "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
   },
+  "bonus_product_view_modal.button.back_to_selection": {
+    "defaultMessage": "Back to Selection"
+  },
   "bonus_product_view_modal.button.view_cart": {
     "defaultMessage": "View Cart"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -195,9 +195,6 @@
   "bonus_product_modal.title": {
     "defaultMessage": "Select Bonus Product ({selected} of {max} selected)"
   },
-  "bonus_product_view_modal.button.back_to_selection": {
-    "defaultMessage": "Back to Selection"
-  },
   "bonus_product_view_modal.button.view_cart": {
     "defaultMessage": "View Cart"
   },


### PR DESCRIPTION
# Description

Updated bonus product modals to have consistent styling, positioning, and behavior with the add-to-cart modal.

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Fixed modal positioning and sizing consistency
- Updated to use productViewModalTheme throughout bonus product details modal
- Fixed gray strip display issue in modal headers
- Improved close button behavior for better user flow
- Added proper header with bonus item count
- Enhanced color/size selector support
- Standardized heading typography (size="md")

# How to Test-Drive This PR

1. Add product to cart to trigger bonus product selection
2. Verify modal positioning matches add-to-cart modal
3. Click bonus product to open details modal
4. Test color/size selectors work properly
5. Verify add to cart closes modal appropriately
6. Check close button returns to selection when appropriate

# Checklists

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes

## Accessibility Compliance

- [x] There are no changes to UI

## Localization

- [x] Changes include a UI text update in the Retail React App (which requires translation)