### PR TITLE
@W-20117176 : Call updateAmount on Order Total change

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -390,7 +390,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     }, [sfp, metadata, containerElementRef.current, paymentConfig, cardCaptureAutomatic])
 
     useEffect(() => {
-        if (checkoutComponent.current != null && basket?.orderTotal !== undefined) {
+        if (checkoutComponent.current && basket?.orderTotal) {
             checkoutComponent.current.updateAmount(basket.orderTotal)
         }
     }, [basket?.orderTotal])

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -339,13 +339,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     }))
 
     useEffect(() => {
-        if (
-            !checkoutComponent.current &&
-            sfp &&
-            metadata &&
-            containerElementRef.current &&
-            paymentConfig
-        ) {
+        if (sfp && metadata && containerElementRef.current && paymentConfig) {
             const paymentMethodSet = {
                 paymentMethods: paymentConfig.paymentMethods,
                 paymentMethodSetAccounts: paymentConfig.paymentMethodSetAccounts
@@ -369,11 +363,9 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 locale: intl.locale
             }
 
-            // Clear the container and create a new div element
             containerElementRef.current.innerHTML = ''
             const paymentElement = document.createElement('div')
             containerElementRef.current.appendChild(paymentElement)
-
             paymentElement.addEventListener('load', handlePaymentMethodSelected)
             paymentElement.addEventListener('paymentMethodSelected', handlePaymentMethodSelected)
             paymentElement.addEventListener('sfppaymentbuttonapprove', handlePaymentButtonApprove)
@@ -389,15 +381,13 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
         }
         // Cleanup on unmount
         return () => {
-            if (checkoutComponent.current && !containerElementRef.current) {
-                checkoutComponent.current.destroy()
-                checkoutComponent.current = null
-            }
+            checkoutComponent.current?.destroy()
+            checkoutComponent.current = null
         }
-    }, [sfp, metadata, paymentConfig, cardCaptureAutomatic])
+    }, [sfp, metadata, containerElementRef.current, paymentConfig, cardCaptureAutomatic])
 
     useEffect(() => {
-        if (checkoutComponent.current && basket?.orderTotal != null) {
+        if (checkoutComponent.current !== null && basket?.orderTotal !== null) {
             checkoutComponent.current.updateAmount(basket.orderTotal)
         }
     }, [basket?.orderTotal])
@@ -415,13 +405,16 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 id: 'toggle_card.action.editPaymentInfo'
             })}
         >
+            <Box display={step === STEPS.PAYMENT ? 'block' : 'none'}>
+                <Box ref={containerElementRef} />
+            </Box>
+            
             <ToggleCardEdit>
                 <Box mt={-2} mb={4}>
                     <PromoCode {...promoCodeProps} itemProps={{border: 'none'}} />
                 </Box>
 
                 <Stack spacing={6}>
-                    <Box ref={containerElementRef} />
 
                     <Divider borderColor="gray.100" />
 

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -362,6 +362,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 country: 'US', // TODO: see W-18812582
                 locale: intl.locale
             }
+
             // Clear the container and create a new div element
             containerElementRef.current.innerHTML = ''
             const paymentElement = document.createElement('div')
@@ -380,7 +381,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 paymentElement
             )
         }
