### PR TITLE
W-21354759: Implement SF Payments support in create app package

### DIFF
--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.1.0-dev",
       "license": "See license in LICENSE",
       "dependencies": {
-        "commerce-sdk-isomorphic": "5.0.0",
+        "commerce-sdk-isomorphic": "5.0.0-unstable-20260223081745",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -920,9 +920,9 @@
       "license": "MIT"
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.0.0.tgz",
-      "integrity": "sha512-9E0wEKq3pBoAdmjLByBdDVfcNbmo+G61WdxpMpHKtRzIlzbVhjLTNIrxxzRGP+267iTCbJg9sgB8SJLjG2hxTg==",
+      "version": "5.0.0-unstable-20260223081745",
+      "resolved": "https://nexus-proxy.repo.local.sfdc.net/nexus/content/groups/npm-all/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.0.0-unstable-20260223081745.tgz",
+      "integrity": "sha512-TJdmMr7ewNuxAdVwCOrGtW2g8aFP6nb7zb1VWwSOz2LkjyqCVY5gewk1m9RZJkIfg/DxzRZE1bB7Jw4K0kEOtw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",
@@ -2843,7 +2843,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2856,7 +2855,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3543,7 +3541,6 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "5.0.0",
+    "commerce-sdk-isomorphic": "5.0.0-unstable-20260223081745",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -40,7 +40,7 @@
     "version": "node ./scripts/version.js"
   },
   "dependencies": {
-    "commerce-sdk-isomorphic": "5.0.0-unstable-20260223081745",
+    "commerce-sdk-isomorphic": "5.1.0-unstable-20260226081656",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
@@ -158,11 +158,11 @@ module.exports = {
             }
         },
         // Salesforce Payments configuration
-        // To enable, set enabled to true and provide the SDK and metadata URLs for your Commerce Cloud instance.
-        // Example URLs: https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js
-        //               https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json
+        // Set enabled to false to disable Salesforce Payments even if the Commerce Cloud instance supports it.
+        // Example URLs: sdkUrl: 'https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js'
+        //               metadataUrl: 'https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
         sfPayments: {
-            enabled: false,
+            enabled: true,
             sdkUrl: '',
             metadataUrl: ''
         },    

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
@@ -157,6 +157,15 @@ module.exports = {
                 groupBonusProductsWithQualifyingProduct: true
             }
         },
