### PR TITLE
@W-20452321: Migrate AWS SDK V2 to V3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "3.16.0-dev",
             "hasInstallScript": true,
             "dependencies": {
+                "@aws-sdk/client-cloudwatch": "^3.962.0",
                 "node-fetch": "^2.6.9"
             },
             "devDependencies": {
@@ -37,6 +38,660 @@
             "engines": {
                 "node": "^16.11.0 || ^18.0.0 || ^20.0.0 || ^22.0.0",
                 "npm": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser": {
+            "version": "5.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-js": "^5.2.0",
+                "@aws-crypto/supports-web-crypto": "^5.2.0",
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "@aws-sdk/util-locate-window": "^3.0.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/sha256-js": {
+            "version": "5.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/util": "^5.2.0",
+                "@aws-sdk/types": "^3.222.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/supports-web-crypto": {
+            "version": "5.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util": {
+            "version": "5.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/util/-/util-5.2.0.tgz",
+            "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.222.0",
+                "@smithy/util-utf8": "^2.0.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+            "version": "2.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+            "version": "2.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+            "version": "2.3.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^2.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cloudwatch": {
+            "version": "3.962.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.962.0.tgz",
+            "integrity": "sha512-zLvLd4INcG+qBmv1zaQZ7P/A5tc98xazgizz6ioQUcm7uJZrhx4oK8tdpD4AhN2Ow3iFD2hlf7aVtiNlMoGd7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/credential-provider-node": "3.962.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-compression": "^4.3.16",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/util-waiter": "^4.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-sso": {
+            "version": "3.958.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-sso/-/client-sso-3.958.0.tgz",
+            "integrity": "sha512-6qNCIeaMzKzfqasy2nNRuYnMuaMebCcCPP4J2CVGkA8QYMbIVKPlkn9bpB20Vxe6H/r3jtCCLQaOJjVTx/6dXg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/core/-/core-3.957.0.tgz",
+            "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/xml-builder": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/signature-v4": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-env/-/credential-provider-env-3.957.0.tgz",
+            "integrity": "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-http/-/credential-provider-http-3.957.0.tgz",
+            "integrity": "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-stream": "^4.5.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.962.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.962.0.tgz",
+            "integrity": "sha512-h0kVnXLW2d3nxbcrR/Pfg3W/+YoCguasWz7/3nYzVqmdKarGrpJzaFdoZtLgvDSZ8VgWUC4lWOTcsDMV0UNqUQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/credential-provider-env": "3.957.0",
+                "@aws-sdk/credential-provider-http": "3.957.0",
+                "@aws-sdk/credential-provider-login": "3.962.0",
+                "@aws-sdk/credential-provider-process": "3.957.0",
+                "@aws-sdk/credential-provider-sso": "3.958.0",
+                "@aws-sdk/credential-provider-web-identity": "3.958.0",
+                "@aws-sdk/nested-clients": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.962.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-login/-/credential-provider-login-3.962.0.tgz",
+            "integrity": "sha512-kHYH6Av2UifG3mPkpPUNRh/PuX6adaAcpmsclJdHdxlixMCRdh8GNeEihq480DC0GmfqdpoSf1w2CLmLLPIS6w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.962.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-node/-/credential-provider-node-3.962.0.tgz",
+            "integrity": "sha512-CS78NsWRxLa+nWqeWBEYMZTLacMFIXs1C5WJuM9kD05LLiWL32ksljoPsvNN24Bc7rCSQIIMx/U3KGvkDVZMVg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.957.0",
+                "@aws-sdk/credential-provider-http": "3.957.0",
+                "@aws-sdk/credential-provider-ini": "3.962.0",
+                "@aws-sdk/credential-provider-process": "3.957.0",
+                "@aws-sdk/credential-provider-sso": "3.958.0",
+                "@aws-sdk/credential-provider-web-identity": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-process/-/credential-provider-process-3.957.0.tgz",
+            "integrity": "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.958.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.958.0.tgz",
+            "integrity": "sha512-CBYHJ5ufp8HC4q+o7IJejCUctJXWaksgpmoFpXerbjAso7/Fg7LLUu9inXVOxlHKLlvYekDXjIUBXDJS2WYdgg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.958.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/token-providers": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.958.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.958.0.tgz",
+            "integrity": "sha512-dgnvwjMq5Y66WozzUzxNkCFap+umHUtqMMKlr8z/vl9NYMLem/WUbWNpFFOVFWquXikc+ewtpBMR4KEDXfZ+KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
+            "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
+            "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
+            "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@aws/lambda-invoke-store": "^0.2.2",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.957.0.tgz",
+            "integrity": "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@smithy/core": "^3.20.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.958.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/nested-clients/-/nested-clients-3.958.0.tgz",
+            "integrity": "sha512-/KuCcS8b5TpQXkYOrPLYytrgxBhv81+5pChkOlhegbeHttjM69pyUpQVJqyfDM/A7wPLnDrzCAnk4zaAOkY0Nw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/middleware-host-header": "3.957.0",
+                "@aws-sdk/middleware-logger": "3.957.0",
+                "@aws-sdk/middleware-recursion-detection": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/region-config-resolver": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/util-user-agent-browser": "3.957.0",
+                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/core": "^3.20.0",
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/hash-node": "^4.2.7",
+                "@smithy/invalid-dependency": "^4.2.7",
+                "@smithy/middleware-content-length": "^4.2.7",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-retry": "^4.4.17",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-body-length-node": "^4.2.1",
+                "@smithy/util-defaults-mode-browser": "^4.3.16",
+                "@smithy/util-defaults-mode-node": "^4.2.19",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
+            "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.958.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/token-providers/-/token-providers-3.958.0.tgz",
+            "integrity": "sha512-UCj7lQXODduD1myNJQkV+LYcGYJ9iiMggR8ow8Hva1g3A/Na5imNXzz6O67k7DAee0TYpy+gkNw+SizC6min8Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.957.0",
+                "@aws-sdk/nested-clients": "3.958.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/types/-/types-3.957.0.tgz",
+            "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
+            "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-endpoints": "^3.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-locate-window": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-locate-window/-/util-locate-window-3.957.0.tgz",
+            "integrity": "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
+            "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/types": "^4.11.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.957.0.tgz",
+            "integrity": "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.957.0",
+                "@aws-sdk/types": "3.957.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.957.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+            "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "fast-xml-parser": "5.2.5",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.2.2",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+            "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@axe-core/playwright": {
@@ -1983,6 +2638,621 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@smithy/abort-controller": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+            "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/config-resolver": {
+            "version": "4.4.5",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+            "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-endpoints": "^3.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/core": {
+            "version": "3.20.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/core/-/core-3.20.0.tgz",
+            "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-body-length-browser": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-stream": "^4.5.8",
+                "@smithy/util-utf8": "^4.2.0",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+            "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.3.8",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+            "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/querystring-builder": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/hash-node": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+            "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/invalid-dependency": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+            "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/is-array-buffer": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+            "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-compression": {
+            "version": "4.3.16",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-compression/-/middleware-compression-4.3.16.tgz",
+            "integrity": "sha512-df41cMk8D/Aa8JRhraZPbeHYUJ012ivOTp9kOs95amfMdRvgNFWz9/qBFbpnTEbsyvFtYfF4HjZ0bgzrkguECQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.20.0",
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-config-provider": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-utf8": "^4.2.0",
+                "fflate": "0.8.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-content-length": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+            "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-endpoint": {
+            "version": "4.4.1",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
+            "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.20.0",
+                "@smithy/middleware-serde": "^4.2.8",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/url-parser": "^4.2.7",
+                "@smithy/util-middleware": "^4.2.7",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-retry": {
+            "version": "4.4.17",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
+            "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/service-error-classification": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-retry": "^4.2.7",
+                "@smithy/uuid": "^1.1.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-serde": {
+            "version": "4.2.8",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+            "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/middleware-stack": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+            "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-config-provider": {
+            "version": "4.3.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+            "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/shared-ini-file-loader": "^4.4.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.4.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+            "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/querystring-builder": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/property-provider": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+            "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/protocol-http": {
+            "version": "5.3.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+            "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-builder": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+            "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/querystring-parser": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+            "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/service-error-classification": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+            "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.4.2",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+            "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.3.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+            "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-middleware": "^4.2.7",
+                "@smithy/util-uri-escape": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/smithy-client": {
+            "version": "4.10.2",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
+            "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.20.0",
+                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/middleware-stack": "^4.2.7",
+                "@smithy/protocol-http": "^5.3.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-stream": "^4.5.8",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.11.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/types/-/types-4.11.0.tgz",
+            "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/url-parser": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+            "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-base64": {
+            "version": "4.3.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+            "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-browser": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+            "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-body-length-node": {
+            "version": "4.2.1",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+            "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-buffer-from": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+            "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-config-provider": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+            "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.3.16",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
+            "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.2.19",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
+            "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.4.5",
+                "@smithy/credential-provider-imds": "^4.2.7",
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/property-provider": "^4.2.7",
+                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-endpoints": {
+            "version": "3.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+            "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.3.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-hex-encoding": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+            "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-middleware": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+            "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-retry": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+            "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-stream": {
+            "version": "4.5.8",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+            "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.3.8",
+                "@smithy/node-http-handler": "^4.4.7",
+                "@smithy/types": "^4.11.0",
+                "@smithy/util-base64": "^4.3.0",
+                "@smithy/util-buffer-from": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.2.0",
+                "@smithy/util-utf8": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-uri-escape": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+            "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-utf8": {
+            "version": "4.2.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+            "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/util-waiter": {
+            "version": "4.2.7",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+            "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.2.7",
+                "@smithy/types": "^4.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/uuid": {
+            "version": "1.1.0",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/uuid/-/uuid-1.1.0.tgz",
+            "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@tootallnate/once": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -2928,6 +4198,12 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.13.1",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/bowser/-/bowser-2.13.1.tgz",
+            "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
@@ -4957,6 +6233,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fast-xml-parser": {
+            "version": "5.2.5",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "strnum": "^2.1.0"
+            },
+            "bin": {
+                "fxparser": "src/cli/cli.js"
+            }
+        },
         "node_modules/fastq": {
             "version": "1.19.1",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -4966,6 +6260,12 @@
             "dependencies": {
                 "reusify": "^1.0.4"
             }
+        },
+        "node_modules/fflate": {
+            "version": "0.8.1",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fflate/-/fflate-0.8.1.tgz",
+            "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+            "license": "MIT"
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -12266,6 +13566,18 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strnum": {
+            "version": "2.1.2",
+            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/strnum/-/strnum-2.1.2.tgz",
+            "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/NaturalIntelligence"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/strong-log-transformer": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -12774,7 +14086,6 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
             "license": "0BSD"
         },
         "node_modules/tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         },
         "node_modules/@aws-crypto/sha256-browser": {
             "version": "5.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
             "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -57,7 +57,7 @@
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
             "version": "2.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
             "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -69,7 +69,7 @@
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
             "version": "2.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
             "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -82,7 +82,7 @@
         },
         "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
             "version": "2.3.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
             "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -95,7 +95,7 @@
         },
         "node_modules/@aws-crypto/sha256-js": {
             "version": "5.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
             "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -109,7 +109,7 @@
         },
         "node_modules/@aws-crypto/supports-web-crypto": {
             "version": "5.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
             "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -118,7 +118,7 @@
         },
         "node_modules/@aws-crypto/util": {
             "version": "5.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/util/-/util-5.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
             "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -129,7 +129,7 @@
         },
         "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
             "version": "2.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
             "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -141,7 +141,7 @@
         },
         "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
             "version": "2.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
             "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -154,7 +154,7 @@
         },
         "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
             "version": "2.3.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
             "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -166,24 +166,24 @@
             }
         },
         "node_modules/@aws-sdk/client-cloudwatch": {
-            "version": "3.962.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.962.0.tgz",
-            "integrity": "sha512-zLvLd4INcG+qBmv1zaQZ7P/A5tc98xazgizz6ioQUcm7uJZrhx4oK8tdpD4AhN2Ow3iFD2hlf7aVtiNlMoGd7A==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.965.0.tgz",
+            "integrity": "sha512-zw1s/JmF7S4+y8oYaTle4WXkMqvA9qNMJIN0CRtbrL4rLNdtkA2gGFS29wo4XiIJVUgRfdsPAc7ft1epjLmbaw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/credential-provider-node": "3.962.0",
-                "@aws-sdk/middleware-host-header": "3.957.0",
-                "@aws-sdk/middleware-logger": "3.957.0",
-                "@aws-sdk/middleware-recursion-detection": "3.957.0",
-                "@aws-sdk/middleware-user-agent": "3.957.0",
-                "@aws-sdk/region-config-resolver": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
-                "@aws-sdk/util-endpoints": "3.957.0",
-                "@aws-sdk/util-user-agent-browser": "3.957.0",
-                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/credential-provider-node": "3.965.0",
+                "@aws-sdk/middleware-host-header": "3.965.0",
+                "@aws-sdk/middleware-logger": "3.965.0",
+                "@aws-sdk/middleware-recursion-detection": "3.965.0",
+                "@aws-sdk/middleware-user-agent": "3.965.0",
+                "@aws-sdk/region-config-resolver": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
+                "@aws-sdk/util-endpoints": "3.965.0",
+                "@aws-sdk/util-user-agent-browser": "3.965.0",
+                "@aws-sdk/util-user-agent-node": "3.965.0",
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/core": "^3.20.0",
                 "@smithy/fetch-http-handler": "^5.3.8",
@@ -218,23 +218,23 @@
             }
         },
         "node_modules/@aws-sdk/client-sso": {
-            "version": "3.958.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-sso/-/client-sso-3.958.0.tgz",
-            "integrity": "sha512-6qNCIeaMzKzfqasy2nNRuYnMuaMebCcCPP4J2CVGkA8QYMbIVKPlkn9bpB20Vxe6H/r3jtCCLQaOJjVTx/6dXg==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.965.0.tgz",
+            "integrity": "sha512-iv2tr+n4aZ+nPUFFvG00hISPuEd4DU+1/Q8rPAYKXsM+vEPJ2nAnP5duUOa2fbOLIUCRxX3dcQaQaghVHDHzQw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/middleware-host-header": "3.957.0",
-                "@aws-sdk/middleware-logger": "3.957.0",
-                "@aws-sdk/middleware-recursion-detection": "3.957.0",
-                "@aws-sdk/middleware-user-agent": "3.957.0",
-                "@aws-sdk/region-config-resolver": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
-                "@aws-sdk/util-endpoints": "3.957.0",
-                "@aws-sdk/util-user-agent-browser": "3.957.0",
-                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/middleware-host-header": "3.965.0",
+                "@aws-sdk/middleware-logger": "3.965.0",
+                "@aws-sdk/middleware-recursion-detection": "3.965.0",
+                "@aws-sdk/middleware-user-agent": "3.965.0",
+                "@aws-sdk/region-config-resolver": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
+                "@aws-sdk/util-endpoints": "3.965.0",
+                "@aws-sdk/util-user-agent-browser": "3.965.0",
+                "@aws-sdk/util-user-agent-node": "3.965.0",
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/core": "^3.20.0",
                 "@smithy/fetch-http-handler": "^5.3.8",
@@ -267,13 +267,13 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/core/-/core-3.957.0.tgz",
-            "integrity": "sha512-DrZgDnF1lQZv75a52nFWs6MExihJF2GZB6ETZRqr6jMwhrk2kbJPUtvgbifwcL7AYmVqHQDJBrR/MqkwwFCpiw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.965.0.tgz",
+            "integrity": "sha512-aq9BhQxdHit8UUJ9C0im9TtuKeK0pT6NXmNJxMTCFeStI7GG7ImIsSislg3BZTIifVg1P6VLdzMyz9de85iutQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
-                "@aws-sdk/xml-builder": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
+                "@aws-sdk/xml-builder": "3.965.0",
                 "@smithy/core": "^3.20.0",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/property-provider": "^4.2.7",
@@ -291,13 +291,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-env/-/credential-provider-env-3.957.0.tgz",
-            "integrity": "sha512-475mkhGaWCr+Z52fOOVb/q2VHuNvqEDixlYIkeaO6xJ6t9qR0wpLt4hOQaR6zR1wfZV0SlE7d8RErdYq/PByog==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.965.0.tgz",
+            "integrity": "sha512-mdGnaIjMxTIjsb70dEj3VsWPWpoq1V5MWzBSfJq2H8zgMBXjn6d5/qHP8HMf53l9PrsgqzMpXGv3Av549A2x1g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
@@ -307,13 +307,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-http/-/credential-provider-http-3.957.0.tgz",
-            "integrity": "sha512-8dS55QHRxXgJlHkEYaCGZIhieCs9NU1HU1BcqQ4RfUdSsfRdxxktqUKgCnBnOOn0oD3PPA8cQOCAVgIyRb3Rfw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.965.0.tgz",
+            "integrity": "sha512-YuGQel9EgA/z25oeLM+GYYQS750+8AESvr7ZEmVnRPL0sg+K3DmGqdv+9gFjFd0UkLjTlC/jtbP2cuY6UcPiHQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/fetch-http-handler": "^5.3.8",
                 "@smithy/node-http-handler": "^4.4.7",
                 "@smithy/property-provider": "^4.2.7",
@@ -328,20 +328,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.962.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.962.0.tgz",
-            "integrity": "sha512-h0kVnXLW2d3nxbcrR/Pfg3W/+YoCguasWz7/3nYzVqmdKarGrpJzaFdoZtLgvDSZ8VgWUC4lWOTcsDMV0UNqUQ==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.965.0.tgz",
+            "integrity": "sha512-xRo72Prer5s0xYVSCxCymVIRSqrVlevK5cmU0GWq9yJtaBNpnx02jwdJg80t/Ni7pgbkQyFWRMcq38c1tc6M/w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/credential-provider-env": "3.957.0",
-                "@aws-sdk/credential-provider-http": "3.957.0",
-                "@aws-sdk/credential-provider-login": "3.962.0",
-                "@aws-sdk/credential-provider-process": "3.957.0",
-                "@aws-sdk/credential-provider-sso": "3.958.0",
-                "@aws-sdk/credential-provider-web-identity": "3.958.0",
-                "@aws-sdk/nested-clients": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/credential-provider-env": "3.965.0",
+                "@aws-sdk/credential-provider-http": "3.965.0",
+                "@aws-sdk/credential-provider-login": "3.965.0",
+                "@aws-sdk/credential-provider-process": "3.965.0",
+                "@aws-sdk/credential-provider-sso": "3.965.0",
+                "@aws-sdk/credential-provider-web-identity": "3.965.0",
+                "@aws-sdk/nested-clients": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -353,14 +353,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.962.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-login/-/credential-provider-login-3.962.0.tgz",
-            "integrity": "sha512-kHYH6Av2UifG3mPkpPUNRh/PuX6adaAcpmsclJdHdxlixMCRdh8GNeEihq480DC0GmfqdpoSf1w2CLmLLPIS6w==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.965.0.tgz",
+            "integrity": "sha512-43/H8Qku8LHyugbhLo8kjD+eauhybCeVkmrnvWl8bXNHJP7xi1jCdtBQJKKJqiIHZws4MOEwkji8kFdAVRCe6g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/nested-clients": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/nested-clients": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -372,18 +372,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.962.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-node/-/credential-provider-node-3.962.0.tgz",
-            "integrity": "sha512-CS78NsWRxLa+nWqeWBEYMZTLacMFIXs1C5WJuM9kD05LLiWL32ksljoPsvNN24Bc7rCSQIIMx/U3KGvkDVZMVg==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.965.0.tgz",
+            "integrity": "sha512-cRxmMHF+Zh2lkkkEVduKl+8OQdtg/DhYA69+/7SPSQURlgyjFQGlRQ58B7q8abuNlrGT3sV+UzeOylZpJbV61Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "3.957.0",
-                "@aws-sdk/credential-provider-http": "3.957.0",
-                "@aws-sdk/credential-provider-ini": "3.962.0",
-                "@aws-sdk/credential-provider-process": "3.957.0",
-                "@aws-sdk/credential-provider-sso": "3.958.0",
-                "@aws-sdk/credential-provider-web-identity": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/credential-provider-env": "3.965.0",
+                "@aws-sdk/credential-provider-http": "3.965.0",
+                "@aws-sdk/credential-provider-ini": "3.965.0",
+                "@aws-sdk/credential-provider-process": "3.965.0",
+                "@aws-sdk/credential-provider-sso": "3.965.0",
+                "@aws-sdk/credential-provider-web-identity": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -395,13 +395,13 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-process/-/credential-provider-process-3.957.0.tgz",
-            "integrity": "sha512-/KIz9kadwbeLy6SKvT79W81Y+hb/8LMDyeloA2zhouE28hmne+hLn0wNCQXAAupFFlYOAtZR2NTBs7HBAReJlg==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.965.0.tgz",
+            "integrity": "sha512-gmkPmdiR0yxnTzLPDb7rwrDhGuCUjtgnj8qWP+m0gSz/W43rR4jRPVEf6DUX2iC+ImQhxo3NFhuB3V42Kzo3TQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
                 "@smithy/types": "^4.11.0",
@@ -412,15 +412,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.958.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.958.0.tgz",
-            "integrity": "sha512-CBYHJ5ufp8HC4q+o7IJejCUctJXWaksgpmoFpXerbjAso7/Fg7LLUu9inXVOxlHKLlvYekDXjIUBXDJS2WYdgg==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.965.0.tgz",
+            "integrity": "sha512-N01AYvtCqG3Wo/s/LvYt19ity18/FqggiXT+elAs3X9Om/Wfx+hw9G+i7jaDmy+/xewmv8AdQ2SK5Q30dXw/Fw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/client-sso": "3.958.0",
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/token-providers": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/client-sso": "3.965.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/token-providers": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
                 "@smithy/types": "^4.11.0",
@@ -431,14 +431,14 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.958.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.958.0.tgz",
-            "integrity": "sha512-dgnvwjMq5Y66WozzUzxNkCFap+umHUtqMMKlr8z/vl9NYMLem/WUbWNpFFOVFWquXikc+ewtpBMR4KEDXfZ+KA==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.965.0.tgz",
+            "integrity": "sha512-T4gMZ2JzXnfxe1oTD+EDGLSxFfk1+WkLZdiHXEMZp8bFI1swP/3YyDFXI+Ib9Uq1JhnAmrCXtOnkicKEhDkdhQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/nested-clients": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/nested-clients": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
                 "@smithy/types": "^4.11.0",
@@ -449,12 +449,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
-            "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.965.0.tgz",
+            "integrity": "sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
@@ -464,12 +464,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
-            "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.965.0.tgz",
+            "integrity": "sha512-gjUvJRZT1bUABKewnvkj51LAynFrfz2h5DYAg5/2F4Utx6UOGByTSr9Rq8JCLbURvvzAbCtcMkkIJRxw+8Zuzw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -478,12 +478,12 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
-            "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.965.0.tgz",
+            "integrity": "sha512-6dvD+18Ni14KCRu+tfEoNxq1sIGVp9tvoZDZ7aMvpnA7mDXuRLrOjRQ/TAZqXwr9ENKVGyxcPl0cRK8jk1YWjA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@aws/lambda-invoke-store": "^0.2.2",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
@@ -494,14 +494,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.957.0.tgz",
-            "integrity": "sha512-50vcHu96XakQnIvlKJ1UoltrFODjsq2KvtTgHiPFteUS884lQnK5VC/8xd1Msz/1ONpLMzdCVproCQqhDTtMPQ==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.965.0.tgz",
+            "integrity": "sha512-RBEYVGgu/WeAt+H/qLrGc+t8LqAUkbyvh3wBfTiuAD+uBcWsKnvnB1iSBX75FearC0fmoxzXRUc0PMxMdqpjJQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
-                "@aws-sdk/util-endpoints": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
+                "@aws-sdk/util-endpoints": "3.965.0",
                 "@smithy/core": "^3.20.0",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
@@ -512,23 +512,23 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.958.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/nested-clients/-/nested-clients-3.958.0.tgz",
-            "integrity": "sha512-/KuCcS8b5TpQXkYOrPLYytrgxBhv81+5pChkOlhegbeHttjM69pyUpQVJqyfDM/A7wPLnDrzCAnk4zaAOkY0Nw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.965.0.tgz",
+            "integrity": "sha512-muNVUjUEU+/KLFrLzQ8PMXyw4+a/MP6t4GIvwLtyx/kH0rpSy5s0YmqacMXheuIe6F/5QT8uksXGNAQenitkGQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/middleware-host-header": "3.957.0",
-                "@aws-sdk/middleware-logger": "3.957.0",
-                "@aws-sdk/middleware-recursion-detection": "3.957.0",
-                "@aws-sdk/middleware-user-agent": "3.957.0",
-                "@aws-sdk/region-config-resolver": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
-                "@aws-sdk/util-endpoints": "3.957.0",
-                "@aws-sdk/util-user-agent-browser": "3.957.0",
-                "@aws-sdk/util-user-agent-node": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/middleware-host-header": "3.965.0",
+                "@aws-sdk/middleware-logger": "3.965.0",
+                "@aws-sdk/middleware-recursion-detection": "3.965.0",
+                "@aws-sdk/middleware-user-agent": "3.965.0",
+                "@aws-sdk/region-config-resolver": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
+                "@aws-sdk/util-endpoints": "3.965.0",
+                "@aws-sdk/util-user-agent-browser": "3.965.0",
+                "@aws-sdk/util-user-agent-node": "3.965.0",
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/core": "^3.20.0",
                 "@smithy/fetch-http-handler": "^5.3.8",
@@ -561,12 +561,12 @@
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
-            "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.965.0.tgz",
+            "integrity": "sha512-RoMhu9ly2B0coxn8ctXosPP2WmDD0MkQlZGLjoYHQUOCBmty5qmCxOqBmBDa6wbWbB8xKtMQ/4VXloQOgzjHXg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/types": "^4.11.0",
@@ -577,14 +577,14 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.958.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/token-providers/-/token-providers-3.958.0.tgz",
-            "integrity": "sha512-UCj7lQXODduD1myNJQkV+LYcGYJ9iiMggR8ow8Hva1g3A/Na5imNXzz6O67k7DAee0TYpy+gkNw+SizC6min8Q==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.965.0.tgz",
+            "integrity": "sha512-aR0qxg0b8flkXJVE+CM1gzo7uJ57md50z2eyCwofC0QIz5Y0P7/7vvb9/dmUQt6eT9XRN5iRcUqq2IVxVDvJOw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "3.957.0",
-                "@aws-sdk/nested-clients": "3.958.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/core": "3.965.0",
+                "@aws-sdk/nested-clients": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/property-provider": "^4.2.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
                 "@smithy/types": "^4.11.0",
@@ -595,9 +595,9 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/types/-/types-3.957.0.tgz",
-            "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.965.0.tgz",
+            "integrity": "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.11.0",
@@ -608,12 +608,12 @@
             }
         },
         "node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
-            "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.965.0.tgz",
+            "integrity": "sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/types": "^4.11.0",
                 "@smithy/url-parser": "^4.2.7",
                 "@smithy/util-endpoints": "^3.2.7",
@@ -624,9 +624,9 @@
             }
         },
         "node_modules/@aws-sdk/util-locate-window": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-locate-window/-/util-locate-window-3.957.0.tgz",