-        
+
         // Cleanup on unmount
         return () => {
             checkoutComponent.current?.destroy()
@@ -389,7 +390,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     }, [sfp, metadata, containerElementRef.current, paymentConfig, cardCaptureAutomatic])
 
     useEffect(() => {
-        if (checkoutComponent.current !== null && basket?.orderTotal !== null) {
+        if (checkoutComponent.current != null && basket?.orderTotal !== undefined) {
             checkoutComponent.current.updateAmount(basket.orderTotal)
         }
     }, [basket?.orderTotal])
@@ -410,14 +411,12 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             <Box display={step === STEPS.PAYMENT ? 'block' : 'none'}>
                 <Box ref={containerElementRef} />
             </Box>
-            
             <ToggleCardEdit>
                 <Box mt={-2} mb={4}>
                     <PromoCode {...promoCodeProps} itemProps={{border: 'none'}} />
                 </Box>
 
                 <Stack spacing={6}>
-
                     <Divider borderColor="gray.100" />
 
                     <Stack spacing={2}>

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -115,6 +115,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     const containerElementRef = useRef(null)
     const config = useRef(null)
     const checkoutComponent = useRef(null)
+    const checkoutInitialized = useRef(false)
     const paymentMethodType = useRef(null)
     const currentBasket = useRef(null)
 
@@ -339,7 +340,13 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     }))
 
     useEffect(() => {
-        if (sfp && metadata && containerElementRef.current && paymentConfig) {
+        if (
+            !checkoutInitialized.current &&
+            sfp &&
+            metadata &&
+            containerElementRef.current &&
+            paymentConfig
+        ) {
             const paymentMethodSet = {
                 paymentMethods: paymentConfig.paymentMethods,
                 paymentMethodSetAccounts: paymentConfig.paymentMethodSetAccounts
@@ -380,14 +387,32 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 paymentRequest,
                 paymentElement
             )
+            checkoutInitialized.current = true
+
+            if (basket?.orderTotal !== undefined && basket?.orderTotal !== null && typeof basket?.orderTotal === 'number') {
+                void checkoutComponent.current.updateAmount(basket.orderTotal)
+            }
         }
 
-        // Cleanup on unmount
         return () => {
-            checkoutComponent.current?.destroy()
-            checkoutComponent.current = null
+            if (checkoutComponent.current && !containerElementRef.current) {
+                checkoutComponent.current.destroy()
+                checkoutComponent.current = null
+                checkoutInitialized.current = false
+            }
         }
-    }, [sfp, metadata, containerElementRef.current, paymentConfig, cardCaptureAutomatic])
+    }, [sfp, metadata, paymentConfig])
+
+    useEffect(() => {
+        const hasComponent = !!checkoutComponent.current
+        const orderTotal = basket?.orderTotal
+        const hasOrderTotal = orderTotal !== undefined && orderTotal !== null && typeof orderTotal === 'number'
+        const isInitialized = checkoutInitialized.current
+        
+        if (hasComponent && hasOrderTotal && isInitialized) {
+            void checkoutComponent.current.updateAmount(orderTotal)
+        }
+    }, [basket?.orderTotal, basket])
 
     return (
         <ToggleCard

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -362,10 +362,11 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 country: 'US', // TODO: see W-18812582
                 locale: intl.locale
             }
-
+            // Clear the container and create a new div element
             containerElementRef.current.innerHTML = ''
             const paymentElement = document.createElement('div')
             containerElementRef.current.appendChild(paymentElement)
+
             paymentElement.addEventListener('load', handlePaymentMethodSelected)
             paymentElement.addEventListener('paymentMethodSelected', handlePaymentMethodSelected)
             paymentElement.addEventListener('sfppaymentbuttonapprove', handlePaymentButtonApprove)
@@ -379,6 +380,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 paymentElement
             )
         }
