### PR TITLE
fix(a11y): Improve color swatch text contrast for WCAG 2 AA compliance

### DIFF
--- a/packages/template-retail-react-app/app/theme/components/project/swatch-group.js
+++ b/packages/template-retail-react-app/app/theme/components/project/swatch-group.js
@@ -41,7 +41,7 @@ export default {
                 marginRight: 2,
                 marginLeft: 0,
                 marginBottom: 2,
-                color: `${props.selected ? 'black' : 'gray.200'}`,
+                color: `${props.selected ? 'black' : 'gray.600'}`,
                 border: `${props.selected ? '1px' : '0'}`,
                 _hover: {
                     borderColor: `${props.selected ? 'black' : 'gray.200'}`,


### PR DESCRIPTION
## Summary
- Fix color contrast accessibility violation on Product Detail Page (PDP)
- Change unselected color swatch text color from `gray.200` (#C9C9C9) to `gray.600` to meet WCAG 2 AA minimum contrast ratio of 4.5:1 against white backgrounds
- Resolves failing `test_e2e_private_client` CI job for a11y snapshot test

## Test plan
- [ ] Run e2e accessibility tests locally: `npx playwright test e2e/tests/a11y/desktop/a11y-snapshot-test-guest.spec.js`
- [ ] Verify color swatch labels are readable on PDP
- [ ] Confirm CI `test_e2e_private_client` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)