### PR TITLE
Adds support for SLAS proxy req/res callbacks

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.14.0-dev (Sep 26, 2025)
 - Replace aws-serverless-express with @h4ad/serverless-adapter [#3325](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3325)
+- Add extensibility hooks for SLAS private client proxy with `onSLASPrivateProxyReq` and `onSLASPrivateProxyRes` callbacks [#3411](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3411)
 
 ## v3.13.0 (Sep 25, 2025)
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -159,17 +159,17 @@ export const RemoteServerFactory = {
             applySLASPrivateClientToEndpoints:
                 /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/,
 
-            // Custom callback to modify the SLAS proxy request. This callback is invoked
+            // Custom callback to modify the SLAS private client proxy request. This callback is invoked
             // after the built-in proxy request handling. Users can provide additional
             // request modifications (e.g., custom headers).
             // Signature: (proxyRequest, incomingRequest, res) => void
-            onSlasProxyReq: undefined,
+            onSLASPrivateProxyReq: undefined,
 
-            // Custom callback to modify the SLAS proxy response. This callback is invoked
+            // Custom callback to modify the SLAS private client proxy response. This callback is invoked
             // after the built-in proxy response handling. Users can modify or replace
             // the response buffer.
             // Signature: (responseBuffer, proxyRes, req, res) => Buffer
-            onSlasProxyRes: undefined
+            onSLASPrivateProxyRes: undefined
         }
 
         options = Object.assign({}, defaults, options)
@@ -944,12 +944,12 @@ export const RemoteServerFactory = {
                     }
 
                     // Allow users to apply additional custom modifications to the proxy request
-                    if (typeof options.onSlasProxyReq === 'function') {
+                    if (typeof options.onSLASPrivateProxyReq === 'function') {
                         try {
-                            options.onSlasProxyReq(proxyRequest, incomingRequest, res)
+                            options.onSLASPrivateProxyReq(proxyRequest, incomingRequest, res)
                         } catch (error) {
                             logger.error(
-                                'Error in custom onSlasProxyReq callback',
+                                'Error in custom onSLASPrivateProxyReq callback',
                                 /* istanbul ignore next */
                                 {
                                     namespace: '_setupSlasPrivateClientProxy',
@@ -981,9 +981,9 @@ export const RemoteServerFactory = {
                         }
 
                         // Allow users to apply additional custom modifications to the proxy response
-                        if (typeof options.onSlasProxyRes === 'function') {
+                        if (typeof options.onSLASPrivateProxyRes === 'function') {
                             try {
-                                const customBuffer = options.onSlasProxyRes(
+                                const customBuffer = options.onSLASPrivateProxyRes(
                                     workingBuffer,
                                     proxyRes,
                                     req,
@@ -995,7 +995,7 @@ export const RemoteServerFactory = {
                                 }
                             } catch (error) {
                                 logger.error(
-                                    'Error in custom onSlasProxyRes callback',
+                                    'Error in custom onSLASPrivateProxyRes callback',
                                     /* istanbul ignore next */
                                     {
                                         namespace: '_setupSlasPrivateClientProxy',
@@ -1382,11 +1382,11 @@ export const RemoteServerFactory = {
      * proxy handler. Requires PWA_KIT_SLAS_CLIENT_SECRET environment variable.
      * @param {RegExp} [options.applySLASPrivateClientToEndpoints] - A regex pattern to match
      * SLAS endpoints where the Authorization header should be injected.
-     * @param {function} [options.onSlasProxyReq] - Custom callback to modify SLAS proxy requests.
-     * Called after built-in request handling. Signature: (proxyRequest, incomingRequest, res) => void.
+     * @param {function} [options.onSLASPrivateProxyReq] - Custom callback to modify SLAS private client
+     * proxy requests. Called after built-in request handling. Signature: (proxyRequest, incomingRequest, res) => void.
      * Use this to add custom headers or modify the proxy request.
-     * @param {function} [options.onSlasProxyRes] - Custom callback to modify SLAS proxy responses.
-     * Called after built-in response handling. Signature: (responseBuffer, proxyRes, req, res) => Buffer.
+     * @param {function} [options.onSLASPrivateProxyRes] - Custom callback to modify SLAS private client
+     * proxy responses. Called after built-in response handling. Signature: (responseBuffer, proxyRes, req, res) => Buffer.
      * Should return the modified buffer or undefined to use the existing buffer.
      */
     createHandler(options, customizeApp) {

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -948,16 +948,12 @@ export const RemoteServerFactory = {
                         try {
                             options.onSLASPrivateProxyReq(proxyRequest, incomingRequest, res)
                         } catch (error) {
-                            logger.error(
-                                'Error in custom onSLASPrivateProxyReq callback',
-                                /* istanbul ignore next */
-                                {
-                                    namespace: '_setupSlasPrivateClientProxy',
-                                    additionalProperties: {
-                                        error: error
-                                    }
+                            logger.error('Error in custom onSLASPrivateProxyReq callback', {
+                                namespace: '_setupSlasPrivateClientProxy',
+                                additionalProperties: {
+                                    error: error
                                 }
-                            )
+                            })
                         }
                     }
                 },

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -157,7 +157,19 @@ export const RemoteServerFactory = {
             // To allow additional SLAS endpoints, users can override this value in
             // their project's ssr.js.
             applySLASPrivateClientToEndpoints:
-                /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/
+                /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/,
+
+            // Custom callback to modify the SLAS proxy request. This callback is invoked
+            // after the built-in proxy request handling. Users can provide additional
+            // request modifications (e.g., custom headers).
+            // Signature: (proxyRequest, incomingRequest, res) => void
+            onSlasProxyReq: undefined,
+
+            // Custom callback to modify the SLAS proxy response. This callback is invoked
+            // after the built-in proxy response handling. Users can modify or replace
+            // the response buffer.
+            // Signature: (responseBuffer, proxyRes, req, res) => Buffer
+            onSlasProxyRes: undefined
         }
 
         options = Object.assign({}, defaults, options)
@@ -930,8 +942,27 @@ export const RemoteServerFactory = {
                         // purpose so we don't want to overwrite the header for those calls.
                         proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
                     }
+
+                    // Allow users to apply additional custom modifications to the proxy request
+                    if (typeof options.onSlasProxyReq === 'function') {
+                        try {
+                            options.onSlasProxyReq(proxyRequest, incomingRequest, res)
+                        } catch (error) {
+                            logger.error(
+                                'Error in custom onSlasProxyReq callback',
+                                /* istanbul ignore next */
+                                {
+                                    namespace: '_setupSlasPrivateClientProxy',
+                                    additionalProperties: {
+                                        error: error
+                                    }
+                                }
+                            )
+                        }
+                    }
                 },
                 onProxyRes: responseInterceptor((responseBuffer, proxyRes, req, res) => {
+                    let workingBuffer = responseBuffer
                     try {
                         // If the passwordless login endpoint returns a 404, which corresponds to a user
                         // email not being found, we mask it with a 200 OK response so that it is not
@@ -946,15 +977,43 @@ export const RemoteServerFactory = {
 
                             // When a /passwordless/login endpoint response returns 200, it has no body
                             // so we return an empty body here to match an actual 200 response.
-                            return Buffer.from('', 'utf8')
+                            workingBuffer = Buffer.from('', 'utf8')
                         }
-                        return responseBuffer
+
+                        // Allow users to apply additional custom modifications to the proxy response
+                        if (typeof options.onSlasProxyRes === 'function') {
+                            try {
+                                const customBuffer = options.onSlasProxyRes(
+                                    workingBuffer,
+                                    proxyRes,
+                                    req,
+                                    res
+                                )
+                                // Only use the custom buffer if it was returned
+                                if (customBuffer !== undefined) {
+                                    workingBuffer = customBuffer
+                                }
+                            } catch (error) {
+                                logger.error(
+                                    'Error in custom onSlasProxyRes callback',
+                                    /* istanbul ignore next */
+                                    {
+                                        namespace: '_setupSlasPrivateClientProxy',
+                                        additionalProperties: {
+                                            error: error
+                                        }
+                                    }
+                                )
+                            }
+                        }
+
+                        return workingBuffer
                     } catch (error) {
                         console.error(
                             'There is an error processing the response from SLAS. Returning original response.',
                             error
                         )
-                        return responseBuffer
+                        return workingBuffer
                     }
                 })
             })
@@ -1319,6 +1378,16 @@ export const RemoteServerFactory = {
      * @param {Boolean} [options.allowCookies] - This boolean value indicates
      * whether or not we strip cookies from requests and block setting of cookies. Defaults
      * to 'false'.
+     * @param {Boolean} [options.useSLASPrivateClient=false] - Enable the SLAS private client
+     * proxy handler. Requires PWA_KIT_SLAS_CLIENT_SECRET environment variable.
+     * @param {RegExp} [options.applySLASPrivateClientToEndpoints] - A regex pattern to match
+     * SLAS endpoints where the Authorization header should be injected.
+     * @param {function} [options.onSlasProxyReq] - Custom callback to modify SLAS proxy requests.
+     * Called after built-in request handling. Signature: (proxyRequest, incomingRequest, res) => void.
+     * Use this to add custom headers or modify the proxy request.
+     * @param {function} [options.onSlasProxyRes] - Custom callback to modify SLAS proxy responses.
+     * Called after built-in response handling. Signature: (responseBuffer, proxyRes, req, res) => Buffer.
+     * Should return the modified buffer or undefined to use the existing buffer.
      */
     createHandler(options, customizeApp) {
         process.on('unhandledRejection', catchAndLog)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -156,3 +156,194 @@ describe('isBinary function', () => {
         expect(isBinary(headers)).toBe(false)
     })
 })
+
+describe('SLAS private proxy', () => {
+    let request
+    let mockExpress
+
+    beforeEach(() => {
+        // Mock express application
+        mockExpress = require('express')
+        request = require('supertest')
+    })
+
+    afterEach(() => {
+        // Clean up environment variables
+        delete process.env.PWA_KIT_SLAS_CLIENT_SECRET
+    })
+
+    test('returns 404 when useSLASPrivateClient is false', async () => {
+        const app = mockExpress()
+        const options = {
+            useSLASPrivateClient: false,
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        }
+
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+        // Attempt to access the SLAS private proxy path
+        const response = await request(app).get(
+            '/mobify/slas/private/shopper/auth/v1/oauth2/token'
+        )
+
+        expect(response.status).toBe(404)
+    })
+
+    test('returns 501 when useSLASPrivateClient is true but no secret is set', async () => {
+        const app = mockExpress()
+        const options = RemoteServerFactory._configure({
+            useSLASPrivateClient: true,
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            organizationId: 'f_ecom_test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        })
+
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+        const response = await request(app).get(
+            '/mobify/slas/private/shopper/auth/v1/oauth2/token'
+        )
+
+        expect(response.status).toBe(501)
+    })
+
+    test('returns 403 for non-SLAS auth paths', async () => {
+        const app = mockExpress()
+        const options = RemoteServerFactory._configure({
+            useSLASPrivateClient: true,
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            organizationId: 'f_ecom_test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        })
+
+        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+        const response = await request(app).get('/mobify/slas/private/shopper/products/v1')
+
+        expect(response.status).toBe(403)
+    })
+
+    test('returns 403 for trusted-system paths', async () => {
+        const app = mockExpress()
+        const options = RemoteServerFactory._configure({
+            useSLASPrivateClient: true,
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            organizationId: 'f_ecom_test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        })
+
+        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+        const response = await request(app).post(
+            '/mobify/slas/private/shopper/auth/v1/oauth2/trusted-system/token'
+        )
+
+        expect(response.status).toBe(403)
+    })
+
+    test('invokes onSLASPrivateProxyReq callback and onSLASPrivateProxyRes callback', async () => {
+        // Create a mock SLAS endpoint for the http-proxy to consume
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            // Reflect the custom header back in the response to verify it was set
+            res.status(200).json({
+                access_token: 'mock-token',
+                reflected_header: req.headers['x-custom-request-header']
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const onSLASPrivateProxyReqMock = jest.fn((proxyRequest, incomingRequest, res) => {
+                proxyRequest.setHeader('X-Custom-Request-Header', 'CustomRequestValue')
+            })
+
+            const onSLASPrivateProxyResMock = jest.fn((responseBuffer, proxyRes, req, res) => {
+                // Add a custom response header
+                res.setHeader('X-Custom-Response-Header', 'CustomResponseValue')
+                return responseBuffer
+            })
+
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: true,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                onSLASPrivateProxyReq: onSLASPrivateProxyReqMock,
+                onSLASPrivateProxyRes: onSLASPrivateProxyResMock,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id'
+                            }
+                        }
+                    }
+                }
+            })
+
+            process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+            const response = await request(app).post(
+                '/mobify/slas/private/shopper/auth/v1/oauth2/token'
+            )
+
+            // Verify the request was successful
+            expect(response.status).toBe(200)
+
+            // Verify the callbacks were invoked
+            expect(onSLASPrivateProxyReqMock).toHaveBeenCalled()
+            expect(onSLASPrivateProxyResMock).toHaveBeenCalled()
+
+            // Verify the custom request header was added (reflected back in response)
+            expect(response.body.reflected_header).toBe('CustomRequestValue')
+
+            // Verify the custom response header was added
+            expect(response.headers['x-custom-response-header']).toBe('CustomResponseValue')
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+})

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -289,7 +289,7 @@ describe('SLAS private proxy', () => {
         const mockSlasPort = mockSlasServerInstance.address().port
 
         try {
-            const onSLASPrivateProxyReqMock = jest.fn((proxyRequest, incomingRequest, res) => {
+            const onSLASPrivateProxyReqMock = jest.fn((proxyRequest) => {
                 proxyRequest.setHeader('X-Custom-Request-Header', 'CustomRequestValue')
             })
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -191,9 +191,7 @@ describe('SLAS private proxy', () => {
         RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
 
         // Attempt to access the SLAS private proxy path
-        const response = await request(app).get(
-            '/mobify/slas/private/shopper/auth/v1/oauth2/token'
-        )
+        const response = await request(app).get('/mobify/slas/private/shopper/auth/v1/oauth2/token')
 
         expect(response.status).toBe(404)
     })
@@ -217,9 +215,7 @@ describe('SLAS private proxy', () => {
 
         RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
 
-        const response = await request(app).get(
-            '/mobify/slas/private/shopper/auth/v1/oauth2/token'
-        )
+        const response = await request(app).get('/mobify/slas/private/shopper/auth/v1/oauth2/token')
 
         expect(response.status).toBe(501)
     })


### PR DESCRIPTION
## Summary

This PR adds extensibility to the SLAS private client proxy by introducing two new optional callback hooks that allow developers to customize proxy request and response handling.

We also added test coverage for this use case and other (uncovered) existing behavior of the proxy.

## New Options

### `onSLASPrivateProxyReq`
A callback invoked after the built-in proxy request handling. Allows developers to add custom headers or modify the proxy request before it's sent to SLAS.

**Signature:** `(proxyRequest, incomingRequest, res) => void`

**Example:**
```javascript
onSLASPrivateProxyReq: (proxyRequest, incomingRequest, res) => {
    // Add custom header to all SLAS private client proxy requests
    proxyRequest.setHeader('X-Custom-Header', 'CustomValue')
}
```

### `onSLASPrivateProxyRes`
A callback invoked after the built-in proxy response handling. Allows developers to modify response headers or transform the response buffer.

**Signature:** `(responseBuffer, proxyRes, req, res) => Buffer`

**Example:**
```javascript
onSLASPrivateProxyRes: (responseBuffer, proxyRes, req, res) => {
    // Add custom response header
    res.setHeader('X-Custom-Response-Header', 'value')
    
    // Return the response buffer unchanged
    return responseBuffer
}
```

## Use Cases

### Cookie Attribute Modification
A common use case is modifying Set-Cookie headers from SLAS `/token` responses. For example, ensuring that SLAS cookies have the `SameSite=None; Secure` attributes set for cross-site and `<iframe>` scenarios.

**Example:**
```javascript
// in ssr.js runtime.createHandler options
useSLASPrivateClient: true,
onSLASPrivateProxyRes: (responseBuffer, proxyRes, req, res) => {
    // Cookie name prefixes that need SameSite=None; Secure attributes
    const COOKIE_PREFIXES_TO_MODIFY = ['dwsid', 'dwanonymous_']

    // Process Set-Cookie headers
    const setCookieHeaders = proxyRes.headers['set-cookie']
    if (setCookieHeaders) {
        const modifiedCookies = (
            Array.isArray(setCookieHeaders) ? setCookieHeaders : [setCookieHeaders]
        ).map((cookie) => {
            // Check if cookie starts with any of the prefixes we want to modify
            const shouldModify = COOKIE_PREFIXES_TO_MODIFY.some((prefix) =>
                cookie.startsWith(prefix)
            )

            if (!shouldModify) {
                return cookie
            }

            // Check if SameSite=None and Secure are already present
            const hasSameSiteNone = /SameSite=None/i.test(cookie)
            const hasSecure = /;\s*Secure/i.test(cookie)

            // Add missing attributes
            let modifiedCookie = cookie
            if (!hasSameSiteNone) {
                modifiedCookie += '; SameSite=None'
            }
            if (!hasSecure) {
                modifiedCookie += '; Secure'
            }

            return modifiedCookie
        })

        // Update the response headers with modified cookies
        res.setHeader('set-cookie', modifiedCookies)
    }

    // Return the response buffer unchanged
    return responseBuffer
}
```

### Custom Header Injection
Add custom headers to SLAS proxy requests for debugging, tracing, or integration with other systems.

### Response Logging and Monitoring
Log response status codes, timing information, or other metrics for monitoring SLAS API interactions.

### Response Transformation
Modify response buffers if needed (though this should be done carefully to avoid breaking API contracts).

### User Enumeration Protection
Mask SLAS responses for endpoints that might enumerate users if security controls and privacy requirements necessitate this.

## Implementation Details

- Both callbacks are optional and maintain backward compatibility
- Callbacks are invoked **after** the built-in proxy handling (Authorization header injection, passwordless login 404 masking, etc.)
- Error handling is built-in - exceptions in user callbacks are caught and logged without breaking the proxy
- For `onSLASPrivateProxyRes`, returning `undefined` will use the existing buffer

---

# Description

<!--- A longer summary of your changes, including: a description of the issue that you're addressing, a list of required dependencies (if applicable), and any other relevant context. --->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: --->

- **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- **Documentation update**
- **Breaking change** (could cause existing functionality to not work as expected)
- **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- adds optional callbacks to change slas private proxy behavior from user space

# How to Test-Drive This PR

- Implement one of the example callbacks from the description above and observe changes in private proxy (i.e. console log, new headers, cookie changes, etc)

# Checklists

<!--- Enter an `x` in all the boxes that apply. --->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! --->

## General

- [x] Changes are covered by test cases
- [X] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [X] There are no changes to UI

## Localization

- Changes include a UI text update in the Retail React App (which requires translation)