### PR TITLE
1CC UX fixes (W-21240479)

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -751,11 +751,6 @@ describe('Checkout One Click', () => {
             })
         ).toBeInTheDocument()
 
-        // Billing address should default to the shipping address
-
-        // Should display billing address that matches shipping address
-        expect(step3Content.getByText('123 Main St')).toBeInTheDocument()
-
         // Edit billing address
         // Toggle to edit billing address (not via same-as-shipping label in this flow)
         // Click the checkbox by role if present; otherwise skip
@@ -1207,10 +1202,6 @@ describe('Checkout One Click', () => {
                 return /5454\b/.test(text)
             })
         ).toBeInTheDocument()
-
-        // Verify billing address is displayed (it shows John Smith from the mock)
-        expect(step3Content.getByText('John Smith')).toBeInTheDocument()
-        expect(step3Content.getByText('123 Main St')).toBeInTheDocument()
 
         // Verify UserRegistration component is hidden for registered customers
         expect(screen.queryByTestId('sf-user-registration-content')).not.toBeInTheDocument()
@@ -2650,7 +2641,7 @@ describe('Checkout One Click', () => {
 
         // Click "Edit Payment Info" button
         const editPaymentButton = screen.getByRole('button', {
-            name: /toggle_card.action.editPaymentInfo|Edit Payment Info/i
+            name: /toggle_card.action.changePaymentInfo|Change/i
         })
         await user.click(editPaymentButton)
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info.jsx
@@ -512,6 +512,9 @@ const ContactInfo = ({isSocialEnabled = false, idps = [], onRegisteredUserChoseG
         }
     }
 
+    const customerEmail = customer?.email || form.getValues('email')
+    const customerPhone = customer?.phoneHome || form.getValues('phone')
+
     return (
         <>
             <ToggleCard
@@ -535,8 +538,8 @@ const ContactInfo = ({isSocialEnabled = false, idps = [], onRegisteredUserChoseG
                               id: 'checkout_contact_info.action.sign_out'
                           })
                         : formatMessage({
-                              defaultMessage: 'Edit',
-                              id: 'checkout_contact_info.action.edit'
+                              defaultMessage: 'Change',
+                              id: 'checkout_contact_info.action.change'
                           })
                 }
             >
@@ -666,18 +669,14 @@ const ContactInfo = ({isSocialEnabled = false, idps = [], onRegisteredUserChoseG
                     </Container>
                 </ToggleCardEdit>
 
-                {(customer?.email || form.getValues('email')) && (
+                {customerEmail ? (
                     <ToggleCardSummary>
                         <Stack spacing={1}>
-                            <Text>{customer?.email || form.getValues('email')}</Text>
-                            {(customer?.phoneHome || form.getValues('phone')) && (
-                                <Text fontSize="sm" color="gray.600">
-                                    {customer?.phoneHome || form.getValues('phone')}
-                                </Text>
-                            )}
+                            <Text>{customerEmail}</Text>
+                            {customerPhone && <Text>{customerPhone}</Text>}
                         </Stack>
                     </ToggleCardSummary>
-                )}
+                ) : null}
             </ToggleCard>
 
             {/* Sign Out Confirmation Dialog */}

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.jsx
@@ -441,8 +441,8 @@ const Payment = ({
                 disabled={appliedPayment == null}
                 onEdit={handleEditPayment}
                 editLabel={formatMessage({
-                    defaultMessage: 'Edit Payment Info',
-                    id: 'toggle_card.action.editPaymentInfo'
+                    defaultMessage: 'Change',
+                    id: 'toggle_card.action.changePaymentInfo'
                 })}
             >
                 <ToggleCardEdit>
@@ -580,8 +580,7 @@ const Payment = ({
 
                         <Divider borderColor="gray.100" />
 
-                        {(selectedBillingAddress ||
-                            (effectiveBillingSameAsShipping && selectedShippingAddress)) && (
+                        {selectedBillingAddress && !effectiveBillingSameAsShipping && (
                             <Stack spacing={2}>
                                 <Heading as="h3" fontSize="md">
                                     <FormattedMessage
@@ -589,9 +588,7 @@ const Payment = ({
                                         id="checkout_payment.heading.billing_address"
                                     />
                                 </Heading>
-                                <AddressDisplay
-                                    address={selectedBillingAddress || selectedShippingAddress}
-                                />
+                                <AddressDisplay address={selectedBillingAddress} />
                             </Stack>
                         )}
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.test.js
@@ -1310,7 +1310,7 @@ describe('Payment Component', () => {
             // Click Edit Payment Info to enter edit mode
             const summary = screen.getAllByTestId('toggle-card-summary').pop()
             const editButton = within(summary).getByRole('button', {
-                name: /toggle_card.action.editPaymentInfo|Edit Payment Info/i
+                name: /toggle_card.action.changePaymentInfo|Change/i
             })
             await user.click(editButton)
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options.jsx
@@ -266,8 +266,8 @@ export default function ShippingOptions() {
             }
             onEdit={() => goToStep(STEPS.SHIPPING_OPTIONS)}
             editLabel={formatMessage({
-                defaultMessage: 'Edit Shipping Options',
-                id: 'toggle_card.action.editShippingOptions'
+                defaultMessage: 'Change',
+                id: 'toggle_card.action.changeShippingOptions'
             })}
         >
             <ToggleCardEdit>

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -1249,10 +1249,10 @@
       "value": " with your confirmation number and receipt shortly."
     }
   ],
-  "checkout_contact_info.action.edit": [
+  "checkout_contact_info.action.change": [
     {
       "type": 0,
-      "value": "Edit"
+      "value": "Change"
     }
   ],
   "checkout_contact_info.action.sign_out": [
@@ -4676,6 +4676,18 @@
     }
   ],
   "toggle_card.action.change": [
+    {
+      "type": 0,
+      "value": "Change"
+    }
+  ],
+  "toggle_card.action.changePaymentInfo": [
+    {
+      "type": 0,
+      "value": "Change"
+    }
+  ],
+  "toggle_card.action.changeShippingOptions": [
     {
       "type": 0,
       "value": "Change"

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -1249,10 +1249,10 @@
       "value": " with your confirmation number and receipt shortly."
     }
   ],
-  "checkout_contact_info.action.edit": [
+  "checkout_contact_info.action.change": [
     {
       "type": 0,
-      "value": "Edit"
+      "value": "Change"
     }
   ],
   "checkout_contact_info.action.sign_out": [
@@ -4676,6 +4676,18 @@
     }
   ],
   "toggle_card.action.change": [
+    {
+      "type": 0,
+      "value": "Change"
+    }
+  ],
+  "toggle_card.action.changePaymentInfo": [
+    {
+      "type": 0,
+      "value": "Change"
+    }
+  ],
+  "toggle_card.action.changeShippingOptions": [
     {
       "type": 0,
       "value": "Change"

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -2473,14 +2473,14 @@
       "value": "]"
     }
   ],
-  "checkout_contact_info.action.edit": [
+  "checkout_contact_info.action.change": [
     {
       "type": 0,
       "value": "["
     },
     {
       "type": 0,
-      "value": "Ḗḓīŧ"
+      "value": "Ƈħȧȧƞɠḗḗ"
     },
     {
       "type": 0,
@@ -9828,6 +9828,34 @@
     }
   ],
   "toggle_card.action.change": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈħȧȧƞɠḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "toggle_card.action.changePaymentInfo": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈħȧȧƞɠḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "toggle_card.action.changeShippingOptions": [
     {
       "type": 0,
       "value": "["

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -460,8 +460,8 @@
   "checkout_confirmation.message.will_email_shortly": {
     "defaultMessage": "We will send an email to <b>{email}</b> with your confirmation number and receipt shortly."
   },
-  "checkout_contact_info.action.edit": {
-    "defaultMessage": "Edit"
+  "checkout_contact_info.action.change": {
+    "defaultMessage": "Change"
   },
   "checkout_contact_info.action.sign_out": {
     "defaultMessage": "Sign Out"
@@ -1947,6 +1947,12 @@
     "defaultMessage": "{label}:"
   },
   "toggle_card.action.change": {
+    "defaultMessage": "Change"
+  },
+  "toggle_card.action.changePaymentInfo": {
+    "defaultMessage": "Change"
+  },
+  "toggle_card.action.changeShippingOptions": {
     "defaultMessage": "Change"
   },
   "toggle_card.action.edit": {

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -460,8 +460,8 @@
   "checkout_confirmation.message.will_email_shortly": {
     "defaultMessage": "We will send an email to <b>{email}</b> with your confirmation number and receipt shortly."
   },
-  "checkout_contact_info.action.edit": {
-    "defaultMessage": "Edit"
+  "checkout_contact_info.action.change": {
+    "defaultMessage": "Change"
   },
   "checkout_contact_info.action.sign_out": {
     "defaultMessage": "Sign Out"
@@ -1947,6 +1947,12 @@
     "defaultMessage": "{label}:"
   },
   "toggle_card.action.change": {
+    "defaultMessage": "Change"
+  },
+  "toggle_card.action.changePaymentInfo": {
+    "defaultMessage": "Change"
+  },
+  "toggle_card.action.changeShippingOptions": {
     "defaultMessage": "Change"
   },
   "toggle_card.action.edit": {


### PR DESCRIPTION
cherry-pick 3.16 bugfix - https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3655

## Summary
- Update "Edit" labels to "Change" on contact info, payment, and shipping options toggle cards
- Fix billing address display logic in payment summary
- Update translations (en-US, en-GB, en-XA)

## Important
**Use "Create a merge commit" when merging — NEVER squash merge on release branches.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)