### PR TITLE
@W-19679519  bug fix: Wrong variant image in bonus product selection modal

### DIFF
--- a/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/components/bonus-product-item.js
+++ b/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/components/bonus-product-item.js
@@ -47,13 +47,30 @@ const BonusProductItem = ({
             return null
         }
 
-        const variantImages = filterImageGroups(productData.imageGroups, product)
+        // Use variant-specific variation values if available for image filtering
+        const variationValues = productData.variationValues || {}
+        const hasVariationValues = Object.keys(variationValues).length > 0
 
-        if (variantImages?.length > 0) {
-            const largeImage = findImageGroupBy(variantImages, {
-                viewType: 'large'
+        if (hasVariationValues) {
+            // Filter images based on the specific variant's variation values
+            const variantImages = filterImageGroups(productData.imageGroups, {
+                variationValues
             })
-            return largeImage
+
+            if (variantImages?.length > 0) {
+                const largeImage = findImageGroupBy(variantImages, {
+                    viewType: 'large'
+                })
+                return largeImage || variantImages[0]
+            }
+        }
+
+        // Fallback: try to find any large image, then small image
+        const defaultLargeImage = findImageGroupBy(productData.imageGroups, {
+            viewType: 'large'
+        })
+        if (defaultLargeImage) {
+            return defaultLargeImage
         }
 
         const defaultSmallImage = findImageGroupBy(productData.imageGroups, {

--- a/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/use-bonus-product-data.js
+++ b/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/use-bonus-product-data.js
@@ -106,22 +106,31 @@ export const useBonusProductData = (modalData) => {
 
     const normalizeProduct = (bonusProduct, foundProductData) => {
         const initial = foundProductData || productById.get(bonusProduct?.productId)
-        return initial
-            ? {
-                  productId: initial.id,
-                  ...initial,
-                  imageGroups: initial.imageGroups || [],
-                  variants: initial.variants || [],
-                  variationAttributes: initial.variationAttributes || [],
-                  type: initial.type || {set: false, bundle: false}
-              }
-            : {
-                  productId: bonusProduct?.productId,
-                  imageGroups: [],
-                  variants: [],
-                  variationAttributes: [],
-                  type: {set: false, bundle: false}
-              }
+
+        if (!initial) {
+            return {
+                productId: bonusProduct?.productId,
+                imageGroups: [],
+                variants: [],
+                variationAttributes: [],
+                type: {set: false, bundle: false}
+            }
+        }
+
+        // Find the specific variant if the bonusProduct.productId is a variant
+        const variant = initial.variants?.find((v) => v.productId === bonusProduct?.productId)
+
+        return {
+            productId: initial.id,
+            ...initial,
+            imageGroups: initial.imageGroups || [],
+            variants: initial.variants || [],
+            variationAttributes: initial.variationAttributes || [],
+            type: initial.type || {set: false, bundle: false},
+            // Include variant information if this is a specific variant
+            selectedVariant: variant || null,
+            variationValues: variant?.variationValues || {}
+        }
     }
 
     return {

--- a/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/use-bonus-product-data.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-bonus-product-selection-modal/use-bonus-product-data.test.js
@@ -166,7 +166,9 @@ describe('useBonusProductData', () => {
             imageGroups: [],
             variants: [],
             variationAttributes: [],
-            type: {set: false, bundle: false}
+            type: {set: false, bundle: false},
+            selectedVariant: null,
+            variationValues: {}
         })
     })
 
@@ -225,5 +227,292 @@ describe('useBonusProductData', () => {
             promotionId: 'promo-1',
             bonusDiscountLineItemId: 'bonus-1'
         })
+    })
+
+    test('normalizeProduct extracts variant information when productId matches a variant', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+        const bonusProduct = {productId: 'variant-123'}
+        const foundData = {
+            id: 'master-product',
+            name: 'Master Product',
+            imageGroups: [],
+            variants: [
+                {
+                    productId: 'variant-123',
+                    variationValues: {color: 'red', size: 'M'}
+                },
+                {
+                    productId: 'variant-456',
+                    variationValues: {color: 'blue', size: 'L'}
+                }
+            ],
+            variationAttributes: [],
+            type: {set: false, bundle: false}
+        }
+
+        const normalized = result.current.normalizeProduct(bonusProduct, foundData)
+
+        expect(normalized.selectedVariant).toEqual({
+            productId: 'variant-123',
+            variationValues: {color: 'red', size: 'M'}
+        })
+        expect(normalized.variationValues).toEqual({color: 'red', size: 'M'})
+    })
+
+    test('normalizeProduct returns empty variationValues when productId matches master product', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+        const bonusProduct = {productId: 'master-product'} // Master product ID
+        const foundData = {
+            id: 'master-product',
+            name: 'Master Product',
+            imageGroups: [],
+            variants: [
+                {
+                    productId: 'variant-123',
+                    variationValues: {color: 'red', size: 'M'}
+                },
+                {
+                    productId: 'variant-456',
+                    variationValues: {color: 'blue', size: 'L'}
+                }
+            ],
+            variationAttributes: [],
+            type: {set: false, bundle: false}
+        }
+
+        const normalized = result.current.normalizeProduct(bonusProduct, foundData)
+
+        expect(normalized.selectedVariant).toBeNull()
+        expect(normalized.variationValues).toEqual({})
+        expect(normalized.productId).toBe('master-product')
+    })
+
+    test('handles multiple bonusDiscountLineItems with mixed variant and master product IDs', () => {
+        const complexModalData = {
+            bonusDiscountLineItems: [
+                {
+                    id: 'bonus-line-1',
+                    promotionId: 'promo-ties',
+                    maxBonusItems: 2,
+                    bonusProducts: [
+                        {productId: 'tie-variant-red', productName: 'Red Tie', title: 'Red Tie'},
+                        {productId: 'tie-variant-blue', productName: 'Blue Tie', title: 'Blue Tie'}
+                    ]
+                },
+                {
+                    id: 'bonus-line-2',
+                    promotionId: 'promo-accessories',
+                    maxBonusItems: 1,
+                    bonusProducts: [
+                        {
+                            productId: 'accessories-master',
+                            productName: 'Accessories',
+                            title: 'Accessories'
+                        },
+                        {
+                            productId: 'watch-variant-silver',
+                            productName: 'Silver Watch',
+                            title: 'Silver Watch'
+                        }
+                    ]
+                }
+            ]
+        }
+
+        // Mock product data for the complex scenario
+        const complexProductData = {
+            data: [
+                {
+                    id: 'tie-master',
+                    name: 'Silk Tie',
+                    imageGroups: [],
+                    variants: [
+                        {productId: 'tie-variant-red', variationValues: {color: 'red'}},
+                        {productId: 'tie-variant-blue', variationValues: {color: 'blue'}}
+                    ],
+                    variationAttributes: [],
+                    type: {set: false, bundle: false}
+                },
+                {
+                    id: 'accessories-master',
+                    name: 'Accessories Collection',
+                    imageGroups: [],
+                    variants: [
+                        {productId: 'acc-variant-1', variationValues: {style: 'classic'}},
+                        {productId: 'acc-variant-2', variationValues: {style: 'modern'}}
+                    ],
+                    variationAttributes: [],
+                    type: {set: false, bundle: false}
+                },
+                {
+                    id: 'watch-master',
+                    name: 'Premium Watch',
+                    imageGroups: [],
+                    variants: [
+                        {
+                            productId: 'watch-variant-silver',
+                            variationValues: {color: 'silver', size: '42mm'}
+                        },
+                        {
+                            productId: 'watch-variant-gold',
+                            variationValues: {color: 'gold', size: '38mm'}
+                        }
+                    ],
+                    variationAttributes: [],
+                    type: {set: false, bundle: false}
+                }
+            ]
+        }
+
+        useProducts.mockReturnValue({
+            data: complexProductData,
+            isLoading: false
+        })
+
+        const {result} = renderHook(() => useBonusProductData(complexModalData))
+
+        // Test deduplication and correct product extraction
+        expect(result.current.uniqueBonusProducts).toHaveLength(4)
+        expect(result.current.maxBonusItems).toBe(3) // 2 + 1
+
+        // Test normalizeProduct for each type
+        // 1. Variant ID (should extract variant info)
+        const redTie = result.current.normalizeProduct(
+            {productId: 'tie-variant-red'},
+            complexProductData.data[0]
+        )
+        expect(redTie.selectedVariant).toEqual({
+            productId: 'tie-variant-red',
+            variationValues: {color: 'red'}
+        })
+        expect(redTie.variationValues).toEqual({color: 'red'})
+
+        // 2. Master product ID (should not extract variant info)
+        const accessories = result.current.normalizeProduct(
+            {productId: 'accessories-master'},
+            complexProductData.data[1]
+        )
+        expect(accessories.selectedVariant).toBeNull()
+        expect(accessories.variationValues).toEqual({})
+        expect(accessories.productId).toBe('accessories-master')
+
+        // 3. Another variant ID with multiple variation values
+        const silverWatch = result.current.normalizeProduct(
+            {productId: 'watch-variant-silver'},
+            complexProductData.data[2]
+        )
+        expect(silverWatch.selectedVariant).toEqual({
+            productId: 'watch-variant-silver',
+            variationValues: {color: 'silver', size: '42mm'}
+        })
+        expect(silverWatch.variationValues).toEqual({color: 'silver', size: '42mm'})
+    })
+
+    test('handles variant ID that does not exist in product variants array', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+        const bonusProduct = {productId: 'non-existent-variant-999'}
+        const foundData = {
+            id: 'master-product',
+            name: 'Master Product',
+            imageGroups: [],
+            variants: [
+                {productId: 'variant-123', variationValues: {color: 'red'}},
+                {productId: 'variant-456', variationValues: {color: 'blue'}}
+            ],
+            variationAttributes: [],
+            type: {set: false, bundle: false}
+        }
+
+        const normalized = result.current.normalizeProduct(bonusProduct, foundData)
+
+        // Should gracefully fallback to master product behavior
+        expect(normalized.selectedVariant).toBeNull()
+        expect(normalized.variationValues).toEqual({})
+        expect(normalized.productId).toBe('master-product')
+    })
+
+    test('handles product data with no variants array', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+        const bonusProduct = {productId: 'some-variant-id'}
+        const foundData = {
+            id: 'master-product-no-variants',
+            name: 'Simple Product',
+            imageGroups: [],
+            // variants: undefined (intentionally missing)
+            variationAttributes: [],
+            type: {set: false, bundle: false}
+        }
+
+        const normalized = result.current.normalizeProduct(bonusProduct, foundData)
+
+        // Should handle gracefully without crashing
+        expect(normalized.selectedVariant).toBeNull()
+        expect(normalized.variationValues).toEqual({})
+        expect(normalized.productId).toBe('master-product-no-variants')
+    })
+
+    test('handles variant with null/undefined variationValues', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+        const bonusProduct = {productId: 'variant-with-null-values'}
+        const foundData = {
+            id: 'master-product',
+            name: 'Master Product',
+            imageGroups: [],
+            variants: [
+                {
+                    productId: 'variant-with-null-values',
+                    variationValues: null // Malformed data
+                },
+                {
+                    productId: 'variant-with-undefined-values'
+                    // variationValues: undefined (missing property)
+                }
+            ],
+            variationAttributes: [],
+            type: {set: false, bundle: false}
+        }
+
+        const normalized = result.current.normalizeProduct(bonusProduct, foundData)
+
+        // Should handle null variationValues gracefully
+        expect(normalized.selectedVariant).toEqual({
+            productId: 'variant-with-null-values',
+            variationValues: null
+        })
+        expect(normalized.variationValues).toEqual({}) // Our code converts null to empty object
+    })
+
+    test('handles product bundles and sets correctly', () => {
+        const {result} = renderHook(() => useBonusProductData(mockModalData))
+
+        // Test bundle
+        const bundleProduct = {productId: 'bundle-variant-123'}
+        const bundleData = {
+            id: 'bundle-master',
+            name: 'Product Bundle',
+            imageGroups: [],
+            variants: [{productId: 'bundle-variant-123', variationValues: {size: 'large'}}],
+            variationAttributes: [],
+            type: {set: false, bundle: true} // This is a bundle
+        }
+
+        const normalizedBundle = result.current.normalizeProduct(bundleProduct, bundleData)
+        expect(normalizedBundle.selectedVariant.variationValues).toEqual({size: 'large'})
+        expect(normalizedBundle.type.bundle).toBe(true)
+
+        // Test set
+        const setProduct = {productId: 'set-variant-456'}
+        const setData = {
+            id: 'set-master',
+            name: 'Product Set',
+            imageGroups: [],
+            variants: [{productId: 'set-variant-456', variationValues: {color: 'multi'}}],
+            variationAttributes: [],
+            type: {set: true, bundle: false} // This is a set
+        }
+
+        const normalizedSet = result.current.normalizeProduct(setProduct, setData)
+        expect(normalizedSet.selectedVariant.variationValues).toEqual({color: 'multi'})
+        expect(normalizedSet.type.set).toBe(true)
     })
 })

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -100,7 +100,7 @@
   "bundlesize": [
     {
       "path": "build/main.js",
-      "maxSize": "80 kB"
+      "maxSize": "81 kB"
     },
     {
       "path": "build/vendor.js",


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
Even if the bonus product available for the shopper to add is a specific variant, the app currently shows the image of the master product on the selection modal. This PR fixes it to show the correct image. 

**Before:**
<img width="1644" height="831" alt="Screenshot 2025-09-18 at 5 42 39 PM" src="https://github.com/user-attachments/assets/37cc50f9-323e-499a-9d11-1a1f4a207c15" />

**After (the changes in this PR):**
<img width="989" height="589" alt="Screenshot 2025-09-18 at 5 43 11 PM" src="https://github.com/user-attachments/assets/61ca546a-ddd9-4f14-b496-0fb537e58821" />


<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

**Problem**: The filterImageGroups function needs variationValues (like {color: 'TURQUSI'}) to select the correct image, but this information wasn't being extracted from the product data.

  1. Enhanced useBonusProductData hook (use-bonus-product-data.js:107-134):
    - Modified the normalizeProduct function to extract variant information when the bonusProduct.productId matches a specific variant
    - Added selectedVariant and variationValues properties to the normalized product object
    - This allows the component to access the variant's color/size information needed for image filtering
  2. Updated BonusProductItem component (bonus-product-item.js:45-80):
    - Enhanced the imageGroup logic to use variant-specific variationValues when calling filterImageGroups
    - Added fallback logic to ensure graceful degradation when variant info is unavailable
    - The component now correctly filters images based on the specific variant's attributes
  3. Tests:
    - Fixed existing test expectations to include the new properties (use-bonus-product-data.test.js:162-260)
    - Added many new test cases to verify variant extraction functionality works correctly

# How to Test-Drive This PR

- [MRT Env](https://cc-sharks-shikhar-test.mobify-storefront-staging.com/global/en-GB/product/25686571M?color=CHARCWL&size=036&pid=750518894553M&width=S)
- Add the sharcoal suit (the link^ takes you to it) to cart 
- Make sure the variant is correct (the turquise tie)
- Think of any other way to test it and try it

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
