### PR TITLE
@W-20313656: Ref App endpoint to support streaming testing

### DIFF
--- a/packages/template-mrt-reference-app/app/ssr.js
+++ b/packages/template-mrt-reference-app/app/ssr.js
@@ -381,6 +381,7 @@ const {handler, app, server} = runtime.createHandler(options, (app) => {
     // before we invoke the handlers)
     app.use((req, res, next) => {
         res.set('Cache-Control', 'no-cache')
+        res.set('Server', 'mrt ref app')
         return next()
     })
 

--- a/packages/template-mrt-reference-app/app/ssr.js
+++ b/packages/template-mrt-reference-app/app/ssr.js
@@ -226,6 +226,14 @@ const ssrShared = async (req, res) => {
 }
 
 /**
+ * Express handler that returns a non-streaming response.
+ */
+const streamingLarge = (req, res) => {
+    res.status(200)
+    res.json({streaming: false})
+}
+
+/**
  * Express handler that allocates a lot of memory, and then removes
  * a reference to the objects, such that they may be garbage collected.
  */
@@ -390,6 +398,7 @@ const {handler, app, server} = runtime.createHandler(options, (app) => {
     app.get('/isolation', isolationTests)
     app.get('/set-response-headers', responseHeadersTest)
     app.get('/ssr-shared', ssrShared)
+    app.get('/streaming-large', streamingLarge)
 
     // Add a /auth/logout path that will always send a 401 (to allow clearing
     // of browser credentials)

--- a/packages/template-mrt-reference-app/app/ssr.test.js
+++ b/packages/template-mrt-reference-app/app/ssr.test.js
@@ -61,7 +61,8 @@ describe('server', () => {
         ['/cookie', 200, 'application/json; charset=utf-8'],
         ['/set-response-headers', 200, 'application/json; charset=utf-8'],
         ['/isolation', 200, 'application/json; charset=utf-8'],
-        ['/memtest', 200, 'application/json; charset=utf-8']
+        ['/memtest', 200, 'application/json; charset=utf-8'],
+        ['/streaming-large', 200, 'application/json; charset=utf-8']
     ])('Path %p should render correctly', (path, expectedStatus, expectedContentType) => {
         return request(app)
             .get(path)
@@ -132,5 +133,11 @@ describe('server', () => {
         expect(response.body.message).toBe(
             'This file is used in the E2E tests to verify that correct header values are set.'
         )
+    })
+
+    test('Path "/streaming-large" returns streaming: false', async () => {
+        const response = await request(app).get('/streaming-large')
+        expect(response.status).toBe(200)
+        expect(response.body).toEqual({streaming: false})
     })
 })

--- a/packages/template-mrt-reference-app/app/ssr.test.js
+++ b/packages/template-mrt-reference-app/app/ssr.test.js
@@ -78,6 +78,10 @@ describe('server', () => {
         return request(app).get('/cache/123').expect('Cache-Control', 's-maxage=123')
     })
 
+    test('All responses have Server header set to "mrt ref app"', () => {
+        return request(app).get('/').expect('Server', 'mrt ref app')
+    })
+
     test('Path "/headers" echoes request headers', async () => {
         const response = await request(app).get('/headers').set('Random-Header', 'random')
 


### PR DESCRIPTION
Adding a new endpoint to the ref app. This endpoint is a no-op for non-streaming which allows the streaming test to kick out for non-streaming environments

# Description

`/streaming-large` endpoint returns a `200` and JSON of streaming = false in this case.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- New endpoint

# How to Test-Drive This PR

- Test via related MRT fit tests. 

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
