### PR TITLE
@W-20398991 - Forgot Password link not working from Account Profile password update form

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v8.3.0-dev (Nov 05, 2025)
-- [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3487](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3487)
+- [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3493](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3493)
 
 ## v8.2.0 (Nov 04, 2025)
 - Add support for Rule Based Promotions for Choice of Bonus Products. We are currently supporting only one product level rule based promotion per product [#3418](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3418)

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v8.3.0-dev (Nov 05, 2025)
+- [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3487](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3487)
 
 ## v8.2.0 (Nov 04, 2025)
 - Add support for Rule Based Promotions for Choice of Bonus Products. We are currently supporting only one product level rule based promotion per product [#3418](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3418)

--- a/packages/template-retail-react-app/app/components/forms/update-password-fields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/update-password-fields.jsx
@@ -17,7 +17,7 @@ import useUpdatePasswordFields from '@salesforce/retail-react-app/app/components
 import Field from '@salesforce/retail-react-app/app/components/field'
 import PasswordRequirements from '@salesforce/retail-react-app/app/components/forms/password-requirements'
 
-const UpdatePasswordFields = ({form, prefix = ''}) => {
+const UpdatePasswordFields = ({form, prefix = '', handleForgotPasswordClick}) => {
     const fields = useUpdatePasswordFields({form, prefix})
     const password = form.watch('password')
 
@@ -25,14 +25,16 @@ const UpdatePasswordFields = ({form, prefix = ''}) => {
         <Stack spacing={5} divider={<StackDivider borderColor="gray.100" />}>
             <Stack>
                 <Field {...fields.currentPassword} />
-                <Box>
-                    <Button variant="link" size="sm" onClick={() => null}>
-                        <FormattedMessage
-                            defaultMessage="Forgot Password?"
-                            id="update_password_fields.button.forgot_password"
-                        />
-                    </Button>
-                </Box>
+                {handleForgotPasswordClick && (
+                    <Box>
+                        <Button variant="link" size="sm" onClick={handleForgotPasswordClick}>
+                            <FormattedMessage
+                                defaultMessage="Forgot Password?"
+                                id="update_password_fields.button.forgot_password"
+                            />
+                        </Button>
+                    </Box>
+                )}
             </Stack>
 
             <Stack spacing={3} pb={2}>
@@ -45,6 +47,7 @@ const UpdatePasswordFields = ({form, prefix = ''}) => {
 }
 
 UpdatePasswordFields.propTypes = {
+    handleForgotPasswordClick: PropTypes.func,
     /** Object returned from `useForm` */
     form: PropTypes.object.isRequired,
 

--- a/packages/template-retail-react-app/app/components/forms/update-password-fields.test.js
+++ b/packages/template-retail-react-app/app/components/forms/update-password-fields.test.js
@@ -58,4 +58,32 @@ describe('UpdatePasswordFields component', () => {
         expect(screen.getByText('Passwords do not match.')).toBeInTheDocument()
         expect(onSubmit).not.toHaveBeenCalled()
     })
+
+    test('does not render "Forgot Password?" button when handleForgotPasswordClick is not provided', () => {
+        renderWithProviders(<WrapperComponent />)
+
+        expect(screen.queryByText(/forgot password/i)).not.toBeInTheDocument()
+    })
+
+    test('renders "Forgot Password?" button when handleForgotPasswordClick is provided', () => {
+        const handleForgotPasswordClick = jest.fn()
+        renderWithProviders(
+            <WrapperComponent handleForgotPasswordClick={handleForgotPasswordClick} />
+        )
+
+        const forgotPasswordButton = screen.getByText(/forgot password/i)
+        expect(forgotPasswordButton).toBeInTheDocument()
+    })
+
+    test('calls handleForgotPasswordClick when "Forgot Password?" button is clicked', async () => {
+        const handleForgotPasswordClick = jest.fn()
+        const {user} = renderWithProviders(
+            <WrapperComponent handleForgotPasswordClick={handleForgotPasswordClick} />
+        )
+
+        const forgotPasswordButton = screen.getByText(/forgot password/i)
+        await user.click(forgotPasswordButton)
+
+        expect(handleForgotPasswordClick).toHaveBeenCalledTimes(1)
+    })
 })

--- a/packages/template-retail-react-app/app/pages/account/index.jsx
+++ b/packages/template-retail-react-app/app/pages/account/index.jsx
@@ -230,7 +230,9 @@ const Account = () => {
 
                 <Switch>
                     <Route exact path={path}>
-                        <AccountDetail />
+                        <AccountDetail
+                            handleForgotPasswordClick={() => navigate('/reset-password')}
+                        />
                     </Route>
                     <Route exact path={`${path}/wishlist`}>
                         <AccountWishlist />

--- a/packages/template-retail-react-app/app/pages/account/index.test.js
+++ b/packages/template-retail-react-app/app/pages/account/index.test.js
@@ -257,4 +257,26 @@ describe('updating password', function () {
 
         expect(await screen.findByTestId('password-update-error')).toBeInTheDocument()
     })
+
+    test('navigates to reset-password page when "Forgot Password?" is clicked', async () => {
+        useCustomerType.mockReturnValue({isRegistered: true, isExternal: false})
+        const {user} = renderWithProviders(<MockedComponent />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+
+        expect(await screen.findByTestId('account-page')).toBeInTheDocument()
+        expect(await screen.findByTestId('account-detail-page')).toBeInTheDocument()
+
+        const el = within(screen.getByTestId('sf-toggle-card-password'))
+        await user.click(el.getByText(/edit/i))
+
+        const forgotPasswordButton = el.getByText(/forgot password/i)
+        expect(forgotPasswordButton).toBeInTheDocument()
+
+        await user.click(forgotPasswordButton)
+
+        await waitFor(() => {
+            expect(window.location.pathname).toBe(`${expectedBasePath}/reset-password`)
+        })
+    })
 })

--- a/packages/template-retail-react-app/app/pages/account/index.test.js
+++ b/packages/template-retail-react-app/app/pages/account/index.test.js
@@ -220,7 +220,6 @@ describe('updating password', function () {
         expect(el.getByText(/forgot password/i)).toBeInTheDocument()
     })
 
-    // TODO: Fix test
     test('Allows customer to update password', async () => {
         global.server.use(
             rest.put('*/password', (req, res, ctx) => res(ctx.status(204), ctx.json()))
@@ -233,10 +232,11 @@ describe('updating password', function () {
         await user.type(el.getByLabelText(/current password/i), 'Password!12345')
         await user.type(el.getByLabelText('New Password'), 'Password!98765')
         await user.type(el.getByLabelText('Confirm New Password'), 'Password!98765')
-        await user.click(el.getByText(/Forgot password/i))
         await user.click(el.getByText(/save/i))
-
-        expect(el.getByTestId('sf-toggle-card-password-content')).toBeInTheDocument()
+        // Wait for form submission to complete and edit mode to close
+        await waitFor(() => {
+            expect(el.getByTestId('sf-toggle-card-password-content')).toBeInTheDocument()
+        })
     })
 
     test('Warns customer when updating password with invalid current password', async () => {

--- a/packages/template-retail-react-app/app/pages/account/profile.jsx
+++ b/packages/template-retail-react-app/app/pages/account/profile.jsx
@@ -235,7 +235,7 @@ ProfileCard.propTypes = {
     allowPasswordChange: PropTypes.bool
 }
 
-const PasswordCard = () => {
+const PasswordCard = ({handleForgotPasswordClick}) => {
     const {formatMessage} = useIntl()
     const headingRef = useRef(null)
     const {data: customer} = useCurrentCustomer()
@@ -300,7 +300,10 @@ const PasswordCard = () => {
                                     </Text>
                                 </Alert>
                             )}
-                            <UpdatePasswordFields form={form} />
+                            <UpdatePasswordFields
+                                form={form}
+                                handleForgotPasswordClick={handleForgotPasswordClick}
+                            />
                             <FormActionButtons
                                 onCancel={() => {
                                     setIsEditing(false)
@@ -336,7 +339,11 @@ const PasswordCard = () => {
     )
 }
 
-const AccountDetail = () => {
+PasswordCard.propTypes = {
+    handleForgotPasswordClick: PropTypes.func
+}
+
+const AccountDetail = ({handleForgotPasswordClick}) => {
     const headingRef = useRef()
     useEffect(() => {
         // Focus the 'Account Details' header when the component mounts for accessibility
@@ -356,10 +363,16 @@ const AccountDetail = () => {
 
             <Stack spacing={4}>
                 <ProfileCard allowPasswordChange={!isExternal} />
-                {!isExternal && <PasswordCard />}
+                {!isExternal && (
+                    <PasswordCard handleForgotPasswordClick={handleForgotPasswordClick} />
+                )}
             </Stack>
         </Stack>
     )
+}
+
+AccountDetail.propTypes = {
+    handleForgotPasswordClick: PropTypes.func
 }
 
 AccountDetail.getTemplateName = () => 'account-detail'

--- a/packages/template-retail-react-app/app/pages/account/profile.test.js
+++ b/packages/template-retail-react-app/app/pages/account/profile.test.js
@@ -115,3 +115,47 @@ test('Non ECOM user cannot see the password card', async () => {
 
     expect(screen.queryByText(/Password/i)).not.toBeInTheDocument()
 })
+
+describe('AccountDetail component', () => {
+    test('passes handleForgotPasswordClick prop to PasswordCard when provided', async () => {
+        sdk.useCustomerType.mockReturnValue({isRegistered: true, isExternal: false})
+        const handleForgotPasswordClick = jest.fn()
+
+        const {user} = renderWithProviders(
+            <AccountDetail handleForgotPasswordClick={handleForgotPasswordClick} />,
+            {
+                wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+            }
+        )
+
+        await waitFor(() => {
+            expect(screen.getByText(/Account Details/i)).toBeInTheDocument()
+        })
+
+        const passwordCard = screen.getByTestId('sf-toggle-card-password')
+        await user.click(within(passwordCard).getByText(/edit/i))
+
+        const forgotPasswordButton = screen.getByText(/forgot password/i)
+        expect(forgotPasswordButton).toBeInTheDocument()
+
+        await user.click(forgotPasswordButton)
+        expect(handleForgotPasswordClick).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not show "Forgot Password?" button when handleForgotPasswordClick is not provided', async () => {
+        sdk.useCustomerType.mockReturnValue({isRegistered: true, isExternal: false})
+
+        const {user} = renderWithProviders(<AccountDetail />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+
+        await waitFor(() => {
+            expect(screen.getByText(/Account Details/i)).toBeInTheDocument()
+        })
+
+        const passwordCard = screen.getByTestId('sf-toggle-card-password')
+        await user.click(within(passwordCard).getByText(/edit/i))
+
+        expect(screen.queryByText(/forgot password/i)).not.toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
fix(account): Correct "Forgot Password" link behavior

The link within the `UpdatePasswordFields` component, which is intended to navigate to `/reset-password`, was not working when accessed from the main Account Profile page (`/account`).

This change ensures that clicking the link allowing the user to navigate to the password reset flow as expected.

Fixes #3486 

https://github.com/user-attachments/assets/5d712cd8-edf7-4c5f-8572-7816c34a52b6

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [x] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

**Files involved:**
- `packages/template-retail-react-app/app/pages/account/index.jsx` (line 234 - passes `handleForgotPasswordClick` prop)
- `packages/template-retail-react-app/app/pages/account/profile.jsx` (line 367 - receives and passes prop to `PasswordCard`)
- `packages/template-retail-react-app/app/components/forms/update-password-fields.jsx` (line 34 - button with onClick handler)

**Code reference:**
The `handleForgotPasswordClick` prop is defined in `app/pages/account/index.jsx`:avascript
```
<AccountDetail 
    handleForgotPasswordClick={() => navigate('/reset-password')}
/>
```
And is used in `app/components/forms/update-password-fields.jsx`:script
```
<Button variant="link" size="sm" onClick={handleForgotPasswordClick}>
    <FormattedMessage
        defaultMessage="Forgot Password?"
        id="update_password_fields.button.forgot_password"
    />
</Button>
```

**Note:** The same pattern works correctly on the login page (`/login`), where the "Forgot password?" link successfully navigates to `/reset-password`. This suggests the issue may be specific to the account profile context or form submission interference.

# How to Test-Drive This PR

https://github.com/user-attachments/assets/2eca8a2e-93c0-472d-9756-a6c269bad9d9

Sandbox Deployment: https://cc-pulse-giri-testing-space.sfdc-3vx9f4-commerceecom.exp-delivery-staging.com/
1. Log in to the application
2. Navigate to the Account page (`/account`)
3. Click to edit the Password section
4. In the password update form, click the "Forgot Password?" link below the "Current Password" field
5. Observe that the navigation to `/reset-password` will work now.


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
