### PR TITLE
@W-21188588 Default to ECOM Shipping when OMS does not return shipping

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Integrate Order History page to display data from OMS [#3581](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3581)
   - Add shipping display support for OMS [#3588](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3588)
   - BOPIS multishipment with OMS [#3613] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3613)
+  - Default to ECOM shipments in case OMS has no shipments [#3639] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3639)
 - [Feature] Update passwordless login and password reset to use email mode by default. The mode can now be configured across the login page, auth modal, and checkout page [#3525](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3525)
 - Update "Continue Securely" button text to "Continue" for passwordless login [#3556](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3556)
 - Util function for passwordless callback URI [#3630](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3630)

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -137,11 +137,19 @@ const AccountOrderDetail = () => {
     // Check if order has OMS data
     const isOmsOrder = useMemo(() => !!order?.omsData, [order?.omsData])
 
+    // Check if OMS is returning shipments
+    const hasOmsShipment = useMemo(
+        () => (order?.omsData?.shipments?.length ?? 0) > 0,
+        [order?.omsData?.shipments?.length]
+    )
+
     // Check if order is multi-shipment order
     const isMultiShipmentOrder = useMemo(
         () => (order?.omsData?.shipments?.length ?? 0) > 1 || (order?.shipments?.length ?? 0) > 1,
-        [isOmsOrder, order?.omsData?.shipments?.length, order?.shipments?.length]
+        [order?.omsData?.shipments?.length, order?.shipments?.length]
     )
+
+    const showShipmentsFromOmsOnly = isOmsOrder && hasOmsShipment && isMultiShipmentOrder
 
     const {pickupShipments, deliveryShipments} = useMemo(() => {
         return storeLocatorEnabled
@@ -396,7 +404,7 @@ const AccountOrderDetail = () => {
                                     )
                                 })}
                                 {/* Any type of Non-OMS or any type of single shipment order: show DeliveryMethods and Shipments info*/}
-                                {(!isOmsOrder || !isMultiShipmentOrder) &&
+                                {!showShipmentsFromOmsOnly &&
                                     deliveryShipments.map((shipment, index) => {
                                         const omsShipment = isOmsOrder
                                             ? order.omsData.shipments?.[index]
@@ -457,8 +465,7 @@ const AccountOrderDetail = () => {
                                     })}
 
                                 {/* Any OMS multi-shipment: Only show OMS Shipments info;*/}
-                                {isOmsOrder &&
-                                    isMultiShipmentOrder &&
+                                {showShipmentsFromOmsOnly &&
                                     order?.omsData?.shipments?.map((shipment, index) => (
                                         <React.Fragment key={`oms-shipment-${index}`}>
                                             {renderShippingMethod(

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -411,7 +411,7 @@ const AccountOrderDetail = () => {
                                             : null
 
                                         const shippingMethodName =
-                                            omsShipment?.provider || shipment.shippingMethod.name
+                                            omsShipment?.provider || shipment.shippingMethod?.name
                                         const shippingStatus =
                                             omsShipment?.status || shipment.shippingStatus
                                         const trackingNumber =

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -137,19 +137,17 @@ const AccountOrderDetail = () => {
     // Check if order has OMS data
     const isOmsOrder = useMemo(() => !!order?.omsData, [order?.omsData])
 
-    // Check if OMS is returning shipments
-    const hasOmsShipment = useMemo(
-        () => (order?.omsData?.shipments?.length ?? 0) > 0,
-        [order?.omsData?.shipments?.length]
-    )
+    const omsShipmentCount = order?.omsData?.shipments?.length ?? 0
+    const ecomShipmentCount = order?.shipments?.length ?? 0
 
-    // Check if order is multi-shipment order
+    const hasOmsShipment = useMemo(() => omsShipmentCount > 0, [omsShipmentCount])
+
     const isMultiShipmentOrder = useMemo(
-        () => (order?.omsData?.shipments?.length ?? 0) > 1 || (order?.shipments?.length ?? 0) > 1,
-        [order?.omsData?.shipments?.length, order?.shipments?.length]
+        () => omsShipmentCount > 1 || ecomShipmentCount > 1,
+        [omsShipmentCount, ecomShipmentCount]
     )
 
-    const showShipmentsFromOmsOnly = isOmsOrder && hasOmsShipment && isMultiShipmentOrder
+    const showMultiShipmentsFromOmsOnly = isOmsOrder && hasOmsShipment && isMultiShipmentOrder
 
     const {pickupShipments, deliveryShipments} = useMemo(() => {
         return storeLocatorEnabled
@@ -404,7 +402,7 @@ const AccountOrderDetail = () => {
                                     )
                                 })}
                                 {/* Any type of Non-OMS or any type of single shipment order: show DeliveryMethods and Shipments info*/}
-                                {!showShipmentsFromOmsOnly &&
+                                {!showMultiShipmentsFromOmsOnly &&
                                     deliveryShipments.map((shipment, index) => {
                                         const omsShipment = isOmsOrder
                                             ? order.omsData.shipments?.[index]
@@ -465,7 +463,7 @@ const AccountOrderDetail = () => {
                                     })}
 
                                 {/* Any OMS multi-shipment: Only show OMS Shipments info;*/}
-                                {showShipmentsFromOmsOnly &&
+                                {showMultiShipmentsFromOmsOnly &&
                                     order?.omsData?.shipments?.map((shipment, index) => (
                                         <React.Fragment key={`oms-shipment-${index}`}>
                                             {renderShippingMethod(
@@ -473,7 +471,7 @@ const AccountOrderDetail = () => {
                                                 shipment.status,
                                                 shipment.trackingNumber,
                                                 shipment.trackingUrl,
-                                                order?.omsData?.shipments?.length ?? 0,
+                                                omsShipmentCount,
                                                 index
                                             )}
                                         </React.Fragment>

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -1388,3 +1388,54 @@ describe('BOPIS Order - ECOM Only (No OMS)', () => {
         expect(screen.queryByRole('heading', {name: /shipping address/i})).not.toBeInTheDocument()
     })
 })
+
+describe('OMS order with no OMS shipments - default to ECOM shipment display (multi-ship)', () => {
+    // Multi-shipment scenario: OMS order has omsData but no OMS shipments.
+    const omsOrderMultiShipNoOmsShipments = createMockOmsOrder({
+        omsData: {
+            status: 'Created'
+        },
+        shipments: [
+            {
+                shipmentId: 'ship1',
+                shippingMethod: {name: 'Ground'},
+                shippingAddress: {
+                    fullName: 'Alex Johnson',
+                    address1: '876 NE 8th st',
+                    city: 'Seattle',
+                    stateCode: 'WA',
+                    postalCode: '98121',
+                    countryCode: 'US'
+                }
+            },
+            {
+                shipmentId: 'ship2',
+                shippingMethod: {name: 'Express'},
+                shippingAddress: {
+                    fullName: 'Bob Smith',
+                    address1: '456 Second St',
+                    city: 'Portland',
+                    stateCode: 'OR',
+                    postalCode: '97201',
+                    countryCode: 'US'
+                }
+            }
+        ]
+    })
+
+    test('should display multi-shipment Shipping Method and Shipping Address from ECOM when OMS has no shipments', async () => {
+        setupOrderDetailsPage(omsOrderMultiShipNoOmsShipments)
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        // Default to ECOM delivery block (multi-shipment) when OMS has no shipments.
+        expect(await screen.findByRole('heading', {name: /shipping method 1/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping method 2/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping address 1/i})).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /shipping address 2/i})).toBeInTheDocument()
+        expect(await screen.findByText(/Alex Johnson/i)).toBeInTheDocument()
+        expect(await screen.findByText(/Bob Smith/i)).toBeInTheDocument()
+        expect(await screen.findByText(/876 NE 8th st/i)).toBeInTheDocument()
+        expect(await screen.findByText(/456 Second St/i)).toBeInTheDocument()
+        expect(await screen.findByText(/Ground/i)).toBeInTheDocument()
+        expect(await screen.findByText(/Express/i)).toBeInTheDocument()
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -1429,8 +1429,12 @@ describe('OMS order with no OMS shipments - default to ECOM shipment display (mu
         // Default to ECOM delivery block (multi-shipment) when OMS has no shipments.
         expect(await screen.findByRole('heading', {name: /shipping method 1/i})).toBeInTheDocument()
         expect(await screen.findByRole('heading', {name: /shipping method 2/i})).toBeInTheDocument()
-        expect(await screen.findByRole('heading', {name: /shipping address 1/i})).toBeInTheDocument()
-        expect(await screen.findByRole('heading', {name: /shipping address 2/i})).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 1/i})
+        ).toBeInTheDocument()
+        expect(
+            await screen.findByRole('heading', {name: /shipping address 2/i})
+        ).toBeInTheDocument()
         expect(await screen.findByText(/Alex Johnson/i)).toBeInTheDocument()
         expect(await screen.findByText(/Bob Smith/i)).toBeInTheDocument()
         expect(await screen.findByText(/876 NE 8th st/i)).toBeInTheDocument()


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description
### Summary
When an order has OMS data but no OMS shipments (e.g. omsData.shipments is empty), the order details page now defaults to the ECOM shipment display instead of the OMS-only view. 
Shoppers see the normal delivery block with Shipping Method and Shipping Address from ECOM for both single- and multi-shipment orders.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- app/pages/account/order-detail.jsx
- hasOmsShipment: New check that OMS has at least one shipment
- showShipmentsFromOmsOnly: isOmsOrder && hasOmsShipment && isMultiShipmentOrder. 
- The OMS-only block (shipment methods only, no addresses) is shown only when the order has OMS data, OMS has shipments, and it's a multi-shipment order.

# How to Test-Drive This PR

- Create a multi shipment order, ingest order to oms and oms not returning shipment

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