-            "integrity": "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.0.tgz",
+            "integrity": "sha512-9LJFand4bIoOjOF4x3wx0UZYiFZRo4oUauxQSiEX2dVg+5qeBOJSjp2SeWykIE6+6frCZ5wvWm2fGLK8D32aJw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -636,25 +636,25 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
-            "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.965.0.tgz",
+            "integrity": "sha512-Xiza/zMntQGpkd2dETQeAK8So1pg5+STTzpcdGWxj5q0jGO5ayjqT/q1Q7BrsX5KIr6PvRkl9/V7lLCv04wGjQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/types": "^4.11.0",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.957.0.tgz",
-            "integrity": "sha512-ycbYCwqXk4gJGp0Oxkzf2KBeeGBdTxz559D41NJP8FlzSej1Gh7Rk40Zo6AyTfsNWkrl/kVi1t937OIzC5t+9Q==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.965.0.tgz",
+            "integrity": "sha512-kokIHUfNT3/P55E4fUJJrFHuuA9BbjFKUIxoLrd3UaRfdafT0ScRfg2eaZie6arf60EuhlUIZH0yALxttMEjxQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "3.957.0",
-                "@aws-sdk/types": "3.957.0",
+                "@aws-sdk/middleware-user-agent": "3.965.0",
+                "@aws-sdk/types": "3.965.0",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
@@ -672,9 +672,9 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.957.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
-            "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+            "version": "3.965.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.965.0.tgz",
+            "integrity": "sha512-Tcod25/BTupraQwtb+Q+GX8bmEZfxIFjjJ/AvkhUZsZlkPeVluzq1uu3Oeqf145DCdMjzLIN6vab5MrykbDP+g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/types": "^4.11.0",
@@ -687,7 +687,7 @@
         },
         "node_modules/@aws/lambda-invoke-store": {
             "version": "0.2.2",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
             "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
             "license": "Apache-2.0",
             "engines": {
@@ -787,9 +787,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.9.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+            "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2640,7 +2640,7 @@
         },
         "node_modules/@smithy/abort-controller": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
             "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2653,7 +2653,7 @@
         },
         "node_modules/@smithy/config-resolver": {
             "version": "4.4.5",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
             "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2669,9 +2669,9 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.20.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/core/-/core-3.20.0.tgz",
-            "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+            "version": "3.20.1",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.1.tgz",
+            "integrity": "sha512-wOboSEdQ85dbKAJ0zL+wQ6b0HTSBRhtGa0PYKysQXkRg+vK0tdCRRVruiFM2QMprkOQwSYOnwF4og96PAaEGag==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/middleware-serde": "^4.2.8",
@@ -2691,7 +2691,7 @@
         },
         "node_modules/@smithy/credential-provider-imds": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
             "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2707,7 +2707,7 @@
         },
         "node_modules/@smithy/fetch-http-handler": {
             "version": "5.3.8",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
             "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2723,7 +2723,7 @@
         },
         "node_modules/@smithy/hash-node": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
             "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2738,7 +2738,7 @@
         },
         "node_modules/@smithy/invalid-dependency": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
             "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2751,7 +2751,7 @@
         },
         "node_modules/@smithy/is-array-buffer": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
             "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2762,12 +2762,12 @@
             }
         },
         "node_modules/@smithy/middleware-compression": {
-            "version": "4.3.16",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-compression/-/middleware-compression-4.3.16.tgz",
-            "integrity": "sha512-df41cMk8D/Aa8JRhraZPbeHYUJ012ivOTp9kOs95amfMdRvgNFWz9/qBFbpnTEbsyvFtYfF4HjZ0bgzrkguECQ==",
+            "version": "4.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.17.tgz",
+            "integrity": "sha512-dqHZDvpat0iqvtvhWKU09nU3E16Eep+0JW986wQphDD8I8b9PV1hpVrNrEoHiJqZ122qxBybnarOeJM2FRXV9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.20.0",
+                "@smithy/core": "^3.20.1",
                 "@smithy/is-array-buffer": "^4.2.0",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/protocol-http": "^5.3.7",
@@ -2784,7 +2784,7 @@
         },
         "node_modules/@smithy/middleware-content-length": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
             "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2797,12 +2797,12 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.4.1",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