+        // Salesforce Payments configuration
+        // To enable, set enabled to true and provide the SDK and metadata URLs for your Commerce Cloud instance.
+        // Example URLs: https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js
+        //               https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json
+        sfPayments: {
+            enabled: false,
+            sdkUrl: '',
+            metadataUrl: ''
+        },    
         // Google Cloud api config
         googleCloudAPI: {
             apiKey: process.env.GOOGLE_CLOUD_API_KEY

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/ssr.js.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/ssr.js.hbs
@@ -10,6 +10,7 @@
 import crypto from 'crypto'
 import express from 'express'
 import helmet from 'helmet'
+import https from 'https'
 import {createRemoteJWKSet as joseCreateRemoteJWKSet, jwtVerify, decodeJwt} from 'jose'
 import path from 'path'
 import {getRuntime} from '@salesforce/pwa-kit-runtime/ssr/server/express'
@@ -345,14 +346,21 @@ const {handler} = runtime.createHandler(options, (app) => {
             'img-src': [
                 // Default source for product images - replace with your CDN
                 '*.commercecloud.salesforce.com',
-                '*.demandware.net'
+                '*.demandware.net',
+                '*.adyen.com' // Payment gateways
             ],
             'script-src': [
                 // Used by the service worker in /worker/main.js
                 'storage.googleapis.com',
                 // Connect to Google Cloud APIs
                 'maps.googleapis.com',
-                'places.googleapis.com'
+                'places.googleapis.com',
+                // Payment gateways
+                '*.stripe.com',
+                '*.paypal.com',
+                '*.adyen.com',
+                '*.google.com',
+                '*.demandware.net', // Used to load a valid payment scripts in test environment
             ],
             'connect-src': [
                 // Connect to Einstein APIs
@@ -363,11 +371,20 @@ const {handler} = runtime.createHandler(options, (app) => {
                 'maps.googleapis.com',
                 'places.googleapis.com',
                 // Connect to SCRT2 URLs
-                '*.salesforce-scrt.com'
+                '*.salesforce-scrt.com',
+                // Payment gateways   
+                '*.demandware.net', // Used to load a valid payment scripts in test environment
+                '*.adyen.com',
+                '*.google.com'
             ],
             'frame-src': [
                 // Allow frames from Salesforce site.com (Needed for MIAW)
-                '*.site.com'
+                '*.site.com',
+                // Payment gateways
+                '*.stripe.com',
+                '*.paypal.com',
+                '*.google.com',
+                '*.adyen.com'
             ]
         }
     }
@@ -429,6 +446,64 @@ const {handler} = runtime.createHandler(options, (app) => {
     app.get('/favicon.ico', runtime.serveStaticFile('static/ico/favicon.ico'))
 
     app.get('/worker.js(.map)?', runtime.serveServiceWorker)
+
+    // Helper function to transform relative icon paths to absolute URLs
+    function transformIconPaths(data, ecomServerHost) {
+        const baseUrl = `https://${ecomServerHost}/on/demandware.static/Sites-Site/-/-/internal`
+        const dataStr = JSON.stringify(data)
+        // Replace all relative icon paths with absolute URLs
+        const transformedStr = dataStr.replace(/"src":\s*"\/icons\//g, `"src":"${baseUrl}/icons/`)
+        return JSON.parse(transformedStr)
+    }
+
+    app.get('/api/payment-metadata', async (req, res) => {
+        try {
+            // Parse the URL to extract hostname and path
+            const url = new URL(config.app.sfPayments.metadataUrl)
+            // Use Node's https module instead of fetch
+            const data = await new Promise((resolve, reject) => {
+                const options = {
+                    hostname: url.hostname,
+                    path: url.pathname,
+                    method: 'GET',
+                    rejectUnauthorized: false, // This bypasses SSL verification
+                    headers: {
+                        Accept: 'application/json'
+                    }
+                }
+
+                const req = https.request(options, (response) => {
+                    let data = ''
+                    response.on('data', (chunk) => {
+                        data += chunk
+                    })
+                    response.on('end', () => {
+                        try {
+                            resolve(JSON.parse(data))
+                        } catch (e) {
+                            reject(e)
+                        }
+                    })
+                })
+
+                req.on('error', reject)
+                req.end()
+            })
+
+            // Transform relative icon paths to absolute URLs
+            const transformedData = transformIconPaths(data, url.hostname)
+
+            res.setHeader('Access-Control-Allow-Origin', '*')
+            res.setHeader('Content-Type', 'application/json')
+            res.json(transformedData)
+        } catch (error) {
+            res.status(500).json({
+                error: 'Failed to fetch metadata',
+                details: error.message
+            })
+        }   
+    })
+    
     app.get('*', runtime.render)
 })
 // SSR requires that we export a single handler function called 'get', that

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/ssr.js.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/ssr.js.hbs
@@ -10,6 +10,7 @@
 import crypto from 'crypto'
 import express from 'express'
 import helmet from 'helmet'
+import https from 'https'
 import {createRemoteJWKSet as joseCreateRemoteJWKSet, jwtVerify, decodeJwt} from 'jose'
 import path from 'path'
 import {getRuntime} from '@salesforce/pwa-kit-runtime/ssr/server/express'
@@ -345,14 +346,21 @@ const {handler} = runtime.createHandler(options, (app) => {
             'img-src': [
                 // Default source for product images - replace with your CDN
                 '*.commercecloud.salesforce.com',
-                '*.demandware.net'
+                '*.demandware.net',
+                '*.adyen.com' // Payment gateways
             ],
             'script-src': [
                 // Used by the service worker in /worker/main.js
                 'storage.googleapis.com',
                 // Connect to Google Cloud APIs
                 'maps.googleapis.com',
-                'places.googleapis.com'
+                'places.googleapis.com',
+                // Payment gateways
+                '*.stripe.com',
+                '*.paypal.com',
+                '*.adyen.com',
+                '*.google.com',
+                '*.demandware.net', // Used to load a valid payment scripts in test environment
             ],
             'connect-src': [
                 // Connect to Einstein APIs
@@ -363,11 +371,20 @@ const {handler} = runtime.createHandler(options, (app) => {
                 'maps.googleapis.com',
                 'places.googleapis.com',
                 // Connect to SCRT2 URLs
-                '*.salesforce-scrt.com'
+                '*.salesforce-scrt.com',
+                // Payment gateways   
+                '*.demandware.net', // Used to load a valid payment scripts in test environment
+                '*.adyen.com',
+                '*.google.com'
             ],
             'frame-src': [
                 // Allow frames from Salesforce site.com (Needed for MIAW)
-                '*.site.com'
+                '*.site.com',
+                // Payment gateways
+                '*.stripe.com',
+                '*.paypal.com',
+                '*.google.com',
+                '*.adyen.com'
             ]
         }
     }
@@ -429,6 +446,64 @@ const {handler} = runtime.createHandler(options, (app) => {
     app.get('/favicon.ico', runtime.serveStaticFile('static/ico/favicon.ico'))
 
     app.get('/worker.js(.map)?', runtime.serveServiceWorker)
+
+    // Helper function to transform relative icon paths to absolute URLs
+    function transformIconPaths(data, ecomServerHost) {
+        const baseUrl = `https://${ecomServerHost}/on/demandware.static/Sites-Site/-/-/internal`
+        const dataStr = JSON.stringify(data)
+        // Replace all relative icon paths with absolute URLs
+        const transformedStr = dataStr.replace(/"src":\s*"\/icons\//g, `"src":"${baseUrl}/icons/`)
+        return JSON.parse(transformedStr)
+    }
+
+    app.get('/api/payment-metadata', async (req, res) => {
+        try {
+            // Parse the URL to extract hostname and path
+            const url = new URL(config.app.sfPayments.metadataUrl)
+            // Use Node's https module instead of fetch
+            const data = await new Promise((resolve, reject) => {
+                const options = {
+                    hostname: url.hostname,
+                    path: url.pathname,
+                    method: 'GET',
+                    rejectUnauthorized: false, // This bypasses SSL verification
+                    headers: {
+                        Accept: 'application/json'
+                    }
+                }
+
+                const req = https.request(options, (response) => {
+                    let data = ''
+                    response.on('data', (chunk) => {
+                        data += chunk
+                    })
+                    response.on('end', () => {
+                        try {
+                            resolve(JSON.parse(data))
+                        } catch (e) {
+                            reject(e)
+                        }
+                    })
+                })
+
+                req.on('error', reject)
+                req.end()
+            })
+
+            // Transform relative icon paths to absolute URLs
+            const transformedData = transformIconPaths(data, url.hostname)
+
+            res.setHeader('Access-Control-Allow-Origin', '*')
+            res.setHeader('Content-Type', 'application/json')
+            res.json(transformedData)
+        } catch (error) {
+            res.status(500).json({
+                error: 'Failed to fetch metadata',
+                details: error.message
+            })
+        }
+    })
+
     app.get('*', runtime.render)
 })
 // SSR requires that we export a single handler function called 'get', that

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
@@ -158,14 +158,14 @@ module.exports = {
             }
         },
         // Salesforce Payments configuration
-        // To enable, set enabled to true and provide the SDK and metadata URLs for your Commerce Cloud instance.
-        // Example URLs: https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js
-        //               https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json
+        // Set enabled to false to disable Salesforce Payments even if the Commerce Cloud instance supports it.
+        // Example URLs: sdkUrl: 'https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js'
+        //               metadataUrl: 'https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
         sfPayments: {
-            enabled: false,
+            enabled: true,
             sdkUrl: '',
             metadataUrl: ''
-        },
+        },  
         // Google Cloud api config
         googleCloudAPI: {
             apiKey: process.env.GOOGLE_CLOUD_API_KEY

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
@@ -157,6 +157,15 @@ module.exports = {
                 groupBonusProductsWithQualifyingProduct: true
             }
         },
+        // Salesforce Payments configuration
+        // To enable, set enabled to true and provide the SDK and metadata URLs for your Commerce Cloud instance.
+        // Example URLs: https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js
+        //               https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json
+        sfPayments: {
+            enabled: false,
+            sdkUrl: '',
+            metadataUrl: ''
+        },
         // Google Cloud api config
         googleCloudAPI: {
             apiKey: process.env.GOOGLE_CLOUD_API_KEY

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -107,7 +107,7 @@ const AppConfig = ({children, locals = {}}) => {
             defaultDnt={DEFAULT_DNT_STATE}
             // Set 'enablePWAKitPrivateClient' to true to use SLAS private client login flows.
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
-            enablePWAKitPrivateClient={true}
+            enablePWAKitPrivateClient={false}
             privateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
             // Uncomment 'hybridAuthEnabled' if the current site has Hybrid Auth enabled. Do NOT set this flag for hybrid storefronts using Plugin SLAS.
             // hybridAuthEnabled={true}

--- a/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
@@ -299,7 +299,7 @@ export default function useAddressFields({
             rules: {
                 required:
                     countryCode === 'CA'
-                        ? 'Please select your province.'
+                        ? 'Please select your province.' // FYI we won't translate this
                         : countryCode === 'US'
                         ? formatMessage({
                               defaultMessage: 'Please select your state.',

--- a/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
@@ -288,39 +288,42 @@ export default function useAddressFields({
             name: `${prefix}stateCode`,
             label: formatMessage(countryCode === 'CA' ? messages.province : messages.state),
             defaultValue: '',
-            type: 'select',
-            options: [
-                {value: '', label: ''},
-                ...(countryCode === 'CA' ? provinceOptions : stateOptions)
-            ],
+            type: countryCode === 'US' || countryCode === 'CA' ? 'select' : 'text',
+            options: countryCode === 'US' || countryCode === 'CA'
+                ? [{value: '', label: ''}, ...(countryCode === 'CA' ? provinceOptions : stateOptions)]
+                : undefined,
             rules: {
-                required:
-                    countryCode === 'CA'
-                        ? 'Please select your province.' // FYI we won't translate this
-                        : formatMessage({
-                              defaultMessage: 'Please select your state.',
-                              id: 'use_address_fields.error.please_select_your_state_or_province',
-                              description: 'Error message for a blank state (US-specific checkout)'
-                          })
+                required: countryCode === 'CA'
+                    ? 'Please select your province.'
+                    : countryCode === 'US'
+                        ? formatMessage({
+                                defaultMessage: 'Please select your state.',
+                                id: 'use_address_fields.error.please_select_your_state_or_province',
+                                description: 'Error message for a blank state (US-specific checkout)'
+                            })
+                        : false
             },
             error: errors[`${prefix}stateCode`],
             control
         },
         postalCode: {
             name: `${prefix}postalCode`,
-            label: formatMessage(countryCode === 'CA' ? messages.postalCode : messages.zipCode),
+            label: formatMessage(countryCode === 'US' ? messages.zipCode : messages.postalCode),
             defaultValue: '',
             type: 'text',
             autoComplete: 'postal-code',
             rules: {
-                required:
-                    countryCode === 'CA'
-                        ? 'Please enter your postal code.' // FYI we won't translate this
-                        : formatMessage({
+                required: countryCode === 'CA'
+                    ? 'Please enter your postal code.'
+                    : countryCode === 'US'
+                        ? formatMessage({
                               defaultMessage: 'Please enter your zip code.',
                               id: 'use_address_fields.error.please_enter_your_postal_or_zip',
-                              description:
-                                  'Error message for a blank zip code (US-specific checkout)'
+                              description: 'Error message for a blank zip code (US-specific checkout)'
+                          })
+                        : formatMessage({
+                              defaultMessage: 'Please enter your postal code.',
+                              id: 'use_address_fields.error.please_enter_postal_code'
                           })
             },
             error: errors[`${prefix}postalCode`],

--- a/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
+++ b/packages/template-retail-react-app/app/components/forms/useAddressFields.jsx
@@ -289,18 +289,23 @@ export default function useAddressFields({
             label: formatMessage(countryCode === 'CA' ? messages.province : messages.state),
             defaultValue: '',
             type: countryCode === 'US' || countryCode === 'CA' ? 'select' : 'text',
-            options: countryCode === 'US' || countryCode === 'CA'
-                ? [{value: '', label: ''}, ...(countryCode === 'CA' ? provinceOptions : stateOptions)]
-                : undefined,
+            options:
+                countryCode === 'US' || countryCode === 'CA'
+                    ? [
+                          {value: '', label: ''},
+                          ...(countryCode === 'CA' ? provinceOptions : stateOptions)
+                      ]
+                    : undefined,
             rules: {
-                required: countryCode === 'CA'
-                    ? 'Please select your province.'
-                    : countryCode === 'US'
+                required:
+                    countryCode === 'CA'
+                        ? 'Please select your province.'
+                        : countryCode === 'US'
                         ? formatMessage({
-                                defaultMessage: 'Please select your state.',
-                                id: 'use_address_fields.error.please_select_your_state_or_province',
-                                description: 'Error message for a blank state (US-specific checkout)'
-                            })
+                              defaultMessage: 'Please select your state.',
+                              id: 'use_address_fields.error.please_select_your_state_or_province',
+                              description: 'Error message for a blank state (US-specific checkout)'
+                          })
                         : false
             },
             error: errors[`${prefix}stateCode`],
@@ -313,13 +318,15 @@ export default function useAddressFields({
             type: 'text',
             autoComplete: 'postal-code',
             rules: {
-                required: countryCode === 'CA'
-                    ? 'Please enter your postal code.'
-                    : countryCode === 'US'
+                required:
+                    countryCode === 'CA'
+                        ? 'Please enter your postal code.'
+                        : countryCode === 'US'
                         ? formatMessage({
                               defaultMessage: 'Please enter your zip code.',
                               id: 'use_address_fields.error.please_enter_your_postal_or_zip',
-                              description: 'Error message for a blank zip code (US-specific checkout)'
+                              description:
+                                  'Error message for a blank zip code (US-specific checkout)'
                           })
                         : formatMessage({
                               defaultMessage: 'Please enter your postal code.',

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -70,10 +70,13 @@ const SFPaymentsExpressButtons = ({
     const {countryCode: fallbackCountryCode} = useSFPaymentsCountry()
     const {sfp, metadata, startConfirming, endConfirming} = useSFPayments()
 
+    // Fetch payment configuration for the buyer's country. Falls back to 'US' if country
+    // detection hasn't resolved yet; React Query will re-fetch with the correct country once available.
+    // chances of not having a country code is very low with the country hook, so we can default to 'US'
     const {data: paymentConfig} = usePaymentConfiguration({
         parameters: {
             currency: paymentCurrency,
-            countryCode: paymentCountryCode || fallbackCountryCode || 'US' // TODO: remove US when parameter made optional
+            countryCode: paymentCountryCode || fallbackCountryCode || 'US' 
             //,zoneId: "stripeUSTest" //if you need to test with a different zone
         }
     })

--- a/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
+++ b/packages/template-retail-react-app/app/components/sf-payments-express-buttons/index.jsx
@@ -76,7 +76,7 @@ const SFPaymentsExpressButtons = ({
     const {data: paymentConfig} = usePaymentConfiguration({
         parameters: {
             currency: paymentCurrency,
-            countryCode: paymentCountryCode || fallbackCountryCode || 'US' 
+            countryCode: paymentCountryCode || fallbackCountryCode || 'US'
             //,zoneId: "stripeUSTest" //if you need to test with a different zone
         }
     })

--- a/packages/template-retail-react-app/app/hooks/use-current-basket.js
+++ b/packages/template-retail-react-app/app/hooks/use-current-basket.js
@@ -22,10 +22,7 @@ export const useCurrentBasket = ({id = ''} = {}) => {
     const storeLocatorEnabled = getConfig()?.app?.storeLocatorEnabled ?? STORE_LOCATOR_IS_ENABLED
     const customerId = useCustomerId()
     const {confirmingBasket} = useSFPayments()
-    const {
-        data: basketsData,
-        ...restOfQuery
-    } = useCustomerBaskets(
+    const {data: basketsData, ...restOfQuery} = useCustomerBaskets(
         {parameters: {customerId}},
         {
             enabled: !!customerId && !isServer

--- a/packages/template-retail-react-app/app/hooks/use-current-basket.js
+++ b/packages/template-retail-react-app/app/hooks/use-current-basket.js
@@ -24,8 +24,7 @@ export const useCurrentBasket = ({id = ''} = {}) => {
     const {confirmingBasket} = useSFPayments()
     const {
         data: basketsData,
-        dataUpdatedAt: basketsDataUpdatedAt,
-        isLoading: basketsIsLoading
+        ...restOfQuery
     } = useCustomerBaskets(
         {parameters: {customerId}},
         {
@@ -100,8 +99,7 @@ export const useCurrentBasket = ({id = ''} = {}) => {
 
     return {
         data: currentBasket,
-        dataUpdatedAt: basketsDataUpdatedAt,
-        isLoading: basketsIsLoading,
+        ...restOfQuery,
         derivedData: {
             // Only true if a non-temporary basket exists (temporary baskets are filtered out above)
             hasBasket: !!currentBasket,

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments-country.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments-country.js
@@ -7,6 +7,7 @@
 
 import {useQuery} from '@tanstack/react-query'
 import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origin'
+import useMultiSite from '@salesforce/retail-react-app/app/hooks/use-multi-site'
 
 /**
  * Hook to detect payment country code
@@ -17,6 +18,7 @@ import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origi
  * const {countryCode, isLoading} = useSFPaymentsCountry()
  */
 export const useSFPaymentsCountry = () => {
+    const {locale} = useMultiSite()
     const appOrigin = useAppOrigin()
 
     const {data: serverCountry, isLoading: serverLoading} = useQuery({
@@ -44,8 +46,11 @@ export const useSFPaymentsCountry = () => {
         }
     })
 
+    // Derive country from locale as fallback (e.g., "de-DE" -> "DE")
+    const localeCountry = locale?.id?.split('-')?.[1] || null
+
     return {
-        countryCode: serverCountry,
+        countryCode: serverCountry || localeCountry,
         isLoading: serverLoading
     }
 }

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments-country.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments-country.test.js
@@ -485,52 +485,52 @@ describe('useSFPaymentsCountry', () => {
         test('falls back to locale country when server detection fails', async () => {
             mockUseMultiSite.mockReturnValue({locale: {id: 'de-DE'}})
             mockFetch.mockResolvedValue({ok: false, status: 500})
-    
+
             renderWithQueryClient(<TestComponent />)
-    
+
             await waitFor(() => {
                 expect(screen.getByTestId('country-code').textContent).toBe('DE')
             })
         })
-    
+
         test('server country takes priority over locale country', async () => {
             mockUseMultiSite.mockReturnValue({locale: {id: 'de-DE'}})
             mockFetch.mockResolvedValue({
                 ok: true,
                 json: async () => ({countryCode: 'GB'})
             })
-    
+
             renderWithQueryClient(<TestComponent />)
-    
+
             await waitFor(() => {
                 expect(screen.getByTestId('country-code').textContent).toBe('GB')
             })
         })
-    
+
         test('returns null when both server and locale are unavailable', async () => {
             mockUseMultiSite.mockReturnValue({locale: {}})
             mockFetch.mockResolvedValue({ok: false, status: 500})
-    
+
             renderWithQueryClient(<TestComponent />)
-    
+
             await waitFor(() => {
                 expect(screen.getByTestId('country-code').textContent).toBe('null')
             })
         })
-    
+
         test('derives country from various locale formats', async () => {
             mockFetch.mockResolvedValue({ok: false, status: 500})
-    
+
             const cases = [
                 {locale: 'fr-FR', expected: 'FR'},
                 {locale: 'ja-JP', expected: 'JP'},
                 {locale: 'zh-CN', expected: 'CN'}
             ]
-    
+
             for (const {locale, expected} of cases) {
                 mockUseMultiSite.mockReturnValue({locale: {id: locale}})
                 const {unmount} = renderWithQueryClient(<TestComponent />)
-    
+
                 await waitFor(() => {
                     expect(screen.getByTestId('country-code').textContent).toBe(expected)
                 })

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments-country.test.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments-country.test.js
@@ -17,6 +17,11 @@ const mockFetch = jest.fn()
 jest.mock('@salesforce/retail-react-app/app/hooks/use-app-origin', () => ({
     useAppOrigin: () => mockUseAppOrigin()
 }))
+const mockUseMultiSite = jest.fn()
+jest.mock('@salesforce/retail-react-app/app/hooks/use-multi-site', () => ({
+    __esModule: true,
+    default: () => mockUseMultiSite()
+}))
 
 // Test component that uses the hook
 const TestComponent = ({onHookData}) => {
@@ -60,7 +65,7 @@ describe('useSFPaymentsCountry', () => {
         jest.clearAllMocks()
         global.fetch = mockFetch
         mockUseAppOrigin.mockReturnValue('https://test-origin.com')
-
+        mockUseMultiSite.mockReturnValue({locale: {}})
         // Suppress console.warn for tests
         jest.spyOn(console, 'warn').mockImplementation(() => {})
     })
@@ -474,6 +479,63 @@ describe('useSFPaymentsCountry', () => {
 
             // Should still only have been called once (shared cache)
             expect(mockFetch).toHaveBeenCalledTimes(1)
+        })
+    })
+    describe('locale country fallback', () => {
+        test('falls back to locale country when server detection fails', async () => {
+            mockUseMultiSite.mockReturnValue({locale: {id: 'de-DE'}})
+            mockFetch.mockResolvedValue({ok: false, status: 500})
+    
+            renderWithQueryClient(<TestComponent />)
+    
+            await waitFor(() => {
+                expect(screen.getByTestId('country-code').textContent).toBe('DE')
+            })
+        })
+    
+        test('server country takes priority over locale country', async () => {
+            mockUseMultiSite.mockReturnValue({locale: {id: 'de-DE'}})
+            mockFetch.mockResolvedValue({
+                ok: true,
+                json: async () => ({countryCode: 'GB'})
+            })
+    
+            renderWithQueryClient(<TestComponent />)
+    
+            await waitFor(() => {
+                expect(screen.getByTestId('country-code').textContent).toBe('GB')
+            })
+        })
+    
+        test('returns null when both server and locale are unavailable', async () => {
+            mockUseMultiSite.mockReturnValue({locale: {}})
+            mockFetch.mockResolvedValue({ok: false, status: 500})
+    
+            renderWithQueryClient(<TestComponent />)
+    
+            await waitFor(() => {
+                expect(screen.getByTestId('country-code').textContent).toBe('null')
+            })
+        })
+    
+        test('derives country from various locale formats', async () => {
+            mockFetch.mockResolvedValue({ok: false, status: 500})
+    
+            const cases = [
+                {locale: 'fr-FR', expected: 'FR'},
+                {locale: 'ja-JP', expected: 'JP'},
+                {locale: 'zh-CN', expected: 'CN'}
+            ]
+    
+            for (const {locale, expected} of cases) {
+                mockUseMultiSite.mockReturnValue({locale: {id: locale}})
+                const {unmount} = renderWithQueryClient(<TestComponent />)
+    
+                await waitFor(() => {
+                    expect(screen.getByTestId('country-code').textContent).toBe(expected)
+                })
+                unmount()
+            }
         })
     })
 })

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments.js
@@ -96,10 +96,15 @@ export const useSFPayments = () => {
 
 /**
  * Custom hook to check if Salesforce Payments is enabled
+ * //?? true means: if the config is missing, default to "don't block it" 
+ * and let the API decide. The local config only matters when someone explicitly sets it to false.
  * @returns {boolean} True if Salesforce Payments is enabled, false otherwise
  */
 export const useSFPaymentsEnabled = () => {
-    return useShopperConfiguration('SalesforcePaymentsAllowed') === true
+    const config = getConfig()
+    const localEnabled = config?.app?.sfPayments?.enabled ?? true
+    const apiEnabled = useShopperConfiguration('SalesforcePaymentsAllowed') === true
+    return localEnabled && apiEnabled
 }
 
 /**

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments.js
@@ -96,7 +96,7 @@ export const useSFPayments = () => {
 
 /**
  * Custom hook to check if Salesforce Payments is enabled
- * //?? true means: if the config is missing, default to "don't block it"
+ * ?? true means: if the config is missing, default to "don't block it"
  * and let the API decide. The local config only matters when someone explicitly sets it to false.
  * @returns {boolean} True if Salesforce Payments is enabled, false otherwise
  */

--- a/packages/template-retail-react-app/app/hooks/use-sf-payments.js
+++ b/packages/template-retail-react-app/app/hooks/use-sf-payments.js
@@ -96,7 +96,7 @@ export const useSFPayments = () => {
 
 /**
  * Custom hook to check if Salesforce Payments is enabled
- * //?? true means: if the config is missing, default to "don't block it" 
+ * //?? true means: if the config is missing, default to "don't block it"
  * and let the API decide. The local config only matters when someone explicitly sets it to false.
  * @returns {boolean} True if Salesforce Payments is enabled, false otherwise
  */

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.jsx
@@ -16,7 +16,10 @@ import {
     Divider
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
-import {useShopperBasketsV2Mutation as useShopperBasketsMutation, useCustomerType} from '@salesforce/commerce-sdk-react'
+import {
+    useShopperBasketsV2Mutation as useShopperBasketsMutation,
+    useCustomerType
+} from '@salesforce/commerce-sdk-react'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 import {useCheckoutAutoSelect} from '@salesforce/retail-react-app/app/hooks/use-checkout-auto-select'

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-payment.test.js
@@ -12,7 +12,10 @@ import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-curre
 import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {useCurrency} from '@salesforce/retail-react-app/app/hooks/use-currency'
-import {useShopperBasketsV2Mutation as useShopperBasketsMutation, useCustomerType} from '@salesforce/commerce-sdk-react'
+import {
+    useShopperBasketsV2Mutation as useShopperBasketsMutation,
+    useCustomerType
+} from '@salesforce/commerce-sdk-react'
 import {useCheckout} from '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context'
 import Payment from '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-payment'
 import {CurrencyProvider} from '@salesforce/retail-react-app/app/contexts'

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-pickup-address.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-pickup-address.jsx
@@ -18,7 +18,10 @@ import StoreDisplay from '@salesforce/retail-react-app/app/components/store-disp
 // Hooks
 import {useCheckout} from '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context'
 import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
-import {useShopperBasketsV2Mutation as useShopperBasketsMutation, useStores} from '@salesforce/commerce-sdk-react'
+import {
+    useShopperBasketsV2Mutation as useShopperBasketsMutation,
+    useStores
+} from '@salesforce/commerce-sdk-react'
 import {isPickupShipment} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 
 const PickupAddress = () => {

--- a/packages/template-retail-react-app/app/pages/checkout/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/index.jsx
@@ -132,7 +132,7 @@ const Checkout = () => {
             if (sfPaymentsEnabled) {
                 order = await sfPaymentsSheetRef.current.confirmPayment()
             } else {
-                order = doCreateOrder()
+                order = await doCreateOrder()
             }
             navigate(`/checkout/confirmation/${order.orderNo}`)
         } catch (error) {

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -40,11 +40,12 @@ const options = {
     mobify: config,
 
     // The port that the local dev server listens on
-    port: 3003,
+    port: 3000,
 
     // The protocol on which the development Express app listens.
     // Note that http://localhost is treated as a secure context for development,
     // except by Safari.
+    // TODO: remove this and document instead in the release docs
     protocol: process.env.DEV_SERVER_PROTOCOL || 'http',
 
     // SSL file path for HTTPS development
@@ -55,14 +56,14 @@ const options = {
     // Set this to false if using a SLAS public client
     // When setting this to true, make sure to also set the PWA_KIT_SLAS_CLIENT_SECRET
     // environment variable as this endpoint will return HTTP 501 if it is not set
-    useSLASPrivateClient: true,
+    useSLASPrivateClient: false,
 
     // If you wish to use additional SLAS endpoints that require private clients,
     // customize this regex to include the additional endpoints the custom SLAS
     // private client secret handler will inject an Authorization header.
     // The default regex is defined in this file: https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
     // applySLASPrivateClientToEndpoints:
-    //     /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/,
+    //    /\/oauth2\/(token|passwordless\/(login|token)|password\/(reset|action))/,
 
     // If this is enabled, any HTTP header that has a non ASCII value will be URI encoded
     // If there any HTTP headers that have been encoded, an additional header will be

--- a/packages/template-retail-react-app/app/ssr.js
+++ b/packages/template-retail-react-app/app/ssr.js
@@ -360,7 +360,6 @@ const {handler} = runtime.createHandler(options, (app) => {
                     'img-src': [
                         // Default source for product images - replace with your CDN
                         '*.commercecloud.salesforce.com',
-                        // TODO: Used to load icons
                         '*.demandware.net',
                         '*.adyen.com'
                     ],
@@ -372,8 +371,7 @@ const {handler} = runtime.createHandler(options, (app) => {
                         '*.paypal.com',
                         '*.adyen.com',
                         '*.google.com',
-                        // TODO: Used to load a valid sfp.js
-                        '*.demandware.net',
+                        '*.demandware.net', // Used to load a valid payment scripts in test environment
                         'maps.googleapis.com',
                         'places.googleapis.com'
                     ],
@@ -387,9 +385,7 @@ const {handler} = runtime.createHandler(options, (app) => {
                         // Connect to SCRT2 URLs
                         '*.salesforce-scrt.com',
                         // Payment gateways
-                        '*.adyen.com',
-                        // TODO: Used to load metadata
-                        '*.demandware.net',
+                        '*.demandware.net', // Used to load a valid payment scripts in test environment
                         '*.adyen.com',
                         '*.google.com'
                     ],
@@ -400,8 +396,7 @@ const {handler} = runtime.createHandler(options, (app) => {
                         '*.stripe.com',
                         '*.paypal.com',
                         '*.adyen.com',
-                        '*.google.com',
-                        '*.adyen.com'
+                        '*.google.com'
                     ]
                 }
             }

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -56,18 +56,18 @@ module.exports = {
         sites,
         commerceAPI: {
             proxyPath: `/mobify/proxy/api`,
-            /*parameters: {
+            parameters: {
                 clientId: '0bb3af38-b52c-4f4b-966e-fe7087ca47e2',
                 organizationId: 'f_ecom_zyoe_006',
                 shortCode: 'sandbox-001',
                 siteId: 'RefArch'
-            }*/
-            parameters: {
+            }
+            /*parameters: {
                 clientId: 'cc62dfa8-777f-486a-8af2-bdc048a4ba52',
                 organizationId: 'f_ecom_zyoe_009',
                 shortCode: 'sandbox-001',
                 siteId: 'RefArch'
-            }
+            }*/
         },
         einsteinAPI: {
             host: 'https://api.cquotient.com',
@@ -96,9 +96,9 @@ module.exports = {
         multishipEnabled: true,
         sfPayments: {
             enabled: true,
-            sdkUrl: 'https://zyoe-009.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js',
+            sdkUrl: 'https://zyoe-006.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js',
             metadataUrl:
-                'https://zyoe-009.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
+                'https://zyoe-006.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
             // sdkUrl: 'https://ocapi-mon.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js',
             // metadataUrl: 'https://ocapi-mon.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
             //sdkUrl: 'https://zyom-011.unified.demandware.net/on/demandware.static/Sites-RefArch-Site/-/default/v0/sfp/sfp.js',
@@ -128,7 +128,7 @@ module.exports = {
                 path: 'api'
             },
             {
-                host: 'zyoe-009.dx.commercecloud.salesforce.com',
+                host: 'zyoe-006.dx.commercecloud.salesforce.com',
                 path: 'ocapi'
             }
         ]

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -94,15 +94,20 @@ module.exports = {
         },
         storeLocatorEnabled: true,
         multishipEnabled: true,
+        // Salesforce Payments configuration
+        // To enable, set enabled to true and provide the SDK and metadata URLs for your Commerce Cloud instance.
+        // Example URLs: https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js
+        //               https://<instance>.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json
+        /*sfPayments: {
+            enabled: false,
+            sdkUrl: '',
+            metadataUrl: ''
+        },*/
         sfPayments: {
             enabled: true,
             sdkUrl: 'https://zyoe-006.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js',
             metadataUrl:
                 'https://zyoe-006.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
-            // sdkUrl: 'https://ocapi-mon.demandware.net/on/demandware.static/Sites-Site/-/-/internal/jscript/sfp/v1/sfp.js',
-            // metadataUrl: 'https://ocapi-mon.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
-            //sdkUrl: 'https://zyom-011.unified.demandware.net/on/demandware.static/Sites-RefArch-Site/-/default/v0/sfp/sfp.js',
-            //metadataUrl: 'https://zyom-011.unified.demandware.net/on/demandware.static/Sites-Site/-/-/internal/metadata/v1.json'
         },
         googleCloudAPI: {
             apiKey: process.env.GOOGLE_CLOUD_API_KEY

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -22,6 +22,7 @@
     "push": "npm run build && pwa-kit-dev push",
     "save-credentials": "pwa-kit-dev save-credentials",
     "start": "cross-env NODE_ICU_DATA=node_modules/full-icu pwa-kit-dev start",
+    "start:https": "cross-env NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ICU_DATA=node_modules/full-icu DEV_SERVER_PROTOCOL=https DEV_SERVER_SSL_FILE_PATH=../../localhost.pem pwa-kit-dev start",
     "start:inspect": "npm run start -- --inspect",
     "start:pseudolocale": "npm run extract-default-translations && npm run compile-translations:pseudo && cross-env USE_PSEUDOLOCALE=true npm run start",
     "tail-logs": "pwa-kit-dev tail-logs",


### PR DESCRIPTION
Multiple issues have been addressed with this PR.  Please see the details in the description below

# Description
**useAddressFields.jsx — internationalized stateCode/postalCode fields**
Without this change (original code), if a customer adds {value: 'DE', label: 'Germany'} to SHIPPING_COUNTRY_CODES:
stateCode field: type is always 'select', options is always countryCode === 'CA' ? provinceOptions : stateOptions. So Germany gets a dropdown with US states (Alabama, Alaska...). So, its already broken!
stateCode required: Always required. So a German customer is forced to pick a US state. Completely wrong.
postalCode label: Says "Zip Code" for everything except CA. Minor but incorrect.
I feel the entire address form is wrong and needs rework but we don't have time for that.  So I am trying to introduce the least invasive risk.  Existing customers (US or Canada) will not see any difference but other international customers will see a textbox for state/province instead of a hard-coded US dropdown.

**hooks/use-sf-payments-country.js -- dynamic country for payment request**
We need to determine the country based on the site locale, else it will always default to US

**use-sf-payments.js — useSFPaymentsEnabled now checks both local config and API**
Currently we only support the value in the API BUT this can break existing customers who might have already modified some of the customers.  They can end up with a mix/match of with and without SF Payments.  So, with this change, sf payments will always be enabled anyway.  But customers have a kill switch to disable it if needed.

**checkout/index.jsx — added missing await on doCreateOrder()**

**Handlebars (bootstrap and templates default.js.hbs)** — need to change enabled: false to enabled: true for SF Payments
These handlebar changes are required so that customers who generate PWA based on our template will get the changes we added to SSR.js and default.js

Everything else (SLAS public/private, client IDs, _app-config changes) -- reverted back to public client instead of private client since PWA will be public by default in this release.  SF Payments works in public client.

Note: There will be a more cleanup tasks in a subsequent PR

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
