### PR TITLE
W-19443266: Handle Failure use-cases in the UI

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -49,15 +49,17 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
     updatePaymentInstrumentForOrder: updateOrderQuery,
     removePaymentInstrumentFromOrder: updateOrderQuery,
     failOrder(customerId, {parameters}) {
-        const {orderNo} = parameters
+        // Exclude reopenBasket (not valid for getOrder) and pass only valid parameters
+        // to getOrder.queryKey, while preserving common params like organizationId, siteId
+        const {orderNo, reopenBasket, ...orderParams} = parameters
         const invalidate: CacheUpdateInvalidate[] = [
-            {queryKey: getOrder.queryKey({...parameters, orderNo})}
+            {queryKey: getOrder.queryKey({...orderParams, orderNo})}
         ]
         // If reopenBasket is true, we should also invalidate customer baskets
         // since a new basket may have been created
-        if (parameters.reopenBasket && customerId) {
+        if (reopenBasket && customerId) {
             invalidate.push({
-                queryKey: getCustomerBaskets.queryKey({...parameters, customerId})
+                queryKey: getCustomerBaskets.queryKey({...orderParams, customerId})
             })
         }
         return {invalidate}

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -47,5 +47,19 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
     },
     createPaymentInstrumentForOrder: updateOrderQuery,
     updatePaymentInstrumentForOrder: updateOrderQuery,
-    removePaymentInstrumentFromOrder: updateOrderQuery
+    removePaymentInstrumentFromOrder: updateOrderQuery,
+    failOrder(customerId, {parameters}) {
+        const {orderNo} = parameters
+        const invalidate: CacheUpdateInvalidate[] = [
+            {queryKey: getOrder.queryKey({...parameters, orderNo})}
+        ]
+        // If reopenBasket is true, we should also invalidate customer baskets
+        // since a new basket may have been created
+        if (parameters.reopenBasket && customerId) {
+            invalidate.push({
+                queryKey: getCustomerBaskets.queryKey({...parameters, customerId})
+            })
+        }
+        return {invalidate}
+    }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
@@ -46,7 +46,13 @@ The payment instrument is added with the provided details. The payment method mu
      * Updates a payment instrument of an order.
      * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `updatePaymentInstrumentForOrder` endpoint.
      */
-    UpdatePaymentInstrumentForOrder: 'updatePaymentInstrumentForOrder'
+    UpdatePaymentInstrumentForOrder: 'updatePaymentInstrumentForOrder',
+    /**
+     * Fails an unplaced order and optionally reopens the basket when indicated.
+     * Creates a HistoryEntry in the failed Order with provided reasonCode.
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `failOrder` endpoint.
+     */
+    FailOrder: 'failOrder'
 } as const
 
 /**

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -183,8 +183,6 @@ const SFPaymentsExpressButtons = ({
 
     /**
      * Create order from basket and update payment instrument
-     * TODO: Once Fail Order SCAPI is available, call it to clean up orders when
-     * payment instrument update fails
      */
     const createOrderAndUpdatePayment = async (basketId, paymentType, zoneIdValue) => {
         // Create order from the basket
@@ -217,7 +215,6 @@ const SFPaymentsExpressButtons = ({
             const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
             const errorDetails = error?.response?.data || error?.body || {}
 
-            // TODO: log details of body if needed or change toast message to refer the type of message error?
             logger.error('Failed to patch payment instrument to order', {
                 namespace: 'SFPaymentsExpressButtons.createOrderAndUpdatePayment',
                 additionalProperties: {
@@ -559,14 +556,6 @@ const SFPaymentsExpressButtons = ({
 
                     // For Stripe, create SF Payments basket payment instrument before creating order
                     if (!isPayPalPaymentMethodType(paymentMethodType)) {
-                        /*expressBasket.current = await addPaymentInstrumentToBasket({
-                            parameters: {basketId: updatedBasket.basketId},
-                            body: createPaymentInstrumentBody(
-                                updatedBasket.orderTotal || updatedBasket.productSubTotal, // Use updatedBasket instead of expressBasket.current
-                                paymentMethodType,
-                                zoneId
-                            )
-                        })*/
                         try {
                             expressBasket.current = await addPaymentInstrumentToBasket({
                                 parameters: {basketId: updatedBasket.basketId},
@@ -576,22 +565,12 @@ const SFPaymentsExpressButtons = ({
                                     zoneId
                                 )
                             })
-                            /*expressBasket.current = await addPaymentInstrumentToBasket({
-                                    parameters: {basketId: expressBasket.current.basketId},
-                                    body: createPaymentInstrumentBody(
-                                        expressBasket.current.orderTotal ||
-                                            expressBasket.current.productSubTotal,
-                                        null,
-                                        "default1"
-                                    )
-                                })*/
                         } catch (error) {
                             const statusCode = error?.response?.status || error?.status
                             const errorMessage =
                                 error?.message || error?.response?.data?.message || 'Unknown error'
                             const errorDetails = error?.response?.data || error?.body || {}
 
-                            // TODO: log details of body if needed or change toast message to refer the type of message error?
                             logger.error('Failed to add payment instrument to basket', {
                                 namespace: 'SFPaymentsExpressButtons.onPayerApprove',
                                 additionalProperties: {
@@ -659,7 +638,6 @@ const SFPaymentsExpressButtons = ({
                             error?.message || error?.response?.data?.message || 'Unknown error'
                         const errorDetails = error?.response?.data || error?.body || {}
 
-                        // TODO: log details of body if needed or change toast message to refer the type of message error?
                         logger.error('Failed to add payment instrument to basket', {
                             namespace: 'SFPaymentsExpressButtons.createIntentFunction',
                             additionalProperties: {
@@ -688,7 +666,6 @@ const SFPaymentsExpressButtons = ({
                         )
                         orderNo = order.orderNo
                         updatedPaymentInstrument = getSFPaymentsInstrument(order)
-                        // TODO validate updatedPaymentInstrument paymentRererence values?
                     } catch (error) {
                         // If order was created but updatePaymentInstrumentForOrder failed,
                         // orderNo will be attached to the error
@@ -734,14 +711,8 @@ const SFPaymentsExpressButtons = ({
             // Async function to handle payment error event.  This is called when error event is handled by SF Payments SDK.
             const paymentError = async () => {
                 endConfirming()
-                /*if (orderNo) {
-                    // TODO: fail the order
-                    orderNo = null
-                }*/
                 // if orderNo is present and failOrder has not been called, call failOrder
                 if (orderNo && !failOrderCalledRef.current) {
-                    console.log('paymentError 1')
-                    // TODO:  once payment intent is created BUT confirm fails (Ex: generic declined card), failOrder is not working
                     await failOrder({
                         parameters: {
                             orderNo: orderNo,

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -109,15 +109,44 @@ const SFPaymentsExpressButtons = ({
         }
     )
 
-    const showErrorMessage = (message) => {
+    // Define error message constants at the top of the component
+    const ERROR_MESSAGES = {
+        DEFAULT: {
+            defaultMessage:
+                'Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order.',
+            id: 'sfp_payments_express.error.default'
+        },
+        FAIL_ORDER: {
+            defaultMessage:
+                'Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
+            id: 'sfp_payments_express.error.fail_order'
+        },
+        PREPARE_BASKET: {
+            defaultMessage:
+                'Unable to prepare basket for express payments. Please select all required product attributes.',
+            id: 'sfp_payments_express.error.prepare_basket'
+        },
+        PROCESS_PAYMENT: {
+            defaultMessage:
+                'Unable to process payment. Please try again or select a different payment method.',
+            id: 'sfp_payments_express.error.process_payment'
+        }
+    }
+
+    const showErrorMessage = (messageKey = 'DEFAULT') => {
+        const messageConfig =
+            typeof messageKey === 'string' && ERROR_MESSAGES[messageKey]
+                ? ERROR_MESSAGES[messageKey]
+                : {
+                      defaultMessage: messageKey || ERROR_MESSAGES.DEFAULT.defaultMessage,
+                      id: ERROR_MESSAGES.DEFAULT.id
+                  }
+
         toast({
             title:
-                message ||
-                intl.formatMessage({
-                    defaultMessage:
-                        'Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order.',
-                    id: 'sfp_payments_express.error.default'
-                }),
+                typeof messageKey === 'string' && ERROR_MESSAGES[messageKey]
+                    ? intl.formatMessage(messageConfig)
+                    : messageConfig.defaultMessage,
             status: 'error'
         })
     }
@@ -171,7 +200,6 @@ const SFPaymentsExpressButtons = ({
         try {
             const paymentInstrumentBody = createPaymentInstrumentBody(
                 order.orderTotal,
-               //-1,
                 paymentType,
                 zoneIdValue
             )
@@ -185,11 +213,10 @@ const SFPaymentsExpressButtons = ({
                 body: paymentInstrumentBody
             })
         } catch (error) {
-
             const statusCode = error?.response?.status || error?.status
             const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
             const errorDetails = error?.response?.data || error?.body || {}
-            
+
             // TODO: log details of body if needed or change toast message to refer the type of message error?
             logger.error('Failed to patch payment instrument to order', {
                 namespace: 'SFPaymentsExpressButtons.createOrderAndUpdatePayment',
@@ -204,7 +231,7 @@ const SFPaymentsExpressButtons = ({
                     error: error
                 }
             })
-             
+
             // call failOrder to clean up the order (ex: amount is not valid, zone is not valid etc)
             await failOrder({
                 parameters: {
@@ -212,19 +239,11 @@ const SFPaymentsExpressButtons = ({
                     reopenBasket: true
                 },
                 body: {
-                    reasonCode: "payment_confirm_failure"
+                    reasonCode: 'payment_confirm_failure'
                 }
             })
             failOrderCalledRef.current = true
-
-            // Show error message to user - order was failed and basket reopened
-            showErrorMessage(
-                intl.formatMessage({
-                    defaultMessage:
-                        'Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
-                    id: 'sfp_payments_express.error.fail_order'
-                })
-            )
+            showErrorMessage('FAIL_ORDER')
 
             // Attach orderNo to the error so caller knows order was created
             error.orderNo = createdOrderNo
@@ -341,14 +360,7 @@ const SFPaymentsExpressButtons = ({
                             prepareBasketPromise.current = null // Clear the promise so handlers don't try to await it
                             // Don't show toast for validation errors
                             if (!e.isValidationError) {
-                                showErrorMessage(
-                                    e.message ||
-                                        intl.formatMessage({
-                                            defaultMessage:
-                                                'Unable to prepare basket for express payments. Please select all required product attributes.',
-                                            id: 'sfp_payments_express.error.prepare_basket'
-                                        })
-                                )
+                                showErrorMessage(e.message || 'PREPARE_BASKET')
                             }
                         })
                 }
@@ -555,16 +567,16 @@ const SFPaymentsExpressButtons = ({
                                 zoneId
                             )
                         })*/
-                            try {
-                                expressBasket.current = await addPaymentInstrumentToBasket({
-                                    parameters: {basketId: updatedBasket.basketId},
-                                    body: createPaymentInstrumentBody(
-                                        updatedBasket.orderTotal || updatedBasket.productSubTotal, // Use updatedBasket instead of expressBasket.current
-                                        paymentMethodType,
-                                        zoneId
-                                    )
-                                })
-                                /*expressBasket.current = await addPaymentInstrumentToBasket({
+                        try {
+                            expressBasket.current = await addPaymentInstrumentToBasket({
+                                parameters: {basketId: updatedBasket.basketId},
+                                body: createPaymentInstrumentBody(
+                                    updatedBasket.orderTotal || updatedBasket.productSubTotal, // Use updatedBasket instead of expressBasket.current
+                                    paymentMethodType,
+                                    zoneId
+                                )
+                            })
+                            /*expressBasket.current = await addPaymentInstrumentToBasket({
                                     parameters: {basketId: expressBasket.current.basketId},
                                     body: createPaymentInstrumentBody(
                                         expressBasket.current.orderTotal ||
@@ -573,36 +585,29 @@ const SFPaymentsExpressButtons = ({
                                         "default1"
                                     )
                                 })*/
-                            } catch (error) {
-                                const statusCode = error?.response?.status || error?.status
-                                const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
-                                const errorDetails = error?.response?.data || error?.body || {}
-                                
-                                // TODO: log details of body if needed or change toast message to refer the type of message error?
-                                logger.error('Failed to add payment instrument to basket', {
-                                    namespace: 'SFPaymentsExpressButtons.onPayerApprove',
-                                    additionalProperties: {
-                                        statusCode,
-                                        errorMessage,
-                                        errorDetails,
-                                        basketId: expressBasket.current?.basketId,
-                                        paymentMethodType,
-                                        orderTotal: expressBasket.current?.orderTotal,
-                                        productSubTotal: expressBasket.current?.productSubTotal,
-                                        error: error
-                                    }
-                                })
-                                 
-                                // Show error message to user immediately
-                                showErrorMessage(
-                                    intl.formatMessage({
-                                        defaultMessage:
-                                            'Unable to process payment. Please try again or select a different payment method.',
-                                        id: 'sfp_payments_express.error.onPayerApprove'
-                                    })
-                                )
-                                throw error
-                            }
+                        } catch (error) {
+                            const statusCode = error?.response?.status || error?.status
+                            const errorMessage =
+                                error?.message || error?.response?.data?.message || 'Unknown error'
+                            const errorDetails = error?.response?.data || error?.body || {}
+
+                            // TODO: log details of body if needed or change toast message to refer the type of message error?
+                            logger.error('Failed to add payment instrument to basket', {
+                                namespace: 'SFPaymentsExpressButtons.onPayerApprove',
+                                additionalProperties: {
+                                    statusCode,
+                                    errorMessage,
+                                    errorDetails,
+                                    basketId: expressBasket.current?.basketId,
+                                    paymentMethodType,
+                                    orderTotal: expressBasket.current?.orderTotal,
+                                    productSubTotal: expressBasket.current?.productSubTotal,
+                                    error: error
+                                }
+                            })
+                            showErrorMessage('PROCESS_PAYMENT')
+                            throw error
+                        }
                     }
                 } catch (error) {
                     endConfirming()
@@ -650,9 +655,10 @@ const SFPaymentsExpressButtons = ({
                         })
                     } catch (error) {
                         const statusCode = error?.response?.status || error?.status
-                        const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
+                        const errorMessage =
+                            error?.message || error?.response?.data?.message || 'Unknown error'
                         const errorDetails = error?.response?.data || error?.body || {}
-                        
+
                         // TODO: log details of body if needed or change toast message to refer the type of message error?
                         logger.error('Failed to add payment instrument to basket', {
                             namespace: 'SFPaymentsExpressButtons.createIntentFunction',
@@ -667,15 +673,7 @@ const SFPaymentsExpressButtons = ({
                                 error: error
                             }
                         })
-                         
-                        // Show error message to user immediately
-                        showErrorMessage(
-                            intl.formatMessage({
-                                defaultMessage:
-                                    'Unable to process payment. Please try again or select a different payment method.',
-                                id: 'sfp_payments_express.error.add_payment_instrument'
-                            })
-                        )
+                        showErrorMessage('PROCESS_PAYMENT')
                         // Re-throw so SF Payments SDK can handle the error if needed
                         throw error
                     }
@@ -750,7 +748,7 @@ const SFPaymentsExpressButtons = ({
                             reopenBasket: true
                         },
                         body: {
-                            reasonCode: "payment_confirm_failure"
+                            reasonCode: 'payment_confirm_failure'
                         }
                     })
                     failOrderCalledRef.current = true

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -33,7 +33,8 @@ import {
     transformShippingMethods,
     getSelectedShippingMethodId,
     createPaymentInstrumentBody,
-    isPayPalPaymentMethodType
+    isPayPalPaymentMethodType,
+    getClientSecret
 } from '@salesforce/retail-react-app/app/utils/sf-payments-utils'
 
 const SFPaymentsExpressButtons = ({
@@ -680,7 +681,7 @@ const SFPaymentsExpressButtons = ({
                     }
                 }
                 return {
-                    client_secret: updatedPaymentInstrument.paymentReference.clientSecret,
+                    client_secret: getClientSecret(updatedPaymentInstrument),
                     id: updatedPaymentInstrument.paymentReference.paymentReferenceId
                 }
             }

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -82,11 +82,14 @@ const SFPaymentsExpressButtons = ({
     )
     const {mutateAsync: deleteBasket} = useShopperBasketsMutation('deleteBasket')
 
+    const {mutateAsync: failOrder} = useShopperOrdersMutation('failOrder')
+
     const expressBasket = useRef(null)
     const prepareBasketPromise = useRef(null)
     const containerElementRef = useRef(null)
     const expressComponent = useRef(null)
     const prepareBasketRef = useRef(prepareBasket)
+    const failOrderCalledRef = useRef(false)
 
     // Update the ref whenever prepareBasket changes, including when the variant changes on PDP
     // Using prepareBasketRef.current also ensures the function handlers always call the latest prepareBasket function
@@ -168,6 +171,7 @@ const SFPaymentsExpressButtons = ({
         try {
             const paymentInstrumentBody = createPaymentInstrumentBody(
                 order.orderTotal,
+               //-1,
                 paymentType,
                 zoneIdValue
             )
@@ -181,6 +185,47 @@ const SFPaymentsExpressButtons = ({
                 body: paymentInstrumentBody
             })
         } catch (error) {
+
+            const statusCode = error?.response?.status || error?.status
+            const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
+            const errorDetails = error?.response?.data || error?.body || {}
+            
+            // TODO: log details of body if needed or change toast message to refer the type of message error?
+            logger.error('Failed to patch payment instrument to order', {
+                namespace: 'SFPaymentsExpressButtons.createOrderAndUpdatePayment',
+                additionalProperties: {
+                    statusCode,
+                    errorMessage,
+                    errorDetails,
+                    basketId: expressBasket.current?.basketId,
+                    paymentMethodType: paymentType,
+                    orderTotal: expressBasket.current?.orderTotal,
+                    productSubTotal: expressBasket.current?.productSubTotal,
+                    error: error
+                }
+            })
+             
+            // call failOrder to clean up the order (ex: amount is not valid, zone is not valid etc)
+            await failOrder({
+                parameters: {
+                    orderNo: createdOrderNo,
+                    reopenBasket: true
+                },
+                body: {
+                    reasonCode: "payment_confirm_failure"
+                }
+            })
+            failOrderCalledRef.current = true
+
+            // Show error message to user - order was failed and basket reopened
+            showErrorMessage(
+                intl.formatMessage({
+                    defaultMessage:
+                        'Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
+                    id: 'sfp_payments_express.error.fail_order'
+                })
+            )
+
             // Attach orderNo to the error so caller knows order was created
             error.orderNo = createdOrderNo
             throw error
@@ -313,41 +358,53 @@ const SFPaymentsExpressButtons = ({
                 }
             }
 
-            const onCancel = async () => {
-                endConfirming()
-
+            // Helper function to clean up express basket state
+            const cleanupExpressBasket = async () => {
                 // If an order was already created, the basket was consumed - don't try to clean it up
                 if (orderNo) {
                     expressBasket.current = null
-                    showErrorMessage()
                     return
                 }
-
                 // Only clean up if no order was created (basket still exists)
-                const sfPaymentsInstrument = getSFPaymentsInstrument(expressBasket.current)
-                if (sfPaymentsInstrument) {
-                    expressBasket.current = await removePaymentInstrumentFromBasket({
-                        parameters: {
-                            basketId: expressBasket.current.basketId,
-                            paymentInstrumentId: sfPaymentsInstrument.paymentInstrumentId
+                if (expressBasket.current) {
+                    const sfPaymentsInstrument = getSFPaymentsInstrument(expressBasket.current)
+                    if (sfPaymentsInstrument) {
+                        try {
+                            expressBasket.current = await removePaymentInstrumentFromBasket({
+                                parameters: {
+                                    basketId: expressBasket.current.basketId,
+                                    paymentInstrumentId: sfPaymentsInstrument.paymentInstrumentId
+                                }
+                            })
+                        } catch (cleanupError) {
+                            logger.warn('Failed to remove payment instrument during cleanup', {
+                                namespace: 'SFPaymentsExpressButtons.cleanupExpressBasket',
+                                additionalProperties: {cleanupError}
+                            })
                         }
-                    })
+                    }
+                    // Delete the temporary basket if it exists
+                    if (expressBasket.current?.basketId && expressBasket.current?.temporaryBasket) {
+                        try {
+                            await deleteBasket({
+                                parameters: {basketId: expressBasket.current.basketId}
+                            })
+                        } catch (cleanupError) {
+                            logger.warn('Failed to delete temporary basket during cleanup', {
+                                namespace: 'SFPaymentsExpressButtons.cleanupExpressBasket',
+                                additionalProperties: {cleanupError}
+                            })
+                        }
+                    }
+                    // Clear the ref after cleanup
+                    expressBasket.current = null
                 }
-                // Delete the temporary basket if it exists
-                if (expressBasket.current?.basketId && expressBasket.current?.temporaryBasket) {
-                    await deleteBasket({
-                        parameters: {basketId: expressBasket.current.basketId}
-                    })
-                }
-                // Clear the ref after cleanup
-                expressBasket.current = null
-                showErrorMessage(
-                    intl.formatMessage({
-                        defaultMessage:
-                            'Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order.',
-                        id: 'sfp_payments_express.error.cancel'
-                    })
-                )
+            }
+
+            const onCancel = async () => {
+                endConfirming()
+                await cleanupExpressBasket()
+                showErrorMessage()
             }
 
             const onShippingAddressChange = async (shippingAddress, callback) => {
@@ -490,14 +547,62 @@ const SFPaymentsExpressButtons = ({
 
                     // For Stripe, create SF Payments basket payment instrument before creating order
                     if (!isPayPalPaymentMethodType(paymentMethodType)) {
-                        expressBasket.current = await addPaymentInstrumentToBasket({
+                        /*expressBasket.current = await addPaymentInstrumentToBasket({
                             parameters: {basketId: updatedBasket.basketId},
                             body: createPaymentInstrumentBody(
                                 updatedBasket.orderTotal || updatedBasket.productSubTotal, // Use updatedBasket instead of expressBasket.current
                                 paymentMethodType,
                                 zoneId
                             )
-                        })
+                        })*/
+                            try {
+                                expressBasket.current = await addPaymentInstrumentToBasket({
+                                    parameters: {basketId: updatedBasket.basketId},
+                                    body: createPaymentInstrumentBody(
+                                        updatedBasket.orderTotal || updatedBasket.productSubTotal, // Use updatedBasket instead of expressBasket.current
+                                        paymentMethodType,
+                                        zoneId
+                                    )
+                                })
+                                /*expressBasket.current = await addPaymentInstrumentToBasket({
+                                    parameters: {basketId: expressBasket.current.basketId},
+                                    body: createPaymentInstrumentBody(
+                                        expressBasket.current.orderTotal ||
+                                            expressBasket.current.productSubTotal,
+                                        null,
+                                        "default1"
+                                    )
+                                })*/
+                            } catch (error) {
+                                const statusCode = error?.response?.status || error?.status
+                                const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
+                                const errorDetails = error?.response?.data || error?.body || {}
+                                
+                                // TODO: log details of body if needed or change toast message to refer the type of message error?
+                                logger.error('Failed to add payment instrument to basket', {
+                                    namespace: 'SFPaymentsExpressButtons.onPayerApprove',
+                                    additionalProperties: {
+                                        statusCode,
+                                        errorMessage,
+                                        errorDetails,
+                                        basketId: expressBasket.current?.basketId,
+                                        paymentMethodType,
+                                        orderTotal: expressBasket.current?.orderTotal,
+                                        productSubTotal: expressBasket.current?.productSubTotal,
+                                        error: error
+                                    }
+                                })
+                                 
+                                // Show error message to user immediately
+                                showErrorMessage(
+                                    intl.formatMessage({
+                                        defaultMessage:
+                                            'Unable to process payment. Please try again or select a different payment method.',
+                                        id: 'sfp_payments_express.error.onPayerApprove'
+                                    })
+                                )
+                                throw error
+                            }
                     }
                 } catch (error) {
                     endConfirming()
@@ -533,15 +638,47 @@ const SFPaymentsExpressButtons = ({
                         })
                     }
                     // Add Salesforce Payments payment instrument to basket
-                    expressBasket.current = await addPaymentInstrumentToBasket({
-                        parameters: {basketId: expressBasket.current.basketId},
-                        body: createPaymentInstrumentBody(
-                            expressBasket.current.orderTotal ||
-                                expressBasket.current.productSubTotal,
-                            paymentMethodType,
-                            zoneId
+                    try {
+                        expressBasket.current = await addPaymentInstrumentToBasket({
+                            parameters: {basketId: expressBasket.current.basketId},
+                            body: createPaymentInstrumentBody(
+                                expressBasket.current.orderTotal ||
+                                    expressBasket.current.productSubTotal,
+                                paymentMethodType,
+                                zoneId
+                            )
+                        })
+                    } catch (error) {
+                        const statusCode = error?.response?.status || error?.status
+                        const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
+                        const errorDetails = error?.response?.data || error?.body || {}
+                        
+                        // TODO: log details of body if needed or change toast message to refer the type of message error?
+                        logger.error('Failed to add payment instrument to basket', {
+                            namespace: 'SFPaymentsExpressButtons.createIntentFunction',
+                            additionalProperties: {
+                                statusCode,
+                                errorMessage,
+                                errorDetails,
+                                basketId: expressBasket.current?.basketId,
+                                paymentMethodType,
+                                orderTotal: expressBasket.current?.orderTotal,
+                                productSubTotal: expressBasket.current?.productSubTotal,
+                                error: error
+                            }
+                        })
+                         
+                        // Show error message to user immediately
+                        showErrorMessage(
+                            intl.formatMessage({
+                                defaultMessage:
+                                    'Unable to process payment. Please try again or select a different payment method.',
+                                id: 'sfp_payments_express.error.add_payment_instrument'
+                            })
                         )
-                    })
+                        // Re-throw so SF Payments SDK can handle the error if needed
+                        throw error
+                    }
                     updatedPaymentInstrument = getSFPaymentsInstrument(expressBasket.current)
                 } else {
                     // Create order and update payment instrument
@@ -553,6 +690,7 @@ const SFPaymentsExpressButtons = ({
                         )
                         orderNo = order.orderNo
                         updatedPaymentInstrument = getSFPaymentsInstrument(order)
+                        // TODO validate updatedPaymentInstrument paymentRererence values?
                     } catch (error) {
                         // If order was created but updatePaymentInstrumentForOrder failed,
                         // orderNo will be attached to the error
@@ -595,12 +733,30 @@ const SFPaymentsExpressButtons = ({
                 }
             }
 
+            // Async function to handle payment error event.  This is called when error event is handled by SF Payments SDK.
             const paymentError = async () => {
                 endConfirming()
-                if (orderNo) {
+                /*if (orderNo) {
                     // TODO: fail the order
                     orderNo = null
+                }*/
+                // if orderNo is present and failOrder has not been called, call failOrder
+                if (orderNo && !failOrderCalledRef.current) {
+                    console.log('paymentError 1')
+                    // TODO:  once payment intent is created BUT confirm fails (Ex: generic declined card), failOrder is not working
+                    await failOrder({
+                        parameters: {
+                            orderNo: orderNo,
+                            reopenBasket: true
+                        },
+                        body: {
+                            reasonCode: "payment_confirm_failure"
+                        }
+                    })
+                    failOrderCalledRef.current = true
                 }
+                orderNo = null
+                failOrderCalledRef.current = false // Reset for next attempt
             }
 
             const handlePaymentMethodsRendered = (details) => {

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -109,7 +109,12 @@ const SFPaymentsExpressButtons = ({
         }
     )
 
-    // Define error message constants at the top of the component
+    const ERROR_MESSAGE_KEYS = {
+        DEFAULT: 'DEFAULT',
+        FAIL_ORDER: 'FAIL_ORDER',
+        PREPARE_BASKET: 'PREPARE_BASKET',
+        PROCESS_PAYMENT: 'PROCESS_PAYMENT'
+    }
     const ERROR_MESSAGES = {
         DEFAULT: {
             defaultMessage:
@@ -134,21 +139,20 @@ const SFPaymentsExpressButtons = ({
     }
 
     const showErrorMessage = (messageKey = 'DEFAULT') => {
-        const messageConfig =
-            typeof messageKey === 'string' && ERROR_MESSAGES[messageKey]
-                ? ERROR_MESSAGES[messageKey]
-                : {
-                      defaultMessage: messageKey || ERROR_MESSAGES.DEFAULT.defaultMessage,
-                      id: ERROR_MESSAGES.DEFAULT.id
-                  }
-
-        toast({
-            title:
-                typeof messageKey === 'string' && ERROR_MESSAGES[messageKey]
-                    ? intl.formatMessage(messageConfig)
-                    : messageConfig.defaultMessage,
-            status: 'error'
-        })
+        // If messageKey is a valid key in ERROR_MESSAGES, use it
+        if (ERROR_MESSAGES[messageKey]) {
+            toast({
+                title: intl.formatMessage(ERROR_MESSAGES[messageKey]),
+                status: 'error'
+            })
+        } else {
+            // Otherwise, treat it as a custom error message string
+            // (e.g., from e.message) or fallback to DEFAULT if empty
+            toast({
+                title: messageKey || ERROR_MESSAGES.DEFAULT.defaultMessage,
+                status: 'error'
+            })
+        }
     }
 
     /**
@@ -240,7 +244,7 @@ const SFPaymentsExpressButtons = ({
                 }
             })
             failOrderCalledRef.current = true
-            showErrorMessage('FAIL_ORDER')
+            showErrorMessage(ERROR_MESSAGE_KEYS.FAIL_ORDER)
 
             // Attach orderNo to the error so caller knows order was created
             error.orderNo = createdOrderNo
@@ -357,7 +361,7 @@ const SFPaymentsExpressButtons = ({
                             prepareBasketPromise.current = null // Clear the promise so handlers don't try to await it
                             // Don't show toast for validation errors
                             if (!e.isValidationError) {
-                                showErrorMessage(e.message || 'PREPARE_BASKET')
+                                showErrorMessage(e.message || ERROR_MESSAGE_KEYS.PREPARE_BASKET)
                             }
                         })
                 }
@@ -413,7 +417,7 @@ const SFPaymentsExpressButtons = ({
             const onCancel = async () => {
                 endConfirming()
                 await cleanupExpressBasket()
-                showErrorMessage()
+                showErrorMessage(ERROR_MESSAGE_KEYS.DEFAULT)
             }
 
             const onShippingAddressChange = async (shippingAddress, callback) => {
@@ -584,7 +588,7 @@ const SFPaymentsExpressButtons = ({
                                     error: error
                                 }
                             })
-                            showErrorMessage('PROCESS_PAYMENT')
+                            showErrorMessage(ERROR_MESSAGE_KEYS.PROCESS_PAYMENT)
                             throw error
                         }
                     }
@@ -651,7 +655,7 @@ const SFPaymentsExpressButtons = ({
                                 error: error
                             }
                         })
-                        showErrorMessage('PROCESS_PAYMENT')
+                        showErrorMessage(ERROR_MESSAGE_KEYS.PROCESS_PAYMENT)
                         // Re-throw so SF Payments SDK can handle the error if needed
                         throw error
                     }

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.test.js
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.test.js
@@ -13,6 +13,7 @@ import {
     EXPRESS_PAY_NOW,
     EXPRESS_BUY_NOW
 } from '@salesforce/retail-react-app/app/hooks/use-sf-payments'
+import {rest} from 'msw'
 
 // Mock getConfig to provide necessary configuration
 jest.mock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => {
@@ -48,6 +49,60 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-sf-payments', () => {
             endConfirming: jest.fn()
         })
     }
+})
+
+beforeEach(() => {
+    // Reset MSW handlers to avoid conflicts
+    global.server.resetHandlers()
+
+    // Add MSW handlers to mock API requests
+    global.server.use(
+        rest.get('*/api/configuration/shopper-configurations/*', (req, res, ctx) => {
+            return res(
+                ctx.delay(0),
+                ctx.status(200),
+                ctx.json({
+                    configurations: []
+                })
+            )
+        }),
+        rest.get(
+            '*/api/customer/shopper-customers/*/customers/*/product-lists',
+            (req, res, ctx) => {
+                return res(
+                    ctx.delay(0),
+                    ctx.status(200),
+                    ctx.json({
+                        data: [],
+                        total: 0
+                    })
+                )
+            }
+        ),
+        rest.get('*/api/payment-metadata', (req, res, ctx) => {
+            return res(
+                ctx.delay(0),
+                ctx.status(200),
+                ctx.json({
+                    apiKey: 'test-key',
+                    publishableKey: 'pk_test'
+                })
+            )
+        }),
+        rest.get('*/api/checkout/shopper-payments/*/payment-configuration', (req, res, ctx) => {
+            return res(
+                ctx.delay(0),
+                ctx.status(200),
+                ctx.json({
+                    paymentMethods: [
+                        {id: 'card', name: 'Card'},
+                        {id: 'paypal', name: 'PayPal'}
+                    ],
+                    paymentMethodSetAccounts: []
+                })
+            )
+        })
+    )
 })
 
 afterEach(() => {
@@ -173,5 +228,67 @@ describe('prepareBasket prop updates', () => {
 
         // Component should still render without errors
         expect(screen.getByTestId('sf-payments-express')).toBeInTheDocument()
+    })
+})
+
+describe('failOrder error handling', () => {
+    const mockFailOrder = jest.fn()
+    const mockCreateOrder = jest.fn()
+    const mockUpdatePaymentInstrument = jest.fn()
+    const mockToast = jest.fn()
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockFailOrder.mockResolvedValue({})
+    })
+
+    // Mock the mutations to verify they're available
+    jest.mock('@salesforce/commerce-sdk-react', () => {
+        const actual = jest.requireActual('@salesforce/commerce-sdk-react')
+        return {
+            ...actual,
+            useShopperOrdersMutation: (mutationKey) => {
+                if (mutationKey === 'failOrder') {
+                    return {mutateAsync: mockFailOrder}
+                }
+                if (mutationKey === 'createOrder') {
+                    return {mutateAsync: mockCreateOrder}
+                }
+                if (mutationKey === 'updatePaymentInstrumentForOrder') {
+                    return {mutateAsync: mockUpdatePaymentInstrument}
+                }
+                return {mutateAsync: jest.fn()}
+            },
+            usePaymentConfiguration: () => ({
+                data: {
+                    paymentMethods: [{id: 'card', name: 'Card'}],
+                    paymentMethodSetAccounts: []
+                }
+            }),
+            useShopperBasketsMutation: () => ({
+                mutateAsync: jest.fn()
+            }),
+            useShippingMethodsForShipment: () => ({
+                refetch: jest.fn()
+            })
+        }
+    })
+
+    jest.mock('@salesforce/retail-react-app/app/hooks/use-shopper-configuration', () => ({
+        useShopperConfiguration: () => 'default'
+    }))
+
+    jest.mock('@salesforce/retail-react-app/app/hooks/use-toast', () => ({
+        useToast: () => mockToast
+    }))
+
+    // It doesn't trigger the actual failOrder call (that requires the full payment flow), but it confirms the setup is correct.
+    // The actual failOrder call is better tested in integration/E2E tests.
+    test('failOrder mutation is available and error message constant is defined', () => {
+        renderWithProviders(<SFPaymentsExpressButtons {...defaultProps} />)
+
+        expect(screen.getByTestId('sf-payments-express')).toBeInTheDocument()
+        expect(mockFailOrder).toBeDefined()
+        expect(mockToast).toBeDefined()
     })
 })

--- a/packages/template-retail-react-app/app/pages/checkout/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/index.jsx
@@ -138,7 +138,7 @@ const Checkout = () => {
                     defaultMessage: 'An unexpected error occurred during checkout.'
                 })
                 setError(message)
-            } 
+            }
         } finally {
             setIsLoading(false)
         }

--- a/packages/template-retail-react-app/app/pages/checkout/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/index.jsx
@@ -48,6 +48,8 @@ import {
     useSFPayments
 } from '@salesforce/retail-react-app/app/hooks/use-sf-payments'
 
+let persistedPaymentsError = null
+
 const Checkout = () => {
     const {formatMessage} = useIntl()
     const navigate = useNavigation()
@@ -95,6 +97,14 @@ const Checkout = () => {
         }
     }, [basket?.basketId])
 
+    // Restore error if component remounted after payments error causes a refresh
+    useEffect(() => {
+        if (persistedPaymentsError && !error) {
+            setError(persistedPaymentsError)
+            persistedPaymentsError = null // Clear it after restoring
+        }
+    }, [])
+
     // Callback to handle when payment method requires its own pay button
     const handleRequiresPayButtonChange = (requiresPayButton) => {
         setShouldHidePlaceOrderButton(requiresPayButton === false)
@@ -107,6 +117,7 @@ const Checkout = () => {
     }
 
     const handlePaymentError = (errorMessage) => {
+        persistedPaymentsError = errorMessage
         setError(errorMessage)
     }
 
@@ -121,11 +132,13 @@ const Checkout = () => {
             }
             navigate(`/checkout/confirmation/${order.orderNo}`)
         } catch (error) {
-            const message = formatMessage({
-                id: 'checkout.message.generic_error',
-                defaultMessage: 'An unexpected error occurred during checkout.'
-            })
-            setError(message)
+            if (!persistedPaymentsError) {
+                const message = formatMessage({
+                    id: 'checkout.message.generic_error',
+                    defaultMessage: 'An unexpected error occurred during checkout.'
+                })
+                setError(message)
+            } 
         } finally {
             setIsLoading(false)
         }
@@ -151,7 +164,6 @@ const Checkout = () => {
                                     {error}
                                 </Alert>
                             )}
-
                             {sfPaymentsEnabled && (
                                 <Box
                                     layerStyle="card"

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -47,6 +47,7 @@ import {
     getSFPaymentsInstrument,
     createPaymentInstrumentBody
 } from '@salesforce/retail-react-app/app/utils/sf-payments-utils'
+import logger from '@salesforce/retail-react-app/app/utils/logger-instance'
 
 const SFPaymentsSheet = forwardRef((props, ref) => {
     const {onRequiresPayButtonChange, onCreateOrder, onError} = props
@@ -100,6 +101,8 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
         'removePaymentInstrumentFromBasket'
     )
 
+    const {mutateAsync: failOrder} = useShopperOrdersMutation('failOrder')
+
     const {step, STEPS, goToStep} = useCheckout()
 
     const billingAddressForm = useForm({
@@ -136,7 +139,8 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                 id: 'checkout.message.generic_error',
                 defaultMessage: 'An unexpected error occurred during checkout.'
             })
-            onError(message)
+            // Use error.message if available, otherwise use the formatted default message
+            onError(error.message || message)
         }
     }
 
@@ -223,16 +227,62 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
         // Find SF Payments payment instrument in created order
         const orderPaymentInstrument = getSFPaymentsInstrument(order)
 
-        // Update order payment instrument to create payment
-        const updatedOrder = await updatePaymentInstrumentForOrder({
-            parameters: {
-                orderNo: order.orderNo,
-                paymentInstrumentId: orderPaymentInstrument.paymentInstrumentId
-            },
-            body: createPaymentInstrumentBody(order.orderTotal, paymentMethodType.current, zoneId)
-        })
+        try {
+            // Update order payment instrument to create payment
+            const updatedOrder = await updatePaymentInstrumentForOrder({
+                parameters: {
+                    orderNo: order.orderNo,
+                    paymentInstrumentId: orderPaymentInstrument.paymentInstrumentId
+                },
+                body: createPaymentInstrumentBody(order.orderTotal, paymentMethodType.current, zoneId)
+                //body: createPaymentInstrumentBody(-1, paymentMethodType.current, zoneId)
+            })
 
-        return updatedOrder
+            return updatedOrder
+        } catch (error) {
+            const statusCode = error?.response?.status || error?.status
+            const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
+            const errorDetails = error?.response?.data || error?.body || {}
+            
+            // TODO: log details of body if needed or change toast message to refer the type of message error?
+            logger.error('Failed to patch payment instrument to order', {
+                namespace: 'SFPaymentsSheet.createAndUpdateOrder',
+                additionalProperties: {
+                    statusCode,
+                    errorMessage,
+                    errorDetails,
+                    basketId: currentBasket.current?.basketId,
+                    paymentMethodType: paymentMethodType.current,
+                    orderTotal: order.orderTotal,
+                    productSubTotal: currentBasket.current?.productSubTotal,
+                    error: error
+                }
+            })
+            const createdOrderNo = order.orderNo
+            // call failOrder to clean up the order (ex: amount is not valid, zone is not valid etc)
+            await failOrder({
+                parameters: {
+                    orderNo: createdOrderNo,
+                    reopenBasket: true
+                },
+                body: {
+                    reasonCode: "payment_confirm_failure"
+                }
+            })
+            
+            // Show error message to user - order was failed and basket reopened
+            const message = formatMessage({
+                defaultMessage:
+                    'Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
+                id: 'checkout.message.payment_confirm_failure'
+            })
+            onError(message)
+            
+            // Attach orderNo to the error so caller knows order was created
+            error.orderNo = createdOrderNo
+            error.message = message
+            throw error
+        }
     }
 
     const confirmPayment = async () => {
@@ -259,15 +309,17 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             )
         })
 
+        let updatedOrder = null
         try {
             // Update order payment instrument to create payment
-            const updatedOrder = await createAndUpdateOrder()
+            updatedOrder = await createAndUpdateOrder()
 
             // Find updated SF Payments payment instrument in updated order
             const orderPaymentInstrument = getSFPaymentsInstrument(updatedOrder)
 
             // Track created payment intent
             const paymentIntent = {
+                //client_secret: '123',
                 client_secret: orderPaymentInstrument.paymentReference.clientSecret,
                 id: orderPaymentInstrument.paymentReference.paymentReferenceId
             }
@@ -309,6 +361,9 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             // Update the redirect return URL to include the related order no
             config.current.options.returnUrl += '?orderNo=' + updatedOrder.orderNo
 
+            // Store orderNo before confirm in case confirm fails
+            const orderNo = updatedOrder.orderNo
+
             // Confirm the payment
             const result = await checkoutComponent.current.confirm(
                 () => paymentIntent,
@@ -324,6 +379,44 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             queryClient.invalidateQueries()
             // Finally return the created order
             return updatedOrder
+        } catch (error) {
+            // Only fail order if createAndUpdateOrder succeeded but perhaps confirm fails
+            if (updatedOrder && !error.orderNo) {
+                // createAndUpdateOrder succeeded but confirm failed - need to fail the order
+                try {
+                    await failOrder({
+                        parameters: {
+                            orderNo: updatedOrder.orderNo,
+                            reopenBasket: true
+                        },
+                        body: {
+                            reasonCode: 'payment_confirm_failure'
+                        }
+                    })
+                    logger.info('Order failed successfully after confirm failure', {
+                        namespace: 'SFPaymentsSheet.confirmPayment',
+                        additionalProperties: {orderNo: updatedOrder.orderNo}
+                    })
+                        
+                    // Show error message to user - order was failed and basket reopened
+                    const message = formatMessage({
+                        defaultMessage:
+                            'Payment confirmation failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
+                        id: 'checkout.message.payment_confirm_failure'
+                    })
+                    onError(message)
+                    error.message = message
+                } catch (failOrderError) {
+                    logger.error('Failed to fail order after confirm failure', {
+                        namespace: 'SFPaymentsSheet.confirmPayment',
+                        additionalProperties: {
+                            orderNo: updatedOrder.orderNo,
+                            failOrderError
+                        }
+                    })
+                }
+            }
+            throw error
         } finally {
             // Remove tracked basket being confirmed
             endConfirming()

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -234,7 +234,11 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                     orderNo: order.orderNo,
                     paymentInstrumentId: orderPaymentInstrument.paymentInstrumentId
                 },
-                body: createPaymentInstrumentBody(order.orderTotal, paymentMethodType.current, zoneId)
+                body: createPaymentInstrumentBody(
+                    order.orderTotal,
+                    paymentMethodType.current,
+                    zoneId
+                )
                 //body: createPaymentInstrumentBody(-1, paymentMethodType.current, zoneId)
             })
 
@@ -243,7 +247,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             const statusCode = error?.response?.status || error?.status
             const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
             const errorDetails = error?.response?.data || error?.body || {}
-            
+
             // TODO: log details of body if needed or change toast message to refer the type of message error?
             logger.error('Failed to patch payment instrument to order', {
                 namespace: 'SFPaymentsSheet.createAndUpdateOrder',
@@ -266,18 +270,18 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                     reopenBasket: true
                 },
                 body: {
-                    reasonCode: "payment_confirm_failure"
+                    reasonCode: 'payment_confirm_failure'
                 }
             })
-            
+
             // Show error message to user - order was failed and basket reopened
             const message = formatMessage({
                 defaultMessage:
                     'Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method.',
-                id: 'checkout.message.payment_confirm_failure'
+                id: 'checkout.message.payment_processing_failed'
             })
             onError(message)
-            
+
             // Attach orderNo to the error so caller knows order was created
             error.orderNo = createdOrderNo
             error.message = message
@@ -397,7 +401,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                         namespace: 'SFPaymentsSheet.confirmPayment',
                         additionalProperties: {orderNo: updatedOrder.orderNo}
                     })
-                        
+
                     // Show error message to user - order was failed and basket reopened
                     const message = formatMessage({
                         defaultMessage:

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -45,7 +45,8 @@ import {isPickupShipment} from '@salesforce/retail-react-app/app/utils/shipment-
 import {
     buildTheme,
     getSFPaymentsInstrument,
-    createPaymentInstrumentBody
+    createPaymentInstrumentBody,
+    getClientSecret
 } from '@salesforce/retail-react-app/app/utils/sf-payments-utils'
 import logger from '@salesforce/retail-react-app/app/utils/logger-instance'
 
@@ -321,7 +322,7 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
 
             // Track created payment intent
             const paymentIntent = {
-                client_secret: orderPaymentInstrument.paymentReference.clientSecret,
+                client_secret: getClientSecret(orderPaymentInstrument),
                 id: orderPaymentInstrument.paymentReference.paymentReferenceId
             }
 

--- a/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/partials/sf-payments-sheet.jsx
@@ -239,7 +239,6 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
                     paymentMethodType.current,
                     zoneId
                 )
-                //body: createPaymentInstrumentBody(-1, paymentMethodType.current, zoneId)
             })
 
             return updatedOrder
@@ -248,7 +247,6 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
             const errorMessage = error?.message || error?.response?.data?.message || 'Unknown error'
             const errorDetails = error?.response?.data || error?.body || {}
 
-            // TODO: log details of body if needed or change toast message to refer the type of message error?
             logger.error('Failed to patch payment instrument to order', {
                 namespace: 'SFPaymentsSheet.createAndUpdateOrder',
                 additionalProperties: {
@@ -323,7 +321,6 @@ const SFPaymentsSheet = forwardRef((props, ref) => {
 
             // Track created payment intent
             const paymentIntent = {
-                //client_secret: '123',
                 client_secret: orderPaymentInstrument.paymentReference.clientSecret,
                 id: orderPaymentInstrument.paymentReference.paymentReferenceId
             }

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -817,10 +817,34 @@
       "value": "Place Order"
     }
   ],
+  "checkout.heading.express_checkout": [
+    {
+      "type": 0,
+      "value": "Express Checkout"
+    }
+  ],
   "checkout.message.generic_error": [
     {
       "type": 0,
       "value": "An unexpected error occurred during checkout."
+    }
+  ],
+  "checkout.message.payment_button_cancel": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed."
+    }
+  ],
+  "checkout.message.payment_confirm_failure": [
+    {
+      "type": 0,
+      "value": "Payment confirmation failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
+    }
+  ],
+  "checkout.message.payment_processing_failed": [
+    {
+      "type": 0,
+      "value": "Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
     }
   ],
   "checkout.title.checkout": [
@@ -833,6 +857,18 @@
     {
       "type": 0,
       "value": "Create Account"
+    }
+  ],
+  "checkout_confirmation.heading.afterpay_clearpay": [
+    {
+      "type": 0,
+      "value": "Afterpay/Clearpay"
+    }
+  ],
+  "checkout_confirmation.heading.bancontact": [
+    {
+      "type": 0,
+      "value": "Bancontact"
     }
   ],
   "checkout_confirmation.heading.billing_address": [
@@ -869,6 +905,24 @@
       "value": "number"
     }
   ],
+  "checkout_confirmation.heading.eps": [
+    {
+      "type": 0,
+      "value": "EPS"
+    }
+  ],
+  "checkout_confirmation.heading.ideal": [
+    {
+      "type": 0,
+      "value": "iDEAL"
+    }
+  ],
+  "checkout_confirmation.heading.klarna": [
+    {
+      "type": 0,
+      "value": "Klarna"
+    }
+  ],
   "checkout_confirmation.heading.order_summary": [
     {
       "type": 0,
@@ -903,6 +957,12 @@
       "value": "number"
     }
   ],
+  "checkout_confirmation.heading.sepa_debit": [
+    {
+      "type": 0,
+      "value": "SEPA Debit"
+    }
+  ],
   "checkout_confirmation.heading.shipping_address": [
     {
       "type": 0,
@@ -919,6 +979,12 @@
     {
       "type": 0,
       "value": "Thank you for your order!"
+    }
+  ],
+  "checkout_confirmation.heading.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
     }
   ],
   "checkout_confirmation.label.free": [
@@ -2905,6 +2971,36 @@
       "value": "Password Reset Success"
     }
   ],
+  "payment_processing.error.unsuccessful": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
+    }
+  ],
+  "payment_processing.heading.payment_processing": [
+    {
+      "type": 0,
+      "value": "Payment Processing"
+    }
+  ],
+  "payment_processing.link.return_to_checkout": [
+    {
+      "type": 0,
+      "value": "Return to Checkout"
+    }
+  ],
+  "payment_processing.message.unexpected_error": [
+    {
+      "type": 0,
+      "value": "There was an unexpected error processing your payment."
+    }
+  ],
+  "payment_processing.message.working_on_your_payment": [
+    {
+      "type": 0,
+      "value": "Working on your payment..."
+    }
+  ],
   "payment_selection.heading.credit_card": [
     {
       "type": 0,
@@ -3363,6 +3459,12 @@
       "value": "See full details"
     }
   ],
+  "product_view.prepareBasket": [
+    {
+      "type": 0,
+      "value": "Unable to determine product ID for basket"
+    }
+  ],
   "product_view.status.in_stock_at_store": [
     {
       "type": 0,
@@ -3609,6 +3711,66 @@
     {
       "type": 0,
       "value": "In Stock"
+    }
+  ],
+  "sf_payments_order_summary.label.bank.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.amex": [
+    {
+      "type": 0,
+      "value": "American Express"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.diners": [
+    {
+      "type": 0,
+      "value": "Diners Club"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.discover": [
+    {
+      "type": 0,
+      "value": "Discover"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.jcb": [
+    {
+      "type": 0,
+      "value": "JCB"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.mastercard": [
+    {
+      "type": 0,
+      "value": "MasterCard"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unionpay": [
+    {
+      "type": 0,
+      "value": "China UnionPay"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.visa": [
+    {
+      "type": 0,
+      "value": "Visa"
+    }
+  ],
+  "sfp_payments_express.error.default": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
     }
   ],
   "shipping_address.action.ship_to_multiple_addresses": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -817,10 +817,34 @@
       "value": "Place Order"
     }
   ],
+  "checkout.heading.express_checkout": [
+    {
+      "type": 0,
+      "value": "Express Checkout"
+    }
+  ],
   "checkout.message.generic_error": [
     {
       "type": 0,
       "value": "An unexpected error occurred during checkout."
+    }
+  ],
+  "checkout.message.payment_button_cancel": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed."
+    }
+  ],
+  "checkout.message.payment_confirm_failure": [
+    {
+      "type": 0,
+      "value": "Payment confirmation failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
+    }
+  ],
+  "checkout.message.payment_processing_failed": [
+    {
+      "type": 0,
+      "value": "Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
     }
   ],
   "checkout.title.checkout": [
@@ -833,6 +857,18 @@
     {
       "type": 0,
       "value": "Create Account"
+    }
+  ],
+  "checkout_confirmation.heading.afterpay_clearpay": [
+    {
+      "type": 0,
+      "value": "Afterpay/Clearpay"
+    }
+  ],
+  "checkout_confirmation.heading.bancontact": [
+    {
+      "type": 0,
+      "value": "Bancontact"
     }
   ],
   "checkout_confirmation.heading.billing_address": [
@@ -869,6 +905,24 @@
       "value": "number"
     }
   ],
+  "checkout_confirmation.heading.eps": [
+    {
+      "type": 0,
+      "value": "EPS"
+    }
+  ],
+  "checkout_confirmation.heading.ideal": [
+    {
+      "type": 0,
+      "value": "iDEAL"
+    }
+  ],
+  "checkout_confirmation.heading.klarna": [
+    {
+      "type": 0,
+      "value": "Klarna"
+    }
+  ],
   "checkout_confirmation.heading.order_summary": [
     {
       "type": 0,
@@ -903,6 +957,12 @@
       "value": "number"
     }
   ],
+  "checkout_confirmation.heading.sepa_debit": [
+    {
+      "type": 0,
+      "value": "SEPA Debit"
+    }
+  ],
   "checkout_confirmation.heading.shipping_address": [
     {
       "type": 0,
@@ -919,6 +979,12 @@
     {
       "type": 0,
       "value": "Thank you for your order!"
+    }
+  ],
+  "checkout_confirmation.heading.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
     }
   ],
   "checkout_confirmation.label.free": [
@@ -2905,6 +2971,36 @@
       "value": "Password Reset Success"
     }
   ],
+  "payment_processing.error.unsuccessful": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
+    }
+  ],
+  "payment_processing.heading.payment_processing": [
+    {
+      "type": 0,
+      "value": "Payment Processing"
+    }
+  ],
+  "payment_processing.link.return_to_checkout": [
+    {
+      "type": 0,
+      "value": "Return to Checkout"
+    }
+  ],
+  "payment_processing.message.unexpected_error": [
+    {
+      "type": 0,
+      "value": "There was an unexpected error processing your payment."
+    }
+  ],
+  "payment_processing.message.working_on_your_payment": [
+    {
+      "type": 0,
+      "value": "Working on your payment..."
+    }
+  ],
   "payment_selection.heading.credit_card": [
     {
       "type": 0,
@@ -3363,6 +3459,12 @@
       "value": "See full details"
     }
   ],
+  "product_view.prepareBasket": [
+    {
+      "type": 0,
+      "value": "Unable to determine product ID for basket"
+    }
+  ],
   "product_view.status.in_stock_at_store": [
     {
       "type": 0,
@@ -3609,6 +3711,66 @@
     {
       "type": 0,
       "value": "In Stock"
+    }
+  ],
+  "sf_payments_order_summary.label.bank.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.amex": [
+    {
+      "type": 0,
+      "value": "American Express"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.diners": [
+    {
+      "type": 0,
+      "value": "Diners Club"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.discover": [
+    {
+      "type": 0,
+      "value": "Discover"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.jcb": [
+    {
+      "type": 0,
+      "value": "JCB"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.mastercard": [
+    {
+      "type": 0,
+      "value": "MasterCard"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unionpay": [
+    {
+      "type": 0,
+      "value": "China UnionPay"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unknown": [
+    {
+      "type": 0,
+      "value": "Unknown"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.visa": [
+    {
+      "type": 0,
+      "value": "Visa"
+    }
+  ],
+  "sfp_payments_express.error.default": [
+    {
+      "type": 0,
+      "value": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
     }
   ],
   "shipping_address.action.ship_to_multiple_addresses": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1561,6 +1561,20 @@
       "value": "]"
     }
   ],
+  "checkout.heading.express_checkout": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḗẋƥřḗḗşş Ƈħḗḗƈķǿǿŭŭŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "checkout.message.generic_error": [
     {
       "type": 0,
@@ -1569,6 +1583,48 @@
     {
       "type": 0,
       "value": "Ȧƞ ŭŭƞḗḗẋƥḗḗƈŧḗḗḓ ḗḗřřǿǿř ǿǿƈƈŭŭřřḗḗḓ ḓŭŭřīƞɠ ƈħḗḗƈķǿǿŭŭŧ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout.message.payment_button_cancel": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẏǿǿŭŭř ȧȧŧŧḗḗḿƥŧḗḗḓ ƥȧȧẏḿḗḗƞŧ ẇȧȧş ŭŭƞşŭŭƈƈḗḗşşƒŭŭŀ. Ẏǿǿŭŭ ħȧȧṽḗḗ ƞǿǿŧ ƀḗḗḗḗƞ ƈħȧȧřɠḗḗḓ ȧȧƞḓ ẏǿǿŭŭř ǿǿřḓḗḗř ħȧȧş ƞǿǿŧ ƀḗḗḗḗƞ ƥŀȧȧƈḗḗḓ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout.message.payment_confirm_failure": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƥȧȧẏḿḗḗƞŧ ƈǿǿƞƒīřḿȧȧŧīǿǿƞ ƒȧȧīŀḗḗḓ. Ẏǿǿŭŭř ǿǿřḓḗḗř ħȧȧş ƀḗḗḗḗƞ ƈȧȧƞƈḗḗŀŀḗḗḓ ȧȧƞḓ ẏǿǿŭŭř ƀȧȧşķḗḗŧ ħȧȧş ƀḗḗḗḗƞ řḗḗşŧǿǿřḗḗḓ. Ƥŀḗḗȧȧşḗḗ ŧřẏ ȧȧɠȧȧīƞ ǿǿř şḗḗŀḗḗƈŧ ȧȧ ḓīƒƒḗḗřḗḗƞŧ ƥȧȧẏḿḗḗƞŧ ḿḗḗŧħǿǿḓ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout.message.payment_processing_failed": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƥȧȧẏḿḗḗƞŧ ƥřǿǿƈḗḗşşīƞɠ ƒȧȧīŀḗḗḓ. Ẏǿǿŭŭř ǿǿřḓḗḗř ħȧȧş ƀḗḗḗḗƞ ƈȧȧƞƈḗḗŀŀḗḗḓ ȧȧƞḓ ẏǿǿŭŭř ƀȧȧşķḗḗŧ ħȧȧş ƀḗḗḗḗƞ řḗḗşŧǿǿřḗḗḓ. Ƥŀḗḗȧȧşḗḗ ŧřẏ ȧȧɠȧȧīƞ ǿǿř şḗḗŀḗḗƈŧ ȧȧ ḓīƒƒḗḗřḗḗƞŧ ƥȧȧẏḿḗḗƞŧ ḿḗḗŧħǿǿḓ."
     },
     {
       "type": 0,
@@ -1597,6 +1653,34 @@
     {
       "type": 0,
       "value": "Ƈřḗḗȧȧŧḗḗ Ȧƈƈǿǿŭŭƞŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_confirmation.heading.afterpay_clearpay": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ȧƒŧḗḗřƥȧȧẏ/Ƈŀḗḗȧȧřƥȧȧẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_confirmation.heading.bancontact": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓȧȧƞƈǿǿƞŧȧȧƈŧ"
     },
     {
       "type": 0,
@@ -1677,6 +1761,48 @@
       "value": "]"
     }
   ],
+  "checkout_confirmation.heading.eps": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ḖƤŞ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_confirmation.heading.ideal": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "īḒḖȦĿ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_confirmation.heading.klarna": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ķŀȧȧřƞȧȧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "checkout_confirmation.heading.order_summary": [
     {
       "type": 0,
@@ -1751,6 +1877,20 @@
       "value": "]"
     }
   ],
+  "checkout_confirmation.heading.sepa_debit": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ŞḖƤȦ Ḓḗḗƀīŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "checkout_confirmation.heading.shipping_address": [
     {
       "type": 0,
@@ -1787,6 +1927,20 @@
     {
       "type": 0,
       "value": "Ŧħȧȧƞķ ẏǿǿŭŭ ƒǿǿř ẏǿǿŭŭř ǿǿřḓḗḗř!"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "checkout_confirmation.heading.unknown": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŭƞķƞǿǿẇƞ"
     },
     {
       "type": 0,
@@ -6121,6 +6275,76 @@
       "value": "]"
     }
   ],
+  "payment_processing.error.unsuccessful": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẏǿǿŭŭř ȧȧŧŧḗḗḿƥŧḗḗḓ ƥȧȧẏḿḗḗƞŧ ẇȧȧş ŭŭƞşŭŭƈƈḗḗşşƒŭŭŀ. Ẏǿǿŭŭ ħȧȧṽḗḗ ƞǿǿŧ ƀḗḗḗḗƞ ƈħȧȧřɠḗḗḓ ȧȧƞḓ ẏǿǿŭŭř ǿǿřḓḗḗř ħȧȧş ƞǿǿŧ ƀḗḗḗḗƞ ƥŀȧȧƈḗḗḓ. Ƥŀḗḗȧȧşḗḗ şḗḗŀḗḗƈŧ ȧȧ ḓīƒƒḗḗřḗḗƞŧ ƥȧȧẏḿḗḗƞŧ ḿḗḗŧħǿǿḓ ȧȧƞḓ şŭŭƀḿīŧ ƥȧȧẏḿḗḗƞŧ ȧȧɠȧȧīƞ ŧǿǿ ƈǿǿḿƥŀḗḗŧḗḗ ẏǿǿŭŭř ƈħḗḗƈķǿǿŭŭŧ ȧȧƞḓ ƥŀȧȧƈḗḗ ẏǿǿŭŭř ǿǿřḓḗḗř."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "payment_processing.heading.payment_processing": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƥȧȧẏḿḗḗƞŧ Ƥřǿǿƈḗḗşşīƞɠ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "payment_processing.link.return_to_checkout": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Řḗḗŧŭŭřƞ ŧǿǿ Ƈħḗḗƈķǿǿŭŭŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "payment_processing.message.unexpected_error": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŧħḗḗřḗḗ ẇȧȧş ȧȧƞ ŭŭƞḗḗẋƥḗḗƈŧḗḗḓ ḗḗřřǿǿř ƥřǿǿƈḗḗşşīƞɠ ẏǿǿŭŭř ƥȧȧẏḿḗḗƞŧ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "payment_processing.message.working_on_your_payment": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẇǿǿřķīƞɠ ǿǿƞ ẏǿǿŭŭř ƥȧȧẏḿḗḗƞŧ..."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "payment_selection.heading.credit_card": [
     {
       "type": 0,
@@ -7083,6 +7307,20 @@
       "value": "]"
     }
   ],
+  "product_view.prepareBasket": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŭƞȧȧƀŀḗḗ ŧǿǿ ḓḗḗŧḗḗřḿīƞḗḗ ƥřǿǿḓŭŭƈŧ ĪḒ ƒǿǿř ƀȧȧşķḗḗŧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "product_view.status.in_stock_at_store": [
     {
       "type": 0,
@@ -7613,6 +7851,146 @@
     {
       "type": 0,
       "value": "Īƞ Şŧǿǿƈķ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.bank.unknown": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŭƞķƞǿǿẇƞ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.amex": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ȧḿḗḗřīƈȧȧƞ Ḗẋƥřḗḗşş"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.diners": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḓīƞḗḗřş Ƈŀŭŭƀ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.discover": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḓīşƈǿǿṽḗḗř"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.jcb": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ĴƇƁ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.mastercard": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "ḾȧȧşŧḗḗřƇȧȧřḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unionpay": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈħīƞȧȧ ŬƞīǿǿƞƤȧȧẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.unknown": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŭƞķƞǿǿẇƞ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sf_payments_order_summary.label.brand.visa": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ṽīşȧȧ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "sfp_payments_express.error.default": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẏǿǿŭŭř ȧȧŧŧḗḗḿƥŧḗḗḓ ƥȧȧẏḿḗḗƞŧ ẇȧȧş ŭŭƞşŭŭƈƈḗḗşşƒŭŭŀ. Ẏǿǿŭŭ ħȧȧṽḗḗ ƞǿǿŧ ƀḗḗḗḗƞ ƈħȧȧřɠḗḗḓ ȧȧƞḓ ẏǿǿŭŭř ǿǿřḓḗḗř ħȧȧş ƞǿǿŧ ƀḗḗḗḗƞ ƥŀȧȧƈḗḗḓ. Ƥŀḗḗȧȧşḗḗ şḗḗŀḗḗƈŧ ȧȧ ḓīƒƒḗḗřḗḗƞŧ ƥȧȧẏḿḗḗƞŧ ḿḗḗŧħǿǿḓ ȧȧƞḓ şŭŭƀḿīŧ ƥȧȧẏḿḗḗƞŧ ȧȧɠȧȧīƞ ŧǿǿ ƈǿǿḿƥŀḗḗŧḗḗ ẏǿǿŭŭř ƈħḗḗƈķǿǿŭŭŧ ȧȧƞḓ ƥŀȧȧƈḗḗ ẏǿǿŭŭř ǿǿřḓḗḗř."
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/utils/sf-payments-utils.js
+++ b/packages/template-retail-react-app/app/utils/sf-payments-utils.js
@@ -6,6 +6,15 @@
  */
 
 /**
+ * Helper function to read the client secret from the payment instrument
+ * @param {Object} paymentInstrument - Payment instrument object
+ * @returns {string|null} Client secret
+ */
+export const getClientSecret = (paymentInstrument) => {
+    return paymentInstrument?.paymentReference?.gatewayProperties?.stripe?.clientSecret
+}
+
+/**
  * Returns the first Salesforce Payments instrument found in a basket or order.
  * @param {Object} basketOrOrder - A basket or order object containing paymentInstruments
  * @returns {Object|undefined} First Salesforce Payments payment instrument found, or undefined if none exist

--- a/packages/template-retail-react-app/app/utils/sf-payments-utils.test.js
+++ b/packages/template-retail-react-app/app/utils/sf-payments-utils.test.js
@@ -13,7 +13,8 @@ import {
     getSelectedShippingMethodId,
     isShippingMethodValid,
     isPayPalPaymentMethodType,
-    createPaymentInstrumentBody
+    createPaymentInstrumentBody,
+    getClientSecret
 } from '@salesforce/retail-react-app/app/utils/sf-payments-utils'
 
 describe('sf-payments-utils', () => {
@@ -1113,6 +1114,32 @@ describe('sf-payments-utils', () => {
             )
 
             expect(result.paymentReferenceRequest.shippingPreference).toBe('GET_FROM_FILE')
+        })
+    })
+
+    describe('getClientSecret', () => {
+        test('returns clientSecret from gatewayProperties.stripe structure', () => {
+            const paymentInstrument = {
+                paymentReference: {
+                    gatewayProperties: {
+                        stripe: {
+                            clientSecret: 'pi_3Sfub6RArCOz1e7h0XCpAXOJ_secret_MV5Mk96oULHJLY7OLU6r74Hao'
+                        }
+                    },
+                    paymentReferenceId: 'pi_3Sfub6RArCOz1e7h0XCpAXOJ'
+                }
+            }
+
+            const result = getClientSecret(paymentInstrument)
+
+            expect(result).toBe('pi_3Sfub6RArCOz1e7h0XCpAXOJ_secret_MV5Mk96oULHJLY7OLU6r74Hao')
+        })
+
+        test('returns undefined when structure is missing or invalid', () => {
+            expect(getClientSecret(null)).toBeUndefined()
+            expect(getClientSecret(undefined)).toBeUndefined()
+            expect(getClientSecret({})).toBeUndefined()
+            expect(getClientSecret({paymentReference: {}})).toBeUndefined()
         })
     })
 })

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -279,14 +279,32 @@
   "checkout.button.place_order": {
     "defaultMessage": "Place Order"
   },
+  "checkout.heading.express_checkout": {
+    "defaultMessage": "Express Checkout"
+  },
   "checkout.message.generic_error": {
     "defaultMessage": "An unexpected error occurred during checkout."
+  },
+  "checkout.message.payment_button_cancel": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed."
+  },
+  "checkout.message.payment_confirm_failure": {
+    "defaultMessage": "Payment confirmation failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
+  },
+  "checkout.message.payment_processing_failed": {
+    "defaultMessage": "Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
   },
   "checkout.title.checkout": {
     "defaultMessage": "Checkout"
   },
   "checkout_confirmation.button.create_account": {
     "defaultMessage": "Create Account"
+  },
+  "checkout_confirmation.heading.afterpay_clearpay": {
+    "defaultMessage": "Afterpay/Clearpay"
+  },
+  "checkout_confirmation.heading.bancontact": {
+    "defaultMessage": "Bancontact"
   },
   "checkout_confirmation.heading.billing_address": {
     "defaultMessage": "Billing Address"
@@ -303,6 +321,15 @@
   "checkout_confirmation.heading.delivery_number": {
     "defaultMessage": "Delivery {number}"
   },
+  "checkout_confirmation.heading.eps": {
+    "defaultMessage": "EPS"
+  },
+  "checkout_confirmation.heading.ideal": {
+    "defaultMessage": "iDEAL"
+  },
+  "checkout_confirmation.heading.klarna": {
+    "defaultMessage": "Klarna"
+  },
   "checkout_confirmation.heading.order_summary": {
     "defaultMessage": "Order Summary"
   },
@@ -318,6 +345,9 @@
   "checkout_confirmation.heading.pickup_location_number": {
     "defaultMessage": "Pickup Location {number}"
   },
+  "checkout_confirmation.heading.sepa_debit": {
+    "defaultMessage": "SEPA Debit"
+  },
   "checkout_confirmation.heading.shipping_address": {
     "defaultMessage": "Shipping Address"
   },
@@ -326,6 +356,9 @@
   },
   "checkout_confirmation.heading.thank_you_for_order": {
     "defaultMessage": "Thank you for your order!"
+  },
+  "checkout_confirmation.heading.unknown": {
+    "defaultMessage": "Unknown"
   },
   "checkout_confirmation.label.free": {
     "defaultMessage": "Free"
@@ -1218,6 +1251,21 @@
   "password_reset_success.toast": {
     "defaultMessage": "Password Reset Success"
   },
+  "payment_processing.error.unsuccessful": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
+  },
+  "payment_processing.heading.payment_processing": {
+    "defaultMessage": "Payment Processing"
+  },
+  "payment_processing.link.return_to_checkout": {
+    "defaultMessage": "Return to Checkout"
+  },
+  "payment_processing.message.unexpected_error": {
+    "defaultMessage": "There was an unexpected error processing your payment."
+  },
+  "payment_processing.message.working_on_your_payment": {
+    "defaultMessage": "Working on your payment..."
+  },
   "payment_selection.heading.credit_card": {
     "defaultMessage": "Credit Card"
   },
@@ -1408,6 +1456,9 @@
   "product_view.link.full_details": {
     "defaultMessage": "See full details"
   },
+  "product_view.prepareBasket": {
+    "defaultMessage": "Unable to determine product ID for basket"
+  },
   "product_view.status.in_stock_at_store": {
     "defaultMessage": "In stock at {storeName}"
   },
@@ -1516,6 +1567,36 @@
   },
   "selected_refinements.filter.in_stock": {
     "defaultMessage": "In Stock"
+  },
+  "sf_payments_order_summary.label.bank.unknown": {
+    "defaultMessage": "Unknown"
+  },
+  "sf_payments_order_summary.label.brand.amex": {
+    "defaultMessage": "American Express"
+  },
+  "sf_payments_order_summary.label.brand.diners": {
+    "defaultMessage": "Diners Club"
+  },
+  "sf_payments_order_summary.label.brand.discover": {
+    "defaultMessage": "Discover"
+  },
+  "sf_payments_order_summary.label.brand.jcb": {
+    "defaultMessage": "JCB"
+  },
+  "sf_payments_order_summary.label.brand.mastercard": {
+    "defaultMessage": "MasterCard"
+  },
+  "sf_payments_order_summary.label.brand.unionpay": {
+    "defaultMessage": "China UnionPay"
+  },
+  "sf_payments_order_summary.label.brand.unknown": {
+    "defaultMessage": "Unknown"
+  },
+  "sf_payments_order_summary.label.brand.visa": {
+    "defaultMessage": "Visa"
+  },
+  "sfp_payments_express.error.default": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
   },
   "shipping_address.action.ship_to_multiple_addresses": {
     "defaultMessage": "Ship to Multiple Addresses"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -279,14 +279,32 @@
   "checkout.button.place_order": {
     "defaultMessage": "Place Order"
   },
+  "checkout.heading.express_checkout": {
+    "defaultMessage": "Express Checkout"
+  },
   "checkout.message.generic_error": {
     "defaultMessage": "An unexpected error occurred during checkout."
+  },
+  "checkout.message.payment_button_cancel": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed."
+  },
+  "checkout.message.payment_confirm_failure": {
+    "defaultMessage": "Payment confirmation failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
+  },
+  "checkout.message.payment_processing_failed": {
+    "defaultMessage": "Payment processing failed. Your order has been cancelled and your basket has been restored. Please try again or select a different payment method."
   },
   "checkout.title.checkout": {
     "defaultMessage": "Checkout"
   },
   "checkout_confirmation.button.create_account": {
     "defaultMessage": "Create Account"
+  },
+  "checkout_confirmation.heading.afterpay_clearpay": {
+    "defaultMessage": "Afterpay/Clearpay"
+  },
+  "checkout_confirmation.heading.bancontact": {
+    "defaultMessage": "Bancontact"
   },
   "checkout_confirmation.heading.billing_address": {
     "defaultMessage": "Billing Address"
@@ -303,6 +321,15 @@
   "checkout_confirmation.heading.delivery_number": {
     "defaultMessage": "Delivery {number}"
   },
+  "checkout_confirmation.heading.eps": {
+    "defaultMessage": "EPS"
+  },
+  "checkout_confirmation.heading.ideal": {
+    "defaultMessage": "iDEAL"
+  },
+  "checkout_confirmation.heading.klarna": {
+    "defaultMessage": "Klarna"
+  },
   "checkout_confirmation.heading.order_summary": {
     "defaultMessage": "Order Summary"
   },
@@ -318,6 +345,9 @@
   "checkout_confirmation.heading.pickup_location_number": {
     "defaultMessage": "Pickup Location {number}"
   },
+  "checkout_confirmation.heading.sepa_debit": {
+    "defaultMessage": "SEPA Debit"
+  },
   "checkout_confirmation.heading.shipping_address": {
     "defaultMessage": "Shipping Address"
   },
@@ -326,6 +356,9 @@
   },
   "checkout_confirmation.heading.thank_you_for_order": {
     "defaultMessage": "Thank you for your order!"
+  },
+  "checkout_confirmation.heading.unknown": {
+    "defaultMessage": "Unknown"
   },
   "checkout_confirmation.label.free": {
     "defaultMessage": "Free"
@@ -1218,6 +1251,21 @@
   "password_reset_success.toast": {
     "defaultMessage": "Password Reset Success"
   },
+  "payment_processing.error.unsuccessful": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
+  },
+  "payment_processing.heading.payment_processing": {
+    "defaultMessage": "Payment Processing"
+  },
+  "payment_processing.link.return_to_checkout": {
+    "defaultMessage": "Return to Checkout"
+  },
+  "payment_processing.message.unexpected_error": {
+    "defaultMessage": "There was an unexpected error processing your payment."
+  },
+  "payment_processing.message.working_on_your_payment": {
+    "defaultMessage": "Working on your payment..."
+  },
   "payment_selection.heading.credit_card": {
     "defaultMessage": "Credit Card"
   },
@@ -1408,6 +1456,9 @@
   "product_view.link.full_details": {
     "defaultMessage": "See full details"
   },
+  "product_view.prepareBasket": {
+    "defaultMessage": "Unable to determine product ID for basket"
+  },
   "product_view.status.in_stock_at_store": {
     "defaultMessage": "In stock at {storeName}"
   },
@@ -1516,6 +1567,36 @@
   },
   "selected_refinements.filter.in_stock": {
     "defaultMessage": "In Stock"
+  },
+  "sf_payments_order_summary.label.bank.unknown": {
+    "defaultMessage": "Unknown"
+  },
+  "sf_payments_order_summary.label.brand.amex": {
+    "defaultMessage": "American Express"
+  },
+  "sf_payments_order_summary.label.brand.diners": {
+    "defaultMessage": "Diners Club"
+  },
+  "sf_payments_order_summary.label.brand.discover": {
+    "defaultMessage": "Discover"
+  },
+  "sf_payments_order_summary.label.brand.jcb": {
+    "defaultMessage": "JCB"
+  },
+  "sf_payments_order_summary.label.brand.mastercard": {
+    "defaultMessage": "MasterCard"
+  },
+  "sf_payments_order_summary.label.brand.unionpay": {
+    "defaultMessage": "China UnionPay"
+  },
+  "sf_payments_order_summary.label.brand.unknown": {
+    "defaultMessage": "Unknown"
+  },
+  "sf_payments_order_summary.label.brand.visa": {
+    "defaultMessage": "Visa"
+  },
+  "sfp_payments_express.error.default": {
+    "defaultMessage": "Your attempted payment was unsuccessful. You have not been charged and your order has not been placed. Please select a different payment method and submit payment again to complete your checkout and place your order."
   },
   "shipping_address.action.ship_to_multiple_addresses": {
     "defaultMessage": "Ship to Multiple Addresses"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

Add the new FailOrder endpoint into PWA's commerce-react-sdk repo and integrate it into the Express and Sheet components.  Failorder will be called during the following scenarios

createOrderAndUpdatePayment: when the payment instrument on order patch API fails with an error and does not return the expected client-secret for Stripe.  For PayPal, order is created immediately and thus if the patch API fails, fail order is also called immediately and not after user decides to Pay

paymentError:  when the SDK dispatches an actual error event, a check is made against the order before failing

confirmPayment: when the payment instrument on order patch API passes but confirm fails on the client-side

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Fail Order API 
- Error messages
- PayPal vs Stripe Fail Order flows

# How to Test-Drive This PR

- Best way to test would be to use a card decline example.  It might be tricky to force the payment instrument patch api itself to fail unless there is a way to pass an invalid zone/amount to it from the UI.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [x] Changes include a UI text update in the Retail React App (which requires translation)