-            "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.2.tgz",
+            "integrity": "sha512-mqpAdux0BNmZu/SqkFhQEnod4fX23xxTvU2LUpmKp0JpSI+kPYCiHJMmzREr8yxbNxKL2/DU1UZm9i++ayU+2g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.20.0",
+                "@smithy/core": "^3.20.1",
                 "@smithy/middleware-serde": "^4.2.8",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -2816,15 +2816,15 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.17",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
-            "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
+            "version": "4.4.18",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.18.tgz",
+            "integrity": "sha512-E5hulijA59nBk/zvcwVMaS7FG7Y4l6hWA9vrW018r+8kiZef4/ETQaPI4oY+3zsy9f6KqDv3c4VKtO4DwwgpCg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/service-error-classification": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/smithy-client": "^4.10.3",
                 "@smithy/types": "^4.11.0",
                 "@smithy/util-middleware": "^4.2.7",
                 "@smithy/util-retry": "^4.2.7",
@@ -2837,7 +2837,7 @@
         },
         "node_modules/@smithy/middleware-serde": {
             "version": "4.2.8",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
             "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2851,7 +2851,7 @@
         },
         "node_modules/@smithy/middleware-stack": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
             "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2864,7 +2864,7 @@
         },
         "node_modules/@smithy/node-config-provider": {
             "version": "4.3.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
             "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2879,7 +2879,7 @@
         },
         "node_modules/@smithy/node-http-handler": {
             "version": "4.4.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
             "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2895,7 +2895,7 @@
         },
         "node_modules/@smithy/property-provider": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
             "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2908,7 +2908,7 @@
         },
         "node_modules/@smithy/protocol-http": {
             "version": "5.3.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
             "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2921,7 +2921,7 @@
         },
         "node_modules/@smithy/querystring-builder": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
             "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2935,7 +2935,7 @@
         },
         "node_modules/@smithy/querystring-parser": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
             "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2948,7 +2948,7 @@
         },
         "node_modules/@smithy/service-error-classification": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
             "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2960,7 +2960,7 @@
         },
         "node_modules/@smithy/shared-ini-file-loader": {
             "version": "4.4.2",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
             "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2973,7 +2973,7 @@
         },
         "node_modules/@smithy/signature-v4": {
             "version": "5.3.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
             "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -2991,13 +2991,13 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.10.2",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
-            "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
+            "version": "4.10.3",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.3.tgz",
+            "integrity": "sha512-EfECiO/0fAfb590LBnUe7rI5ux7XfquQ8LBzTe7gxw0j9QW/q8UT/EHWHlxV/+jhQ3+Ssga9uUYXCQgImGMbNg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.20.0",
-                "@smithy/middleware-endpoint": "^4.4.1",
+                "@smithy/core": "^3.20.1",
+                "@smithy/middleware-endpoint": "^4.4.2",
                 "@smithy/middleware-stack": "^4.2.7",
                 "@smithy/protocol-http": "^5.3.7",
                 "@smithy/types": "^4.11.0",
@@ -3010,7 +3010,7 @@
         },
         "node_modules/@smithy/types": {
             "version": "4.11.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/types/-/types-4.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
             "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3022,7 +3022,7 @@
         },
         "node_modules/@smithy/url-parser": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
             "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3036,7 +3036,7 @@
         },
         "node_modules/@smithy/util-base64": {
             "version": "4.3.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
             "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3050,7 +3050,7 @@
         },
         "node_modules/@smithy/util-body-length-browser": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
             "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3062,7 +3062,7 @@
         },
         "node_modules/@smithy/util-body-length-node": {
             "version": "4.2.1",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
             "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3074,7 +3074,7 @@
         },
         "node_modules/@smithy/util-buffer-from": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
             "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3087,7 +3087,7 @@
         },
         "node_modules/@smithy/util-config-provider": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
             "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3098,13 +3098,13 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.16",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
