### PR TITLE
@W-19548614 Revert proxy changes for passwordless login

### DIFF
--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -52,7 +52,7 @@ import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
 import awsServerlessExpress from 'aws-serverless-express'
 import expressLogging from 'morgan'
 import logger from '../../utils/logger-instance'
-import {createProxyMiddleware, responseInterceptor} from 'http-proxy-middleware'
+import {createProxyMiddleware} from 'http-proxy-middleware'
 import {convertExpressRouteToRegex} from '../../utils/ssr-server/convert-express-route'
 
 /**
@@ -886,8 +886,8 @@ export const RemoteServerFactory = {
                     const regex = new RegExp(`^${basePathRegexEntry}${slasPrivateProxyPath}`)
                     return path.replace(regex, '')
                 },
-                selfHandleResponse: true,
-                onProxyReq: (proxyRequest, incomingRequest, res) => {
+                selfHandleResponse: false,
+                onProxyReq: (proxyRequest, incomingRequest) => {
                     applyProxyRequestHeaders({
                         proxyRequest,
                         incomingRequest,
@@ -911,33 +911,7 @@ export const RemoteServerFactory = {
                         // purpose so we don't want to overwrite the header for those calls.
                         proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
                     }
-                },
-                onProxyRes: responseInterceptor((responseBuffer, proxyRes, req, res) => {
-                    try {
-                        // If the passwordless login endpoint returns a 404, which corresponds to a user
-                        // email not being found, we mask it with a 200 OK response so that it is not
-                        // obvious that the user does not exist.
-                        // We do this to prevent user enumeration.
-                        if (
-                            req.path?.match(/\/oauth2\/passwordless\/login/) &&
-                            proxyRes.statusCode === 404
-                        ) {
-                            res.statusCode = 200
-                            res.statusMessage = 'OK'
-
-                            // When a /passwordless/login endpoint response returns 200, it has no body
-                            // so we return an empty body here to match an actual 200 response.
-                            return Buffer.from('', 'utf8')
-                        }
-                        return responseBuffer
-                    } catch (error) {
-                        console.error(
-                            'There is an error processing the response from SLAS. Returning original response.',
-                            error
-                        )
-                        return responseBuffer
-                    }
-                })
+                }
             })
         )
     },

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1395,3 +1395,22 @@ describe('Base path tests', () => {
             })
     }, 15000)
 })
+
+describe('Forwarded headers', () => {
+    test('sets xForwardedOrigin from x-forwarded-* headers', async () => {
+        const app = RemoteServerFactory._createApp(opts())
+
+        app.get('/xfo', (req, res) => {
+            res.json({origin: res.locals.xForwardedOrigin || null})
+        })
+
+        return request(app)
+            .get('/xfo')
+            .set('x-forwarded-host', 'example.com')
+            .set('x-forwarded-proto', 'http')
+            .then((response) => {
+                expect(response.status).toBe(200)
+                expect(response.body.origin).toBe('http://example.com')
+            })
+    }, 15000)
+})

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1281,45 +1281,6 @@ describe('SLAS private client proxy', () => {
             'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'
         )
     }, 15000)
-
-    test('proxy returns a 200 OK masking a user not found error', async () => {
-        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'a secret'
-
-        // Create a new mock server specifically for this test so we can mock a response from SLAS
-        const testProxyApp = express()
-        const testProxyPort = 12346
-        const testSlasTarget = `http://localhost:${testProxyPort}/shopper/auth/responseHeaders`
-
-        // Set up the mock server to return a 404 for passwordless login
-        testProxyApp.use('/shopper/auth/responseHeaders', (req, res) => {
-            if (req.url.includes('/oauth2/passwordless/login')) {
-                res.status(404).send()
-            } else {
-                res.send(req.headers)
-            }
-        })
-
-        const testProxyServer = testProxyApp.listen(testProxyPort)
-
-        try {
-            const testAppConfig = {
-                ...appConfig,
-                slasTarget: testSlasTarget
-            }
-
-            const app = RemoteServerFactory._createApp(opts(testAppConfig))
-
-            return await request(app)
-                .get('/mobify/slas/private/shopper/auth/v1/oauth2/passwordless/login')
-                .expect(200)
-                .then((response) => {
-                    expect(response.text).toBe('')
-                })
-        } finally {
-            // Clean up the test server
-            testProxyServer.close()
-        }
-    })
 })
 
 describe('Base path tests', () => {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Revert some of the changes inhttps://github.com/SalesforceCommerceCloud/pwa-kit/pull/3113 to remove intercepting the passwordless login call.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Passwordless login call is no longer intercepted. It returns the SLAS response as is. This means we will see a 404 when user is not found and 200 when user is found. Earlier it would return a 200 in both cases for user enumeration. There will be a separate approach to remove user enumeration and hence the rollback of these changes.

# How to Test-Drive This PR

- In one click checkout, enter a un-registered email address -> see the 404 login in the network tab -> OTP modal is not seen and user can checkout 
- Enter a registered email address -> see the 200 login in the network tab -> OTP modal is seen and the user can authorize and checkout

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
