### PR TITLE
Add shipping support for OMS

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Feature] PWA Integration with OMS
   - Integrate Order Details page to display orders data from OMS [#3573](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3573)
   - Integrate Order History page to display data from OMS [#3581](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3581)
+  - Add shipping display support for OMS [#3588](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3588)
 
 ## v8.3.0 (Dec 17, 2025)
 - [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3493](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3493)

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -326,11 +326,33 @@ const AccountOrderDetail = () => {
                                     )
                                 })}
 
-                                {/* Delivery Shipments */}
+                                {/* Delivery Shipments - Orders shipped to customer addresses
+                                    
+                                    Each delivery shipment displays two columns:
+                                    1. Shipping Method Column:
+                                       - Status (shipped, not_shipped, part_shipped, or OMS status)
+                                       - Method name (e.g., "Ground", "Express")
+                                       - Tracking number (clickable link if trackingUrl is available)
+                                    2. Shipping Address Column:
+                                       - Recipient name (firstName + lastName, or fullName fallback)
+                                       - Street address, City, State, Postal Code
+                                    
+                                    Multi-Shipment Display:
+                                    - When order has multiple shipments, each gets its own pair of columns
+                                    - Headings are numbered: "Shipping Method 1", "Shipping Address 1", etc.
+                                    - Single shipment orders show headings without numbers
+                                    
+                                    OMS Integration:
+                                    - order.shipments and order.omsData.shipments are matched by index
+                                    - Note: Index correlation may not be accurate - OMS shipments may not
+                                      directly map to ECOM shipments as there is no shared ID between them
+                                    - OMS data takes priority: status, trackingNumber, trackingUrl
+                                    - When OMS data exists, ECOM shippingStatus may not be present
+                                    - trackingUrl makes tracking number a clickable external link
+                                */}
                                 {deliveryShipments.map((shipment, index) => {
                                     // Use index to match with omsData.shipments
                                     const omsShipment = order?.omsData?.shipments?.[index]
-                                    // OMS data takes priority, fallback to ECOM
                                     const shippingStatus =
                                         omsShipment?.status || shipment.shippingStatus
                                     const trackingNumber =

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -18,6 +18,7 @@ import {
     Button,
     Divider,
     Grid,
+    Link as ChakraLink,
     SimpleGrid,
     Skeleton
 } from '@salesforce/retail-react-app/app/components/shared/ui'
@@ -326,27 +327,36 @@ const AccountOrderDetail = () => {
                                 })}
 
                                 {/* Delivery Shipments */}
-                                {deliveryShipments.map((shipment, index) => (
-                                    <React.Fragment key={`delivery-${index}`}>
-                                        <Stack spacing={1}>
-                                            <Heading as="h2" fontSize="sm" pt={1}>
-                                                {deliveryShipments.length > 1 ? (
-                                                    <FormattedMessage
-                                                        defaultMessage="Shipping Method {number}"
-                                                        id="account_order_detail.heading.shipping_method_number"
-                                                        values={{number: index + 1}}
-                                                    />
-                                                ) : (
-                                                    <FormattedMessage
-                                                        defaultMessage="Shipping Method"
-                                                        id="account_order_detail.heading.shipping_method"
-                                                    />
-                                                )}
-                                            </Heading>
-                                            <Box>
-                                                <Text fontSize="sm" textTransform="titlecase">
-                                                    {
-                                                        {
+                                {deliveryShipments.map((shipment, index) => {
+                                    // Use index to match with omsData.shipments
+                                    const omsShipment = order?.omsData?.shipments?.[index]
+                                    // OMS data takes priority, fallback to ECOM
+                                    const shippingStatus =
+                                        omsShipment?.status || shipment.shippingStatus
+                                    const trackingNumber =
+                                        omsShipment?.trackingNumber || shipment.trackingNumber
+                                    const trackingUrl = omsShipment?.trackingUrl
+
+                                    return (
+                                        <React.Fragment key={`delivery-${index}`}>
+                                            <Stack spacing={1}>
+                                                <Heading as="h2" fontSize="sm" pt={1}>
+                                                    {deliveryShipments.length > 1 ? (
+                                                        <FormattedMessage
+                                                            defaultMessage="Shipping Method {number}"
+                                                            id="account_order_detail.heading.shipping_method_number"
+                                                            values={{number: index + 1}}
+                                                        />
+                                                    ) : (
+                                                        <FormattedMessage
+                                                            defaultMessage="Shipping Method"
+                                                            id="account_order_detail.heading.shipping_method"
+                                                        />
+                                                    )}
+                                                </Heading>
+                                                <Box>
+                                                    <Text fontSize="sm" textTransform="titlecase">
+                                                        {{
                                                             not_shipped: formatMessage({
                                                                 defaultMessage: 'Not shipped',
                                                                 id: 'account_order_detail.shipping_status.not_shipped'
@@ -359,57 +369,68 @@ const AccountOrderDetail = () => {
                                                                 defaultMessage: 'Shipped',
                                                                 id: 'account_order_detail.shipping_status.shipped'
                                                             })
-                                                        }[shipment.shippingStatus]
-                                                    }
-                                                </Text>
-                                                <Text fontSize="sm">
-                                                    {shipment.shippingMethod.name}
-                                                </Text>
-                                                {shipment.trackingNumber && (
-                                                    <Text fontSize="sm">
-                                                        <FormattedMessage
-                                                            defaultMessage="Tracking Number"
-                                                            id="account_order_detail.label.tracking_number"
-                                                        />
-                                                        : {shipment.trackingNumber}
+                                                        }[shippingStatus] || shippingStatus}
                                                     </Text>
-                                                )}
-                                            </Box>
-                                        </Stack>
-                                        <Stack spacing={1}>
-                                            <Heading as="h2" fontSize="sm" pt={1}>
-                                                {deliveryShipments.length > 1 ? (
-                                                    <FormattedMessage
-                                                        defaultMessage="Shipping Address {number}"
-                                                        id="account_order_detail.heading.shipping_address_number"
-                                                        values={{number: index + 1}}
-                                                    />
-                                                ) : (
-                                                    <FormattedMessage
-                                                        defaultMessage="Shipping Address"
-                                                        id="account_order_detail.heading.shipping_address"
-                                                    />
-                                                )}
-                                            </Heading>
-                                            <Box>
-                                                <Text fontSize="sm">
-                                                    {shipment.shippingAddress.firstName &&
-                                                    shipment.shippingAddress.lastName
-                                                        ? `${shipment.shippingAddress.firstName} ${shipment.shippingAddress.lastName}`
-                                                        : shipment.shippingAddress.fullName}
-                                                </Text>
-                                                <Text fontSize="sm">
-                                                    {shipment.shippingAddress.address1}
-                                                </Text>
-                                                <Text fontSize="sm">
-                                                    {shipment.shippingAddress.city},{' '}
-                                                    {shipment.shippingAddress.stateCode}{' '}
-                                                    {shipment.shippingAddress.postalCode}
-                                                </Text>
-                                            </Box>
-                                        </Stack>
-                                    </React.Fragment>
-                                ))}
+                                                    <Text fontSize="sm">
+                                                        {shipment.shippingMethod.name}
+                                                    </Text>
+                                                    {trackingNumber && (
+                                                        <Text fontSize="sm">
+                                                            <FormattedMessage
+                                                                defaultMessage="Tracking Number"
+                                                                id="account_order_detail.label.tracking_number"
+                                                            />
+                                                            :{' '}
+                                                            {trackingUrl ? (
+                                                                <ChakraLink
+                                                                    href={trackingUrl}
+                                                                    isExternal
+                                                                    color="blue.600"
+                                                                >
+                                                                    {trackingNumber}
+                                                                </ChakraLink>
+                                                            ) : (
+                                                                trackingNumber
+                                                            )}
+                                                        </Text>
+                                                    )}
+                                                </Box>
+                                            </Stack>
+                                            <Stack spacing={1}>
+                                                <Heading as="h2" fontSize="sm" pt={1}>
+                                                    {deliveryShipments.length > 1 ? (
+                                                        <FormattedMessage
+                                                            defaultMessage="Shipping Address {number}"
+                                                            id="account_order_detail.heading.shipping_address_number"
+                                                            values={{number: index + 1}}
+                                                        />
+                                                    ) : (
+                                                        <FormattedMessage
+                                                            defaultMessage="Shipping Address"
+                                                            id="account_order_detail.heading.shipping_address"
+                                                        />
+                                                    )}
+                                                </Heading>
+                                                <Box>
+                                                    <Text fontSize="sm">
+                                                        {shipment.shippingAddress.firstName &&
+                                                        shipment.shippingAddress.lastName
+                                                            ? `${shipment.shippingAddress.firstName} ${shipment.shippingAddress.lastName}`
+                                                            : shipment.shippingAddress.fullName}
+                                                    </Text>
+                                                    <Text fontSize="sm">
+                                                        {shipment.shippingAddress?.address1}
+                                                    </Text>
+                                                    <Text fontSize="sm">
+                                                        {shipment.shippingAddress.city},{' '}
+                                                        {shipment.shippingAddress.stateCode}{' '}
+                                                        {shipment.shippingAddress.postalCode}
+                                                    </Text>
+                                                </Box>
+                                            </Stack>
+                                        </React.Fragment>
+                                    )
+                                })}
 
                                 {/* Payment Method */}
                                 {paymentCard && (

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -330,15 +330,15 @@ const AccountOrderDetail = () => {
                                 {deliveryShipments.map((shipment, index) => {
                                     // Hide shipping address for OMS multi-shipment orders
                                     // Can't reliably correlate OMS shipments to ECOM addresses by index
-
-                                    const hasOmsData = order?.omsData
+                                    const isOmsOrder = !!order?.omsData
+                                    const omsShipment = isOmsOrder
+                                        ? order.omsData.shipments?.[index]
+                                        : null
                                     const isOmsMultiShipment =
-                                        hasOmsData &&
-                                        (order?.omsData?.shipments?.length > 1 ||
-                                            order?.shipments?.length > 1)
+                                        isOmsOrder &&
+                                        (order.omsData.shipments?.length > 1 ||
+                                            order.shipments?.length > 1)
 
-                                    const omsShipment =
-                                        hasOmsData && order?.omsData?.shipments?.[index]
                                     const shippingMethodName =
                                         omsShipment?.provider || shipment.shippingMethod.name
                                     const shippingStatus =

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -329,17 +329,22 @@ const AccountOrderDetail = () => {
                                 {/* Delivery Shipments */}
                                 {deliveryShipments.map((shipment, index) => {
                                     // Hide shipping address for OMS multi-shipment orders
-                                    // (can't reliably correlate OMS shipments to ECOM addresses by index)
+                                    // Can't reliably correlate OMS shipments to ECOM addresses by index
 
-                                    const hasOmsData = order?.omsData;
-                                    const isOmsMultiShipment = hasOmsData && (
-                                        order?.omsData?.shipments?.length > 1 ||
-                                        order?.shipments?.length > 1)
+                                    const hasOmsData = order?.omsData
+                                    const isOmsMultiShipment =
+                                        hasOmsData &&
+                                        (order?.omsData?.shipments?.length > 1 ||
+                                            order?.shipments?.length > 1)
 
-                                    const omsShipment = hasOmsData && order?.omsData?.shipments?.[index]
-                                    const shippingMethodName = omsShipment?.provider || shipment.shippingMethod.name
-                                    const shippingStatus = omsShipment?.status || shipment.shippingStatus
-                                    const trackingNumber = omsShipment?.trackingNumber || shipment.trackingNumber
+                                    const omsShipment =
+                                        hasOmsData && order?.omsData?.shipments?.[index]
+                                    const shippingMethodName =
+                                        omsShipment?.provider || shipment.shippingMethod.name
+                                    const shippingStatus =
+                                        omsShipment?.status || shipment.shippingStatus
+                                    const trackingNumber =
+                                        omsShipment?.trackingNumber || shipment.trackingNumber
                                     const trackingUrl = omsShipment?.trackingUrl
 
                                     return (
@@ -361,26 +366,22 @@ const AccountOrderDetail = () => {
                                                 </Heading>
                                                 <Box>
                                                     <Text fontSize="sm" textTransform="titlecase">
-                                                        {
-                                                            {
-                                                                not_shipped: formatMessage({
-                                                                    defaultMessage: 'Not shipped',
-                                                                    id: 'account_order_detail.shipping_status.not_shipped'
-                                                                }),
-                                                                part_shipped: formatMessage({
-                                                                    defaultMessage: 'Partially shipped',
-                                                                    id: 'account_order_detail.shipping_status.part_shipped'
-                                                                }),
-                                                                shipped: formatMessage({
-                                                                    defaultMessage: 'Shipped',
-                                                                    id: 'account_order_detail.shipping_status.shipped'
-                                                                })
-                                                            }[shippingStatus] || shippingStatus
-                                                        }
+                                                        {{
+                                                            not_shipped: formatMessage({
+                                                                defaultMessage: 'Not shipped',
+                                                                id: 'account_order_detail.shipping_status.not_shipped'
+                                                            }),
+                                                            part_shipped: formatMessage({
+                                                                defaultMessage: 'Partially shipped',
+                                                                id: 'account_order_detail.shipping_status.part_shipped'
+                                                            }),
+                                                            shipped: formatMessage({
+                                                                defaultMessage: 'Shipped',
+                                                                id: 'account_order_detail.shipping_status.shipped'
+                                                            })
+                                                        }[shippingStatus] || shippingStatus}
                                                     </Text>
-                                                    <Text fontSize="sm">
-                                                        {shippingMethodName}
-                                                    </Text>
+                                                    <Text fontSize="sm">{shippingMethodName}</Text>
                                                     {trackingNumber && (
                                                         <Text fontSize="sm">
                                                             <FormattedMessage

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -326,37 +326,20 @@ const AccountOrderDetail = () => {
                                     )
                                 })}
 
-                                {/* Delivery Shipments - Orders shipped to customer addresses
-                                    
-                                    Each delivery shipment displays two columns:
-                                    1. Shipping Method Column:
-                                       - Status (shipped, not_shipped, part_shipped, or OMS status)
-                                       - Method name (e.g., "Ground", "Express")
-                                       - Tracking number (clickable link if trackingUrl is available)
-                                    2. Shipping Address Column:
-                                       - Recipient name (firstName + lastName, or fullName fallback)
-                                       - Street address, City, State, Postal Code
-                                    
-                                    Multi-Shipment Display:
-                                    - When order has multiple shipments, each gets its own pair of columns
-                                    - Headings are numbered: "Shipping Method 1", "Shipping Address 1", etc.
-                                    - Single shipment orders show headings without numbers
-                                    
-                                    OMS Integration:
-                                    - order.shipments and order.omsData.shipments are matched by index
-                                    - Note: Index correlation may not be accurate - OMS shipments may not
-                                      directly map to ECOM shipments as there is no shared ID between them
-                                    - OMS data takes priority: status, trackingNumber, trackingUrl
-                                    - When OMS data exists, ECOM shippingStatus may not be present
-                                    - trackingUrl makes tracking number a clickable external link
-                                */}
+                                {/* Delivery Shipments */}
                                 {deliveryShipments.map((shipment, index) => {
-                                    // Use index to match with omsData.shipments
-                                    const omsShipment = order?.omsData?.shipments?.[index]
-                                    const shippingStatus =
-                                        omsShipment?.status || shipment.shippingStatus
-                                    const trackingNumber =
-                                        omsShipment?.trackingNumber || shipment.trackingNumber
+                                    // Hide shipping address for OMS multi-shipment orders
+                                    // (can't reliably correlate OMS shipments to ECOM addresses by index)
+
+                                    const hasOmsData = order?.omsData;
+                                    const isOmsMultiShipment = hasOmsData && (
+                                        order?.omsData?.shipments?.length > 1 ||
+                                        order?.shipments?.length > 1)
+
+                                    const omsShipment = hasOmsData && order?.omsData?.shipments?.[index]
+                                    const shippingMethodName = omsShipment?.provider || shipment.shippingMethod.name
+                                    const shippingStatus = omsShipment?.status || shipment.shippingStatus
+                                    const trackingNumber = omsShipment?.trackingNumber || shipment.trackingNumber
                                     const trackingUrl = omsShipment?.trackingUrl
 
                                     return (
@@ -378,23 +361,25 @@ const AccountOrderDetail = () => {
                                                 </Heading>
                                                 <Box>
                                                     <Text fontSize="sm" textTransform="titlecase">
-                                                        {{
-                                                            not_shipped: formatMessage({
-                                                                defaultMessage: 'Not shipped',
-                                                                id: 'account_order_detail.shipping_status.not_shipped'
-                                                            }),
-                                                            part_shipped: formatMessage({
-                                                                defaultMessage: 'Partially shipped',
-                                                                id: 'account_order_detail.shipping_status.part_shipped'
-                                                            }),
-                                                            shipped: formatMessage({
-                                                                defaultMessage: 'Shipped',
-                                                                id: 'account_order_detail.shipping_status.shipped'
-                                                            })
-                                                        }[shippingStatus] || shippingStatus}
+                                                        {
+                                                            {
+                                                                not_shipped: formatMessage({
+                                                                    defaultMessage: 'Not shipped',
+                                                                    id: 'account_order_detail.shipping_status.not_shipped'
+                                                                }),
+                                                                part_shipped: formatMessage({
+                                                                    defaultMessage: 'Partially shipped',
+                                                                    id: 'account_order_detail.shipping_status.part_shipped'
+                                                                }),
+                                                                shipped: formatMessage({
+                                                                    defaultMessage: 'Shipped',
+                                                                    id: 'account_order_detail.shipping_status.shipped'
+                                                                })
+                                                            }[shippingStatus] || shippingStatus
+                                                        }
                                                     </Text>
                                                     <Text fontSize="sm">
-                                                        {shipment.shippingMethod.name}
+                                                        {shippingMethodName}
                                                     </Text>
                                                     {trackingNumber && (
                                                         <Text fontSize="sm">
@@ -418,38 +403,40 @@ const AccountOrderDetail = () => {
                                                     )}
                                                 </Box>
                                             </Stack>
-                                            <Stack spacing={1}>
-                                                <Heading as="h2" fontSize="sm" pt={1}>
-                                                    {deliveryShipments.length > 1 ? (
-                                                        <FormattedMessage
-                                                            defaultMessage="Shipping Address {number}"
-                                                            id="account_order_detail.heading.shipping_address_number"
-                                                            values={{number: index + 1}}
-                                                        />
-                                                    ) : (
-                                                        <FormattedMessage
-                                                            defaultMessage="Shipping Address"
-                                                            id="account_order_detail.heading.shipping_address"
-                                                        />
-                                                    )}
-                                                </Heading>
-                                                <Box>
-                                                    <Text fontSize="sm">
-                                                        {shipment.shippingAddress.firstName &&
-                                                        shipment.shippingAddress.lastName
-                                                            ? `${shipment.shippingAddress.firstName} ${shipment.shippingAddress.lastName}`
-                                                            : shipment.shippingAddress.fullName}
-                                                    </Text>
-                                                    <Text fontSize="sm">
-                                                        {shipment.shippingAddress?.address1}
-                                                    </Text>
-                                                    <Text fontSize="sm">
-                                                        {shipment.shippingAddress.city},{' '}
-                                                        {shipment.shippingAddress.stateCode}{' '}
-                                                        {shipment.shippingAddress.postalCode}
-                                                    </Text>
-                                                </Box>
-                                            </Stack>
+                                            {!isOmsMultiShipment && (
+                                                <Stack spacing={1}>
+                                                    <Heading as="h2" fontSize="sm" pt={1}>
+                                                        {deliveryShipments.length > 1 ? (
+                                                            <FormattedMessage
+                                                                defaultMessage="Shipping Address {number}"
+                                                                id="account_order_detail.heading.shipping_address_number"
+                                                                values={{number: index + 1}}
+                                                            />
+                                                        ) : (
+                                                            <FormattedMessage
+                                                                defaultMessage="Shipping Address"
+                                                                id="account_order_detail.heading.shipping_address"
+                                                            />
+                                                        )}
+                                                    </Heading>
+                                                    <Box>
+                                                        <Text fontSize="sm">
+                                                            {shipment.shippingAddress.firstName &&
+                                                            shipment.shippingAddress.lastName
+                                                                ? `${shipment.shippingAddress.firstName} ${shipment.shippingAddress.lastName}`
+                                                                : shipment.shippingAddress.fullName}
+                                                        </Text>
+                                                        <Text fontSize="sm">
+                                                            {shipment.shippingAddress.address1}
+                                                        </Text>
+                                                        <Text fontSize="sm">
+                                                            {shipment.shippingAddress.city},{' '}
+                                                            {shipment.shippingAddress.stateCode}{' '}
+                                                            {shipment.shippingAddress.postalCode}
+                                                        </Text>
+                                                    </Box>
+                                                </Stack>
+                                            )}
                                         </React.Fragment>
                                     )
                                 })}

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -536,18 +536,40 @@ describe('OMS Multi-shipment - Shipping address hidden', () => {
         shipments: [
             {
                 shippingMethod: {name: 'Ground'},
-                shippingAddress: {fullName: 'Alice Johnson', address1: '123 First St', city: 'Seattle', stateCode: 'WA', postalCode: '98101'}
+                shippingAddress: {
+                    fullName: 'Alice Johnson',
+                    address1: '123 First St',
+                    city: 'Seattle',
+                    stateCode: 'WA',
+                    postalCode: '98101'
+                }
             },
             {
                 shippingMethod: {name: 'Express'},
-                shippingAddress: {fullName: 'Bob Smith', address1: '456 Second St', city: 'Portland', stateCode: 'OR', postalCode: '97201'}
+                shippingAddress: {
+                    fullName: 'Bob Smith',
+                    address1: '456 Second St',
+                    city: 'Portland',
+                    stateCode: 'OR',
+                    postalCode: '97201'
+                }
             }
         ],
         omsData: {
             status: 'Processing',
             shipments: [
-                {status: 'SHIPPED', trackingNumber: 'OMS-001', trackingUrl: 'https://track.example.com/OMS-001', provider: 'FedEx'},
-                {status: 'PENDING', trackingNumber: 'OMS-002', trackingUrl: 'https://track.example.com/OMS-002', provider: 'UPS'}
+                {
+                    status: 'SHIPPED',
+                    trackingNumber: 'OMS-001',
+                    trackingUrl: 'https://track.example.com/OMS-001',
+                    provider: 'FedEx'
+                },
+                {
+                    status: 'PENDING',
+                    trackingNumber: 'OMS-002',
+                    trackingUrl: 'https://track.example.com/OMS-002',
+                    provider: 'UPS'
+                }
             ]
         }
     })
@@ -597,12 +619,26 @@ describe('ECOM Multi-shipment - Shipping address shown', () => {
                 shippingMethod: {name: 'Ground'},
                 shippingStatus: 'shipped',
                 trackingNumber: 'ECOM-001',
-                shippingAddress: {firstName: 'John', lastName: 'Doe', address1: '123 First St', city: 'Boston', stateCode: 'MA', postalCode: '02101'}
+                shippingAddress: {
+                    firstName: 'John',
+                    lastName: 'Doe',
+                    address1: '123 First St',
+                    city: 'Boston',
+                    stateCode: 'MA',
+                    postalCode: '02101'
+                }
             },
             {
                 shippingMethod: {name: 'Express'},
                 shippingStatus: 'not_shipped',
-                shippingAddress: {firstName: 'Jane', lastName: 'Smith', address1: '456 Second St', city: 'Chicago', stateCode: 'IL', postalCode: '60601'}
+                shippingAddress: {
+                    firstName: 'Jane',
+                    lastName: 'Smith',
+                    address1: '456 Second St',
+                    city: 'Chicago',
+                    stateCode: 'IL',
+                    postalCode: '60601'
+                }
             }
         ]
     })
@@ -621,15 +657,19 @@ describe('ECOM Multi-shipment - Shipping address shown', () => {
     })
 
     test('should display numbered shipping address headings for ECOM multi-shipment', async () => {
-        expect(await screen.findByRole('heading', {name: /shipping address 1/i})).toBeInTheDocument()
-        expect(await screen.findByRole('heading', {name: /shipping address 2/i})).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 1/i})
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 2/i})
+        ).toBeInTheDocument()
     })
 
     test('should display both shipping addresses', async () => {
         expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
         // Jane Smith appears in both shipping and billing address
         const janeSmithElements = await screen.findAllByText(/Jane Smith/i)
-        expect(janeSmithElements.length).toBe(2)
+        expect(janeSmithElements).toHaveLength(2)
     })
 
     test('should display ECOM shipping statuses', async () => {
@@ -645,13 +685,24 @@ describe('OMS Single shipment with tracking URL', () => {
         shipments: [
             {
                 shippingMethod: {name: 'Standard'},
-                shippingAddress: {fullName: 'Alex Johnson', address1: '789 Main St', city: 'Seattle', stateCode: 'WA', postalCode: '98101'}
+                shippingAddress: {
+                    fullName: 'Alex Johnson',
+                    address1: '789 Main St',
+                    city: 'Seattle',
+                    stateCode: 'WA',
+                    postalCode: '98101'
+                }
             }
         ],
         omsData: {
             status: 'SHIPPED',
             shipments: [
-                {status: 'DELIVERED', trackingNumber: 'TRACK-12345', trackingUrl: 'https://tracking.fedex.com/TRACK-12345', provider: 'FedEx Ground'}
+                {
+                    status: 'DELIVERED',
+                    trackingNumber: 'TRACK-12345',
+                    trackingUrl: 'https://tracking.fedex.com/TRACK-12345',
+                    provider: 'FedEx Ground'
+                }
             ]
         }
     })
@@ -661,7 +712,9 @@ describe('OMS Single shipment with tracking URL', () => {
     })
 
     test('should display shipping address for single OMS shipment', async () => {
-        expect(await screen.findByRole('heading', {name: /^shipping address$/i})).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /^shipping address$/i})
+        ).toBeInTheDocument()
         expect(await screen.findByText(/Alex Johnson/i)).toBeInTheDocument()
     })
 
@@ -685,7 +738,13 @@ describe('OMS Single shipment with partial data (missing provider, trackingUrl)'
         shipments: [
             {
                 shippingMethod: {name: 'Ground Shipping'},
-                shippingAddress: {fullName: 'Mike Brown', address1: '100 Oak St', city: 'Denver', stateCode: 'CO', postalCode: '80201'}
+                shippingAddress: {
+                    fullName: 'Mike Brown',
+                    address1: '100 Oak St',
+                    city: 'Denver',
+                    stateCode: 'CO',
+                    postalCode: '80201'
+                }
             }
         ],
         omsData: {

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -528,3 +528,235 @@ describe('Order with multiple shipments (pickup and delivery)', () => {
         expect(await screen.findByRole('heading', {name: /billing address/i})).toBeInTheDocument()
     })
 })
+
+// Single shipment scenarios - ECOM vs OMS data
+describe('Single shipment - ECOM data only', () => {
+    beforeEach(() => {
+        // ECOM order with single shipment, no OMS data
+        setupOrderDetailsPage(createMockOrder())
+    })
+
+    test('should display shipping status from ECOM', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/not shipped/i)).toBeInTheDocument()
+    })
+
+    test('should display shipping method name', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/Ground/i)).toBeInTheDocument()
+    })
+
+    test('should display single shipping address heading (no number)', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /^shipping address$/i})
+        ).toBeInTheDocument()
+    })
+
+    test('should display shipping address fields', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
+        expect(await screen.findByText(/123 Test St/i)).toBeInTheDocument()
+        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
+        expect((await screen.findAllByText(/MA/i)).length).toBeGreaterThanOrEqual(1)
+        expect((await screen.findAllByText(/02101/i)).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('should not display tracking number when not present', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByText(/tracking number/i)).not.toBeInTheDocument()
+    })
+})
+
+describe('Single shipment - OMS data with tracking', () => {
+    beforeEach(() => {
+        // Order with OMS data including tracking info
+        // Note: When omsData is present, shipments don't have shippingStatus
+        const orderWithOmsTracking = createMockOrder({
+            status: undefined, // No ECOM status
+            shipments: [
+                {
+                    shippingMethod: {name: 'Ground'},
+                    // No shippingStatus - OMS orders use omsData.shipments[].status instead
+                    shippingAddress: {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        address1: '123 Test St',
+                        city: 'Boston',
+                        stateCode: 'MA',
+                        postalCode: '02101'
+                    }
+                }
+            ],
+            omsData: {
+                status: 'SHIPPED',
+                shipments: [
+                    {
+                        status: 'shipped',
+                        trackingNumber: '1Z999AA10123456784',
+                        trackingUrl: 'https://www.ups.com/track?tracknum=1Z999AA10123456784'
+                    }
+                ]
+            }
+        })
+        setupOrderDetailsPage(orderWithOmsTracking)
+    })
+
+    test('should display OMS order status', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText('SHIPPED')).toBeInTheDocument()
+    })
+
+    test('should display OMS tracking number', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/1Z999AA10123456784/i)).toBeInTheDocument()
+    })
+
+    test('should render tracking number as clickable link', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        const trackingLink = await screen.findByRole('link', {name: /1Z999AA10123456784/i})
+        expect(trackingLink).toHaveAttribute(
+            'href',
+            'https://www.ups.com/track?tracknum=1Z999AA10123456784'
+        )
+    })
+
+    test('should display tracking number label', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/tracking number/i)).toBeInTheDocument()
+    })
+
+    test('should display shipping address fields from ECOM', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
+        expect(await screen.findByText(/123 Test St/i)).toBeInTheDocument()
+        // Boston appears in both shipping and billing
+        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
+    })
+})
+
+// Multi-shipment scenarios with OMS data
+describe('Multiple shipments - OMS data with different statuses', () => {
+    beforeEach(() => {
+        // Order with 2 delivery shipments and OMS data
+        // Note: When omsData is present, shipments don't have shippingStatus - status comes from omsData.shipments[]
+        const multiShipmentOmsOrder = createMockOrder({
+            status: undefined,
+            shipments: [
+                {
+                    shipmentId: 'ship-1',
+                    shippingMethod: {name: 'Express'},
+                    // No shippingStatus - uses omsData.shipments[0].status
+                    shippingAddress: {
+                        firstName: 'John',
+                        lastName: 'Doe',
+                        address1: '123 Main St',
+                        city: 'Boston',
+                        stateCode: 'MA',
+                        postalCode: '02101'
+                    }
+                },
+                {
+                    shipmentId: 'ship-2',
+                    shippingMethod: {name: 'Ground'},
+                    // No shippingStatus - uses omsData.shipments[1].status
+                    shippingAddress: {
+                        firstName: 'Jane',
+                        lastName: 'Smith',
+                        address1: '456 Oak Ave',
+                        city: 'Los Angeles',
+                        stateCode: 'CA',
+                        postalCode: '90001'
+                    }
+                }
+            ],
+            omsData: {
+                status: 'PARTIALLY_SHIPPED',
+                shipments: [
+                    {
+                        status: 'shipped',
+                        trackingNumber: '1Z999AA10123456784',
+                        trackingUrl: 'https://www.ups.com/track?tracknum=1Z999AA10123456784'
+                    },
+                    {
+                        status: 'in_transit',
+                        trackingNumber: '9400111899223334445566',
+                        trackingUrl: 'https://tools.usps.com/track?tracknum=9400111899223334445566'
+                    }
+                ]
+            }
+        })
+        setupOrderDetailsPage(multiShipmentOmsOrder)
+    })
+
+    test('should display order status from OMS', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText('PARTIALLY_SHIPPED')).toBeInTheDocument()
+    })
+
+    test('should display numbered shipping method headings', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping method 1/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping method 2/i})).toBeInTheDocument()
+    })
+
+    test('should display numbered shipping address headings', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 1/i})
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 2/i})
+        ).toBeInTheDocument()
+    })
+
+    test('should display both shipping addresses', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
+        // Jane Smith appears in both shipping and billing - verify both exist
+        expect((await screen.findAllByText(/Jane Smith/i)).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('should display first shipment address fields', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/123 Main St/i)).toBeInTheDocument()
+        // Boston, MA, 02101 may appear in billing too - verify they exist
+        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
+        expect((await screen.findAllByText(/MA/i)).length).toBeGreaterThanOrEqual(1)
+        expect((await screen.findAllByText(/02101/i)).length).toBeGreaterThanOrEqual(1)
+    })
+
+    test('should display second shipment address fields', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/456 Oak Ave/i)).toBeInTheDocument()
+        expect(await screen.findByText(/Los Angeles/i)).toBeInTheDocument()
+        expect(await screen.findByText(/CA/i)).toBeInTheDocument()
+        expect(await screen.findByText(/90001/i)).toBeInTheDocument()
+    })
+
+    test('should display both tracking numbers from OMS', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText(/1Z999AA10123456784/i)).toBeInTheDocument()
+        expect(await screen.findByText(/9400111899223334445566/i)).toBeInTheDocument()
+    })
+
+    test('should render both tracking numbers as clickable links', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        const upsLink = await screen.findByRole('link', {name: /1Z999AA10123456784/i})
+        const uspsLink = await screen.findByRole('link', {name: /9400111899223334445566/i})
+        expect(upsLink).toHaveAttribute(
+            'href',
+            'https://www.ups.com/track?tracknum=1Z999AA10123456784'
+        )
+        expect(uspsLink).toHaveAttribute(
+            'href',
+            'https://tools.usps.com/track?tracknum=9400111899223334445566'
+        )
+    })
+
+    test('should display tracking number labels for both shipments', async () => {
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        const trackingLabels = await screen.findAllByText(/tracking number/i)
+        expect(trackingLabels).toHaveLength(2)
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -529,234 +529,209 @@ describe('Order with multiple shipments (pickup and delivery)', () => {
     })
 })
 
