### PR TITLE
@W-20892603: Remove empty shipment fix

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -143,6 +143,7 @@ const CheckoutOneClick = () => {
             setIsShipmentCleanupComplete(true)
             return
         }
+
         let cancelled = false
         setIsShipmentCleanupComplete(false)
         removeEmptyShipments(basket).then(() => {

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -99,6 +99,7 @@ const CheckoutOneClick = () => {
     const hasDeliveryShipments = deliveryShipments.length > 0
     const isPickupOnly = hasPickupShipments && !hasDeliveryShipments
     const [billingSameAsShipping, setBillingSameAsShipping] = useState(true)
+    const [isShipmentCleanupComplete, setIsShipmentCleanupComplete] = useState(false)
     // For billing=shipping, align with legacy: use the first delivery shipment's address
     const selectedShippingAddress =
         deliveryShipments.length > 0 ? deliveryShipments[0]?.shippingAddress : null
@@ -135,8 +136,22 @@ const CheckoutOneClick = () => {
     // Remove any empty shipments whenever navigating to the checkout page
     // Using basketId ensures that the basket is in a valid state before removing empty shipments
     useEffect(() => {
-        if (basket?.shipments?.length > 1) {
-            removeEmptyShipments(basket)
+        if (!basket?.basketId) {
+            return
+        }
+        if (basket?.shipments?.length <= 1) {
+            setIsShipmentCleanupComplete(true)
+            return
+        }
+        let cancelled = false
+        setIsShipmentCleanupComplete(false)
+        removeEmptyShipments(basket).then(() => {
+            if (!cancelled) {
+                setIsShipmentCleanupComplete(true)
+            }
+        })
+        return () => {
+            cancelled = true
         }
     }, [basket?.basketId])
 
@@ -587,7 +602,10 @@ const CheckoutOneClick = () => {
                             />
                             {hasPickupShipments && <PickupAddress />}
                             {hasDeliveryShipments && (
-                                <ShippingAddress enableUserRegistration={enableUserRegistration} />
+                                <ShippingAddress
+                                    enableUserRegistration={enableUserRegistration}
+                                    isShipmentCleanupComplete={isShipmentCleanupComplete}
+                                />
                             )}
                             {hasDeliveryShipments && <ShippingOptions />}
                             <Payment
@@ -615,7 +633,11 @@ const CheckoutOneClick = () => {
                                             w="full"
                                             onClick={onPlaceOrder}
                                             isLoading={isLoading}
-                                            disabled={isOtpLoading || isPlacingOrder}
+                                            disabled={
+                                                isOtpLoading ||
+                                                isPlacingOrder ||
+                                                !isShipmentCleanupComplete
+                                            }
                                             data-testid="place-order-button"
                                             size="lg"
                                             px={8}

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -28,6 +28,20 @@ jest.setTimeout(40_000)
 
 mockConfig.app.oneClickCheckout.enabled = true
 
+const mockRemoveEmptyShipments = jest.fn().mockResolvedValue(undefined)
+jest.mock('@salesforce/retail-react-app/app/hooks/use-multiship', () => {
+    const actual = jest.requireActual('@salesforce/retail-react-app/app/hooks/use-multiship')
+    return {
+        useMultiship: jest.fn((basket) => ({
+            ...actual.useMultiship(basket),
+            removeEmptyShipments: (...args) => {
+                mockRemoveEmptyShipments(...args)
+                return Promise.resolve()
+            }
+        }))
+    }
+})
+
 jest.mock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => {
     return {
         getConfig: jest.fn()
@@ -306,6 +320,46 @@ describe('Checkout One Click', () => {
         )
 
         getConfig.mockImplementation(() => mockConfig)
+        mockRemoveEmptyShipments.mockClear()
+    })
+
+    test('calls removeEmptyShipments when basket has multiple shipments', async () => {
+        const basketWithMultipleShipments = JSON.parse(JSON.stringify(scapiBasketWithItem))
+        basketWithMultipleShipments.shipments = [
+            basketWithMultipleShipments.shipments[0],
+            {
+                shipmentId: 'shipment-2',
+                shippingAddress: null,
+                shippingMethod: null
+            }
+        ]
+        global.server.use(
+            rest.get('*/baskets', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        baskets: [basketWithMultipleShipments],
+                        total: 1
+                    })
+                )
+            })
+        )
+        window.history.pushState({}, 'Checkout', createPathWithDefaults('/checkout'))
+        renderWithProviders(<WrappedCheckout history={history} />, {
+            wrapperProps: {
+                isGuest: true,
+                siteAlias: 'uk',
+                appConfig: mockConfig.app
+            }
+        })
+        await waitFor(
+            () => {
+                expect(mockRemoveEmptyShipments).toHaveBeenCalled()
+                const [basket] = mockRemoveEmptyShipments.mock.calls[0]
+                expect(basket?.basketId).toBe(basketWithMultipleShipments.basketId)
+                expect(basket?.shipments?.length).toBeGreaterThan(1)
+            },
+            {timeout: 5000}
+        )
     })
 
     test('renders pickup and shipping sections for mixed baskets', async () => {

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.jsx
@@ -45,7 +45,7 @@ const shippingAddressAriaLabel = defineMessage({
 })
 
 export default function ShippingAddress(props) {
-    const {enableUserRegistration = false} = props
+    const {enableUserRegistration = false, isShipmentCleanupComplete = true} = props
     const {formatMessage} = useIntl()
     const [isManualSubmitLoading, setIsManualSubmitLoading] = useState(false)
     const [isMultiShipping, setIsMultiShipping] = useState(false)
@@ -210,6 +210,7 @@ export default function ShippingAddress(props) {
         getPreferredItem: (addresses) =>
             addresses.find((addr) => addr.preferred === true) || addresses[0],
         shouldSkip: () => {
+            if (!isShipmentCleanupComplete) return true
             if (openedByUser) return true
             if (selectedShippingAddress?.address1) {
                 if (typeof goToNextStep === 'function') {
@@ -223,6 +224,7 @@ export default function ShippingAddress(props) {
         applyItem: async (address) => {
             await submitAndContinue(address)
         },
+        enabled: isShipmentCleanupComplete,
         // Navigation is already handled inside submitAndContinue (goToStep/goToNextStep)
         onSuccess: () => {},
         onError: (error) => {
@@ -230,7 +232,7 @@ export default function ShippingAddress(props) {
         }
     })
 
-    const isLoading = isAutoSelectLoading || isManualSubmitLoading
+    const isLoading = isAutoSelectLoading || isManualSubmitLoading || !isShipmentCleanupComplete
 
     const handleEdit = () => {
         setOpenedByUser(true)
@@ -311,5 +313,6 @@ export default function ShippingAddress(props) {
 }
 
 ShippingAddress.propTypes = {
-    enableUserRegistration: PropTypes.bool
+    enableUserRegistration: PropTypes.bool,
+    isShipmentCleanupComplete: PropTypes.bool
 }

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.test.js
@@ -317,6 +317,26 @@ describe('ShippingAddress Component', () => {
         ).toBeInTheDocument()
     })
 
+    test('does not run auto-select when isShipmentCleanupComplete is false', async () => {
+        mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
+        renderWithProviders(<ShippingAddress isShipmentCleanupComplete={false} />)
+        // Allow time for useCheckoutAutoSelect effect to run (it should skip due to enabled: false)
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 50))
+        })
+        // Auto-select must not have called updateShippingAddressForShipment
+        expect(mockUpdateShippingAddress.mutateAsync).not.toHaveBeenCalled()
+    })
+
+    test('runs auto-select when isShipmentCleanupComplete is true', async () => {
+        mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
+        renderWithProviders(<ShippingAddress isShipmentCleanupComplete={true} />)
+        await waitFor(() => {
+            expect(mockUpdateShippingAddress.mutateAsync).toHaveBeenCalled()
+        })
+        await waitForNotLoading()
+    })
+
     test('handles submission errors gracefully', async () => {
         mockUpdateShippingAddress.mutateAsync.mockRejectedValue(new Error('API Error'))
 


### PR DESCRIPTION
As a registered shopper, go to checkout with BOPIS. Then go back to Cart page, opt for Ship to Address instead. Go to checkout again. 
Not seeing the default address chosen as shipping address, laggy UX as well. It works well if I go back to Cart page -> Checkout, the shipping address then is applied correctly.

ROOT CAUSE: in one-click checkout, we have a `useEffect` hook that (line 138) that calls `removeEmptyShipments` when we go into checkout. What it does is transferring the items, etc. from the extra shipment to the default shipment (shipmentId = "me") if it's empty (3 different calls/actions). 
The `removeEmptyShipments` is helpful in 2 situations:
- BOPIS -> Ship to Address in Cart page: From the basket with 1 default pick-up shipment, it actually ADDS another delivery shipment and transfer the items to this shipment from the default pick-up shipment (leaving it "empty"). There will 2 shipments before going into checkout.
- Consolidate multiple shipments in Checkout page: Say we have 2 items getting shipped to different addresses (hence different shipments), but now we decide to ship to one address (one shipment). It actually transfer the item from the extra shipment to the other shipment (with the consolidated shipping address), leaving one "empty".

For the BOPIS -> Checkout case, the original version works fine for traditional checkout because the user has to go through each checkout step regardless. For one-click checkout, we are applying the saved information (shipping address + payment) from registered user to the basket automatically after entering checkout.

The problem occurs when the useEffect hook is called BEFORE the shipping address/payment is applied correctly on the basket. The hook will transfer over the delivery information from the non-default shipment (without shipping address applied just yet) and remove it. Also, by checking the Network tab, the useEffect hook is actually called TWICE: removeEmptyShipment calls -> apply shipping address to the "deleted" shipment -> removeEmptyShipment calls.

SOLUTION: We need a way to "time" the action - the hook must be called ONCE, basket is in a "stable" state -> apply shipping address to the "right" (default) shipment.

- We're introducing a new `isShipmentCleanupComplete` flag to track the empty shipment cleanup effort
- useEffect hook now has more conditions to make sure we only run when needed and has a hook cleanup for component unmounting - to make sure not running twice
- ShippingAddress component will be in loading state when the cleanup is being done, Place Order should not be visible.

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- The 2 scenarios above

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
