### PR TITLE
Remove transfer-encoding if chunked

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Replace aws-serverless-express with @h4ad/serverless-adapter [#3325](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3325)
 - Added Hybrid Proxy support for local and ODS hybrid development [#3409] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3409)
 - Add extensibility hooks for SLAS private client proxy with `onSLASPrivateProxyReq` and `onSLASPrivateProxyRes` callbacks [#3411](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3411)
+- Remove exception when transfer-encoding: chunked [#3439](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3439)
 
 ## v3.13.0 (Sep 25, 2025)
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -1276,7 +1276,13 @@ export const RemoteServerFactory = {
             .setFramework(new ExpressFramework())
             .setHandler(new DefaultHandler())
             .setResolver(new CallbackResolver())
-            .addAdapter(new ApiGatewayV1Adapter({lowercaseRequestHeaders: true}))
+            .addAdapter(
+                new ApiGatewayV1Adapter({
+                    // Preserve the original aws-serverless-express behavior
+                    lowercaseRequestHeaders: true,
+                    throwOnChunkedTransfer: false
+                })
+            )
             .build()
 
         const handler = (event, context, callback) => {


### PR DESCRIPTION
Remove transfer-encoding if chunked

# Description

The default behaviour of the new serverless-adapter throws and error if the transfer-encoding header is set to `chunked`. To keep compatibility with the old library it needs to just delete the header without an error.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Don't throw on `transfer-encoding: chunked`, just delete

# How to Test-Drive This PR

- 

# Checklists

## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