-            "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
+            "version": "4.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.17.tgz",
+            "integrity": "sha512-dwN4GmivYF1QphnP3xJESXKtHvkkvKHSZI8GrSKMVoENVSKW2cFPRYC4ZgstYjUHdR3zwaDkIaTDIp26JuY7Cw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/property-provider": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/smithy-client": "^4.10.3",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -3113,16 +3113,16 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.19",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
-            "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
+            "version": "4.2.20",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.20.tgz",
+            "integrity": "sha512-VD/I4AEhF1lpB3B//pmOIMBNLMrtdMXwy9yCOfa2QkJGDr63vH3RqPbSAKzoGMov3iryCxTXCxSsyGmEB8PDpg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@smithy/config-resolver": "^4.4.5",
                 "@smithy/credential-provider-imds": "^4.2.7",
                 "@smithy/node-config-provider": "^4.3.7",
                 "@smithy/property-provider": "^4.2.7",
-                "@smithy/smithy-client": "^4.10.2",
+                "@smithy/smithy-client": "^4.10.3",
                 "@smithy/types": "^4.11.0",
                 "tslib": "^2.6.2"
             },
@@ -3132,7 +3132,7 @@
         },
         "node_modules/@smithy/util-endpoints": {
             "version": "3.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
             "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3146,7 +3146,7 @@
         },
         "node_modules/@smithy/util-hex-encoding": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
             "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3158,7 +3158,7 @@
         },
         "node_modules/@smithy/util-middleware": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
             "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3171,7 +3171,7 @@
         },
         "node_modules/@smithy/util-retry": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
             "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3185,7 +3185,7 @@
         },
         "node_modules/@smithy/util-stream": {
             "version": "4.5.8",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
             "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3204,7 +3204,7 @@
         },
         "node_modules/@smithy/util-uri-escape": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
             "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3216,7 +3216,7 @@
         },
         "node_modules/@smithy/util-utf8": {
             "version": "4.2.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
             "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3229,7 +3229,7 @@
         },
         "node_modules/@smithy/util-waiter": {
             "version": "4.2.7",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
             "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -3243,7 +3243,7 @@
         },
         "node_modules/@smithy/uuid": {
             "version": "1.1.0",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/uuid/-/uuid-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
             "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
             "license": "Apache-2.0",
             "dependencies": {
@@ -4058,9 +4058,9 @@
             }
         },
         "node_modules/axe-core": {
-            "version": "4.11.0",
-            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-            "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+            "version": "4.11.1",
+            "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+            "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
             "dev": true,
             "license": "MPL-2.0",
             "engines": {
@@ -4201,7 +4201,7 @@
         },
         "node_modules/bowser": {
             "version": "2.13.1",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/bowser/-/bowser-2.13.1.tgz",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
             "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
             "license": "MIT"
         },
@@ -6021,9 +6021,9 @@
             }
         },
         "node_modules/esquery": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+            "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6235,7 +6235,7 @@
         },
         "node_modules/fast-xml-parser": {
             "version": "5.2.5",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
             "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
             "funding": [
                 {
@@ -6252,9 +6252,9 @@
             }
         },
         "node_modules/fastq": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+            "version": "1.20.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+            "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -6263,7 +6263,7 @@
         },
         "node_modules/fflate": {
             "version": "0.8.1",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fflate/-/fflate-0.8.1.tgz",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
             "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
             "license": "MIT"
         },
@@ -10571,9 +10571,9 @@
             }
         },
         "node_modules/nx/node_modules/fs-extra": {
-            "version": "11.3.2",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-            "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+            "version": "11.3.3",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+            "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11654,9 +11654,9 @@
             }
         },
         "node_modules/prettier-linter-helpers": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-            "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+            "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -13568,7 +13568,7 @@
         },
         "node_modules/strnum": {
             "version": "2.1.2",
-            "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/strnum/-/strnum-2.1.2.tgz",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
             "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
             "funding": [
                 {
@@ -14553,6 +14553,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
             "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -14876,9 +14877,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.18.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+            "version": "8.19.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -26,24 +26,24 @@
         "test:e2e:extra_features": "npx playwright test --project=extra-features-desktop --project=extra-features-mobile"
     },
     "devDependencies": {
-        "@playwright/test": "^1.49.0",
         "@axe-core/playwright": "^4.10.1",
-        "commander": "^9.5.0",
-        "eslint": "^8.37.0",
-        "eslint-plugin-header": "^3.1.1",
-        "eslint-plugin-no-relative-import-paths": "^1.5.3",
+        "@playwright/test": "^1.49.0",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.57.0",
+        "commander": "^9.5.0",
+        "eslint": "^8.37.0",
         "eslint-config-prettier": "8.8.0",
+        "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-jest": "^27.2.1",
         "eslint-plugin-jsx-a11y": "6.7.1",
+        "eslint-plugin-no-relative-import-paths": "^1.5.3",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-react": "^7.32.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-use-effect-no-deps": "^1.1.2",
-        "prettier": "^2.8.6",
         "jsdom": "^22.1.0",
         "lerna": "^6.6.1",
+        "prettier": "^2.8.6",
         "semver": "^7.5.2",
         "shelljs": "^0.9.2",
         "syncpack": "^10.1.0"
@@ -53,6 +53,7 @@
         "npm": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
     },
     "dependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.962.0",
         "node-fetch": "^2.6.9"
     }
 }

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -9,9 +9,9 @@
       "version": "3.16.0-dev",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
+        "@aws-sdk/client-cloudwatch": "^3.962.0",
         "@h4ad/serverless-adapter": "4.4.0",
         "@loadable/babel-plugin": "^5.15.3",
-        "aws-sdk": "^2.1354.0",
         "cosmiconfig": "8.1.3",
         "cross-env": "^5.2.1",
         "express": "^4.19.2",
@@ -45,6 +45,660 @@
         "@salesforce/pwa-kit-dev": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.964.0.tgz",
