### PR TITLE
@W-20217010: Remove default checkbox for address form

### DIFF
--- a/packages/template-retail-react-app/app/components/forms/address-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/address-fields.jsx
@@ -28,7 +28,8 @@ const AddressFields = ({
     prefix = '',
     formTitleAriaLabel = defaultFormTitleAriaLabel,
     isBillingAddress = false,
-    hidePhone = false
+    hidePhone = false,
+    hidePreferred = false
 }) => {
     const {data: customer} = useCurrentCustomer()
     const fields = useAddressFields({form, prefix})
@@ -62,7 +63,9 @@ const AddressFields = ({
                     <Field {...fields.postalCode} />
                 </GridItem>
             </Grid>
-            {customer.isRegistered && !isBillingAddress && <Field {...fields.preferred} />}
+            {customer.isRegistered && !isBillingAddress && !hidePreferred && (
+                <Field {...fields.preferred} />
+            )}
         </Stack>
     )
 }
@@ -81,7 +84,10 @@ AddressFields.propTypes = {
     isBillingAddress: PropTypes.bool,
 
     /** Optional flag to hide the phone field */
-    hidePhone: PropTypes.bool
+    hidePhone: PropTypes.bool,
+
+    /** Optional flag to hide the preferred/default checkbox */
+    hidePreferred: PropTypes.bool
 }
 
 export default AddressFields

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection.jsx
@@ -71,6 +71,7 @@ const ShippingAddressEditForm = ({
                         formTitleAriaLabel={formTitleAriaLabel}
                         isBillingAddress={isBillingAddress}
                         hidePhone={hidePhone}
+                        hidePreferred={true}
                     />
 
                     {hasSavedAddresses && !hideSubmitButton ? (
@@ -175,17 +176,6 @@ const ShippingAddressSelection = ({
             }
         }
     }, [])
-
-    // After guest OTP success (customer becomes registered), default the address as preferred
-    useEffect(() => {
-        if (!isBillingAddress && customer?.isRegistered) {
-            try {
-                form.setValue('preferred', true, {shouldValidate: false, shouldDirty: true})
-            } catch (_e) {
-                // ignore
-            }
-        }
-    }, [customer?.isRegistered])
 
     useEffect(() => {
         // If the customer deletes all their saved addresses during checkout,
@@ -357,7 +347,7 @@ const ShippingAddressSelection = ({
                                                 </RadioCard>
                                                 {isEditingAddress &&
                                                     address.addressId === selectedAddressId && (
-                                                            <ShippingAddressEditForm
+                                                        <ShippingAddressEditForm
                                                             title={formatMessage({
                                                                 defaultMessage:
                                                                     'Edit Shipping Address',
@@ -367,7 +357,8 @@ const ShippingAddressSelection = ({
                                                             toggleAddressEdit={toggleAddressEdit}
                                                             hideSubmitButton={hideSubmitButton}
                                                             form={form}
-                                                                hidePhone={!isBillingAddress}
+                                                            hidePhone={!isBillingAddress}
+                                                            hidePreferred={true}
                                                             submitButtonLabel={submitButtonLabel}
                                                             formTitleAriaLabel={formTitleAriaLabel}
                                                         />
@@ -427,6 +418,7 @@ const ShippingAddressSelection = ({
                         form={form}
                         isBillingAddress={isBillingAddress}
                         hidePhone={!isBillingAddress}
+                        hidePreferred={true}
                         submitButtonLabel={submitButtonLabel}
                         formTitleAriaLabel={formTitleAriaLabel}
                     />

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection.test.js
@@ -82,4 +82,53 @@ describe('ShippingAddressSelection Component', () => {
             expect(screen.queryByTestId('error')).not.toBeInTheDocument()
         })
     })
+
+    describe('Preferred Address Checkbox', () => {
+        test('does not show "Set as default" checkbox for registered customers in checkout', () => {
+            useCurrentCustomer.mockReturnValue({
+                data: {
+                    customerId: 'test-customer-id',
+                    isRegistered: true,
+                    addresses: []
+                },
+                isLoading: false,
+                isFetching: false
+            })
+
+            render(<ShippingAddressSelection />)
+
+            // The "Set as default" checkbox should not be present in checkout
+            expect(screen.queryByText('Set as default')).not.toBeInTheDocument()
+            expect(screen.queryByLabelText('Set as default')).not.toBeInTheDocument()
+        })
+
+        test('does not show "Set as default" checkbox for registered customers with saved addresses', () => {
+            useCurrentCustomer.mockReturnValue({
+                data: {
+                    customerId: 'test-customer-id',
+                    isRegistered: true,
+                    addresses: [
+                        {
+                            addressId: 'addr-1',
+                            address1: '123 Main St',
+                            city: 'Test City',
+                            countryCode: 'US',
+                            firstName: 'John',
+                            lastName: 'Doe',
+                            postalCode: '12345',
+                            stateCode: 'CA'
+                        }
+                    ]
+                },
+                isLoading: false,
+                isFetching: false
+            })
+
+            render(<ShippingAddressSelection />)
+
+            // The "Set as default" checkbox should not be present in checkout
+            expect(screen.queryByText('Set as default')).not.toBeInTheDocument()
+            expect(screen.queryByLabelText('Set as default')).not.toBeInTheDocument()
+        })
+    })
 })


### PR DESCRIPTION
Remove `Set as default` checkbox for address forms in 1CC layout

# Description

Remove `Set as default` checkbox for address forms in 1CC layout, both for adding/editing shipping addresses as well editing billing address.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

Remove `Set as default` checkbox for address forms in 1CC layout, both for adding/editing shipping addresses as well editing billing address.

<img width="848" height="800" alt="Screenshot 2025-11-19 at 7 34 54 PM" src="https://github.com/user-attachments/assets/99858003-16cc-436d-ab04-1f73a49750bc" />
<img width="788" height="785" alt="Screenshot 2025-11-19 at 7 35 02 PM" src="https://github.com/user-attachments/assets/d41c6581-e6d2-4ccb-ba3e-1f635ab0b68b" />
<img width="759" height="649" alt="Screenshot 2025-11-19 at 7 35 10 PM" src="https://github.com/user-attachments/assets/62ee0f98-847b-41b9-80bf-38afa1d7c61c" />


# How to Test-Drive This PR

Follow returning shopper flow in 1CC. Try add/edit new shipping address and edit billing address.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
