### PR TITLE
@W-19292755: feat: react hooks for Shopper Consents v1.1.3.

### DIFF
--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.2.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
-        "commerce-sdk-isomorphic": "^4.0.0",
+        "commerce-sdk-isomorphic": "4.0.0-nightly-20251031080733",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -846,9 +846,9 @@
       "dev": true
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-4.0.0.tgz",
-      "integrity": "sha512-dYZkfGd7MjfWdzRV5RX5d3MlgmTgTkzNizZI9WgIujOHXst+M7tF304Au8vN+Yl6kHVKG3/hOHCZedlKOHB2xw==",
+      "version": "4.0.0-nightly-20251031080733",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-4.0.0-nightly-20251031080733.tgz",
+      "integrity": "sha512-4IHNy2PFGhdlaEMIPPO7umPg7lUtgz4Ny2t+69LgtIpUihejw+HKFZ/JeuA/Vyy5OPlnph1W/uaw+djqU/owTQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "^4.0.0",
+    "commerce-sdk-isomorphic": "4.0.0-nightly-20251031080733",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/constant.ts
+++ b/packages/commerce-sdk-react/src/constant.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Salesforce, Inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -46,6 +46,7 @@ export const SERVER_AFFINITY_HEADER_KEY = 'sfdc_dwsid'
 
 export const CLIENT_KEYS = {
     SHOPPER_BASKETS: 'shopperBaskets',
+    SHOPPER_CONSENTS: 'shopperConsents',
     SHOPPER_CONTEXTS: 'shopperContexts',
     SHOPPER_CUSTOMERS: 'shopperCustomers',
     SHOPPER_EXPERIENCE: 'shopperExperience',

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/cache.ts
@@ -27,4 +27,3 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
         }
     }
 }
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/cache.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ApiClients, CacheUpdateMatrix} from '../types'
+import {getSubscriptions} from './queryKeyHelpers'
+import {CLIENT_KEYS} from '../../constant'
+
+const CLIENT_KEY = CLIENT_KEYS.SHOPPER_CONSENTS
+type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
+
+export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
+    updateSubscription(customerId, {parameters}, response) {
+        // When a subscription is updated, we invalidate the getSubscriptions query
+        // to ensure the UI reflects the latest subscription state
+        return {
+            invalidate: [{queryKey: getSubscriptions.queryKey(parameters)}]
+        }
+    },
+    updateSubscriptions(customerId, {parameters}, response) {
+        // When multiple subscriptions are updated, we invalidate the getSubscriptions query
+        // to ensure the UI reflects the latest subscription states
+        return {
+            invalidate: [{queryKey: getSubscriptions.queryKey(parameters)}]
+        }
+    }
+}
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.test.ts
@@ -29,4 +29,3 @@ describe('Shopper Consents hooks', () => {
         expect([...unimplemented]).toEqual([])
     })
 })
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ShopperConsents} from 'commerce-sdk-isomorphic'
+import {getUnimplementedEndpoints} from '../../test-utils'
+import {cacheUpdateMatrix} from './cache'
+import {ShopperConsentsMutations as mutations} from './mutation'
+import * as queries from './query'
+
+describe('Shopper Consents hooks', () => {
+    test('all endpoints have hooks', () => {
+        // unimplemented = SDK method exists, but no query hook or value in mutations enum
+        const unimplemented = getUnimplementedEndpoints(ShopperConsents, queries, mutations)
+        // If this test fails: create a new query hook, add the endpoint to the mutations enum,
+        // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
+        expect(unimplemented).toEqual([])
+    })
+    test('all mutations have cache update logic', () => {
+        // unimplemented = value in mutations enum, but no method in cache update matrix
+        const unimplemented = new Set<string>(Object.values(mutations))
+        Object.entries(cacheUpdateMatrix).forEach(([method, implementation]) => {
+            if (implementation) unimplemented.delete(method)
+        })
+        // If this test fails: add cache update logic, remove the endpoint from the mutations enum,
+        // or add it to the `expected` array to indicate that it is still a TODO.
+        expect([...unimplemented]).toEqual([])
+    })
+})
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export * from './mutation'
+export * from './query'
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/index.ts
@@ -6,4 +6,3 @@
  */
 export * from './mutation'
 export * from './query'
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {act} from '@testing-library/react'
+import {ShopperConsentsTypes} from 'commerce-sdk-isomorphic'
+import nock from 'nock'
+import {
+    assertInvalidateQuery,
+    mockMutationEndpoints,
+    mockQueryEndpoint,
+    renderHookWithProviders,
+    waitAndExpectSuccess
+} from '../../test-utils'
+import {ShopperConsentsMutation, useShopperConsentsMutation} from '../ShopperConsents'
+import {ApiClients, Argument} from '../types'
+import * as queries from './query'
+import {CLIENT_KEYS} from '../../constant'
+
+jest.mock('../../auth/index.ts', () => {
+    const {default: mockAuth} = jest.requireActual('../../auth/index.ts')
+    mockAuth.prototype.ready = jest.fn().mockResolvedValue({access_token: 'access_token'})
+    return mockAuth
+})
+
+const CLIENT_KEY = CLIENT_KEYS.SHOPPER_CONSENTS
+type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
+const consentsEndpoint = '/shopper/shopper-consents/'
+/** All Shopper Consents parameters. Can be used for all endpoints, as unused params are ignored. */
+const PARAMETERS = {
+    siteId: 'RefArch'
+} as const
+/** Options object that can be used for all query endpoints. */
+const queryOptions = {parameters: PARAMETERS}
+
+const baseSubscriptionResponse: ShopperConsentsTypes.ConsentSubscriptionResponse = {
+    data: [
+        {
+            subscriptionId: 'test-subscription',
+            channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
+            contactPointValue: 'test@example.com'
+        }
+    ]
+}
+
+type Mutation = ShopperConsentsMutation
+/** Map of mutation method name to test options. */
+type TestMap = {[Mut in Mutation]?: Argument<Client[Mut]>}
+const testMap: TestMap = {
+    updateSubscription: {
+        parameters: PARAMETERS,
+        body: {
+            subscriptionId: 'test-subscription',
+            channel: 'email',
+            status: 'opt_in',
+            contactPointValue: 'test@example.com'
+        }
+    },
+    updateSubscriptions: {
+        parameters: PARAMETERS,
+        body: {
+            subscriptions: [
+                {
+                    subscriptionId: 'test-subscription',
+                    channel: 'email' as ShopperConsentsTypes.ChannelType,
+                    status: 'opt_in' as ShopperConsentsTypes.ConsentStatus,
+                    contactPointValue: 'test@example.com'
+                }
+            ]
+        }
+    }
+}
+// Type assertion is necessary because `Object.entries` is limited
+type TestCase = [Mutation, NonNullable<TestMap[Mutation]>]
+const testCases = Object.entries(testMap) as TestCase[]
+
+describe('Shopper Consents mutations', () => {
+    beforeEach(() => nock.cleanAll())
+    test.each(testCases)('`%s` returns data on success', async (mutationName, options) => {
+        mockMutationEndpoints(consentsEndpoint, {})
+        const {result} = renderHookWithProviders(() => {
+            return useShopperConsentsMutation(mutationName)
+        })
+        act(() => result.current.mutate(options))
+        await waitAndExpectSuccess(() => result.current)
+    })
+})
+
+describe('Cache update behavior', () => {
+    describe('updateSubscription', () => {
+        beforeEach(() => nock.cleanAll())
+        
+        test('invalidates `getSubscriptions` query', async () => {
+            mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
+            mockMutationEndpoints(consentsEndpoint, {})
+            const {result} = renderHookWithProviders(() => {
+                return {
+                    query: queries.useSubscriptions(queryOptions),
+                    mutation: useShopperConsentsMutation('updateSubscription')
+                }
+            })
+            await waitAndExpectSuccess(() => result.current.query)
+            const oldData = result.current.query.data
+
+            act(() =>
+                result.current.mutation.mutate({
+                    parameters: PARAMETERS,
+                    body: {
+                        subscriptionId: 'test-subscription',
+                        channel: 'email',
+                        status: 'opt_out',
+                        contactPointValue: 'test@example.com'
+                    }
+                })
+            )
+            await waitAndExpectSuccess(() => result.current.mutation)
+            assertInvalidateQuery(result.current.query, oldData)
+        })
+
+        test('triggers refetch after cache invalidation', async () => {
+            const updatedResponse: ShopperConsentsTypes.ConsentSubscriptionResponse = {
+                data: [
+                    {
+                        subscriptionId: 'test-subscription',
+                        channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
+                        contactPointValue: 'test@example.com'
+                    }
+                ]
+            }
+
+            mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
+            mockMutationEndpoints(consentsEndpoint, {})
+            mockQueryEndpoint(consentsEndpoint, updatedResponse) // Refetch returns updated data
+            
+            const {result} = renderHookWithProviders(() => {
+                return {
+                    query: queries.useSubscriptions(queryOptions),
+                    mutation: useShopperConsentsMutation('updateSubscription')
+                }
+            })
+            await waitAndExpectSuccess(() => result.current.query)
+            expect(result.current.query.data).toEqual(baseSubscriptionResponse)
+
+            act(() =>
+                result.current.mutation.mutate({
+                    parameters: PARAMETERS,
+                    body: {
+                        subscriptionId: 'test-subscription',
+                        channel: 'email',
+                        status: 'opt_out',
+                        contactPointValue: 'test@example.com'
+                    }
+                })
+            )
+            await waitAndExpectSuccess(() => result.current.mutation)
+            
+            // Wait for refetch to complete
+            await waitAndExpectSuccess(() => result.current.query)
+            // After refetch, data should be updated
+            expect(result.current.query.data).toEqual(updatedResponse)
+        })
+    })
+
+    describe('updateSubscriptions', () => {
+        beforeEach(() => nock.cleanAll())
+        
+        test('invalidates `getSubscriptions` query', async () => {
+            mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
+            mockMutationEndpoints(consentsEndpoint, {})
+            const {result} = renderHookWithProviders(() => {
+                return {
+                    query: queries.useSubscriptions(queryOptions),
+                    mutation: useShopperConsentsMutation('updateSubscriptions')
+                }
+            })
+            await waitAndExpectSuccess(() => result.current.query)
+            const oldData = result.current.query.data
+
+            act(() =>
+                result.current.mutation.mutate({
+                    parameters: PARAMETERS,
+                    body: {
+                        subscriptions: [
+                            {
+                                subscriptionId: 'test-subscription',
+                                channel: 'email' as ShopperConsentsTypes.ChannelType,
+                                status: 'opt_out' as ShopperConsentsTypes.ConsentStatus,
+                                contactPointValue: 'test@example.com'
+                            },
+                            {
+                                subscriptionId: 'test-subscription-2',
+                                channel: 'sms' as ShopperConsentsTypes.ChannelType,
+                                status: 'opt_in' as ShopperConsentsTypes.ConsentStatus,
+                                contactPointValue: '+15551234567'
+                            }
+                        ]
+                    }
+                })
+            )
+            await waitAndExpectSuccess(() => result.current.mutation)
+            assertInvalidateQuery(result.current.query, oldData)
+        })
+
+        test('ensures stale cache is not served after mutation', async () => {
+            const staleResponse = baseSubscriptionResponse
+            const freshResponse: ShopperConsentsTypes.ConsentSubscriptionResponse = {
+                data: [
+                    {
+                        subscriptionId: 'test-subscription',
+                        channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
+                        contactPointValue: 'test@example.com'
+                    },
+                    {
+                        subscriptionId: 'test-subscription-2',
+                        channels: new Set(['sms' as ShopperConsentsTypes.ChannelType]),
+                        contactPointValue: '+15551234567'
+                    }
+                ]
+            }
+
+            mockQueryEndpoint(consentsEndpoint, staleResponse)
+            mockMutationEndpoints(consentsEndpoint, {})
+            mockQueryEndpoint(consentsEndpoint, freshResponse) // Refetch returns fresh data
+            
+            const {result} = renderHookWithProviders(() => {
+                return {
+                    query: queries.useSubscriptions(queryOptions),
+                    mutation: useShopperConsentsMutation('updateSubscriptions')
+                }
+            })
+            
+            // Initial fetch - get stale data
+            await waitAndExpectSuccess(() => result.current.query)
+            expect(result.current.query.data?.data).toHaveLength(1)
+
+            // Perform mutation
+            act(() =>
+                result.current.mutation.mutate({
+                    parameters: PARAMETERS,
+                    body: {
+                        subscriptions: [
+                            {
+                                subscriptionId: 'test-subscription',
+                                channel: 'email' as ShopperConsentsTypes.ChannelType,
+                                status: 'opt_out' as ShopperConsentsTypes.ConsentStatus,
+                                contactPointValue: 'test@example.com'
+                            },
+                            {
+                                subscriptionId: 'test-subscription-2',
+                                channel: 'sms' as ShopperConsentsTypes.ChannelType,
+                                status: 'opt_in' as ShopperConsentsTypes.ConsentStatus,
+                                contactPointValue: '+15551234567'
+                            }
+                        ]
+                    }
+                })
+            )
+            await waitAndExpectSuccess(() => result.current.mutation)
+            
+            // Wait for automatic refetch
+            await waitAndExpectSuccess(() => result.current.query)
+            // Should have fresh data, not stale
+            expect(result.current.query.data?.data).toHaveLength(2)
+            expect(result.current.query.data).toEqual(freshResponse)
+        })
+    })
+})
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
@@ -91,7 +91,7 @@ describe('Shopper Consents mutations', () => {
 describe('Cache update behavior', () => {
     describe('updateSubscription', () => {
         beforeEach(() => nock.cleanAll())
-        
+
         test('invalidates `getSubscriptions` query', async () => {
             mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
             mockMutationEndpoints(consentsEndpoint, {})
@@ -133,7 +133,7 @@ describe('Cache update behavior', () => {
             mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
             mockMutationEndpoints(consentsEndpoint, {})
             mockQueryEndpoint(consentsEndpoint, updatedResponse) // Refetch returns updated data
-            
+
             const {result} = renderHookWithProviders(() => {
                 return {
                     query: queries.useSubscriptions(queryOptions),
@@ -155,7 +155,7 @@ describe('Cache update behavior', () => {
                 })
             )
             await waitAndExpectSuccess(() => result.current.mutation)
-            
+
             // Wait for refetch to complete
             await waitAndExpectSuccess(() => result.current.query)
             // After refetch, data should be updated
@@ -165,7 +165,7 @@ describe('Cache update behavior', () => {
 
     describe('updateSubscriptions', () => {
         beforeEach(() => nock.cleanAll())
-        
+
         test('invalidates `getSubscriptions` query', async () => {
             mockQueryEndpoint(consentsEndpoint, baseSubscriptionResponse)
             mockMutationEndpoints(consentsEndpoint, {})
@@ -223,14 +223,14 @@ describe('Cache update behavior', () => {
             mockQueryEndpoint(consentsEndpoint, staleResponse)
             mockMutationEndpoints(consentsEndpoint, {})
             mockQueryEndpoint(consentsEndpoint, freshResponse) // Refetch returns fresh data
-            
+
             const {result} = renderHookWithProviders(() => {
                 return {
                     query: queries.useSubscriptions(queryOptions),
                     mutation: useShopperConsentsMutation('updateSubscriptions')
                 }
             })
-            
+
             // Initial fetch - get stale data
             await waitAndExpectSuccess(() => result.current.query)
             expect(result.current.query.data?.data).toHaveLength(1)
@@ -258,7 +258,7 @@ describe('Cache update behavior', () => {
                 })
             )
             await waitAndExpectSuccess(() => result.current.mutation)
-            
+
             // Wait for automatic refetch
             await waitAndExpectSuccess(() => result.current.query)
             // Should have fresh data, not stale
@@ -267,4 +267,3 @@ describe('Cache update behavior', () => {
         })
     })
 })
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ApiClients, ApiMethod, Argument, CacheUpdateGetter, DataType, MergedOptions} from '../types'
+import {useMutation} from '../useMutation'
+import {UseMutationResult} from '@tanstack/react-query'
+import {NotImplementedError} from '../utils'
+import {cacheUpdateMatrix} from './cache'
+import {CLIENT_KEYS} from '../../constant'
+import useCommerceApi from '../useCommerceApi'
+
+const CLIENT_KEY = CLIENT_KEYS.SHOPPER_CONSENTS
+type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
+
+/**
+ * Mutations available for Shopper Consents.
+ * @group ShopperConsents
+ * @category Mutation
+ * @enum
+ */
+export const ShopperConsentsMutations = {
+    /**
+     * Updates the customer's consent subscription for a specific channel.
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Consents `updateSubscription` endpoint.
+     */
+    UpdateSubscription: 'updateSubscription',
+    /**
+     * Updates multiple customer consent subscriptions.
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Consents `updateSubscriptions` endpoint.
+     */
+    UpdateSubscriptions: 'updateSubscriptions'
+} as const
+
+/**
+ * Mutation for Shopper Consents.
+ * @group ShopperConsents
+ * @category Mutation
+ */
+export type ShopperConsentsMutation =
+    (typeof ShopperConsentsMutations)[keyof typeof ShopperConsentsMutations]
+
+/**
+ * Mutation hook for Shopper Consents.
+ * @group ShopperConsents
+ * @category Mutation
+ */
+export function useShopperConsentsMutation<Mutation extends ShopperConsentsMutation>(
+    mutation: Mutation
+): UseMutationResult<DataType<Client[Mutation]>, unknown, Argument<Client[Mutation]>> {
+    const getCacheUpdates = cacheUpdateMatrix[mutation]
+    // TODO: Remove this check when all mutations are implemented.
+    if (!getCacheUpdates) throw new NotImplementedError(`The '${mutation}' mutation`)
+
+    // The `Options` and `Data` types for each mutation are similar, but distinct, and the union
+    // type generated from `Client[Mutation]` seems to be too complex for TypeScript to handle.
+    // I'm not sure if there's a way to avoid the type assertions in here for the methods that
+    // use them. However, I'm fairly confident that they are safe to do, as they seem to be simply
+    // re-asserting what we already have.
+    const client = useCommerceApi(CLIENT_KEY)
+    type Options = Argument<Client[Mutation]>
+    type Data = DataType<Client[Mutation]>
+    return useMutation({
+        client,
+        method: (opts: Options) => (client[mutation] as ApiMethod<Options, Data>)(opts),
+        getCacheUpdates: getCacheUpdates as unknown as CacheUpdateGetter<MergedOptions<Client, Options>, Data>
+    })
+}
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.ts
@@ -65,7 +65,9 @@ export function useShopperConsentsMutation<Mutation extends ShopperConsentsMutat
     return useMutation({
         client,
         method: (opts: Options) => (client[mutation] as ApiMethod<Options, Data>)(opts),
-        getCacheUpdates: getCacheUpdates as unknown as CacheUpdateGetter<MergedOptions<Client, Options>, Data>
+        getCacheUpdates: getCacheUpdates as unknown as CacheUpdateGetter<
+            MergedOptions<Client, Options>,
+            Data
+        >
     })
 }
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.test.ts
@@ -69,4 +69,3 @@ describe('Shopper Consents query hooks', () => {
         await waitAndExpectError(() => result.current)
     })
 })
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ShopperConsentsTypes} from 'commerce-sdk-isomorphic'
+import nock from 'nock'
+import {
+    mockQueryEndpoint,
+    renderHookWithProviders,
+    waitAndExpectError,
+    waitAndExpectSuccess,
+    createQueryClient
+} from '../../test-utils'
+import * as queries from './query'
+
+jest.mock('../../auth/index.ts', () => {
+    const {default: mockAuth} = jest.requireActual('../../auth/index.ts')
+    mockAuth.prototype.ready = jest.fn().mockResolvedValue({access_token: 'access_token'})
+    return mockAuth
+})
+type Queries = typeof queries
+const consentsEndpoint = '/shopper/shopper-consents/'
+// Not all endpoints use all parameters, but unused parameters are safely discarded
+const OPTIONS = {parameters: {siteId: 'RefArch'}}
+
+/** Map of query name to returned data type */
+type TestMap = {[K in keyof Queries]: NonNullable<ReturnType<Queries[K]>['data']>}
+// This is an object rather than an array to more easily ensure we cover all hooks
+const testMap: TestMap = {
+    // Type assertion so that we don't have to implement the full type
+    useSubscriptions: {data: []} as ShopperConsentsTypes.ConsentSubscriptionResponse
+}
+// Type assertion is necessary because `Object.entries` is limited
+const testCases = Object.entries(testMap) as Array<[keyof TestMap, TestMap[keyof TestMap]]>
+describe('Shopper Consents query hooks', () => {
+    beforeEach(() => nock.cleanAll())
+    afterEach(() => {
+        expect(nock.pendingMocks()).toHaveLength(0)
+    })
+    test.each(testCases)('`%s` returns data on success', async (queryName, data) => {
+        mockQueryEndpoint(consentsEndpoint, data)
+        const {result} = renderHookWithProviders(() => {
+            return queries[queryName](OPTIONS)
+        })
+        await waitAndExpectSuccess(() => result.current)
+        expect(result.current.data).toEqual(data)
+    })
+
+    test.each(testCases)('`%s` has meta.displayName defined', async (queryName, data) => {
+        mockQueryEndpoint(consentsEndpoint, data)
+        const queryClient = createQueryClient()
+        const {result} = renderHookWithProviders(
+            () => {
+                return queries[queryName](OPTIONS)
+            },
+            {queryClient}
+        )
+        await waitAndExpectSuccess(() => result.current)
+        expect(queryClient.getQueryCache().getAll()[0].meta?.displayName).toBe(queryName)
+    })
+
+    test.each(testCases)('`%s` returns error on error', async (queryName) => {
+        mockQueryEndpoint(consentsEndpoint, {}, 400)
+        const {result} = renderHookWithProviders(() => {
+            return queries[queryName](OPTIONS)
+        })
+        await waitAndExpectError(() => result.current)
+    })
+})
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {UseQueryResult} from '@tanstack/react-query'
+import {ShopperConsents} from 'commerce-sdk-isomorphic'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
+import {useQuery} from '../useQuery'
+import {mergeOptions, omitNullableParameters, pickValidParams} from '../utils'
+import * as queryKeyHelpers from './queryKeyHelpers'
+import {CLIENT_KEYS} from '../../constant'
+import useCommerceApi from '../useCommerceApi'
+
+const CLIENT_KEY = CLIENT_KEYS.SHOPPER_CONSENTS
+type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
+
+/**
+ * Gets the customer's consents for receiving marketing emails, SMS, etc.
+ * @group ShopperConsents
+ * @category Query
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
+ * @returns A TanStack Query query hook with data from the Shopper Consents `getSubscriptions` endpoint.
+ * @see {@link https://developer.salesforce.com/docs/commerce/commerce-api/references/shopper-consents?meta=getSubscriptions| Salesforce Developer Center} for more information about the API endpoint.
+ * @see {@link https://salesforcecommercecloud.github.io/commerce-sdk-isomorphic/classes/shopperconsents.shopperconsents-1.html#getsubscriptions | `commerce-sdk-isomorphic` documentation} for more information on the parameters and returned data type.
+ * @see {@link https://tanstack.com/query/latest/docs/react/reference/useQuery | TanStack Query `useQuery` reference} for more information about the return value.
+ */
+export const useSubscriptions = (
+    apiOptions: NullableParameters<Argument<Client['getSubscriptions']>>,
+    queryOptions: ApiQueryOptions<Client['getSubscriptions']> = {}
+): UseQueryResult<DataType<Client['getSubscriptions']>> => {
+    type Options = Argument<Client['getSubscriptions']>
+    type Data = DataType<Client['getSubscriptions']>
+    const client = useCommerceApi(CLIENT_KEY)
+    const methodName = 'getSubscriptions'
+    const requiredParameters = ShopperConsents.paramKeys[`${methodName}Required`]
+
+    // Parameters can be set in `apiOptions` or `client.clientConfig`;
+    // we must merge them in order to generate the correct query key.
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    const parameters = pickValidParams(
+        netOptions.parameters,
+        ShopperConsents.paramKeys[methodName]
+    )
+    const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+
+    // We don't use `netOptions` here because we manipulate the options in `useQuery`.
+    const method = async (options: Options) => await client[methodName](options)
+
+    queryOptions.meta = {
+        displayName: 'useSubscriptions',
+        ...queryOptions.meta
+    }
+
+    // For some reason, if we don't explicitly set these generic parameters, the inferred type for
+    // `Data` sometimes, but not always, includes `Response`, which is incorrect. I don't know why.
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
+        method,
+        queryKey,
+        requiredParameters
+    })
+}
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/query.ts
@@ -40,10 +40,7 @@ export const useSubscriptions = (
     // Parameters can be set in `apiOptions` or `client.clientConfig`;
     // we must merge them in order to generate the correct query key.
     const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
-    const parameters = pickValidParams(
-        netOptions.parameters,
-        ShopperConsents.paramKeys[methodName]
-    )
+    const parameters = pickValidParams(netOptions.parameters, ShopperConsents.paramKeys[methodName])
     const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
 
     // We don't use `netOptions` here because we manipulate the options in `useQuery`.
@@ -62,4 +59,3 @@ export const useSubscriptions = (
         requiredParameters
     })
 }
-

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/queryKeyHelpers.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ShopperConsents} from 'commerce-sdk-isomorphic'
+import {Argument, ExcludeTail} from '../types'
+import {pickValidParams} from '../utils'
+
+// We must use a client with no parameters in order to have required/optional match the API spec
+type Client = ShopperConsents<{shortCode: string}>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
+export type QueryKeys = {
+    getSubscriptions: [
+        '/commerce-sdk-react',
+        '/organizations/',
+        string | undefined,
+        '/shopper-consents/subscriptions',
+        Params<'getSubscriptions'>
+    ]
+}
+
+// This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
+// and making those generic would add too much complexity.
+type QueryKeyHelper<T extends keyof QueryKeys> = {
+    /** Generates the path component of the query key for an endpoint. */
+    path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
+    /** Generates the full query key for an endpoint. */
+    queryKey: (params: Params<T>) => QueryKeys[T]
+}
+
+export const getSubscriptions: QueryKeyHelper<'getSubscriptions'> = {
+    path: (params) => [
+        '/commerce-sdk-react',
+        '/organizations/',
+        params?.organizationId,
+        '/shopper-consents/subscriptions'
+    ],
+    queryKey: (params: Params<'getSubscriptions'>) => {
+        return [
+            ...getSubscriptions.path(params),
+            pickValidParams(params || {}, ShopperConsents.paramKeys.getSubscriptions)
+        ]
+    }
+}
+

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/queryKeyHelpers.ts
@@ -44,4 +44,3 @@ export const getSubscriptions: QueryKeyHelper<'getSubscriptions'> = {
         ]
     }
 }
-

--- a/packages/commerce-sdk-react/src/hooks/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/index.ts
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2024, Salesforce, Inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 export * from './ShopperBaskets'
+export * from './ShopperConsents'
 export * from './ShopperContexts'
 export * from './ShopperCustomers'
 export * from './ShopperExperience'

--- a/packages/commerce-sdk-react/src/hooks/types.ts
+++ b/packages/commerce-sdk-react/src/hooks/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Salesforce, Inc.
+ * Copyright (c) 2025, Salesforce, Inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -7,6 +7,7 @@
 import {InvalidateQueryFilters, QueryFilters, Updater, UseQueryOptions} from '@tanstack/react-query'
 import {
     ShopperBaskets,
+    ShopperConsents,
     ShopperContexts,
     ShopperCustomers,
     ShopperExperience,
@@ -85,6 +86,7 @@ export type ApiClientConfigParams = {
  */
 export interface ApiClients {
     shopperBaskets?: ShopperBaskets<ApiClientConfigParams>
+    shopperConsents?: ShopperConsents<ApiClientConfigParams>
     shopperContexts?: ShopperContexts<ApiClientConfigParams>
     shopperCustomers?: ShopperCustomers<ApiClientConfigParams>
     shopperExperience?: ShopperExperience<ApiClientConfigParams>

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2025, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -11,6 +11,7 @@ import {Logger} from './types'
 import {DWSID_COOKIE_NAME, SERVER_AFFINITY_HEADER_KEY} from './constant'
 import {
     ShopperBaskets,
+    ShopperConsents,
     ShopperContexts,
     ShopperCustomers,
     ShopperExperience,
@@ -256,6 +257,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
 
         return {
             shopperBaskets: new ShopperBaskets(config),
+            shopperConsents: new ShopperConsents(config),
             shopperContexts: new ShopperContexts(config),
             shopperCustomers: new ShopperCustomers(config),
             shopperExperience: new ShopperExperience(config),


### PR DESCRIPTION
React hooks for Shopper Consents v1.1.3. Linking with [commerce-sdk-isomorphic@4.0.0-nightly-20251031080733](https://github.com/SalesforceCommerceCloud/commerce-sdk-isomorphic/pull/238). (Will update to official Nightly build when feature is nearing completion).

**note:** I'm requesting a review for this, even though it is currently only merging into a feature branch. (The goal is to keep the feature branch in a mergable state). The feature branch will be updated to include UI component updates and ShopperConfiguration service flag reads.

# Description

Shopper Consents SCAPI API updates to enable:
* getSubscriptions()
* updateSubscription()
* updateSubscriptions()

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Will publish pwa-kit UI component usage of this invocation as a follow-up.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