-// Single shipment scenarios - ECOM vs OMS data
-describe('Single shipment - ECOM data only', () => {
-    beforeEach(() => {
-        // ECOM order with single shipment, no OMS data
-        setupOrderDetailsPage(createMockOrder())
-    })
-
-    test('should display shipping status from ECOM', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/not shipped/i)).toBeInTheDocument()
-    })
-
-    test('should display shipping method name', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/Ground/i)).toBeInTheDocument()
-    })
-
-    test('should display single shipping address heading (no number)', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(
-            await screen.findByRole('heading', {name: /^shipping address$/i})
-        ).toBeInTheDocument()
-    })
-
-    test('should display shipping address fields', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
-        expect(await screen.findByText(/123 Test St/i)).toBeInTheDocument()
-        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
-        expect((await screen.findAllByText(/MA/i)).length).toBeGreaterThanOrEqual(1)
-        expect((await screen.findAllByText(/02101/i)).length).toBeGreaterThanOrEqual(1)
-    })
-
-    test('should not display tracking number when not present', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(screen.queryByText(/tracking number/i)).not.toBeInTheDocument()
-    })
-})
-
-describe('Single shipment - OMS data with tracking', () => {
-    beforeEach(() => {
-        // Order with OMS data including tracking info
-        // Note: When omsData is present, shipments don't have shippingStatus
-        const orderWithOmsTracking = createMockOrder({
-            status: undefined, // No ECOM status
-            shipments: [
-                {
-                    shippingMethod: {name: 'Ground'},
-                    // No shippingStatus - OMS orders use omsData.shipments[].status instead
-                    shippingAddress: {
-                        firstName: 'John',
-                        lastName: 'Doe',
-                        address1: '123 Test St',
-                        city: 'Boston',
-                        stateCode: 'MA',
-                        postalCode: '02101'
-                    }
-                }
-            ],
-            omsData: {
-                status: 'SHIPPED',
-                shipments: [
-                    {
-                        status: 'shipped',
-                        trackingNumber: '1Z999AA10123456784',
-                        trackingUrl: 'https://www.ups.com/track?tracknum=1Z999AA10123456784'
-                    }
-                ]
+describe('OMS Multi-shipment - Shipping address hidden', () => {
+    // When OMS has multiple shipments, shipping address should be hidden
+    // (can't reliably correlate OMS shipments to ECOM addresses by index)
+    const omsMultiShipmentOrder = createMockOmsOrder({
+        shipments: [
+            {
+                shippingMethod: {name: 'Ground'},
+                shippingAddress: {fullName: 'Alice Johnson', address1: '123 First St', city: 'Seattle', stateCode: 'WA', postalCode: '98101'}
+            },
+            {
+                shippingMethod: {name: 'Express'},
+                shippingAddress: {fullName: 'Bob Smith', address1: '456 Second St', city: 'Portland', stateCode: 'OR', postalCode: '97201'}
             }
-        })
-        setupOrderDetailsPage(orderWithOmsTracking)
-    })
-
-    test('should display OMS order status', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText('SHIPPED')).toBeInTheDocument()
-    })
-
-    test('should display OMS tracking number', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/1Z999AA10123456784/i)).toBeInTheDocument()
-    })
-
-    test('should render tracking number as clickable link', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        const trackingLink = await screen.findByRole('link', {name: /1Z999AA10123456784/i})
-        expect(trackingLink).toHaveAttribute(
-            'href',
-            'https://www.ups.com/track?tracknum=1Z999AA10123456784'
-        )
-    })
-
-    test('should display tracking number label', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/tracking number/i)).toBeInTheDocument()
-    })
-
-    test('should display shipping address fields from ECOM', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
-        expect(await screen.findByText(/123 Test St/i)).toBeInTheDocument()
-        // Boston appears in both shipping and billing
-        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
-    })
-})
-
-// Multi-shipment scenarios with OMS data
-describe('Multiple shipments - OMS data with different statuses', () => {
-    beforeEach(() => {
-        // Order with 2 delivery shipments and OMS data
-        // Note: When omsData is present, shipments don't have shippingStatus - status comes from omsData.shipments[]
-        const multiShipmentOmsOrder = createMockOrder({
-            status: undefined,
+        ],
+        omsData: {
+            status: 'Processing',
             shipments: [
-                {
-                    shipmentId: 'ship-1',
-                    shippingMethod: {name: 'Express'},
-                    // No shippingStatus - uses omsData.shipments[0].status
-                    shippingAddress: {
-                        firstName: 'John',
-                        lastName: 'Doe',
-                        address1: '123 Main St',
-                        city: 'Boston',
-                        stateCode: 'MA',
-                        postalCode: '02101'
-                    }
-                },
-                {
-                    shipmentId: 'ship-2',
-                    shippingMethod: {name: 'Ground'},
-                    // No shippingStatus - uses omsData.shipments[1].status
-                    shippingAddress: {
-                        firstName: 'Jane',
-                        lastName: 'Smith',
-                        address1: '456 Oak Ave',
-                        city: 'Los Angeles',
-                        stateCode: 'CA',
-                        postalCode: '90001'
-                    }
-                }
-            ],
-            omsData: {
-                status: 'PARTIALLY_SHIPPED',
-                shipments: [
-                    {
-                        status: 'shipped',
-                        trackingNumber: '1Z999AA10123456784',
-                        trackingUrl: 'https://www.ups.com/track?tracknum=1Z999AA10123456784'
-                    },
-                    {
-                        status: 'in_transit',
-                        trackingNumber: '9400111899223334445566',
-                        trackingUrl: 'https://tools.usps.com/track?tracknum=9400111899223334445566'
-                    }
-                ]
-            }
-        })
-        setupOrderDetailsPage(multiShipmentOmsOrder)
+                {status: 'SHIPPED', trackingNumber: 'OMS-001', trackingUrl: 'https://track.example.com/OMS-001', provider: 'FedEx'},
+                {status: 'PENDING', trackingNumber: 'OMS-002', trackingUrl: 'https://track.example.com/OMS-002', provider: 'UPS'}
+            ]
+        }
     })
 
