### PR TITLE
@W-21551291: [1CC][PWA Kit] Custom billing address lost after OTP registration

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import {
     Alert,
     AlertIcon,
@@ -102,6 +102,12 @@ const CheckoutOneClick = () => {
     const hasDeliveryShipments = deliveryShipments.length > 0
     const isPickupOnly = hasPickupShipments && !hasDeliveryShipments
     const [billingSameAsShipping, setBillingSameAsShipping] = useState(true)
+
+    const billingSameAsShippingRef = useRef(billingSameAsShipping)
+    useEffect(() => {
+        billingSameAsShippingRef.current = billingSameAsShipping
+    }, [billingSameAsShipping])
+
     const [isShipmentCleanupComplete, setIsShipmentCleanupComplete] = useState(false)
     // For billing=shipping, align with legacy: use the first delivery shipment's address
     const selectedShippingAddress =
@@ -221,9 +227,11 @@ const CheckoutOneClick = () => {
         }
     }, [isPickupOnly])
 
-    const onBillingSubmit = async () => {
+    const onBillingSubmit = async (billingFormSnapshot) => {
         let billingAddress
-        if (billingSameAsShipping && selectedShippingAddress) {
+        // Read from ref to avoid stale closures during async onPlaceOrder flow
+        const isSameAsShipping = billingSameAsShippingRef.current
+        if (isSameAsShipping && selectedShippingAddress) {
             billingAddress = selectedShippingAddress
             // Validate that shipping address has required address fields
             if (!billingAddress?.address1) {
@@ -236,6 +244,11 @@ const CheckoutOneClick = () => {
                 return
             }
         } else {
+            // If a pre-captured snapshot was provided, restore it to the form.
+            if (billingFormSnapshot) {
+                billingAddressForm.reset(billingFormSnapshot, {keepDirty: true})
+            }
+
             // Validate all required address fields (excluding phone for billing)
             const fieldsToValidate = [
                 'address1',
@@ -421,6 +434,11 @@ const CheckoutOneClick = () => {
                 }
             }
 
+            // Snapshot billing form values BEFORE any payment mutations to preserve custom billing address during auth transitions
+            const billingFormSnapshot = !billingSameAsShippingRef.current
+                ? {...billingAddressForm.getValues()}
+                : null
+
             // PCI: Cardholder data (CHD) - use only for single submission to API. Do not log, persist, or expose.
             let fullCardDetails = null
             if (hasFormValues) {
@@ -480,7 +498,7 @@ const CheckoutOneClick = () => {
 
             // If successful `onBillingSubmit` returns the updated basket. If the form was invalid on
             // submit, `undefined` is returned.
-            const updatedBasket = await onBillingSubmit()
+            const updatedBasket = await onBillingSubmit(billingFormSnapshot)
 
             if (updatedBasket) {
                 await submitOrder(fullCardDetails)
@@ -619,6 +637,13 @@ const CheckoutContainer = () => {
     const toast = useToast()
     const [isDeletingUnavailableItem, setIsDeletingUnavailableItem] = useState(false)
 
+    // Track whether the checkout has rendered at least once to persist data during auth transitions
+    const hasRenderedCheckoutRef = useRef(false)
+    const canRender = !!customer?.customerId && !!basket?.basketId
+    if (canRender) {
+        hasRenderedCheckoutRef.current = true
+    }
+
     const handleRemoveItem = async (product) => {
         await removeItemFromBasketMutation.mutateAsync(
             {
@@ -651,7 +676,8 @@ const CheckoutContainer = () => {
         setIsDeletingUnavailableItem(false)
     }
 
-    if (!customer || !customer.customerId || !basket || !basket.basketId) {
+    // Show skeleton only on the initial load
+    if (!canRender && !hasRenderedCheckoutRef.current) {
         return <CheckoutSkeleton />
     }
 


### PR DESCRIPTION
Summary of bug: When a guest user enters a custom billing address (different from shipping) and then registers via OTP during one-click checkout, the order is placed with the shipping address as the billing address instead of the custom one the shopper entered.

# Description

Root cause: After OTP registration, the checkout step advances to REVIEW_ORDER, which toggles the payment ToggleCard to summary mode and unmounts the billing ShippingAddressSelection component. When onPlaceOrder calls setIsEditingPayment(true), the component remounts and its mount effect resets the billing form to the customer's preferred saved address (the shipping address), overwriting the custom billing values. onBillingSubmit then reads the reset form and sends the shipping address to the API.

Fix: Snapshot the billing form values in onPlaceOrder before any payment mutations, and restore them in onBillingSubmit before validation. Additionally, keep CheckoutOneClick mounted during auth transitions using a ref guard in CheckoutContainer, and use a ref mirror of billingSameAsShipping to prevent stale closure reads in the async Place Order flow.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

The actual fix relies on the three remaining changes:
billingSameAsShippingRef -- reads the latest value in async flows
Billing form snapshot in onPlaceOrder -- captures values before payment mutations
onBillingSubmit(billingFormSnapshot) -- restores the snapshot before validation
hasRenderedCheckoutRef in CheckoutContainer -- keeps the component mounted during auth transitions

# How to Test-Drive This PR

Newly registered shoppers via OTP in 1CC in 2 scenarios:
-- Enter a custom billing address -> Register with OTP -> See the custom billing address retained -> Place Order
-- Keep billing address same as shipping -> Register with OTP -> Enter a custom billing address -> Place Order

Returning shoppers + Guest shoppers behavior should be the same.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