+        
         // Cleanup on unmount
         return () => {
             checkoutComponent.current?.destroy()

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -115,7 +115,6 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
     const containerElementRef = useRef(null)
     const config = useRef(null)
     const checkoutComponent = useRef(null)
-    const checkoutInitialized = useRef(false)
     const paymentMethodType = useRef(null)
     const currentBasket = useRef(null)
 
@@ -341,7 +340,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
 
     useEffect(() => {
         if (
-            !checkoutInitialized.current &&
+            !checkoutComponent.current &&
             sfp &&
             metadata &&
             containerElementRef.current &&
@@ -387,32 +386,21 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 paymentRequest,
                 paymentElement
             )
-            checkoutInitialized.current = true
-
-            if (basket?.orderTotal !== undefined && basket?.orderTotal !== null && typeof basket?.orderTotal === 'number') {
-                void checkoutComponent.current.updateAmount(basket.orderTotal)
-            }
         }
         // Cleanup on unmount
         return () => {
             if (checkoutComponent.current && !containerElementRef.current) {
                 checkoutComponent.current.destroy()
                 checkoutComponent.current = null
-                checkoutInitialized.current = false
             }
         }
     }, [sfp, metadata, paymentConfig, cardCaptureAutomatic])
 
     useEffect(() => {
-        const hasComponent = !!checkoutComponent.current
-        const orderTotal = basket?.orderTotal
-        const hasOrderTotal = orderTotal !== undefined && orderTotal !== null && typeof orderTotal === 'number'
-        const isInitialized = checkoutInitialized.current
-        
-        if (hasComponent && hasOrderTotal && isInitialized) {
-            void checkoutComponent.current.updateAmount(orderTotal)
+        if (checkoutComponent.current && basket?.orderTotal != null) {
+            checkoutComponent.current.updateAmount(basket.orderTotal)
         }
-    }, [basket?.orderTotal, basket])
+    }, [basket?.orderTotal])
 
     return (
         <ToggleCard

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -393,7 +393,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 void checkoutComponent.current.updateAmount(basket.orderTotal)
             }
         }
-
+        // Cleanup on unmount
         return () => {
             if (checkoutComponent.current && !containerElementRef.current) {
                 checkoutComponent.current.destroy()
@@ -401,7 +401,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 checkoutInitialized.current = false
             }
         }
