### PR TITLE
[release] Avoid accidentally releasing the mcp package 

### DIFF
--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -10,7 +10,7 @@
 const sh = require('shelljs')
 const path = require('path')
 const program = require('commander')
-const {saveJSONToFile, setPackageVersion} = require('../utils')
+const {saveJSONToFile, setPackageVersion, getLatestVersion} = require('../utils')
 
 // Exit upon error
 sh.set('-e')
@@ -68,11 +68,20 @@ const main = (program) => {
     // update versions for root package and root package lock
     setPackageVersion(newMonorepoVersion, {cwd: rootPath})
 
+    const notices = []
     independentPackages.forEach((pkg) => {
-        const {location, version: oldVersion} = pkg
+        const {name, location, version: repoVersion} = pkg
+        let restoreVersion = repoVersion
+        if (name === '@salesforce/pwa-kit-mcp') {
+            restoreVersion = getLatestVersion(name)
+            notices.push(
+                `⚠️  Restoring ${name} to its latest published npm version (${restoreVersion}) instead of the repo's dev version (${repoVersion}).\n` +
+                `   This package is released independently and excluded from the monorepo SDK version bump to avoid publishing an unreleased dev version to npm.`
+            )
+        }
         // Restore to the original version
         // TODO: is it possible to _not_ trigger the lifecycle scripts? See commerce-sdk-react/CHANGELOG.md
-        setPackageVersion(oldVersion, {cwd: location})
+        setPackageVersion(restoreVersion, {cwd: location})
     })
 
     // Now that all of the package version updates are done,
@@ -91,6 +100,8 @@ const main = (program) => {
     sh.exec('npm install')
 
     listAllVersions()
+
+    notices.forEach((msg) => console.log(`\n${msg}`))
 }
 
 const updatePeerDeps = (pkgJson, newMonorepoVersion) => {

--- a/scripts/bump-version/index.js
+++ b/scripts/bump-version/index.js
@@ -76,7 +76,7 @@ const main = (program) => {
             restoreVersion = getLatestVersion(name)
             notices.push(
                 `⚠️  Restoring ${name} to its latest published npm version (${restoreVersion}) instead of the repo's dev version (${repoVersion}).\n` +
-                `   This package is released independently and excluded from the monorepo SDK version bump to avoid publishing an unreleased dev version to npm.`
+                    `   This package is released independently and excluded from the monorepo SDK version bump to avoid publishing an unreleased dev version to npm.`
             )
         }
         // Restore to the original version

--- a/scripts/bump-version/pwa-kit-deps-version.js
+++ b/scripts/bump-version/pwa-kit-deps-version.js
@@ -8,7 +8,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const sh = require('shelljs')
 const path = require('path')
-const {saveJSONToFile} = require('../utils')
+const {saveJSONToFile, getLatestVersion} = require('../utils')
 
 // Exit upon error
 sh.set('-e')
@@ -49,10 +49,6 @@ const main = () => {
     }
 
     saveJSONToFile(pkgJson, pathToPackageJson)
-}
-
-const getLatestVersion = (pkgName) => {
-    return sh.exec(`npm info ${pkgName}@latest version`, {silent: true}).trim()
 }
 
 main()

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -16,7 +16,12 @@ const setPackageVersion = (version, shellOptions = {}) => {
     sh.exec(`npm version --no-git-tag ${version}`, {silent: true, ...shellOptions})
 }
 
+const getLatestVersion = (pkgName) => {
+    return sh.exec(`npm info ${pkgName}@latest version`, {silent: true}).trim()
+}
+
 module.exports = {
     saveJSONToFile,
-    setPackageVersion
+    setPackageVersion,
+    getLatestVersion
 }


### PR DESCRIPTION
Since pwa-kit-mcp package is to be released separately, whenever we bump up the versions of the SDK packages, we need to:
- avoid bumping up the version of the mcp package
- and actually _downgrading_ its version to the latest published version (so it won't get published to npm)

## How to test drive the PR

Let's try bumping up the SDK versions:

1. Run `npm run bump-version -- 3.20.0` in your terminal
2. Verify that all the SDK packages are bumped up to the new version
3. ...except for the MCP package, which will be downgraded to the latest npm version 0.4.0.

The result of `bump-version` script should look like this:

<img width="1305" height="522" alt="Ghostty 2026-03-06 at 12 21 16" src="https://github.com/user-attachments/assets/dc8bc687-e043-43a4-9ac9-856a3bf93dd0" />