+      "integrity": "sha512-UN8ehVMK5CVV4vPx1zAQ4E7Of6RBur1k5rVH4/vWQlFgXESZMrahA7vLK0Y6Bq9gEjnISNC10uYryFhwtnkl2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/credential-provider-node": "3.964.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.964.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-compression": "^4.3.16",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-sso/-/client-sso-3.964.0.tgz",
+      "integrity": "sha512-IenVyY8Io2CwBgmS22xk/H5LibmSbvLnPA9oFqLORO6Ji1Ks8z/ow+ud/ZurVjFekz3LD/uxVFX3ZKGo6N7Byw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.964.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/core/-/core-3.964.0.tgz",
+      "integrity": "sha512-1gIfbt0KRxI8am1UYFcIxQ5QKb22JyN3k52sxyrKXJYC8Knn/rTUAZbYti45CfETe5PLadInGvWqClwGRlZKNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/xml-builder": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/signature-v4": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-env/-/credential-provider-env-3.964.0.tgz",
+      "integrity": "sha512-jWNSXOOBMYuxzI2rXi8x91YL07dhomyGzzh0CdaLej0LRmknmDrZcZNkVpa7Fredy1PFcmOlokwCS5PmZMN8ZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-http/-/credential-provider-http-3.964.0.tgz",
+      "integrity": "sha512-up7dl6vcaoXuYSwGXDvx8RnF8Lwj3jGChhyUR7krZOXLarIfUUN3ILOZnVNK5s/HnVNkEILlkdPvjhr9LVC1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.964.0.tgz",
+      "integrity": "sha512-t4FN9qTWU4nXDU6EQ6jopvyhXw0dbQ3n+3g6x5hmc1ECFAqA+xmFd1i5LljdZCi79cUXHduQWwvW8RJHMf0qJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/credential-provider-env": "3.964.0",
+        "@aws-sdk/credential-provider-http": "3.964.0",
+        "@aws-sdk/credential-provider-login": "3.964.0",
+        "@aws-sdk/credential-provider-process": "3.964.0",
+        "@aws-sdk/credential-provider-sso": "3.964.0",
+        "@aws-sdk/credential-provider-web-identity": "3.964.0",
+        "@aws-sdk/nested-clients": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-login/-/credential-provider-login-3.964.0.tgz",
+      "integrity": "sha512-c64dmTizMkJXDRzN3NYPTmUpKxegr5lmLOYPeQ60Zcbft6HFwPme8Gwy8pNxO4gG1fw6Ja2Vu6fZuSTn8aDFOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/nested-clients": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-node/-/credential-provider-node-3.964.0.tgz",
+      "integrity": "sha512-FHxDXPOj888/qc/X8s0x4aUBdp4Y3k9VePRehUJBWRhhTsAyuIJis5V0iQeY1qvtqHXYa2qd1EZHGJ3bTjHxSw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.964.0",
+        "@aws-sdk/credential-provider-http": "3.964.0",
+        "@aws-sdk/credential-provider-ini": "3.964.0",
+        "@aws-sdk/credential-provider-process": "3.964.0",
+        "@aws-sdk/credential-provider-sso": "3.964.0",
+        "@aws-sdk/credential-provider-web-identity": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-process/-/credential-provider-process-3.964.0.tgz",
+      "integrity": "sha512-HaTLKqj3jeZY88E/iBjsNJsXgmRTTT7TghqeRiF8FKb/7UY1xEvasBO0c1xqfOye8dsyt35nTfTTyIsd/CBfww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.964.0.tgz",
+      "integrity": "sha512-oR78TjSpjVf1IpPWQnGHEGqlnQs+K4f5nCxLK2P6JDPprXay6oknsoSiU4x2urav6VCyMPMC9KTCGjBoFKUIxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.964.0",
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/token-providers": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.964.0.tgz",
+      "integrity": "sha512-07JQDmbjZjOt3nL/j1wTcvQqjmPkynQYftUV/ooZ+qTbmJXFbCBdal1VCElyeiu0AgBq9dfhw0rBBcbND1ZMlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/nested-clients": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
+      "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
+      "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
+      "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.964.0.tgz",
+      "integrity": "sha512-/QyBl8WLNtqw3ucyAggumQXVCi8GRxaDGE1ElyYMmacfiwHl37S9y8JVW/QLL1lIEXGcsrhMUKV3pyFJFALA7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/nested-clients/-/nested-clients-3.964.0.tgz",
+      "integrity": "sha512-ql+ftRwjyZkZeG3qbrRJFVmNR0id83WEUqhFVjvrQMWspNApBhz0Ar4YVSn7Uv0QaKkaR7ALPtmdMzFr3/E4bQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/middleware-host-header": "3.957.0",
+        "@aws-sdk/middleware-logger": "3.957.0",
+        "@aws-sdk/middleware-recursion-detection": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.964.0",
+        "@aws-sdk/region-config-resolver": "3.957.0",
+        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/util-user-agent-browser": "3.957.0",
+        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
+      "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/token-providers/-/token-providers-3.964.0.tgz",
+      "integrity": "sha512-UqouLQbYepZnMFJGB/DVpA5GhF9uT98vNWSMz9PVbhgEPUKa73FECRT6YFZvZOh8kA+0JiENrnmS6d93I70ykQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.964.0",
+        "@aws-sdk/nested-clients": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/types/-/types-3.957.0.tgz",
+      "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
+      "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-locate-window/-/util-locate-window-3.957.0.tgz",
+      "integrity": "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
+      "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/types": "^4.11.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.964.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.964.0.tgz",
+      "integrity": "sha512-jgob8Z/bZIh1dwEgLqE12q+aCf0ieLy7anT8bWpqMijMJqsnrPBToa7smSykfom9YHrdOgrQhXswMpE75dzLRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.964.0",
+        "@aws-sdk/types": "3.957.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.957.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
+      "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -567,6 +1221,621 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.5",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.20.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/core/-/core-3.20.0.tgz",
+      "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.8",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-compression": {
+      "version": "4.3.16",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-compression/-/middleware-compression-4.3.16.tgz",
+      "integrity": "sha512-df41cMk8D/Aa8JRhraZPbeHYUJ012ivOTp9kOs95amfMdRvgNFWz9/qBFbpnTEbsyvFtYfF4HjZ0bgzrkguECQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "fflate": "0.8.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
+      "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.17",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
+      "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.8",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.2",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.10.2",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
+      "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.20.0",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.11.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/types/-/types-4.11.0.tgz",
+      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.16",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
+      "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.19",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
+      "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.8",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.7",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+      "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -669,21 +1938,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/aws-lambda-mock-context": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/aws-lambda-mock-context/-/aws-lambda-mock-context-3.2.1.tgz",
@@ -699,62 +1953,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/aws-sdk": {
-      "version": "2.1693.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1693.0.tgz",
-      "integrity": "sha512-cJmb8xEnVLT+R6fBS5sn/EFJiX7tUnDaPtOPZ1vFbOJtd0fnZn/Ky2XGgsvvoeliWeH7mL3TWSX5zXXGSQV6gQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "buffer": "4.9.2",
-        "events": "1.1.1",
-        "ieee754": "1.1.13",
-        "jmespath": "0.16.0",
-        "querystring": "0.2.0",
-        "sax": "1.2.1",
-        "url": "0.10.3",
-        "util": "^0.12.4",
-        "uuid": "8.0.0",
-        "xml2js": "0.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/aws-sdk/node_modules/uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -837,6 +2040,12 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/bowser": {
+      "version": "2.13.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -894,17 +2103,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "4.9.2",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
-      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4",
-        "isarray": "^1.0.0"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -912,24 +2110,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -1179,23 +2359,6 @@
         }
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1357,15 +2520,6 @@
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
-    "node_modules/events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.x"
-      }
-    },
     "node_modules/express": {
       "version": "4.22.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
@@ -1441,6 +2595,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1504,21 +2682,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/form-data": {
@@ -1604,15 +2767,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/generator-function": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/gensync": {
@@ -1704,18 +2858,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -1732,6 +2874,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -1845,12 +2988,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
@@ -1889,22 +3026,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1924,18 +3045,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1943,25 +3052,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-glob": {
@@ -1997,43 +3087,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-regex": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -2041,15 +3099,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
-    },
-    "node_modules/jmespath": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
-      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2589,15 +3638,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -2635,12 +3675,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
-      "license": "MIT"
-    },
     "node_modules/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
@@ -2654,15 +3688,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/querystring": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
-      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
-      "engines": {
-        "node": ">=0.4.x"
       }
     },
     "node_modules/range-parser": {
@@ -2770,34 +3795,11 @@
       ],
       "license": "MIT"
     },
-    "node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
-    },
-    "node_modules/sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
-      "license": "ISC"
     },
     "node_modules/semver": {
       "version": "7.7.3",
@@ -2870,23 +3872,6 @@
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -3071,6 +4056,18 @@
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/superagent": {
       "version": "6.1.0",
@@ -3259,6 +4256,12 @@
         "nodetouch": "bin/nodetouch.js"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -3351,29 +4354,6 @@
       "integrity": "sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==",
       "license": "MIT"
     },
-    "node_modules/url": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-      "integrity": "sha512-hzSUW2q06EqL1gKM/a+obYHLIO6ct2hwPuviqTTOcfFVc61UbfJ2Q32+uGL/HCPxKqrdGB5QUwIe7UqlDgwsOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      }
-    },
-    "node_modules/util": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
-      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "which-typed-array": "^1.1.2"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3429,49 +4409,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
-      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/xml2js": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
-      "license": "MIT",
-      "dependencies": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~11.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/xmlbuilder": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/packages/pwa-kit-runtime/package-lock.json
+++ b/packages/pwa-kit-runtime/package-lock.json
@@ -49,7 +49,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -64,7 +64,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -76,7 +76,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -89,7 +89,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -102,7 +102,7 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -116,7 +116,7 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -125,7 +125,7 @@
     },
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-crypto/util/-/util-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -136,7 +136,7 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -148,7 +148,7 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -161,7 +161,7 @@
     },
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -173,24 +173,24 @@
       }
     },
     "node_modules/@aws-sdk/client-cloudwatch": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.964.0.tgz",
-      "integrity": "sha512-UN8ehVMK5CVV4vPx1zAQ4E7Of6RBur1k5rVH4/vWQlFgXESZMrahA7vLK0Y6Bq9gEjnISNC10uYryFhwtnkl2g==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.965.0.tgz",
+      "integrity": "sha512-zw1s/JmF7S4+y8oYaTle4WXkMqvA9qNMJIN0CRtbrL4rLNdtkA2gGFS29wo4XiIJVUgRfdsPAc7ft1epjLmbaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/credential-provider-node": "3.964.0",
-        "@aws-sdk/middleware-host-header": "3.957.0",
-        "@aws-sdk/middleware-logger": "3.957.0",
-        "@aws-sdk/middleware-recursion-detection": "3.957.0",
-        "@aws-sdk/middleware-user-agent": "3.964.0",
-        "@aws-sdk/region-config-resolver": "3.957.0",
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/util-endpoints": "3.957.0",
-        "@aws-sdk/util-user-agent-browser": "3.957.0",
-        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/credential-provider-node": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/core": "^3.20.0",
         "@smithy/fetch-http-handler": "^5.3.8",
@@ -225,23 +225,23 @@
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/client-sso/-/client-sso-3.964.0.tgz",
-      "integrity": "sha512-IenVyY8Io2CwBgmS22xk/H5LibmSbvLnPA9oFqLORO6Ji1Ks8z/ow+ud/ZurVjFekz3LD/uxVFX3ZKGo6N7Byw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.965.0.tgz",
+      "integrity": "sha512-iv2tr+n4aZ+nPUFFvG00hISPuEd4DU+1/Q8rPAYKXsM+vEPJ2nAnP5duUOa2fbOLIUCRxX3dcQaQaghVHDHzQw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/middleware-host-header": "3.957.0",
-        "@aws-sdk/middleware-logger": "3.957.0",
-        "@aws-sdk/middleware-recursion-detection": "3.957.0",
-        "@aws-sdk/middleware-user-agent": "3.964.0",
-        "@aws-sdk/region-config-resolver": "3.957.0",
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/util-endpoints": "3.957.0",
-        "@aws-sdk/util-user-agent-browser": "3.957.0",
-        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/core": "^3.20.0",
         "@smithy/fetch-http-handler": "^5.3.8",
@@ -274,13 +274,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/core/-/core-3.964.0.tgz",
-      "integrity": "sha512-1gIfbt0KRxI8am1UYFcIxQ5QKb22JyN3k52sxyrKXJYC8Knn/rTUAZbYti45CfETe5PLadInGvWqClwGRlZKNg==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.965.0.tgz",
+      "integrity": "sha512-aq9BhQxdHit8UUJ9C0im9TtuKeK0pT6NXmNJxMTCFeStI7GG7ImIsSislg3BZTIifVg1P6VLdzMyz9de85iutQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/xml-builder": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/xml-builder": "3.965.0",
         "@smithy/core": "^3.20.0",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/property-provider": "^4.2.7",
@@ -298,13 +298,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-env/-/credential-provider-env-3.964.0.tgz",
-      "integrity": "sha512-jWNSXOOBMYuxzI2rXi8x91YL07dhomyGzzh0CdaLej0LRmknmDrZcZNkVpa7Fredy1PFcmOlokwCS5PmZMN8ZQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.965.0.tgz",
+      "integrity": "sha512-mdGnaIjMxTIjsb70dEj3VsWPWpoq1V5MWzBSfJq2H8zgMBXjn6d5/qHP8HMf53l9PrsgqzMpXGv3Av549A2x1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
@@ -314,13 +314,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-http/-/credential-provider-http-3.964.0.tgz",
-      "integrity": "sha512-up7dl6vcaoXuYSwGXDvx8RnF8Lwj3jGChhyUR7krZOXLarIfUUN3ILOZnVNK5s/HnVNkEILlkdPvjhr9LVC1/Q==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.965.0.tgz",
+      "integrity": "sha512-YuGQel9EgA/z25oeLM+GYYQS750+8AESvr7ZEmVnRPL0sg+K3DmGqdv+9gFjFd0UkLjTlC/jtbP2cuY6UcPiHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/fetch-http-handler": "^5.3.8",
         "@smithy/node-http-handler": "^4.4.7",
         "@smithy/property-provider": "^4.2.7",
