### PR TITLE
@W-21414441@ Bugfix - Fix adding to cart from a master product in the wishlist

### DIFF
--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -791,3 +791,77 @@ export const selectStoreFromPLP = async ({page}) => {
         await page.getByRole('button', {name: 'Close'}).click()
     }
 }
+
+/**
+ * Tests that a master product in the wishlist can be added to cart via the "View Options" modal.
+ *
+ * Flow:
+ * 1. Log in or register a shopper
+ * 2. Navigate to PDP and add a product to wishlist without selecting all variants (master product)
+ * 3. Go to wishlist page
+ * 4. Click "View Options" to open the product modal
+ * 5. Select variant attributes in the modal
+ * 6. Click "Add to Cart"
+ * 7. Verify the item was added successfully
+ */
+export const wishlistMasterProductAddToCartFlow = async ({page, registeredUserCredentials}) => {
+    const isLoggedIn = await loginShopper({
+        page,
+        userCredentials: registeredUserCredentials
+    })
+
+    if (!isLoggedIn) {
+        try {
+            await registerShopper({
+                page,
+                userCredentials: registeredUserCredentials
+            })
+        } catch (error) {
+            const secondLoginAttempt = await loginShopper({
+                page,
+                userCredentials: registeredUserCredentials
+            })
+            if (!secondLoginAttempt) {
+                throw new Error('Authentication failed: Both login and registration unsuccessful')
+            }
+        }
+    }
+
+    await answerConsentTrackingForm(page)
+    await page.waitForLoadState()
+
+    // Navigate to PDP without selecting all variants so the master product is added to wishlist
+    await navigateToPDPDesktop({page})
+    await expect(page.getByRole('heading', {name: /Cotton Turtleneck Sweater/i})).toBeVisible()
+
+    // Do NOT select a size — this ensures the master product ID is used for the wishlist item
+    await page.getByRole('button', {name: /Add to Wishlist/i}).click()
+    await expect(page.getByText(/1 item added to wishlist/i)).toBeVisible()
+
+    // Navigate to wishlist page
+    await page.goto(config.RETAIL_APP_HOME + '/account/wishlist')
+    await answerConsentTrackingForm(page)
+
+    await expect(page.getByRole('heading', {name: /Wishlist/i})).toBeVisible()
+    await expect(page.getByRole('heading', {name: /Cotton Turtleneck Sweater/i})).toBeVisible()
+
+    // Master product should show "View Options" button instead of "Add to Cart"
+    const viewOptionsButton = page.getByRole('button', {name: /View Options/i})
+    await expect(viewOptionsButton).toBeVisible()
+    await viewOptionsButton.click()
+
+    // Wait for the product view modal to appear
+    const modal = page.getByTestId('product-view-modal')
+    await expect(modal).toBeVisible({timeout: 10000})
+
+    // Select variant attributes in the modal
+    await modal.getByRole('radio', {name: 'L', exact: true}).click()
+
+    // Click "Add to Cart" in the modal
+    const addToCartButton = modal.getByRole('button', {name: /Add to Cart/i})
+    await expect(addToCartButton).toBeEnabled({timeout: 5000})
+    await addToCartButton.click()
+
+    // Verify item was added to cart successfully (no API error)
+    await expect(page.getByText(/1 item added to cart/i)).toBeVisible({timeout: 10000})
+}

--- a/e2e/tests/desktop/registered-shopper.spec.js
+++ b/e2e/tests/desktop/registered-shopper.spec.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import {wishlistFlow} from '../../scripts/pageHelpers'
+import {wishlistFlow, wishlistMasterProductAddToCartFlow} from '../../scripts/pageHelpers'
 
 const {test, expect} = require('@playwright/test')
 const {
@@ -38,6 +38,14 @@ test.skip('Registered shopper can checkout items', async ({page}) => {
  */
 test('Registered shopper can add item to wishlist', async ({page}) => {
     await wishlistFlow({page, registeredUserCredentials})
+})
+
+/**
+ * Test that a master product in the wishlist can be added to cart
+ * via the "View Options" modal with correct quantity
+ */
+test('Registered shopper can add master product from wishlist to cart', async ({page}) => {
+    await wishlistMasterProductAddToCartFlow({page, registeredUserCredentials})
 })
 
 /**

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v9.1.0-preview.0 (Mar 06, 2026)
 - [Bugfix] Fix in checkout and cart page: LoadingSpinner to have full screen overlay [#3730](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3730)
+- [Bugfix] Fix adding to cart from a master product in the wishlist
 - Add Page Designer Support [#3727](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3727)
 - [Feature] Add Salesforce Payments support in checkout [#3725](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3725)
 - One Click Checkout removed from Developer Preview. When shoppers use passwordless OTP login with one-click checkout, the system saves their shipping and payment information for faster checkout in the future. Security safeguards required: (1) Captcha - Protects the passwordless login from bots. (2) OTP for Email Changes - Verifies identity before an email update, prevents accidental account lockouts from typos, and prevents unauthorized access to saved payment methods.

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v9.1.0-preview.0 (Mar 06, 2026)
 - [Bugfix] Fix in checkout and cart page: LoadingSpinner to have full screen overlay [#3730](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3730)
-- [Bugfix] Fix adding to cart from a master product in the wishlist
+- [Bugfix] Fix adding to cart from a master product in the wishlist [#3732](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3732)
 - Add Page Designer Support [#3727](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3727)
 - [Feature] Add Salesforce Payments support in checkout [#3725](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3725)
 - One Click Checkout removed from Developer Preview. When shoppers use passwordless OTP login with one-click checkout, the system saves their shipping and payment information for faster checkout in the future. Security safeguards required: (1) Captcha - Protects the passwordless login from bots. (2) OTP for Email Changes - Verifies identity before an email update, prevents accidental account lockouts from typos, and prevents unauthorized access to saved payment methods.

--- a/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.jsx
+++ b/packages/template-retail-react-app/app/pages/account/wishlist/partials/wishlist-primary-action.jsx
@@ -181,7 +181,10 @@ const WishlistPrimaryAction = () => {
                             onOpen={onOpen}
                             onClose={onClose}
                             product={variant}
-                            addToCart={(variant, quantity) => handleAddToCart(variant, quantity)}
+                            addToCart={(items) => {
+                                const {product, variant, quantity} = items[0]
+                                return handleAddToCart(variant || product, quantity)
+                            }}
                         />
                     )}
                 </>


### PR DESCRIPTION
This PR fixes an add to cart bug in the wishlist when the product in the wishlist is a master.

The root cause of the problem was a function signature mismatch.
The ProductView component calls `addToCart([{product, variant, quantity}])` ([as seen here](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/template-retail-react-app/app/components/product-view/index.jsx#L401)) , a singular array argument.

Meanwhile, wishlist-primary-action expects `addToCart={(variant, quantity) => handleAddToCart(variant, quantity)}`. Note the separate variant / quantity args. As a result, the entire array of [{product, variant, quantity}] would get passed into variant, leaving quantity undefined.

Test steps:
- Start the app
- Log in
- Add a master product to the wishlist (ie. Cotton Turtleneck Sweater)
- Go to the wishlist and verify the master product is present (You'll see a `More Options` rather than an `Add to Cart` button)
- Click `More Options`
- Select a variant and add to cart