### PR TITLE
W-21372336: Fail Order for redirect based payments

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
@@ -14,12 +14,7 @@ import {FormattedMessage} from 'react-intl'
 import {Heading, Stack, Text} from '@salesforce/retail-react-app/app/components/shared/ui'
 import Link from '@salesforce/retail-react-app/app/components/link'
 
-import {
-    useOrder,
-    useShopperOrdersMutation,
-    useCommerceApi,
-    useAccessToken
-} from '@salesforce/commerce-sdk-react'
+import {useOrder, useShopperOrdersMutation} from '@salesforce/commerce-sdk-react'
 import {useQueryClient} from '@tanstack/react-query'
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'
 import {useSFPayments, STATUS_SUCCESS} from '@salesforce/retail-react-app/app/hooks/use-sf-payments'
@@ -49,8 +44,6 @@ const PaymentProcessing = () => {
     const {sfp} = useSFPayments()
     const toast = useToast()
     const queryClient = useQueryClient()
-    const api = useCommerceApi()
-    const {getTokenWhenReady} = useAccessToken()
 
     const {mutateAsync: updatePaymentInstrumentForOrder} = useShopperOrdersMutation(
         'updatePaymentInstrumentForOrder'
@@ -60,7 +53,7 @@ const PaymentProcessing = () => {
     const params = new URLSearchParams(location.search)
     const vendor = params.get('vendor')
     const orderNo = params.get('orderNo')
-    const {data: order} = useOrder(
+    const {data: order, refetch} = useOrder(
         {
             parameters: {orderNo}
         },
@@ -129,7 +122,7 @@ const PaymentProcessing = () => {
     /**
      * Attempts to fail an order and reopen the basket.
      * Only calls failOrder if the order status is 'created' (avoids hanging when order
-     * was already failed by webhook.)
+     * was already failed by webhook).
      * @returns {Promise<void>}
      */
     async function attemptFailOrderForPayment() {
@@ -138,13 +131,8 @@ const PaymentProcessing = () => {
         }
 
         try {
-            const token = await getTokenWhenReady()
-            const currentOrder = await api.shopperOrders.getOrder({
-                parameters: {orderNo},
-                headers: {Authorization: `Bearer ${token}`}
-            })
-
-            if (currentOrder.status === 'created') {
+            const {data: currentOrder} = await refetch()
+            if (currentOrder?.status === 'created') {
                 await failOrder({
                     parameters: {
                         orderNo,
@@ -156,9 +144,9 @@ const PaymentProcessing = () => {
                 })
             }
         } catch (error) {
-            // Swallow so flow continues (invalidate, navigate). Causes: (1) Race: getOrder
-            // returned 'created' but webhook already failed the order, so failOrder fails. (2) getOrder,
-            // getTokenWhenReady, or failOrder threw error. Behavior for all: don't hang.
+            // Swallow so flow continues (invalidate, navigate). Causes: (1) Race: refetch
+            // returned 'created' but webhook already failed the order, so failOrder fails. (2) refetch
+            // or failOrder threw (network, 4xx/5xx). Same behavior for all: don't hang.
         } finally {
             queryClient.invalidateQueries()
         }
@@ -210,7 +198,7 @@ const PaymentProcessing = () => {
                     duration: 30000
                 })
 
-                // Attempt to fail the order (no-op if already failed by webhook)
+                // Attempt to fail the order (no-op if already failed by webhook, e.g. 3DS declined)
                 await attemptFailOrderForPayment()
 
                 // Navigate back to the checkout page to try again

--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
@@ -90,7 +90,6 @@ const PaymentProcessing = () => {
 
     const isError = !isValidReturnUrl()
     const isHandled = useRef(false)
-    const failOrderCalledRef = useRef(false)
 
     async function handleAdyenRedirect() {
         // Find SF Payments payment instrument in order
@@ -134,7 +133,7 @@ const PaymentProcessing = () => {
      * @returns {Promise<void>}
      */
     async function attemptFailOrderForPayment() {
-        if (!orderNo || failOrderCalledRef.current) {
+        if (!orderNo) {
             return
         }
 
@@ -156,10 +155,11 @@ const PaymentProcessing = () => {
                     }
                 })
             }
-        } catch {
-            // Order may already be failed by webhook; avoid hanging
+        } catch (error) {
+            // Swallow so flow continues (invalidate, navigate). Causes: (1) Race: getOrder
+            // returned 'created' but webhook already failed the order, so failOrder fails. (2) getOrder,
+            // getTokenWhenReady, or failOrder threw error. Behavior for all: don't hang.
         } finally {
-            failOrderCalledRef.current = true
             queryClient.invalidateQueries()
         }
     }
@@ -210,11 +210,11 @@ const PaymentProcessing = () => {
                     duration: 30000
                 })
 
-                // Attempt to fail the order (no-op if already failed by webhook
+                // Attempt to fail the order (no-op if already failed by webhook)
                 await attemptFailOrderForPayment()
 
-                // Redirect to cart when payment fails
-                navigate('/cart')
+                // Navigate back to the checkout page to try again
+                navigate('/checkout')
             })()
         }
     }, [sfp, order])

--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.jsx
@@ -14,7 +14,13 @@ import {FormattedMessage} from 'react-intl'
 import {Heading, Stack, Text} from '@salesforce/retail-react-app/app/components/shared/ui'
 import Link from '@salesforce/retail-react-app/app/components/link'
 
-import {useOrder, useShopperOrdersMutation} from '@salesforce/commerce-sdk-react'
+import {
+    useOrder,
+    useShopperOrdersMutation,
+    useCommerceApi,
+    useAccessToken
+} from '@salesforce/commerce-sdk-react'
+import {useQueryClient} from '@tanstack/react-query'
 import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation'
 import {useSFPayments, STATUS_SUCCESS} from '@salesforce/retail-react-app/app/hooks/use-sf-payments'
 import {getSFPaymentsInstrument} from '@salesforce/retail-react-app/app/utils/sf-payments-utils'
@@ -42,6 +48,9 @@ const PaymentProcessing = () => {
     const navigate = useNavigation()
     const {sfp} = useSFPayments()
     const toast = useToast()
+    const queryClient = useQueryClient()
+    const api = useCommerceApi()
+    const {getTokenWhenReady} = useAccessToken()
 
     const {mutateAsync: updatePaymentInstrumentForOrder} = useShopperOrdersMutation(
         'updatePaymentInstrumentForOrder'
@@ -81,6 +90,7 @@ const PaymentProcessing = () => {
 
     const isError = !isValidReturnUrl()
     const isHandled = useRef(false)
+    const failOrderCalledRef = useRef(false)
 
     async function handleAdyenRedirect() {
         // Find SF Payments payment instrument in order
@@ -117,16 +127,41 @@ const PaymentProcessing = () => {
         )
     }
 
-    async function failOrderForPayment() {
-        await failOrder({
-            parameters: {
-                orderNo,
-                reopenBasket: true
-            },
-            body: {
-                reasonCode: 'payment_confirm_failure'
+    /**
+     * Attempts to fail an order and reopen the basket.
+     * Only calls failOrder if the order status is 'created' (avoids hanging when order
+     * was already failed by webhook.)
+     * @returns {Promise<void>}
+     */
+    async function attemptFailOrderForPayment() {
+        if (!orderNo || failOrderCalledRef.current) {
+            return
+        }
+
+        try {
+            const token = await getTokenWhenReady()
+            const currentOrder = await api.shopperOrders.getOrder({
+                parameters: {orderNo},
+                headers: {Authorization: `Bearer ${token}`}
+            })
+
+            if (currentOrder.status === 'created') {
+                await failOrder({
+                    parameters: {
+                        orderNo,
+                        reopenBasket: true
+                    },
+                    body: {
+                        reasonCode: 'payment_confirm_failure'
+                    }
+                })
             }
-        })
+        } catch {
+            // Order may already be failed by webhook; avoid hanging
+        } finally {
+            failOrderCalledRef.current = true
+            queryClient.invalidateQueries()
+        }
     }
 
     function showOrderConfirmation() {
@@ -139,7 +174,7 @@ const PaymentProcessing = () => {
             isHandled.current = true
 
             // Order exists but payment can't be processed for return URL
-            failOrderForPayment()
+            attemptFailOrderForPayment()
         } else if (!isError && sfp && order) {
             ;(async () => {
                 if (isHandled.current) {
@@ -175,11 +210,11 @@ const PaymentProcessing = () => {
                     duration: 30000
                 })
 
-                // Attempt to fail the order
-                await failOrderForPayment()
+                // Attempt to fail the order (no-op if already failed by webhook
+                await attemptFailOrderForPayment()
 
-                // Navigate back to the checkout page to try again
-                navigate('/checkout')
+                // Redirect to cart when payment fails
+                navigate('/cart')
             })()
         }
     }, [sfp, order])

--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
@@ -20,8 +20,7 @@ const mockUseOrder = jest.fn()
 const mockUpdatePaymentInstrumentForOrder = jest.fn()
 const mockFailOrder = jest.fn()
 const mockGetSFPaymentsInstrument = jest.fn()
-const mockGetOrder = jest.fn()
-const mockGetTokenWhenReady = jest.fn()
+const mockRefetchOrder = jest.fn()
 const mockInvalidateQueries = jest.fn()
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-navigation', () => ({
@@ -43,14 +42,6 @@ jest.mock('@salesforce/commerce-sdk-react', () => {
     const actual = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
         ...actual,
-        useCommerceApi: () => ({
-            shopperOrders: {
-                getOrder: mockGetOrder
-            }
-        }),
-        useAccessToken: () => ({
-            getTokenWhenReady: mockGetTokenWhenReady
-        }),
         useShopperOrdersMutation: (mutationKey) => {
             if (mutationKey === 'updatePaymentInstrumentForOrder') {
                 return {mutateAsync: mockUpdatePaymentInstrumentForOrder}
@@ -104,16 +95,18 @@ describe('PaymentProcessing', () => {
 
         mockUseOrder.mockReturnValue({
             data: {
-                orderNo: '12345'
-            }
+                orderNo: '12345',
+                status: 'created'
+            },
+            refetch: mockRefetchOrder
+        })
+        mockRefetchOrder.mockResolvedValue({
+            data: {orderNo: '12345', status: 'created'}
         })
 
         mockUpdatePaymentInstrumentForOrder.mockReturnValue({})
 
         mockGetSFPaymentsInstrument.mockReturnValue({})
-
-        mockGetOrder.mockResolvedValue({status: 'created'})
-        mockGetTokenWhenReady.mockResolvedValue('token')
     })
 
     afterEach(() => {
@@ -220,6 +213,13 @@ describe('PaymentProcessing', () => {
 
         test('renders error message for invalid Adyen URL missing type', async () => {
             mockLocation.search = '?vendor=Adyen&orderNo=12345&zoneId=default&redirectResult=ABC123'
+            mockUseOrder.mockReturnValue({
+                data: {orderNo: '12345'},
+                refetch: mockRefetchOrder
+            })
+            mockRefetchOrder.mockResolvedValue({
+                data: {orderNo: '12345', status: 'created'}
+            })
 
             renderWithProviders(<PaymentProcessing />)
 
@@ -229,7 +229,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
-                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockRefetchOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -245,6 +245,13 @@ describe('PaymentProcessing', () => {
 
         test('renders error message for invalid Adyen URL missing zone id', async () => {
             mockLocation.search = '?vendor=Adyen&orderNo=12345&type=klarna&redirectResult=ABC123'
+            mockUseOrder.mockReturnValue({
+                data: {orderNo: '12345'},
+                refetch: mockRefetchOrder
+            })
+            mockRefetchOrder.mockResolvedValue({
+                data: {orderNo: '12345', status: 'created'}
+            })
 
             renderWithProviders(<PaymentProcessing />)
 
@@ -254,7 +261,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
-                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockRefetchOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -270,6 +277,13 @@ describe('PaymentProcessing', () => {
 
         test('renders error message for invalid Adyen URL missing redirect result', async () => {
             mockLocation.search = '?vendor=Adyen&orderNo=12345&type=klarna&zoneId=default'
+            mockUseOrder.mockReturnValue({
+                data: {orderNo: '12345'},
+                refetch: mockRefetchOrder
+            })
+            mockRefetchOrder.mockResolvedValue({
+                data: {orderNo: '12345', status: 'created'}
+            })
 
             renderWithProviders(<PaymentProcessing />)
 
@@ -279,7 +293,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
-                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockRefetchOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -419,6 +433,9 @@ describe('PaymentProcessing', () => {
 
             test('shows toast and calls failOrder before navigating on failed payment', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
+                mockRefetchOrder.mockResolvedValue({
+                    data: {orderNo: '12345', status: 'created'}
+                })
 
                 renderWithProviders(<PaymentProcessing />)
 
@@ -427,7 +444,7 @@ describe('PaymentProcessing', () => {
                 })
 
                 await waitFor(() => {
-                    expect(mockGetOrder).toHaveBeenCalled()
+                    expect(mockRefetchOrder).toHaveBeenCalled()
                     expect(mockFailOrder).toHaveBeenCalledTimes(1)
                     expect(mockFailOrder).toHaveBeenCalledWith({
                         parameters: {
@@ -445,7 +462,9 @@ describe('PaymentProcessing', () => {
 
             test('does not call failOrder when order already failed by webhook', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
-                mockGetOrder.mockResolvedValue({status: 'failed'})
+                mockRefetchOrder.mockResolvedValue({
+                    data: {orderNo: '12345', status: 'failed'}
+                })
 
                 renderWithProviders(<PaymentProcessing />)
 
@@ -454,13 +473,15 @@ describe('PaymentProcessing', () => {
                     expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                 })
 
-                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockRefetchOrder).toHaveBeenCalled()
                 expect(mockFailOrder).not.toHaveBeenCalled()
             })
 
             test('shows toast and navigates to checkout when failOrder fails', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
-                mockGetOrder.mockResolvedValue({status: 'created'})
+                mockRefetchOrder.mockResolvedValue({
+                    data: {orderNo: '12345', status: 'created'}
+                })
                 mockFailOrder.mockRejectedValue(new Error('Order already failed'))
 
                 renderWithProviders(<PaymentProcessing />)
@@ -470,7 +491,7 @@ describe('PaymentProcessing', () => {
                     expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                 })
 
-                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockRefetchOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockInvalidateQueries).toHaveBeenCalled()
             })
@@ -481,8 +502,13 @@ describe('PaymentProcessing', () => {
                 for (const code of errorCodes) {
                     jest.clearAllMocks()
                     mockHandleRedirect.mockResolvedValue({responseCode: code})
-                    mockGetOrder.mockResolvedValue({status: 'created'})
-                    mockGetTokenWhenReady.mockResolvedValue('token')
+                    mockUseOrder.mockReturnValue({
+                        data: {orderNo: '12345', status: 'created'},
+                        refetch: mockRefetchOrder
+                    })
+                    mockRefetchOrder.mockResolvedValue({
+                        data: {orderNo: '12345', status: 'created'}
+                    })
 
                     renderWithProviders(<PaymentProcessing />)
 
@@ -607,6 +633,10 @@ describe('PaymentProcessing', () => {
             })
 
             test('shows toast and calls failOrder before navigating on failed payment', async () => {
+                mockRefetchOrder.mockResolvedValue({
+                    data: {orderNo: '12345', status: 'created'}
+                })
+
                 renderWithProviders(<PaymentProcessing />)
 
                 await waitFor(() => {
@@ -614,7 +644,7 @@ describe('PaymentProcessing', () => {
                 })
 
                 await waitFor(() => {
-                    expect(mockGetOrder).toHaveBeenCalled()
+                    expect(mockRefetchOrder).toHaveBeenCalled()
                     expect(mockFailOrder).toHaveBeenCalledTimes(1)
                     expect(mockFailOrder).toHaveBeenCalledWith({
                         parameters: {

--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
@@ -20,6 +20,9 @@ const mockUseOrder = jest.fn()
 const mockUpdatePaymentInstrumentForOrder = jest.fn()
 const mockFailOrder = jest.fn()
 const mockGetSFPaymentsInstrument = jest.fn()
+const mockGetOrder = jest.fn()
+const mockGetTokenWhenReady = jest.fn()
+const mockInvalidateQueries = jest.fn()
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-navigation', () => ({
     __esModule: true,
@@ -40,6 +43,14 @@ jest.mock('@salesforce/commerce-sdk-react', () => {
     const actual = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
         ...actual,
+        useCommerceApi: () => ({
+            shopperOrders: {
+                getOrder: mockGetOrder
+            }
+        }),
+        useAccessToken: () => ({
+            getTokenWhenReady: mockGetTokenWhenReady
+        }),
         useShopperOrdersMutation: (mutationKey) => {
             if (mutationKey === 'updatePaymentInstrumentForOrder') {
                 return {mutateAsync: mockUpdatePaymentInstrumentForOrder}
@@ -50,6 +61,16 @@ jest.mock('@salesforce/commerce-sdk-react', () => {
             return {mutateAsync: jest.fn()}
         },
         useOrder: () => mockUseOrder()
+    }
+})
+
+jest.mock('@tanstack/react-query', () => {
+    const actual = jest.requireActual('@tanstack/react-query')
+    return {
+        ...actual,
+        useQueryClient: () => ({
+            invalidateQueries: mockInvalidateQueries
+        })
     }
 })
 
@@ -90,6 +111,9 @@ describe('PaymentProcessing', () => {
         mockUpdatePaymentInstrumentForOrder.mockReturnValue({})
 
         mockGetSFPaymentsInstrument.mockReturnValue({})
+
+        mockGetOrder.mockResolvedValue({status: 'created'})
+        mockGetTokenWhenReady.mockResolvedValue('token')
     })
 
     afterEach(() => {
@@ -205,6 +229,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
+                expect(mockGetOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -229,6 +254,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
+                expect(mockGetOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -253,6 +279,7 @@ describe('PaymentProcessing', () => {
             expect(screen.getByText('Return to Checkout')).toBeInTheDocument()
 
             await waitFor(() => {
+                expect(mockGetOrder).toHaveBeenCalled()
                 expect(mockFailOrder).toHaveBeenCalledTimes(1)
                 expect(mockFailOrder).toHaveBeenCalledWith({
                     parameters: {
@@ -380,13 +407,13 @@ describe('PaymentProcessing', () => {
                 })
             })
 
-            test('navigates back to checkout on failed payment', async () => {
+            test('navigates to cart on failed payment', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
 
                 renderWithProviders(<PaymentProcessing />)
 
                 await waitFor(() => {
-                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
                 })
             })
 
@@ -400,6 +427,7 @@ describe('PaymentProcessing', () => {
                 })
 
                 await waitFor(() => {
+                    expect(mockGetOrder).toHaveBeenCalled()
                     expect(mockFailOrder).toHaveBeenCalledTimes(1)
                     expect(mockFailOrder).toHaveBeenCalledWith({
                         parameters: {
@@ -412,7 +440,22 @@ describe('PaymentProcessing', () => {
                     })
                 })
 
-                expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                expect(mockNavigate).toHaveBeenCalledWith('/cart')
+            })
+
+            test('does not call failOrder when order already failed by webhook (e.g. 3DS declined)', async () => {
+                mockHandleRedirect.mockResolvedValue({responseCode: 1})
+                mockGetOrder.mockResolvedValue({status: 'failed'})
+
+                renderWithProviders(<PaymentProcessing />)
+
+                await waitFor(() => {
+                    expect(mockToast).toHaveBeenCalled()
+                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                })
+
+                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockFailOrder).not.toHaveBeenCalled()
             })
 
             test('handles different error response codes', async () => {
@@ -421,12 +464,14 @@ describe('PaymentProcessing', () => {
                 for (const code of errorCodes) {
                     jest.clearAllMocks()
                     mockHandleRedirect.mockResolvedValue({responseCode: code})
+                    mockGetOrder.mockResolvedValue({status: 'created'})
+                    mockGetTokenWhenReady.mockResolvedValue('token')
 
                     renderWithProviders(<PaymentProcessing />)
 
                     await waitFor(() => {
                         expect(mockToast).toHaveBeenCalled()
-                        expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                        expect(mockNavigate).toHaveBeenCalledWith('/cart')
                     })
                 }
             })
@@ -536,11 +581,11 @@ describe('PaymentProcessing', () => {
                 })
             })
 
-            test('navigates back to checkout on failed payment', async () => {
+            test('navigates to cart on failed payment', async () => {
                 renderWithProviders(<PaymentProcessing />)
 
                 await waitFor(() => {
-                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
                 })
             })
 
@@ -552,6 +597,7 @@ describe('PaymentProcessing', () => {
                 })
 
                 await waitFor(() => {
+                    expect(mockGetOrder).toHaveBeenCalled()
                     expect(mockFailOrder).toHaveBeenCalledTimes(1)
                     expect(mockFailOrder).toHaveBeenCalledWith({
                         parameters: {
@@ -564,7 +610,7 @@ describe('PaymentProcessing', () => {
                     })
                 })
 
-                expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                expect(mockNavigate).toHaveBeenCalledWith('/cart')
             })
         })
     })

--- a/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout/payment-processing.test.js
@@ -407,13 +407,13 @@ describe('PaymentProcessing', () => {
                 })
             })
 
-            test('navigates to cart on failed payment', async () => {
+            test('navigates back to checkout on failed payment', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
 
                 renderWithProviders(<PaymentProcessing />)
 
                 await waitFor(() => {
-                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                 })
             })
 
@@ -440,10 +440,10 @@ describe('PaymentProcessing', () => {
                     })
                 })
 
-                expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                expect(mockNavigate).toHaveBeenCalledWith('/checkout')
             })
 
-            test('does not call failOrder when order already failed by webhook (e.g. 3DS declined)', async () => {
+            test('does not call failOrder when order already failed by webhook', async () => {
                 mockHandleRedirect.mockResolvedValue({responseCode: 1})
                 mockGetOrder.mockResolvedValue({status: 'failed'})
 
@@ -451,11 +451,28 @@ describe('PaymentProcessing', () => {
 
                 await waitFor(() => {
                     expect(mockToast).toHaveBeenCalled()
-                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                 })
 
                 expect(mockGetOrder).toHaveBeenCalled()
                 expect(mockFailOrder).not.toHaveBeenCalled()
+            })
+
+            test('shows toast and navigates to checkout when failOrder fails', async () => {
+                mockHandleRedirect.mockResolvedValue({responseCode: 1})
+                mockGetOrder.mockResolvedValue({status: 'created'})
+                mockFailOrder.mockRejectedValue(new Error('Order already failed'))
+
+                renderWithProviders(<PaymentProcessing />)
+
+                await waitFor(() => {
+                    expect(mockToast).toHaveBeenCalled()
+                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
+                })
+
+                expect(mockGetOrder).toHaveBeenCalled()
+                expect(mockFailOrder).toHaveBeenCalledTimes(1)
+                expect(mockInvalidateQueries).toHaveBeenCalled()
             })
 
             test('handles different error response codes', async () => {
@@ -471,7 +488,7 @@ describe('PaymentProcessing', () => {
 
                     await waitFor(() => {
                         expect(mockToast).toHaveBeenCalled()
-                        expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                        expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                     })
                 }
             })
@@ -581,11 +598,11 @@ describe('PaymentProcessing', () => {
                 })
             })
 
-            test('navigates to cart on failed payment', async () => {
+            test('navigates back to checkout on failed payment', async () => {
                 renderWithProviders(<PaymentProcessing />)
 
                 await waitFor(() => {
-                    expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                    expect(mockNavigate).toHaveBeenCalledWith('/checkout')
                 })
             })
 
@@ -610,7 +627,7 @@ describe('PaymentProcessing', () => {
                     })
                 })
 
-                expect(mockNavigate).toHaveBeenCalledWith('/cart')
+                expect(mockNavigate).toHaveBeenCalledWith('/checkout')
             })
         })
     })


### PR DESCRIPTION
# Description

When we have a failed order on redirect based payments, checkout page just kept loading indefinitely. 

Cause:
Previously, the code always called failOrder when payment failed or the return URL was invalid. But this caused an issue when either payment already failed on provider's end, or a webhook already failed it : the user landed on the checkout page, and tried to fail the same order again which caused the load indefinitely.

Fix: We try to fail an order if the order is still in a state we can fail. We also attempt to fail the order only once per page load (guardrail against multiple failOrders)

Testing:

1. Tested failOrder with 3DS declined card:
<img width="1722" height="944" alt="Screenshot 2026-03-03 at 9 47 38 AM" src="https://github.com/user-attachments/assets/47d2864b-05df-44a4-9e4e-97a146d59a75" />


3. Tested Afterpay declined  transaction:

<img width="1727" height="994" alt="Screenshot 2026-03-03 at 8 21 29 AM" src="https://github.com/user-attachments/assets/fa7a73fd-904a-4d05-8fb5-7da36c8a2522" />








# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