@@ -335,20 +335,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.964.0.tgz",
-      "integrity": "sha512-t4FN9qTWU4nXDU6EQ6jopvyhXw0dbQ3n+3g6x5hmc1ECFAqA+xmFd1i5LljdZCi79cUXHduQWwvW8RJHMf0qJw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.965.0.tgz",
+      "integrity": "sha512-xRo72Prer5s0xYVSCxCymVIRSqrVlevK5cmU0GWq9yJtaBNpnx02jwdJg80t/Ni7pgbkQyFWRMcq38c1tc6M/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/credential-provider-env": "3.964.0",
-        "@aws-sdk/credential-provider-http": "3.964.0",
-        "@aws-sdk/credential-provider-login": "3.964.0",
-        "@aws-sdk/credential-provider-process": "3.964.0",
-        "@aws-sdk/credential-provider-sso": "3.964.0",
-        "@aws-sdk/credential-provider-web-identity": "3.964.0",
-        "@aws-sdk/nested-clients": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/credential-provider-env": "3.965.0",
+        "@aws-sdk/credential-provider-http": "3.965.0",
+        "@aws-sdk/credential-provider-login": "3.965.0",
+        "@aws-sdk/credential-provider-process": "3.965.0",
+        "@aws-sdk/credential-provider-sso": "3.965.0",
+        "@aws-sdk/credential-provider-web-identity": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -360,14 +360,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-login/-/credential-provider-login-3.964.0.tgz",
-      "integrity": "sha512-c64dmTizMkJXDRzN3NYPTmUpKxegr5lmLOYPeQ60Zcbft6HFwPme8Gwy8pNxO4gG1fw6Ja2Vu6fZuSTn8aDFOQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.965.0.tgz",
+      "integrity": "sha512-43/H8Qku8LHyugbhLo8kjD+eauhybCeVkmrnvWl8bXNHJP7xi1jCdtBQJKKJqiIHZws4MOEwkji8kFdAVRCe6g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/nested-clients": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -379,18 +379,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-node/-/credential-provider-node-3.964.0.tgz",
-      "integrity": "sha512-FHxDXPOj888/qc/X8s0x4aUBdp4Y3k9VePRehUJBWRhhTsAyuIJis5V0iQeY1qvtqHXYa2qd1EZHGJ3bTjHxSw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.965.0.tgz",
+      "integrity": "sha512-cRxmMHF+Zh2lkkkEVduKl+8OQdtg/DhYA69+/7SPSQURlgyjFQGlRQ58B7q8abuNlrGT3sV+UzeOylZpJbV61Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.964.0",
-        "@aws-sdk/credential-provider-http": "3.964.0",
-        "@aws-sdk/credential-provider-ini": "3.964.0",
-        "@aws-sdk/credential-provider-process": "3.964.0",
-        "@aws-sdk/credential-provider-sso": "3.964.0",
-        "@aws-sdk/credential-provider-web-identity": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/credential-provider-env": "3.965.0",
+        "@aws-sdk/credential-provider-http": "3.965.0",
+        "@aws-sdk/credential-provider-ini": "3.965.0",
+        "@aws-sdk/credential-provider-process": "3.965.0",
+        "@aws-sdk/credential-provider-sso": "3.965.0",
+        "@aws-sdk/credential-provider-web-identity": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -402,13 +402,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-process/-/credential-provider-process-3.964.0.tgz",
-      "integrity": "sha512-HaTLKqj3jeZY88E/iBjsNJsXgmRTTT7TghqeRiF8FKb/7UY1xEvasBO0c1xqfOye8dsyt35nTfTTyIsd/CBfww==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.965.0.tgz",
+      "integrity": "sha512-gmkPmdiR0yxnTzLPDb7rwrDhGuCUjtgnj8qWP+m0gSz/W43rR4jRPVEf6DUX2iC+ImQhxo3NFhuB3V42Kzo3TQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
         "@smithy/types": "^4.11.0",
@@ -419,15 +419,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.964.0.tgz",
-      "integrity": "sha512-oR78TjSpjVf1IpPWQnGHEGqlnQs+K4f5nCxLK2P6JDPprXay6oknsoSiU4x2urav6VCyMPMC9KTCGjBoFKUIxQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.965.0.tgz",
+      "integrity": "sha512-N01AYvtCqG3Wo/s/LvYt19ity18/FqggiXT+elAs3X9Om/Wfx+hw9G+i7jaDmy+/xewmv8AdQ2SK5Q30dXw/Fw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.964.0",
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/token-providers": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/client-sso": "3.965.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/token-providers": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
         "@smithy/types": "^4.11.0",
@@ -438,14 +438,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.964.0.tgz",
-      "integrity": "sha512-07JQDmbjZjOt3nL/j1wTcvQqjmPkynQYftUV/ooZ+qTbmJXFbCBdal1VCElyeiu0AgBq9dfhw0rBBcbND1ZMlA==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.965.0.tgz",
+      "integrity": "sha512-T4gMZ2JzXnfxe1oTD+EDGLSxFfk1+WkLZdiHXEMZp8bFI1swP/3YyDFXI+Ib9Uq1JhnAmrCXtOnkicKEhDkdhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/nested-clients": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
         "@smithy/types": "^4.11.0",
@@ -456,12 +456,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-host-header/-/middleware-host-header-3.957.0.tgz",
-      "integrity": "sha512-BBgKawVyfQZglEkNTuBBdC3azlyqNXsvvN4jPkWAiNYcY0x1BasaJFl+7u/HisfULstryweJq/dAvIZIxzlZaA==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.965.0.tgz",
+      "integrity": "sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
@@ -471,12 +471,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-logger/-/middleware-logger-3.957.0.tgz",
-      "integrity": "sha512-w1qfKrSKHf9b5a8O76yQ1t69u6NWuBjr5kBX+jRWFx/5mu6RLpqERXRpVJxfosbep7k3B+DSB5tZMZ82GKcJtQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.965.0.tgz",
+      "integrity": "sha512-gjUvJRZT1bUABKewnvkj51LAynFrfz2h5DYAg5/2F4Utx6UOGByTSr9Rq8JCLbURvvzAbCtcMkkIJRxw+8Zuzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
@@ -485,12 +485,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.957.0.tgz",
-      "integrity": "sha512-D2H/WoxhAZNYX+IjkKTdOhOkWQaK0jjJrDBj56hKjU5c9ltQiaX/1PqJ4dfjHntEshJfu0w+E6XJ+/6A6ILBBA==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.965.0.tgz",
+      "integrity": "sha512-6dvD+18Ni14KCRu+tfEoNxq1sIGVp9tvoZDZ7aMvpnA7mDXuRLrOjRQ/TAZqXwr9ENKVGyxcPl0cRK8jk1YWjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
@@ -501,14 +501,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.964.0.tgz",
-      "integrity": "sha512-/QyBl8WLNtqw3ucyAggumQXVCi8GRxaDGE1ElyYMmacfiwHl37S9y8JVW/QLL1lIEXGcsrhMUKV3pyFJFALA7w==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.965.0.tgz",
+      "integrity": "sha512-RBEYVGgu/WeAt+H/qLrGc+t8LqAUkbyvh3wBfTiuAD+uBcWsKnvnB1iSBX75FearC0fmoxzXRUc0PMxMdqpjJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/util-endpoints": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
         "@smithy/core": "^3.20.0",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
@@ -519,23 +519,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/nested-clients/-/nested-clients-3.964.0.tgz",
-      "integrity": "sha512-ql+ftRwjyZkZeG3qbrRJFVmNR0id83WEUqhFVjvrQMWspNApBhz0Ar4YVSn7Uv0QaKkaR7ALPtmdMzFr3/E4bQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.965.0.tgz",
+      "integrity": "sha512-muNVUjUEU+/KLFrLzQ8PMXyw4+a/MP6t4GIvwLtyx/kH0rpSy5s0YmqacMXheuIe6F/5QT8uksXGNAQenitkGQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/middleware-host-header": "3.957.0",
-        "@aws-sdk/middleware-logger": "3.957.0",
-        "@aws-sdk/middleware-recursion-detection": "3.957.0",
-        "@aws-sdk/middleware-user-agent": "3.964.0",
-        "@aws-sdk/region-config-resolver": "3.957.0",
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/util-endpoints": "3.957.0",
-        "@aws-sdk/util-user-agent-browser": "3.957.0",
-        "@aws-sdk/util-user-agent-node": "3.964.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/core": "^3.20.0",
         "@smithy/fetch-http-handler": "^5.3.8",
@@ -568,12 +568,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/region-config-resolver/-/region-config-resolver-3.957.0.tgz",
-      "integrity": "sha512-V8iY3blh8l2iaOqXWW88HbkY5jDoWjH56jonprG/cpyqqCnprvpMUZWPWYJoI8rHRf2bqzZeql1slxG6EnKI7A==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.965.0.tgz",
+      "integrity": "sha512-RoMhu9ly2B0coxn8ctXosPP2WmDD0MkQlZGLjoYHQUOCBmty5qmCxOqBmBDa6wbWbB8xKtMQ/4VXloQOgzjHXg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/types": "^4.11.0",
@@ -584,14 +584,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/token-providers/-/token-providers-3.964.0.tgz",
-      "integrity": "sha512-UqouLQbYepZnMFJGB/DVpA5GhF9uT98vNWSMz9PVbhgEPUKa73FECRT6YFZvZOh8kA+0JiENrnmS6d93I70ykQ==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.965.0.tgz",
+      "integrity": "sha512-aR0qxg0b8flkXJVE+CM1gzo7uJ57md50z2eyCwofC0QIz5Y0P7/7vvb9/dmUQt6eT9XRN5iRcUqq2IVxVDvJOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.964.0",
-        "@aws-sdk/nested-clients": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/property-provider": "^4.2.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
         "@smithy/types": "^4.11.0",
