### PR TITLE
@@W-19811971@@ - Fix address name encoding for server double-decoding issue

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v8.2.0-dev (Sep 26, 2025)
-
+- [Bugfix] Use `serverSafeEncode` util for address mutations. [#3380](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3380)
 ## v8.1.0 (Sep 25, 2025)
 - Updated search UX - prices, images, suggestions new layout [#3271](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3271)
 - Updated the UI for StoreDisplay component which displays pickup in-store information on different pages. [#3248](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3248)

--- a/packages/template-retail-react-app/app/pages/account/addresses.jsx
+++ b/packages/template-retail-react-app/app/pages/account/addresses.jsx
@@ -36,6 +36,7 @@ import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-cur
 import {useShopperCustomersMutation} from '@salesforce/commerce-sdk-react'
 import {nanoid} from 'nanoid'
 import {API_ERROR_MESSAGE} from '@salesforce/retail-react-app/app/constants'
+import {serverSafeEncode} from '@salesforce/retail-react-app/app/utils/url'
 
 const DEFAULT_SKELETON_COUNT = 3
 
@@ -183,7 +184,7 @@ const AccountAddresses = () => {
                     body,
                     parameters: {
                         customerId,
-                        addressName: selectedAddressId
+                        addressName: serverSafeEncode(selectedAddressId)
                     }
                 })
             } else {
@@ -222,7 +223,7 @@ const AccountAddresses = () => {
                 {
                     parameters: {
                         customerId,
-                        addressName: addressId
+                        addressName: serverSafeEncode(addressId)
                     }
                 },
                 {

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -284,3 +284,31 @@ export const removeSiteLocaleFromPath = (pathName = '') => {
 
     return pathName
 }
+
+/**
+ * Encodes a string to work around server-side double-decoding issues.
+ *
+ * This function applies a second level of URL encoding to handle cases where the server
+ * performs double URL decoding, which can cause issues with special characters
+ * in address names and other URL parameters.
+ *
+ * This utility is centralized in one place so that if the server-side double-decoding
+ * issue is fixed in the future, we can easily revert all usages by simply changing
+ * this function to return the input unchanged or removing the encoding entirely.
+ *
+ * @param {string} input - The string that is double double-decoded on the server
+ * @returns {string} The encoded string
+ * @example
+ * import {serverSafeEncode} from '/path/to/utils/url'
+ *
+ * serverSafeEncode('My Address & Co.')
+ * // Returns: 'My%20Address%20%26%20Co.'
+ *
+ * @warning Only use this function when you know the server will double-decode
+ *          URL components. This is a workaround for server-side behavior that
+ *          is out of your control.
+ */
+export const serverSafeEncode = (input) => {
+    // WARNING: only use this because server double-decodes URL components
+    return encodeURIComponent(input)
+}

--- a/packages/template-retail-react-app/app/utils/url.test.js
+++ b/packages/template-retail-react-app/app/utils/url.test.js
@@ -466,4 +466,13 @@ describe('serverSafeEncode', () => {
         const decoded = decodeURIComponent(encoded)
         expect(decoded).toBe(input)
     })
+
+    test('correctly double encodes', () => {
+        const input = 'My%20Address%20%26%20Co.'
+        const encoded = serverSafeEncode(input)
+
+        // Decode should give us original string
+        const decoded = decodeURIComponent(encoded)
+        expect(decoded).toBe(input)
+    })
 })

--- a/packages/template-retail-react-app/app/utils/url.test.js
+++ b/packages/template-retail-react-app/app/utils/url.test.js
@@ -15,7 +15,8 @@ import {
     removeQueryParamsFromPath,
     absoluteUrl,
     createUrlTemplate,
-    removeSiteLocaleFromPath
+    removeSiteLocaleFromPath,
+    serverSafeEncode
 } from '@salesforce/retail-react-app/app/utils/url'
 import {getUrlConfig} from '@salesforce/retail-react-app/app/utils/site-utils'
 import mockConfig from '@salesforce/retail-react-app/config/mocks/default'
@@ -417,5 +418,52 @@ describe('removeSiteLocaleFromPath', function () {
     test('return empty string when no path name is passed', () => {
         const pathName = removeSiteLocaleFromPath()
         expect(pathName).toBe('')
+    })
+})
+
+describe('serverSafeEncode', () => {
+    test('encodes simple string', () => {
+        const input = 'My Address'
+        const result = serverSafeEncode(input)
+        expect(result).toBe('My%20Address')
+    })
+
+    test('encodes string with special characters', () => {
+        const input = 'My Address & Co.'
+        const result = serverSafeEncode(input)
+        expect(result).toBe('My%20Address%20%26%20Co.')
+    })
+
+    test('encodes string with spaces and symbols', () => {
+        const input = 'Home Address #123'
+        const result = serverSafeEncode(input)
+        expect(result).toBe('Home%20Address%20%23123')
+    })
+
+    test('encodes string with unicode characters', () => {
+        const input = 'Café & Résumé'
+        const result = serverSafeEncode(input)
+        expect(result).toBe('Caf%C3%A9%20%26%20R%C3%A9sum%C3%A9')
+    })
+
+    test('encodes empty string', () => {
+        const input = ''
+        const result = serverSafeEncode(input)
+        expect(result).toBe('')
+    })
+
+    test('encodes string with URL-unsafe characters', () => {
+        const input = 'test@example.com'
+        const result = serverSafeEncode(input)
+        expect(result).toBe('test%40example.com')
+    })
+
+    test('verifies encoding behavior', () => {
+        const input = 'My Address & Co.'
+        const encoded = serverSafeEncode(input)
+
+        // Decode should give us original string
+        const decoded = decodeURIComponent(encoded)
+        expect(decoded).toBe(input)
     })
 })


### PR DESCRIPTION
## Fix address name encoding for server double-decoding issue

### Problem
The server (SCAPI) performs double URL decoding on address names (potentially others), causing special characters (like `%`, `,`) to be incorrectly decoded when passed as URL parameters in address mutations, causing a 500 error.

### Solution
- Added `serverSafeEncode()` utility function in `utils/url.js` that applies URL encoding to work around the server's double-decoding behavior
- Updated `addresses.jsx` to use `serverSafeEncode()` for `addressName` parameters in both update and remove address mutations
- Added comprehensive tests covering various character types and edge cases

### Changes
- **New utility**: `serverSafeEncode()` function with JSDoc documentation
- **Updated**: Address mutations now encode `addressName` before sending to server
- **Added**: 7 test cases for the new utility function

### Future Maintenance
The utility is centralized in one place, making it easy to revert if the server-side double-decoding issue is fixed in the future by simply changing the function implementation.

### How to test drive this:

1. Open the SFRA [demo site](https://zzrf-001.dx.commercecloud.salesforce.com/s/RefArch/home?lang=en_US).
2. Login and add a new address in account pages. Use `Home%%` as the address name.
3. Not goto the PWA-Kit [demo site](http://localhost:3000/global/en-GB/account/addresses) and edit the address you just created in SFRA. 
4. Save the address.

This should work without issue. If you test this on production demo site you'll see a 500 error on save of the pwa kit address. 