-    test('should display order status from OMS', async () => {
+    beforeEach(async () => {
+        setupOrderDetailsPage(omsMultiShipmentOrder)
+    })
+
+    test('should render order details page', async () => {
         expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText('PARTIALLY_SHIPPED')).toBeInTheDocument()
     })
 
     test('should display numbered shipping method headings', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
         expect(await screen.findByRole('heading', {name: /shipping method 1/i})).toBeInTheDocument()
         expect(await screen.findByRole('heading', {name: /shipping method 2/i})).toBeInTheDocument()
     })
 
-    test('should display numbered shipping address headings', async () => {
+    test('should NOT display shipping address headings for OMS multi-shipment', async () => {
+        await screen.findByTestId('account-order-details-page')
+        expect(screen.queryByRole('heading', {name: /shipping address/i})).not.toBeInTheDocument()
+    })
+
+    test('should display OMS provider name instead of ECOM shipping method', async () => {
+        expect(await screen.findByText(/FedEx/i)).toBeInTheDocument()
+        expect(await screen.findByText(/UPS/i)).toBeInTheDocument()
+    })
+
+    test('should display OMS shipment status', async () => {
+        expect(await screen.findByText(/SHIPPED/i)).toBeInTheDocument()
+        expect(await screen.findByText(/PENDING/i)).toBeInTheDocument()
+    })
+
+    test('should display tracking numbers as clickable links', async () => {
+        const trackingLink1 = await screen.findByRole('link', {name: /OMS-001/i})
+        expect(trackingLink1).toHaveAttribute('href', 'https://track.example.com/OMS-001')
+
+        const trackingLink2 = await screen.findByRole('link', {name: /OMS-002/i})
+        expect(trackingLink2).toHaveAttribute('href', 'https://track.example.com/OMS-002')
+    })
+})
+
+describe('ECOM Multi-shipment - Shipping address shown', () => {
+    // When ECOM has multiple shipments but NO OMS data, shipping address should be shown
+    const ecomMultiShipmentOrder = createMockOrder({
+        shipments: [
+            {
+                shippingMethod: {name: 'Ground'},
+                shippingStatus: 'shipped',
+                trackingNumber: 'ECOM-001',
+                shippingAddress: {firstName: 'John', lastName: 'Doe', address1: '123 First St', city: 'Boston', stateCode: 'MA', postalCode: '02101'}
+            },
+            {
+                shippingMethod: {name: 'Express'},
+                shippingStatus: 'not_shipped',
+                shippingAddress: {firstName: 'Jane', lastName: 'Smith', address1: '456 Second St', city: 'Chicago', stateCode: 'IL', postalCode: '60601'}
+            }
+        ]
+    })
+
+    beforeEach(async () => {
+        setupOrderDetailsPage(ecomMultiShipmentOrder)
+    })
+
+    test('should render order details page', async () => {
         expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(
-            await screen.findByRole('heading', {name: /shipping address 1/i})
-        ).toBeInTheDocument()
-        expect(
-            await screen.findByRole('heading', {name: /shipping address 2/i})
-        ).toBeInTheDocument()
+    })
+
+    test('should display numbered shipping method headings', async () => {
+        expect(await screen.findByRole('heading', {name: /shipping method 1/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping method 2/i})).toBeInTheDocument()
+    })
+
+    test('should display numbered shipping address headings for ECOM multi-shipment', async () => {
+        expect(await screen.findByRole('heading', {name: /shipping address 1/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping address 2/i})).toBeInTheDocument()
     })
 
     test('should display both shipping addresses', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
         expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
-        // Jane Smith appears in both shipping and billing - verify both exist
-        expect((await screen.findAllByText(/Jane Smith/i)).length).toBeGreaterThanOrEqual(1)
+        // Jane Smith appears in both shipping and billing address
+        const janeSmithElements = await screen.findAllByText(/Jane Smith/i)
+        expect(janeSmithElements.length).toBe(2)
     })
 
-    test('should display first shipment address fields', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/123 Main St/i)).toBeInTheDocument()
-        // Boston, MA, 02101 may appear in billing too - verify they exist
-        expect((await screen.findAllByText(/Boston/i)).length).toBeGreaterThanOrEqual(1)
-        expect((await screen.findAllByText(/MA/i)).length).toBeGreaterThanOrEqual(1)
-        expect((await screen.findAllByText(/02101/i)).length).toBeGreaterThanOrEqual(1)
+    test('should display ECOM shipping statuses', async () => {
+        // Use exact match to avoid "Not shipped" matching "Shipped"
+        expect(await screen.findByText('Shipped')).toBeInTheDocument()
+        expect(await screen.findByText('Not shipped')).toBeInTheDocument()
+    })
+})
+
+describe('OMS Single shipment with tracking URL', () => {
+    // Single OMS shipment should show shipping address and tracking as clickable link
+    const omsSingleShipmentOrder = createMockOmsOrder({
+        shipments: [
+            {
+                shippingMethod: {name: 'Standard'},
+                shippingAddress: {fullName: 'Alex Johnson', address1: '789 Main St', city: 'Seattle', stateCode: 'WA', postalCode: '98101'}
+            }
+        ],
+        omsData: {
+            status: 'SHIPPED',
+            shipments: [
+                {status: 'DELIVERED', trackingNumber: 'TRACK-12345', trackingUrl: 'https://tracking.fedex.com/TRACK-12345', provider: 'FedEx Ground'}
+            ]
+        }
     })
 
-    test('should display second shipment address fields', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/456 Oak Ave/i)).toBeInTheDocument()
-        expect(await screen.findByText(/Los Angeles/i)).toBeInTheDocument()
-        expect(await screen.findByText(/CA/i)).toBeInTheDocument()
-        expect(await screen.findByText(/90001/i)).toBeInTheDocument()
+    beforeEach(async () => {
+        setupOrderDetailsPage(omsSingleShipmentOrder)
     })
 
-    test('should display both tracking numbers from OMS', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        expect(await screen.findByText(/1Z999AA10123456784/i)).toBeInTheDocument()
-        expect(await screen.findByText(/9400111899223334445566/i)).toBeInTheDocument()
+    test('should display shipping address for single OMS shipment', async () => {
+        expect(await screen.findByRole('heading', {name: /^shipping address$/i})).toBeInTheDocument()
+        expect(await screen.findByText(/Alex Johnson/i)).toBeInTheDocument()
     })
 
-    test('should render both tracking numbers as clickable links', async () => {
-        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        const upsLink = await screen.findByRole('link', {name: /1Z999AA10123456784/i})
-        const uspsLink = await screen.findByRole('link', {name: /9400111899223334445566/i})
-        expect(upsLink).toHaveAttribute(
-            'href',
-            'https://www.ups.com/track?tracknum=1Z999AA10123456784'
-        )
-        expect(uspsLink).toHaveAttribute(
-            'href',
-            'https://tools.usps.com/track?tracknum=9400111899223334445566'
-        )
+    test('should display OMS provider instead of ECOM method name', async () => {
+        expect(await screen.findByText(/FedEx Ground/i)).toBeInTheDocument()
     })
 
-    test('should display tracking number labels for both shipments', async () => {
+    test('should display tracking number as clickable link', async () => {
+        const trackingLink = await screen.findByRole('link', {name: /TRACK-12345/i})
+        expect(trackingLink).toHaveAttribute('href', 'https://tracking.fedex.com/TRACK-12345')
+    })
+
+    test('should display OMS shipment status (fallback to raw value)', async () => {
+        expect(await screen.findByText(/DELIVERED/i)).toBeInTheDocument()
+    })
+})
+
+describe('OMS Single shipment with partial data (missing provider, trackingUrl)', () => {
+    // Tests fallback behavior when OMS data is partially available
+    const omsPartialDataOrder = createMockOmsOrder({
+        shipments: [
+            {
+                shippingMethod: {name: 'Ground Shipping'},
+                shippingAddress: {fullName: 'Mike Brown', address1: '100 Oak St', city: 'Denver', stateCode: 'CO', postalCode: '80201'}
+            }
+        ],
+        omsData: {
+            status: 'Processing',
+            shipments: [
+                {
+                    status: 'ALLOCATED',
+                    trackingNumber: 'OMS-TRACK-999'
+                    // No provider field
+                    // No trackingUrl - tracking number displayed as plain text
+                }
+            ]
+        }
+    })
+
+    beforeEach(async () => {
+        setupOrderDetailsPage(omsPartialDataOrder)
+    })
+
+    test('should render order details page', async () => {
         expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
-        const trackingLabels = await screen.findAllByText(/tracking number/i)
-        expect(trackingLabels).toHaveLength(2)
+    })
+
+    test('should fallback to ECOM shipping method name when OMS provider is missing', async () => {
+        expect(await screen.findByText(/Ground Shipping/i)).toBeInTheDocument()
+    })
+
+    test('should display OMS status even when other OMS fields are missing', async () => {
+        expect(await screen.findByText(/ALLOCATED/i)).toBeInTheDocument()
+    })
+
+    test('should display OMS tracking number (takes priority over ECOM)', async () => {
+        expect(await screen.findByText(/OMS-TRACK-999/i)).toBeInTheDocument()
+        // ECOM tracking should NOT be displayed
+        expect(screen.queryByText(/ECOM-TRACK-999/i)).not.toBeInTheDocument()
+    })
+
+    test('should display tracking number as plain text when trackingUrl is missing', async () => {
+        // Should NOT be a link
+        expect(screen.queryByRole('link', {name: /OMS-TRACK-999/i})).not.toBeInTheDocument()
+        // But should still show the tracking number as text
+        expect(await screen.findByText(/OMS-TRACK-999/i)).toBeInTheDocument()
+    })
+
+    test('should display shipping address with fullName', async () => {
+        expect(await screen.findByText(/Mike Brown/i)).toBeInTheDocument()
+        expect(await screen.findByText(/100 Oak St/i)).toBeInTheDocument()
     })
 })


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

This PR integrates Order Details page with Order Management System (OMS) data and adds support for multi-shipment order display.

In case of OMS order, if there is more than 1 delivery group, do not show delivery address, just the tracking link.

With OMS Single shipment. OMS does not provide payment data yet.
<img width="856" height="384" alt="Screenshot 2026-01-22 at 6 01 17 PM" src="https://github.com/user-attachments/assets/e3e93399-2c23-4414-b849-f9a6b180e6d0" />

OMS with multiple shipment
<img width="856" height="392" alt="Screenshot 2026-01-22 at 6 00 45 PM" src="https://github.com/user-attachments/assets/2d50584e-b9ac-4e04-b672-3c7c4ad45c60" />

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- OMS data takes priority for order status, shipment status, and tracking info
- Tracking numbers link to carrier URLs when `trackingUrl` is available
- Multi-shipment orders show numbered headings (e.g., "Shipping Method 1")
- order.shipments and order.omsData.shipments are matched by index
- Note: Index correlation may not be accurate - OMS shipments may not directly map to ECOM shipments as there is no shared ID between them
- Address falls back to `fullName` when `firstName`/`lastName` missing
- Hide payment/billing sections when data not present

# How to Test-Drive This PR

- Connect your local pwa with org with latest transact changes and oms setup
- Place order and check shipping info on order details page

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