@@ -602,9 +602,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/types/-/types-3.957.0.tgz",
-      "integrity": "sha512-wzWC2Nrt859ABk6UCAVY/WYEbAd7FjkdrQL6m24+tfmWYDNRByTJ9uOgU/kw9zqLCAwb//CPvrJdhqjTznWXAg==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.965.0.tgz",
+      "integrity": "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.11.0",
@@ -615,12 +615,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-endpoints/-/util-endpoints-3.957.0.tgz",
-      "integrity": "sha512-xwF9K24mZSxcxKS3UKQFeX/dPYkEps9wF1b+MGON7EvnbcucrJGyQyK1v1xFPn1aqXkBTFi+SZaMRx5E5YCVFw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.965.0.tgz",
+      "integrity": "sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/types": "^4.11.0",
         "@smithy/url-parser": "^4.2.7",
         "@smithy/util-endpoints": "^3.2.7",
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-locate-window/-/util-locate-window-3.957.0.tgz",
-      "integrity": "sha512-nhmgKHnNV9K+i9daumaIz8JTLsIIML9PE/HUks5liyrjUzenjW/aHoc7WJ9/Td/gPZtayxFnXQSJRb/fDlBuJw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.0.tgz",
+      "integrity": "sha512-9LJFand4bIoOjOF4x3wx0UZYiFZRo4oUauxQSiEX2dVg+5qeBOJSjp2SeWykIE6+6frCZ5wvWm2fGLK8D32aJw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -643,25 +643,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.957.0.tgz",
-      "integrity": "sha512-exueuwxef0lUJRnGaVkNSC674eAiWU07ORhxBnevFFZEKisln+09Qrtw823iyv5I1N8T+wKfh95xvtWQrNKNQw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.965.0.tgz",
+      "integrity": "sha512-Xiza/zMntQGpkd2dETQeAK8So1pg5+STTzpcdGWxj5q0jGO5ayjqT/q1Q7BrsX5KIr6PvRkl9/V7lLCv04wGjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/types": "^4.11.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.964.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.964.0.tgz",
-      "integrity": "sha512-jgob8Z/bZIh1dwEgLqE12q+aCf0ieLy7anT8bWpqMijMJqsnrPBToa7smSykfom9YHrdOgrQhXswMpE75dzLRw==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.965.0.tgz",
+      "integrity": "sha512-kokIHUfNT3/P55E4fUJJrFHuuA9BbjFKUIxoLrd3UaRfdafT0ScRfg2eaZie6arf60EuhlUIZH0yALxttMEjxQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.964.0",
-        "@aws-sdk/types": "3.957.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.957.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws-sdk/xml-builder/-/xml-builder-3.957.0.tgz",
-      "integrity": "sha512-Ai5iiQqS8kJ5PjzMhWcLKN0G2yasAkvpnPlq2EnqlIMdB48HsizElt62qcktdxp4neRMyGkFq4NzgmDbXnhRiA==",
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.965.0.tgz",
+      "integrity": "sha512-Tcod25/BTupraQwtb+Q+GX8bmEZfxIFjjJ/AvkhUZsZlkPeVluzq1uu3Oeqf145DCdMjzLIN6vab5MrykbDP+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.11.0",
@@ -694,7 +694,7 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.2",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
       "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
       "license": "Apache-2.0",
       "engines": {
@@ -1223,7 +1223,7 @@
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
       "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1236,7 +1236,7 @@
     },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.5",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
       "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1252,9 +1252,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.20.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/core/-/core-3.20.0.tgz",
-      "integrity": "sha512-WsSHCPq/neD5G/MkK4csLI5Y5Pkd9c1NMfpYEKeghSGaD4Ja1qLIohRQf2D5c1Uy5aXp76DeKHkzWZ9KAlHroQ==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.1.tgz",
+      "integrity": "sha512-wOboSEdQ85dbKAJ0zL+wQ6b0HTSBRhtGa0PYKysQXkRg+vK0tdCRRVruiFM2QMprkOQwSYOnwF4og96PAaEGag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.8",
@@ -1274,7 +1274,7 @@
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
       "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1290,7 +1290,7 @@
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.3.8",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
       "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1306,7 +1306,7 @@
     },
     "node_modules/@smithy/hash-node": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
       "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1321,7 +1321,7 @@
     },
     "node_modules/@smithy/invalid-dependency": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
       "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1334,7 +1334,7 @@
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
       "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1345,12 +1345,12 @@
       }
     },
     "node_modules/@smithy/middleware-compression": {
-      "version": "4.3.16",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-compression/-/middleware-compression-4.3.16.tgz",
-      "integrity": "sha512-df41cMk8D/Aa8JRhraZPbeHYUJ012ivOTp9kOs95amfMdRvgNFWz9/qBFbpnTEbsyvFtYfF4HjZ0bgzrkguECQ==",
+      "version": "4.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-compression/-/middleware-compression-4.3.17.tgz",
+      "integrity": "sha512-dqHZDvpat0iqvtvhWKU09nU3E16Eep+0JW986wQphDD8I8b9PV1hpVrNrEoHiJqZ122qxBybnarOeJM2FRXV9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/is-array-buffer": "^4.2.0",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/protocol-http": "^5.3.7",
@@ -1367,7 +1367,7 @@
     },
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
       "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1380,12 +1380,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.4.1",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.1.tgz",
-      "integrity": "sha512-gpLspUAoe6f1M6H0u4cVuFzxZBrsGZmjx2O9SigurTx4PbntYa4AJ+o0G0oGm1L2oSX6oBhcGHwrfJHup2JnJg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.2.tgz",
+      "integrity": "sha512-mqpAdux0BNmZu/SqkFhQEnod4fX23xxTvU2LUpmKp0JpSI+kPYCiHJMmzREr8yxbNxKL2/DU1UZm9i++ayU+2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.0",
+        "@smithy/core": "^3.20.1",
         "@smithy/middleware-serde": "^4.2.8",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/shared-ini-file-loader": "^4.4.2",
@@ -1399,15 +1399,15 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.17",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-retry/-/middleware-retry-4.4.17.tgz",
-      "integrity": "sha512-MqbXK6Y9uq17h+4r0ogu/sBT6V/rdV+5NvYL7ZV444BKfQygYe8wAhDrVXagVebN6w2RE0Fm245l69mOsPGZzg==",
+      "version": "4.4.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.18.tgz",
+      "integrity": "sha512-E5hulijA59nBk/zvcwVMaS7FG7Y4l6hWA9vrW018r+8kiZef4/ETQaPI4oY+3zsy9f6KqDv3c4VKtO4DwwgpCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/service-error-classification": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "@smithy/util-middleware": "^4.2.7",
         "@smithy/util-retry": "^4.2.7",
@@ -1420,7 +1420,7 @@
     },
     "node_modules/@smithy/middleware-serde": {
       "version": "4.2.8",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
       "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1434,7 +1434,7 @@
     },
     "node_modules/@smithy/middleware-stack": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
       "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1447,7 +1447,7 @@
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "4.3.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
       "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1462,7 +1462,7 @@
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.4.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
       "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1478,7 +1478,7 @@
     },
     "node_modules/@smithy/property-provider": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
       "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1491,7 +1491,7 @@
     },
     "node_modules/@smithy/protocol-http": {
       "version": "5.3.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
       "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1504,7 +1504,7 @@
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
       "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1518,7 +1518,7 @@
     },
     "node_modules/@smithy/querystring-parser": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
       "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1531,7 +1531,7 @@
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
       "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1543,7 +1543,7 @@
     },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "4.4.2",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
       "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1556,7 +1556,7 @@
     },
     "node_modules/@smithy/signature-v4": {
       "version": "5.3.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
       "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1574,13 +1574,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.10.2",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/smithy-client/-/smithy-client-4.10.2.tgz",
-      "integrity": "sha512-D5z79xQWpgrGpAHb054Fn2CCTQZpog7JELbVQ6XAvXs5MNKWf28U9gzSBlJkOyMl9LA1TZEjRtwvGXfP0Sl90g==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.3.tgz",
+      "integrity": "sha512-EfECiO/0fAfb590LBnUe7rI5ux7XfquQ8LBzTe7gxw0j9QW/q8UT/EHWHlxV/+jhQ3+Ssga9uUYXCQgImGMbNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.20.0",
-        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/core": "^3.20.1",
+        "@smithy/middleware-endpoint": "^4.4.2",
         "@smithy/middleware-stack": "^4.2.7",
         "@smithy/protocol-http": "^5.3.7",
         "@smithy/types": "^4.11.0",
@@ -1593,7 +1593,7 @@
     },
     "node_modules/@smithy/types": {
       "version": "4.11.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/types/-/types-4.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
       "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1605,7 +1605,7 @@
     },
     "node_modules/@smithy/url-parser": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
       "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1619,7 +1619,7 @@
     },
     "node_modules/@smithy/util-base64": {
       "version": "4.3.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
       "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1633,7 +1633,7 @@
     },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
       "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1645,7 +1645,7 @@
     },
     "node_modules/@smithy/util-body-length-node": {
       "version": "4.2.1",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
       "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1657,7 +1657,7 @@
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
       "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1670,7 +1670,7 @@
     },
     "node_modules/@smithy/util-config-provider": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
       "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1681,13 +1681,13 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.16",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.16.tgz",
-      "integrity": "sha512-/eiSP3mzY3TsvUOYMeL4EqUX6fgUOj2eUOU4rMMgVbq67TiRLyxT7Xsjxq0bW3OwuzK009qOwF0L2OgJqperAQ==",
+      "version": "4.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.17.tgz",
+      "integrity": "sha512-dwN4GmivYF1QphnP3xJESXKtHvkkvKHSZI8GrSKMVoENVSKW2cFPRYC4ZgstYjUHdR3zwaDkIaTDIp26JuY7Cw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
@@ -1696,16 +1696,16 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.19",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.19.tgz",
-      "integrity": "sha512-3a4+4mhf6VycEJyHIQLypRbiwG6aJvbQAeRAVXydMmfweEPnLLabRbdyo/Pjw8Rew9vjsh5WCdhmDaHkQnhhhA==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.20.tgz",
+      "integrity": "sha512-VD/I4AEhF1lpB3B//pmOIMBNLMrtdMXwy9yCOfa2QkJGDr63vH3RqPbSAKzoGMov3iryCxTXCxSsyGmEB8PDpg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.5",
         "@smithy/credential-provider-imds": "^4.2.7",
         "@smithy/node-config-provider": "^4.3.7",
         "@smithy/property-provider": "^4.2.7",
-        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/smithy-client": "^4.10.3",
         "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
