### PR TITLE
@W-19444572 pwa-dev-kit push uses deployment defaults

### DIFF
--- a/packages/pwa-kit-dev/bin/pwa-kit-dev.js
+++ b/packages/pwa-kit-dev/bin/pwa-kit-dev.js
@@ -378,16 +378,15 @@ const main = async () => {
                 const mobify = getConfig({buildDirectory}) || {}
 
                 if (!projectSlug) {
-                    projectSlug =
-                        mobify.app?.deployment?.defaultMRTProject || (await getProjectName())
+                    projectSlug = mobify.deployment?.defaultMRTProject || (await getProjectName())
                 }
 
                 // Set the deployment target env var, this is required to ensure we
                 // get the correct configuration object. Do not assign the variable it if
                 // the target value is `undefined` as it will serialied as a "undefined"
                 // string value.
-                if (!target && mobify.app?.deployment?.defaultMRTTarget) {
-                    target = mobify.app.deployment.defaultMRTTarget
+                if (!target && mobify.deployment?.defaultMRTTarget) {
+                    target = mobify.deployment.defaultMRTTarget
                 }
                 if (target) {
                     process.env.DEPLOY_TARGET = target

--- a/packages/pwa-kit-dev/bin/pwa-kit-dev.js
+++ b/packages/pwa-kit-dev/bin/pwa-kit-dev.js
@@ -334,7 +334,10 @@ const main = async () => {
             )
                 // We load the slug from the package.json by default, but we don't want to do that
                 // unless we need to, so it is loaded conditionally in the action implementation
-                .default(null, "the 'name' key from the package.json")
+                .default(
+                    null,
+                    "configured 'deployment' values if specified, or the 'name' key from the package.json"
+                )
         )
         .addOption(
             new program.Option(
@@ -357,18 +360,6 @@ const main = async () => {
                 user,
                 key
             }) => {
-                // Set the deployment target env var, this is required to ensure we
-                // get the correct configuration object. Do not assign the variable it if
-                // the target value is `undefined` as it will serialied as a "undefined"
-                // string value.
-                if (target) {
-                    process.env.DEPLOY_TARGET = target
-                } else if (wait) {
-                    throw new Error(
-                        'You must provide a target to deploy to when using --wait to wait for deployment to finish.'
-                    )
-                }
-
                 /** @type {Credentials} */
                 let credentials
                 if (user && key) {
@@ -387,7 +378,23 @@ const main = async () => {
                 const mobify = getConfig({buildDirectory}) || {}
 
                 if (!projectSlug) {
-                    projectSlug = await getProjectName()
+                    projectSlug =
+                        mobify.app?.deployment?.defaultMRTProject || (await getProjectName())
+                }
+
+                // Set the deployment target env var, this is required to ensure we
+                // get the correct configuration object. Do not assign the variable it if
+                // the target value is `undefined` as it will serialied as a "undefined"
+                // string value.
+                if (!target && mobify.app?.deployment?.defaultMRTTarget) {
+                    target = mobify.app.deployment.defaultMRTTarget
+                }
+                if (target) {
+                    process.env.DEPLOY_TARGET = target
+                } else if (wait) {
+                    throw new Error(
+                        'You must provide a target to deploy to when using --wait to wait for deployment to finish.'
+                    )
                 }
 
                 const bundle = await scriptUtils.createBundle({


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

Use the configured deployment defaults for defaultMRTProject and defaultMRTTarget when the `pwa-dev-kit push` command is given without explicit arguments.  If the deployment defaults were not configured then the behavior of `pwa-dev-kit push` without arguments is unchanged.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- create projects with all four combinations of defaultMRTProject and defaultMRTTarget defined or left blank
- run the command `pwa-dev-kit push` with and without the explicit `projectSlug` and `target` command line arguments.
- confirm the correct push behavior for each combination

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
