### PR TITLE
[CI] Fix the publish script for a specific package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,12 @@ jobs:
       - name: Setup Ubuntu Machine
         uses: "./.github/actions/setup_ubuntu"
 
+      # Running `git commit`, for example, requires these user.name and user.email to be set
+      - name: Configure Git
+        run: |-
+          git config --global user.name ${{ secrets.GIT_CONFIG_USERNAME }}
+          git config --global user.email ${{ secrets.GIT_CONFIG_EMAIL }}
+
       - name: Run unit tests
         uses: "./.github/actions/unit_tests"
 

--- a/scripts/publish-to-npm.js
+++ b/scripts/publish-to-npm.js
@@ -70,7 +70,26 @@ const publishPackages = (packages = [], isNightly = false) => {
         })
 
         sh.exec('git add .', {silent: true})
-        sh.exec('git commit -m "temporary commit to have clean working tree"', {silent: true})
+        const commitResult = sh.exec(
+            'git commit -m "temporary commit to have clean working tree"',
+            {silent: true}
+        )
+
+        if (commitResult.code !== 0) {
+            console.error(
+                'Failed to create temporary commit. Git user.name and user.email might not be configured.'
+            )
+            console.error('Commit error:', commitResult.stderr)
+
+            // Clean up the package.json changes before exiting
+            packagesToIgnore.forEach((pkg) => {
+                sh.exec('npm pkg delete private', {cwd: pkg.location})
+            })
+            // Unstage the files that were staged with 'git add .' above
+            sh.exec('git reset HEAD', {silent: true})
+
+            process.exit(1)
+        }
     }
 
     // Why do we still want `lerna publish`? It turns out that we do need it. Sometimes we wanted some behaviour that's unique to Lerna.


### PR DESCRIPTION
Our publishing script would fail when committing a temporary commit because there is no git user.name and user.email set yet.

Related to the failed publishing for mcp package in PR #3426. And the CI job where the error occurred: https://github.com/SalesforceCommerceCloud/pwa-kit/actions/runs/18788307194/job/53612168980