-    }, [sfp, metadata, paymentConfig])
+    }, [sfp, metadata, paymentConfig, cardCaptureAutomatic])
 
     useEffect(() => {
         const hasComponent = !!checkoutComponent.current

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.test.js
@@ -149,6 +149,7 @@ const mockStartConfirming = jest.fn()
 const mockEndConfirming = jest.fn()
 const mockCheckoutConfirm = jest.fn()
 const mockCheckoutDestroy = jest.fn()
+const mockUpdateAmount = jest.fn()
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-sf-payments', () => {
     const actual = jest.requireActual('@salesforce/retail-react-app/app/hooks/use-sf-payments')
@@ -158,7 +159,8 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-sf-payments', () => {
             sfp: {
                 checkout: jest.fn(() => ({
                     confirm: mockCheckoutConfirm,
-                    destroy: mockCheckoutDestroy
+                    destroy: mockCheckoutDestroy,
+                    updateAmount: mockUpdateAmount
                 }))
             },
             metadata: {key: 'value'},
@@ -195,15 +197,16 @@ jest.mock('@salesforce/retail-react-app/app/components/address-display', () => {
 })
 
 jest.mock('@salesforce/retail-react-app/app/components/toggle-card', () => {
-    const ToggleCard = ({children, title}) => (
-        <div data-testid="toggle-card">
+    const ToggleCard = ({children, title, editing}) => (
+        <div data-testid="toggle-card" data-editing={editing ? 'true' : 'false'}>
             <h2>{title}</h2>
             {children}
         </div>
     )
     ToggleCard.propTypes = {
         children: () => null,
-        title: () => null
+        title: () => null,
+        editing: () => null
     }
 
     const ToggleCardEdit = ({children}) => <div data-testid="toggle-card-edit">{children}</div>
@@ -706,6 +709,172 @@ describe('SFPaymentsSheet', () => {
             expect(screen.getByTestId('toggle-card')).toBeInTheDocument()
             expect(mockOnRequiresPayButtonChange).toBeDefined()
             expect(mockOnRequiresPayButtonChange).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('container element persistence', () => {
+        test('payment container is rendered outside ToggleCardEdit to prevent unmounting', () => {
+            renderWithCheckoutContext(
+                <SFPaymentsSheet
+                    ref={mockRef}
+                    onCreateOrder={mockOnCreateOrder}
+                    onError={mockOnError}
+                />
+            )
+
+            const toggleCard = screen.getByTestId('toggle-card')
+
+            expect(toggleCard).toBeInTheDocument()
+            expect(toggleCard).toBeInTheDocument()
+        })
+    })
+
+    describe('updateAmount', () => {
+        beforeEach(() => {
+            mockUpdateAmount.mockClear()
+        })
+
+        test('calls updateAmount when basket orderTotal changes', async () => {
+            const initialBasket = {
+                ...mockBasket,
+                orderTotal: 100.0
+            }
+
+            mockUseCurrentBasket.mockImplementation(() => ({
+                data: initialBasket,
+                derivedData: {
+                    totalItems: 2,
+                    isMissingShippingAddress: false,
+                    isMissingShippingMethod: false,
+                    totalDeliveryShipments: 1,
+                    totalPickupShipments: 0
+                },
+                isLoading: false
+            }))
+
+            const {rerender} = renderWithCheckoutContext(
+                <SFPaymentsSheet
+                    ref={mockRef}
+                    onCreateOrder={mockOnCreateOrder}
+                    onError={mockOnError}
+                />
+            )
+
+            await waitFor(() => {
+                expect(screen.getByTestId('toggle-card')).toBeInTheDocument()
+            })
+
+            await waitFor(
+                () => {
+                    expect(mockUpdateAmount).toHaveBeenCalledWith(100.0)
+                },
+                {timeout: 2000}
+            )
+
+            mockUpdateAmount.mockClear()
+
+            const updatedBasket = {
+                ...initialBasket,
+                orderTotal: 150.0
+            }
+
+            mockUseCurrentBasket.mockImplementation(() => ({
+                data: updatedBasket,
+                derivedData: {
+                    totalItems: 2,
+                    isMissingShippingAddress: false,
+                    isMissingShippingMethod: false,
+                    totalDeliveryShipments: 1,
+                    totalPickupShipments: 0
+                },
+                isLoading: false
+            }))
+
+            rerender(
+                <CheckoutProvider>
+                    <SFPaymentsSheet
+                        ref={mockRef}
+                        onCreateOrder={mockOnCreateOrder}
+                        onError={mockOnError}
+                    />
+                </CheckoutProvider>
+            )
+
+            await waitFor(
+                () => {
+                    expect(mockUpdateAmount).toHaveBeenCalledWith(150.0)
+                },
+                {timeout: 2000}
+            )
+        })
+
+        test('does not call updateAmount when orderTotal is undefined', async () => {
+            const basketWithoutOrderTotal = {
+                ...mockBasket,
+                orderTotal: undefined
+            }
+
+            mockUseCurrentBasket.mockImplementation(() => ({
+                data: basketWithoutOrderTotal,
+                derivedData: {
+                    totalItems: 2,
+                    isMissingShippingAddress: false,
+                    isMissingShippingMethod: false,
+                    totalDeliveryShipments: 1,
+                    totalPickupShipments: 0
+                },
+                isLoading: false
+            }))
+
+            renderWithCheckoutContext(
+                <SFPaymentsSheet
+                    ref={mockRef}
+                    onCreateOrder={mockOnCreateOrder}
+                    onError={mockOnError}
+                />
+            )
+
+            await waitFor(() => {
+                expect(screen.getByTestId('toggle-card')).toBeInTheDocument()
+            })
+
+            await new Promise((resolve) => setTimeout(resolve, 100))
+
+            expect(mockUpdateAmount).not.toHaveBeenCalled()
+        })
+
+        test('calls updateAmount with correct orderTotal value on initial render', async () => {
+            const basketWithOrderTotal = {
+                ...mockBasket,
+                orderTotal: 250.75
+            }
+
+            mockUseCurrentBasket.mockImplementation(() => ({
+                data: basketWithOrderTotal,
+                derivedData: {
+                    totalItems: 2,
+                    isMissingShippingAddress: false,
+                    isMissingShippingMethod: false,
+                    totalDeliveryShipments: 1,
+                    totalPickupShipments: 0
+                },
+                isLoading: false
+            }))
+
+            renderWithCheckoutContext(
+                <SFPaymentsSheet
+                    ref={mockRef}
+                    onCreateOrder={mockOnCreateOrder}
+                    onError={mockOnError}
+                />
+            )
+
+            await waitFor(
+                () => {
+                    expect(mockUpdateAmount).toHaveBeenCalledWith(250.75)
+                },
+                {timeout: 2000}
+            )
         })
     })
 })


### PR DESCRIPTION
Call SDK updateAmount function when payment sheet component detects update to basket amount.

# Description

Payment sheet used to re-render when it detected any changes to Order Total (For example: Change in Shipping method). This used to destroy the checkout component Ref and re initialize it. This'll cause issues when dealing with Stripe payment, when it loses existing Ref. 
Fix:
- Added a checkoutInitialized ref guard to ensure sfp.checkout() is only called once, even when dependencies change or the component re-renders
- Added a separate useEffect that watches basket?.orderTotal and calls checkoutComponent.current.updateAmount() when the basket total changes (e.g., when shipping method is updated)
- Modified the cleanup function to only destroy the payment sheet when the component is actually unmounting (checked via !containerElementRef.current), preventing destroying during re-renders.

Test cases:
<img width="894" height="462" alt="Screenshot 2025-12-10 at 1 05 06 PM" src="https://github.com/user-attachments/assets/34b86b01-d2f9-437a-aef1-3cecbb4418c1" />

Lint run
```
npm run lint -- app/pages/checkout/partials/sf-payments-sheet.jsx app/pages/checkout/partials/sf-payments-sheet.test.js
npm warn Unknown user config "always-auth" (//nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/:always-auth). This will stop working in the next major version of npm.
npm warn Unknown user config "always-auth" (//nexus-proxy.repo.local.sfdc.net/nexus/content/repositories/npmjs-internal/:always-auth). This will stop working in the next major version of npm.
npm warn Unknown user config "always-auth". This will stop working in the next major version of npm.
npm warn Unknown user config "email". This will stop working in the next major version of npm.

> @salesforce/retail-react-app@8.2.0-dev lint
> pwa-kit-dev lint "**/*.{js,jsx}" app/pages/checkout/partials/sf-payments-sheet.jsx app/pages/checkout/partials/sf-payments-sheet.test.js


/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/components/passwordless-login/index.jsx
  23:5  warning  'setLoginType' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
    8:9   warning  'useLocation' is defined but never used        @typescript-eslint/no-unused-vars
  160:20  warning  'buildUrl' is assigned a value but never used  @typescript-eslint/no-unused-vars

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/hooks/use-auth-modal.test.js
  146:1  warning  Disabled test  jest/no-disabled-tests

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/hooks/use-miaw.test.js
  8:8  warning  'React' is defined but never used  @typescript-eslint/no-unused-vars

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/pages/cart/index.jsx
  133:9   warning  'findOrCreateDeliveryShipment' is assigned a value but never used  @typescript-eslint/no-unused-vars
  880:11  warning  'allQualifyingProducts' is assigned a value but never used         @typescript-eslint/no-unused-vars

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/pages/cart/index.test.js
  331:1  warning  Disabled test suite  jest/no-disabled-tests

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/pages/cart/partials/select-bonus-products-card.test.jsx
  114:1  warning  Disabled test suite  jest/no-disabled-tests

/Users/rvishwanathbhat/dev/git-repos/pwa-kit/packages/template-retail-react-app/app/pages/checkout/confirmation.test.js
  9:26  warning  'within' is defined but never used  @typescript-eslint/no-unused-vars

✖ 10 problems (0 errors, 10 warnings)

```
# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- Got to checkout page, fill out necessary shipping details
- Change the shipping method of the order again
- The order amount should change on the checkout page without the payment sheet being re-rendered.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
