### PR TITLE
[Cleanup] Remove unused absoluteUrl util from retail react app

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,7 +1,5 @@
-## v8.5.0-dev (Jan 19, 2026)
+## v9.0.0-dev (Jan 19, 2026)
 - [Feature] One Click Checkout [#3552](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3552)
-
-## v8.4.0-dev (Dec 17, 2025)
 - [Feature] Add `fuzzyPathMatching` to reduce computational overhead of route generation at time of application load [#3530](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3530)
 - [Bugfix] Fix Passwordless Login landingPath, Reset Password landingPath, and Social Login redirectUri value in config not being used [#3560](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3560)
 - [Feature] PWA Integration with OMS
@@ -12,7 +10,7 @@
 - [Feature] Update passwordless login and password reset to use email mode by default. The mode can now be configured across the login page, auth modal, and checkout page [#3525](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3525)
 - Update "Continue Securely" button text to "Continue" for passwordless login [#3556](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3556)
 - Util function for passwordless callback URI [#3630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3630)
-- [Cleanup] Remove unused absoluteUrl util from retail react app [#3633](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3633)
+- [BREAKING] Remove unused absoluteUrl util from retail react app [#3633](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3633)
 
 ## v8.3.0 (Dec 17, 2025)
 - [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3493](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3493)

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [Feature] Update passwordless login and password reset to use email mode by default. The mode can now be configured across the login page, auth modal, and checkout page [#3525](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3525)
 - Update "Continue Securely" button text to "Continue" for passwordless login [#3556](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3556)
 - Util function for passwordless callback URI [#3630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3630)
+- [Cleanup] Remove unused absoluteUrl util from retail react app [#3633](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3633)
 
 ## v8.3.0 (Dec 17, 2025)
 - [Bugfix] Fix Forgot Password link not working from Account Profile password update form [#3493](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3493)

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -5,7 +5,6 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {getAppOrigin} from '@salesforce/pwa-kit-react-sdk/utils/url'
 import {
     getLocaleByReference,
     getParamsFromPath,

--- a/packages/template-retail-react-app/app/utils/url.js
+++ b/packages/template-retail-react-app/app/utils/url.js
@@ -13,26 +13,6 @@ import {
     getSiteByReference
 } from '@salesforce/retail-react-app/app/utils/site-utils'
 import {HOME_HREF, urlPartPositions} from '@salesforce/retail-react-app/app/constants'
-import {isAbsoluteURL} from '@salesforce/retail-react-app/app/page-designer/utils'
-
-/**
- * Constructs an absolute URL from a given path and an optional application origin.
- * TODO: How should this work with base path?
- *
- * @param {string} path - The relative URL path to be appended to the origin.
- * @param {string} [appOrigin] - The optional application origin (e.g., "https://example.com").
- *                                If not provided, the function will call `getAppOrigin()`.
- * @returns {string} - The fully qualified URL as a string.
- */
-export const absoluteUrl = (path, appOrigin) => {
-    // If path is not provided or already an absolute URL, return it as-is
-    if (!path || isAbsoluteURL(path)) {
-        return path
-    }
-
-    // absoluteUrl is not a react hook so we cannot use the useAppOrigin hook here
-    return new URL(path, appOrigin || getAppOrigin()).toString()
-}
 
 /**
  * Modifies a given url by adding/updating query parameters.

--- a/packages/template-retail-react-app/app/utils/url.test.js
+++ b/packages/template-retail-react-app/app/utils/url.test.js
@@ -13,7 +13,6 @@ import {
     getPathWithLocale,
     rebuildPathWithParams,
     removeQueryParamsFromPath,
-    absoluteUrl,
     createUrlTemplate,
     removeSiteLocaleFromPath,
     serverSafeEncode
@@ -391,36 +390,6 @@ describe('removeQueryParamsFromPath test', () => {
         const url = '/en/product/25501032M?color=black&size=M&something=123'
         const updatedUrl = removeQueryParamsFromPath(url, ['color', 'size'])
         expect(updatedUrl).toBe('/en/product/25501032M?something=123')
-    })
-})
-
-describe('absoluteUrl', function () {
-    test('return undefined when path is not provided', () => {
-        const url = absoluteUrl()
-        expect(url).toBeUndefined()
-    })
-
-    test('return expected when path is a relative url', () => {
-        const url = absoluteUrl('/uk/en/women/dresses')
-        expect(url).toBe('https://www.example.com/uk/en/women/dresses')
-    })
-
-    test('return expected when path is an absolute url', () => {
-        const url = absoluteUrl('https://www.example.com/uk/en/women/dresses')
-        expect(url).toBe('https://www.example.com/uk/en/women/dresses')
-    })
-
-    test('return expected when path is a relative url and appOrigin is provided', () => {
-        const url = absoluteUrl('uk/en/women/dresses', 'https://www.custom.com')
-        expect(url).toBe('https://www.custom.com/uk/en/women/dresses')
-    })
-
-    test('return expected when path is an absolute url and appOrigin is provided', () => {
-        const url = absoluteUrl(
-            'https://www.example.com/uk/en/women/dresses',
-            'https://www.should-be-ignored.com'
-        )
-        expect(url).toBe('https://www.example.com/uk/en/women/dresses')
     })
 })
 

--- a/packages/template-retail-react-app/app/utils/url.test.js
+++ b/packages/template-retail-react-app/app/utils/url.test.js
@@ -24,13 +24,6 @@ afterEach(() => {
     jest.clearAllMocks()
 })
 
-jest.mock('@salesforce/pwa-kit-react-sdk/utils/url', () => {
-    const original = jest.requireActual('@salesforce/pwa-kit-react-sdk/utils/url')
-    return {
-        ...original,
-        getAppOrigin: jest.fn(() => 'https://www.example.com')
-    }
-})
 jest.mock('./utils', () => {
     const original = jest.requireActual('./utils')
     return {


### PR DESCRIPTION
Small PR to remove an unused function from the retail-react-app.

Removing `absoluteUrl` now as it is incompatible with current work to add base path prefixes.