@@ -1715,7 +1715,7 @@
     },
     "node_modules/@smithy/util-endpoints": {
       "version": "3.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
       "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1729,7 +1729,7 @@
     },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
       "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1741,7 +1741,7 @@
     },
     "node_modules/@smithy/util-middleware": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
       "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1754,7 +1754,7 @@
     },
     "node_modules/@smithy/util-retry": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
       "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1768,7 +1768,7 @@
     },
     "node_modules/@smithy/util-stream": {
       "version": "4.5.8",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
       "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1787,7 +1787,7 @@
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
       "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1799,7 +1799,7 @@
     },
     "node_modules/@smithy/util-utf8": {
       "version": "4.2.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
       "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1812,7 +1812,7 @@
     },
     "node_modules/@smithy/util-waiter": {
       "version": "4.2.7",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.7.tgz",
       "integrity": "sha512-vHJFXi9b7kUEpHWUCY3Twl+9NPOZvQ0SAi+Ewtn48mbiJk4JY9MZmKQjGB4SCvVb9WPiSphZJYY6RIbs+grrzw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1826,7 +1826,7 @@
     },
     "node_modules/@smithy/uuid": {
       "version": "1.1.0",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
       "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -1884,9 +1884,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
-      "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
+      "version": "25.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
+      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1961,9 +1961,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.7.tgz",
-      "integrity": "sha512-k9xFKplee6KIio3IDbwj+uaCLpqzOwakOgmqzPezM0sFJlFKcg30vk2wOiAJtkTSfx0SSQDSe8q+mWA/fSH5Zg==",
+      "version": "2.9.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.12.tgz",
+      "integrity": "sha512-Mij6Lij93pTAIsSYy5cyBQ975Qh9uLEc5rwGTpomiZeXZL9yIS6uORJakb3ScHgfs0serMMfIbXzokPMuEiRyw==",
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -2042,7 +2042,7 @@
     },
     "node_modules/bowser": {
       "version": "2.13.1",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/bowser/-/bowser-2.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
       "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
       "license": "MIT"
     },
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001760",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001760.tgz",
-      "integrity": "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw==",
+      "version": "1.0.30001763",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001763.tgz",
+      "integrity": "sha512-mh/dGtq56uN98LlNX9qdbKnzINhX0QzhiWBFEkFfsFO4QyCvL8YegrJAazCwXIeqkIob8BlZPGM3xdnY+sgmvQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -2597,7 +2597,7 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
       "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
       "funding": [
         {
@@ -2615,7 +2615,7 @@
     },
     "node_modules/fflate": {
       "version": "0.8.1",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/fflate/-/fflate-0.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
       "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
       "license": "MIT"
     },
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
-      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3676,9 +3676,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -4059,7 +4059,7 @@
     },
     "node_modules/strnum": {
       "version": "2.1.2",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/strnum/-/strnum-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
       "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
@@ -4258,7 +4258,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/tslib/-/tslib-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
@@ -4318,9 +4318,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.2.tgz",
-      "integrity": "sha512-E85pfNzMQ9jpKkA7+TJAi4TJN+tBCuWh5rUcS/sv6cFi+1q9LYDwDI5dpUL0u/73EElyQ8d3TEaeW4sPedBqYA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4394,6 +4394,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
       "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.4.24"

--- a/packages/pwa-kit-runtime/package.json
+++ b/packages/pwa-kit-runtime/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@h4ad/serverless-adapter": "4.4.0",
     "@loadable/babel-plugin": "^5.15.3",
-    "aws-sdk": "^2.1354.0",
+    "@aws-sdk/client-cloudwatch": "^3.962.0",
     "cosmiconfig": "8.1.3",
     "cross-env": "^5.2.1",
     "express": "^4.19.2",

--- a/packages/pwa-kit-runtime/src/ssr/server/express.lambda.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.lambda.test.js
@@ -310,7 +310,7 @@ describe('SSRServer Lambda integration', () => {
             app.metrics._CW = {
                 putMetricData: (params, callback) => {
                     metrics.push(params)
-                    callback(null)
+                    return Promise.resolve()
                 }
             }
             const metricSent = (name) =>

--- a/packages/pwa-kit-runtime/src/ssr/server/express.lambda.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.lambda.test.js
@@ -308,7 +308,7 @@ describe('SSRServer Lambda integration', () => {
             // track them.
             const metrics = []
             app.metrics._CW = {
-                putMetricData: (params, callback) => {
+                putMetricData: (params) => {
                     metrics.push(params)
                     return Promise.resolve()
                 }

--- a/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
@@ -506,7 +506,7 @@ describe('MetricsSender', () => {
                 expect(actual).toBeDefined()
                 expect(actual.MetricName).toEqual(metric.name)
                 expect(actual.Value).toEqual(metric.value || 0)
-                expect(actual.Timestamp).toEqual(nowISO)
+                expect(actual.Timestamp.toISOString()).toEqual(nowISO)
 
                 if (metric.dimensions) {
                     expect(actual.Dimensions).toBeDefined()

--- a/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server.test.js
@@ -472,13 +472,14 @@ describe('MetricsSender', () => {
         const calledParams = []
         let callCount = 0
         sender._CW = {
-            putMetricData: (params, callback) => {
+            putMetricData: (params) => {
                 callCount += 1
-                // This returns a fake error on the first call, and then
-                // accepts all subsequent calls.
-                const err = calledParams.length ? null : new Error('imaginary error')
                 params.MetricData.forEach((metric) => calledParams.push(metric))
-                callback(err, null)
+                // This returns a fake promise that resolves immediately
+                if (callCount === 1) {
+                    return Promise.reject(new Error('Some error'))
+                }
+                return Promise.resolve()
             }
         }
 
@@ -539,10 +540,8 @@ describe('MetricsSender', () => {
         // Set up a fake CloudWatch client that will return a Throttling
         // error every time it's called.
         sender._CW = {
-            putMetricData: (params, callback) => {
-                const err = new Error('Throttled')
-                err.code = 'Throttling'
-                callback(err)
+            putMetricData: (params) => {
+                return Promise.reject(new Error('Throttled'))
             }
         }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
@@ -46,17 +46,20 @@ export class MetricsSender {
     _setup() {
         /* istanbul ignore next */
         if (!this._CW && (isRemote() || MetricsSender._override)) {
-            // eslint-disable-next-line @typescript-eslint/no-var-requires
-            const Cloudwatch = require('aws-sdk/clients/cloudwatch')
+            const {
+                CloudWatch: Cloudwatch
+            } = require('@aws-sdk/client-cloudwatch');
             this._CW = new Cloudwatch({
-                apiVersion: '2010-08-01',
                 // The AWS_REGION variable is defined by the Lambda
                 // environment.
                 region: process.env.AWS_REGION || 'us-east-1',
+
                 // Setting maxRetries to 0 will prevent the SDK from retrying.
                 // This is necessary because under high load, there will be backpressure
                 // on the Lambda function, and causing severe performance issues (400-500ms latency)
-                maxRetries: 0
+                // The key maxRetries is renamed to maxAttempts.
+                // The value of maxAttempts needs to be maxRetries + 1.
+                maxAttempts: 1
             })
         }
         return this._CW
@@ -77,25 +80,18 @@ export class MetricsSender {
             return Promise.resolve()
         }
 
-        return new Promise((resolve) => {
-            cw.putMetricData(
-                {
-                    MetricData: metrics,
-                    Namespace: 'ssr'
-                },
-                (err) => {
-                    if (err) {
-                        logger.warn(`Metrics: error sending data: ${err}`, {
-                            namespace: 'metrics-sender._putMetricData',
-                            additionalProperties: {
-                                metrics,
-                                error: err
-                            }
-                        })
-                    }
-                    resolve()
+        // v3 supports promises, so we can use that instead of a callback.
+        return cw.putMetricData({ 
+            MetricData: metrics, 
+            Namespace: 'ssr' 
+        }).catch((err) => {
+            logger.warn(`Metrics: error sending data: ${err}`, {
+                namespace: 'metrics-sender._putMetricData',
+                additionalProperties: {
+                    metrics,
+                    error: err
                 }
-            )
+            })
         })
     }
 
@@ -170,8 +166,10 @@ export class MetricsSender {
                 // This value must be a string
                 Timestamp: (metric.timestamp instanceof Date
                     ? metric.timestamp
-                    : now
-                ).toISOString(),
+                    : (typeof metric.timestamp === 'number'
+                        ? new Date(metric.timestamp)
+                        : now)
+                ),
                 Unit: metric.unit || 'Count'
             }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
@@ -46,9 +46,8 @@ export class MetricsSender {
     _setup() {
         /* istanbul ignore next */
         if (!this._CW && (isRemote() || MetricsSender._override)) {
-            const {
-                CloudWatch: Cloudwatch
-            } = require('@aws-sdk/client-cloudwatch');
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            const {CloudWatch: Cloudwatch} = require('@aws-sdk/client-cloudwatch')
             this._CW = new Cloudwatch({
                 // The AWS_REGION variable is defined by the Lambda
                 // environment.
@@ -81,18 +80,20 @@ export class MetricsSender {
         }
 
         // v3 supports promises, so we can use that instead of a callback.
-        return cw.putMetricData({ 
-            MetricData: metrics, 
-            Namespace: 'ssr' 
-        }).catch((err) => {
-            logger.warn(`Metrics: error sending data: ${err}`, {
-                namespace: 'metrics-sender._putMetricData',
-                additionalProperties: {
-                    metrics,
-                    error: err
-                }
+        return cw
+            .putMetricData({
+                MetricData: metrics,
+                Namespace: 'ssr'
             })
-        })
+            .catch((err) => {
+                logger.warn(`Metrics: error sending data: ${err}`, {
+                    namespace: 'metrics-sender._putMetricData',
+                    additionalProperties: {
+                        metrics,
+                        error: err
+                    }
+                })
+            })
     }
 
     /**
@@ -164,12 +165,12 @@ export class MetricsSender {
                 MetricName: metric.name,
                 Value: metric.value || 0,
                 // This value must be a string
-                Timestamp: (metric.timestamp instanceof Date
-                    ? metric.timestamp
-                    : (typeof metric.timestamp === 'number'
+                Timestamp:
+                    metric.timestamp instanceof Date
+                        ? metric.timestamp
+                        : typeof metric.timestamp === 'number'
                         ? new Date(metric.timestamp)
-                        : now)
-                ),
+                        : now,
                 Unit: metric.unit || 'Count'
             }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/metrics-sender.js
@@ -164,7 +164,7 @@ export class MetricsSender {
             const metricData = {
                 MetricName: metric.name,
                 Value: metric.value || 0,
-                // This value must be a string
+                // AWS SDK expects a Date object
                 Timestamp:
                     metric.timestamp instanceof Date
                         ? metric.timestamp


### PR DESCRIPTION
Migrate AWS SDK FROM Version 2 TO Version 3

# Description
End of life support FOR AWS-SDK was reached on September 8, 2025

The JS AWS SDK is used to send metrics to cloudwatch from pwa kit runtime library. The goal is to update the library to use v3 version. We utilize codemod scripts for the migration (recommended by AWS) and manually adjust discrepancies between the two versions

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [x] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Change of import; use of `client-cloudwatch` instead for v3
- The key maxRetries was renamed to maxAttempts for v3
- v3 supports promises instead of callback functionality
- Adjust metric sender to convert timestamp to Date where necessary

# How to Test-Drive This PR

- Run `npm install` and `npm ci` at the root
- cd into `packages/template-mrt-reference-app`
- Run the following commands:
```
npm run save-credentials -- --cloud-origin https://cloud-<env>.mobify-staging.com/ -u <email> -k <api-key>
npx pwa-kit-create-app
npm run push -- --cloud-origin https://cloud-<env>.mobify-staging.com -s <project>
```
- Deploy the bundle to your target
- Run the command below about 5 times to ping the endpoint
`curl -s -o /dev/null -w "%{http_code}\n" https://{project}-{target}.[mobify-storefront-staging.com](http://mobify-storefront-staging.com`
Wait for a few minutes and then check your subaccount of the target for the following metrics
`Cloudwatch > Metrics > ssr > Project, Target`
Ensure `RequestTime` and `RequestSuccess` are displayed in metrics
- Run the command below about 5 times to ping the endpoint
`curl -s -o /dev/null -w "%{http_code}\n" https://{project}-{target}.[mobify-storefront-staging.com](http://mobify-storefront-staging.com/exception`
Wait for a few minutes and then check your subaccount of the target for the following metrics
`Cloudwatch > Metrics > ssr > Project, Target`
Ensure `RequestTime` and `RequestFailed500` are displayed in metrics

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
