### PR TITLE
@W-21551291: [1CC][PWA Kit] Custom billing address lost after OTP registration

### DIFF
--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -500,7 +500,7 @@ const CheckoutOneClick = () => {
 
             // If successful `onBillingSubmit` returns the updated basket. If the form was invalid on
             // submit, `undefined` is returned.
-            
+
             const updatedBasket = await onBillingSubmit(billingFormSnapshot)
 
             if (updatedBasket) {

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import {
     Alert,
     AlertIcon,
@@ -102,6 +102,12 @@ const CheckoutOneClick = () => {
     const hasDeliveryShipments = deliveryShipments.length > 0
     const isPickupOnly = hasPickupShipments && !hasDeliveryShipments
     const [billingSameAsShipping, setBillingSameAsShipping] = useState(true)
+
+    const billingSameAsShippingRef = useRef(billingSameAsShipping)
+    useEffect(() => {
+        billingSameAsShippingRef.current = billingSameAsShipping
+    }, [billingSameAsShipping])
+
     const [isShipmentCleanupComplete, setIsShipmentCleanupComplete] = useState(false)
     // For billing=shipping, align with legacy: use the first delivery shipment's address
     const selectedShippingAddress =
@@ -221,9 +227,11 @@ const CheckoutOneClick = () => {
         }
     }, [isPickupOnly])
 
-    const onBillingSubmit = async () => {
+    const onBillingSubmit = async (billingFormSnapshot) => {
         let billingAddress
-        if (billingSameAsShipping && selectedShippingAddress) {
+        // Read from ref to avoid stale closures during async onPlaceOrder flow
+        const isSameAsShipping = billingSameAsShippingRef.current
+        if (isSameAsShipping && selectedShippingAddress) {
             billingAddress = selectedShippingAddress
             // Validate that shipping address has required address fields
             if (!billingAddress?.address1) {
@@ -236,6 +244,11 @@ const CheckoutOneClick = () => {
                 return
             }
         } else {
+            // If a pre-captured snapshot was provided, restore it to the form.
+            if (billingFormSnapshot) {
+                billingAddressForm.reset(billingFormSnapshot, {keepDirty: true})
+            }
+
             // Validate all required address fields (excluding phone for billing)
             const fieldsToValidate = [
                 'address1',
@@ -421,6 +434,11 @@ const CheckoutOneClick = () => {
                 }
             }
 
+            // Snapshot billing form values BEFORE any payment mutations to preserve custom billing address during auth transitions
+            const billingFormSnapshot = !billingSameAsShippingRef.current
+                ? {...billingAddressForm.getValues()}
+                : null
+
             // PCI: Cardholder data (CHD) - use only for single submission to API. Do not log, persist, or expose.
             let fullCardDetails = null
             if (hasFormValues) {
@@ -480,7 +498,7 @@ const CheckoutOneClick = () => {
 
             // If successful `onBillingSubmit` returns the updated basket. If the form was invalid on
             // submit, `undefined` is returned.
-            const updatedBasket = await onBillingSubmit()
+            const updatedBasket = await onBillingSubmit(billingFormSnapshot)
 
             if (updatedBasket) {
                 await submitOrder(fullCardDetails)
@@ -619,6 +637,13 @@ const CheckoutContainer = () => {
     const toast = useToast()
     const [isDeletingUnavailableItem, setIsDeletingUnavailableItem] = useState(false)
 
+    // Track whether the checkout has rendered at least once to persist data during auth transitions
+    const hasRenderedCheckoutRef = useRef(false)
+    const canRender = !!customer?.customerId && !!basket?.basketId
+    if (canRender) {
+        hasRenderedCheckoutRef.current = true
+    }
+
     const handleRemoveItem = async (product) => {
         await removeItemFromBasketMutation.mutateAsync(
             {
@@ -651,7 +676,8 @@ const CheckoutContainer = () => {
         setIsDeletingUnavailableItem(false)
     }
 
-    if (!customer || !customer.customerId || !basket || !basket.basketId) {
+    // Show skeleton only on the initial load
+    if (!canRender && !hasRenderedCheckoutRef.current) {
         return <CheckoutSkeleton />
     }
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -297,8 +297,10 @@ const CheckoutOneClick = () => {
         }
 
         const latestBasketId = currentBasketQuery.data?.basketId || basket.basketId
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const {addressId, creationDate, lastModified, preferred, ...address} = billingAddress
         return await updateBillingAddressForBasket({
-            body: billingAddress,
+            body: address,
             parameters: {basketId: latestBasketId}
         })
     }
@@ -498,6 +500,7 @@ const CheckoutOneClick = () => {
 
             // If successful `onBillingSubmit` returns the updated basket. If the form was invalid on
             // submit, `undefined` is returned.
+            
             const updatedBasket = await onBillingSubmit(billingFormSnapshot)
 
             if (updatedBasket) {

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -830,7 +830,6 @@ describe('Checkout One Click', () => {
         window.history.pushState({}, 'Checkout', createPathWithDefaults('/checkout'))
         const {user} = renderWithProviders(<WrappedCheckout history={history} />, {
             wrapperProps: {
-                // Not bypassing auth as usual, so we can test the guest-to-registered flow
                 bypassAuth: true,
                 isGuest: false,
                 siteAlias: 'uk',
@@ -839,14 +838,13 @@ describe('Checkout One Click', () => {
             }
         })
 
-        await waitFor(() => {
-            expect(screen.getByTestId('sf-checkout-shipping-address-0')).toBeInTheDocument()
-        })
+        // If the step auto-advanced, reopen the Shipping Address step
+        const reopenBtn = screen.queryByRole('button', {name: /edit shipping address/i})
+        if (reopenBtn) {
+            await user.click(reopenBtn)
+        }
 
-        // Add address
-        await user.click(screen.getByText(/add new address/i))
-
-        // Wait for the shipping address section to show a name (either address)
+        // Wait for the shipping address card or summary to be visible in step-1
         await waitFor(() => {
             const container = screen.getByTestId('sf-toggle-card-step-1-content')
             const names = within(container).getAllByText((_, n) =>
@@ -855,7 +853,13 @@ describe('Checkout One Click', () => {
             expect(names.length).toBeGreaterThan(0)
         })
 
-        // Verify the saved address is displayed (automatically selected in one-click checkout)
+        // Click "Add New Address" if visible (edit mode), otherwise click "Change" to reopen
+        const addNewBtn = screen.queryByText(/add new address/i)
+        if (addNewBtn) {
+            await user.click(addNewBtn)
+        }
+
+        // Verify the saved address is displayed
         const addressElements = screen.getAllByText('123 Main St')
         expect(addressElements.length).toBeGreaterThan(0)
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info.test.js
@@ -7,7 +7,10 @@
 import React from 'react'
 import {screen, waitFor, fireEvent, act} from '@testing-library/react'
 import ContactInfo from '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info'
-import {setCheckoutGuestChoiceInStorage} from '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context'
+import {
+    setCheckoutGuestChoiceInStorage,
+    useCheckout
+} from '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 import {rest} from 'msw'
 import {AuthHelpers, useCustomerType} from '@salesforce/commerce-sdk-react'
@@ -165,6 +168,19 @@ beforeEach(() => {
     mockUpdateCustomer.mutateAsync.mockResolvedValue({})
     // Reset useCustomerType mock to ensure phone input is not disabled
     useCustomerType.mockReturnValue({isRegistered: false})
+    // Reset useCheckout mock to default (step 0 = form view, not summary)
+    useCheckout.mockReturnValue({
+        customer: null,
+        basket: {basketId: 'test-basket-id'},
+        isGuestCheckout: true,
+        setIsGuestCheckout: jest.fn(),
+        step: 0,
+        login: null,
+        STEPS: {CONTACT_INFO: 0},
+        goToStep: null,
+        goToNextStep: mockGoToNextStep,
+        setContactPhone: mockSetContactPhone
+    })
 })
 
 afterEach(() => {})
@@ -219,97 +235,45 @@ describe('ContactInfo Component', () => {
         expect(phoneInput.value).toMatch(/[0-9]/)
     })
 
-    test('shows phone disabled and prefilled for registered shopper', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/commerce-sdk-react', () => {
-            const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
-            return {
-                ...originalModule,
-                useCustomerType: jest.fn(() => ({isRegistered: true})),
-                useAuthHelper: jest
-                    .fn()
-                    .mockImplementation(
-                        (helperType) =>
-                            mockAuthHelperFunctions[helperType] || {mutateAsync: jest.fn()}
-                    )
+    test('shows phone disabled and prefilled for registered shopper', () => {
+        useCustomerType.mockReturnValue({isRegistered: true})
+        mockUseCurrentCustomer.mockReturnValue({
+            data: {
+                email: 'reg@salesforce.com',
+                isRegistered: true,
+                phoneHome: '(111) 222-3333'
             }
         })
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    email: 'reg@salesforce.com',
-                    isRegistered: true,
-                    phoneHome: '(111) 222-3333'
-                }
-            })
-        }))
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info'
-        )
-        const Component = module.default
 
-        localRenderWithProviders(<Component />)
+        renderWithProviders(<ContactInfo />)
         const phoneInput = screen.getByLabelText('Phone')
         expect(phoneInput).toBeInTheDocument()
         expect(phoneInput).toHaveAttribute('disabled')
     })
 
-    test('displays phone number in summary card for registered user', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/commerce-sdk-react', () => {
-            const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
-            return {
-                ...originalModule,
-                useCustomerType: jest.fn(() => ({isRegistered: true})),
-                useAuthHelper: jest
-                    .fn()
-                    .mockImplementation(
-                        (helperType) =>
-                            mockAuthHelperFunctions[helperType] || {mutateAsync: jest.fn()}
-                    )
+    test('displays phone number in summary card for registered user', () => {
+        useCustomerType.mockReturnValue({isRegistered: true})
+        mockUseCurrentCustomer.mockReturnValue({
+            data: {
+                email: 'reg@salesforce.com',
+                isRegistered: true,
+                phoneHome: '(111) 222-3333'
             }
         })
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    email: 'reg@salesforce.com',
-                    isRegistered: true,
-                    phoneHome: '(111) 222-3333'
-                }
-            })
-        }))
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-            () => {
-                return {
-                    useCheckout: jest.fn().mockReturnValue({
-                        customer: null,
-                        basket: {basketId: 'test-basket-id'},
-                        isGuestCheckout: false,
-                        setIsGuestCheckout: jest.fn(),
-                        step: 1, // Not on CONTACT_INFO step, so summary shows
-                        login: null,
-                        STEPS: {CONTACT_INFO: 0},
-                        goToStep: jest.fn(),
-                        goToNextStep: jest.fn(),
-                        setContactPhone: jest.fn()
-                    }),
-                    setCheckoutGuestChoiceInStorage: jest.fn()
-                }
-            }
-        )
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-contact-info'
-        )
-        const Component = module.default
+        useCheckout.mockReturnValue({
+            customer: null,
+            basket: {basketId: 'test-basket-id'},
+            isGuestCheckout: false,
+            setIsGuestCheckout: jest.fn(),
+            step: 1,
+            login: null,
+            STEPS: {CONTACT_INFO: 0},
+            goToStep: jest.fn(),
+            goToNextStep: jest.fn(),
+            setContactPhone: jest.fn()
+        })
 
-        localRenderWithProviders(<Component />)
+        renderWithProviders(<ContactInfo />)
 
         // Verify email and phone are displayed in summary
         expect(screen.getByText('reg@salesforce.com')).toBeInTheDocument()

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address.test.js
@@ -9,7 +9,9 @@ import {screen, waitFor, within, act} from '@testing-library/react'
 import {rest} from 'msw'
 import ShippingAddress from '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
-import mockConfig from '@salesforce/retail-react-app/config/mocks/default'
+import {useCurrentCustomer} from '@salesforce/retail-react-app/app/hooks/use-current-customer'
+import {useCurrentBasket} from '@salesforce/retail-react-app/app/hooks/use-current-basket'
+import {useCheckout} from '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context'
 
 // Global filter for noisy act warnings in this spec only
 let globalConsoleErrorSpy
@@ -37,6 +39,19 @@ const mockUpdateCustomerAddress = {mutateAsync: jest.fn()}
 const mockCreateCustomerProductList = {mutate: jest.fn(), mutateAsync: jest.fn()}
 const mockRefetch = jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
 
+// Mutable address payload used by the mock ShippingAddressSelection; tests can override per-case
+let mockSubmitAddressData = {
+    addressId: 'test-address',
+    address1: '123 Test St',
+    city: 'Test City',
+    countryCode: 'US',
+    firstName: 'Test',
+    lastName: 'User',
+    phone: '555-0123',
+    postalCode: '12345',
+    stateCode: 'CA'
+}
+
 jest.mock('@salesforce/commerce-sdk-react', () => {
     const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
@@ -63,61 +78,17 @@ jest.mock('@salesforce/commerce-sdk-react', () => {
 })
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-    useCurrentCustomer: () => ({
-        data: {
-            customerId: 'test-customer-id',
-            isRegistered: true,
-            addresses: [
-                {
-                    addressId: 'preferred-address',
-                    address1: '123 Main St',
-                    city: 'Test City',
-                    countryCode: 'US',
-                    firstName: 'John',
-                    lastName: 'Doe',
-                    phone: '555-1234',
-                    postalCode: '12345',
-                    stateCode: 'CA',
-                    preferred: true
-                }
-            ]
-        }
-    })
+    useCurrentCustomer: jest.fn()
 }))
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-    useCurrentBasket: () => ({
-        data: {
-            basketId: 'test-basket-id',
-            shipments: [
-                {
-                    shippingAddress: null
-                }
-            ]
-        },
-        derivedData: {
-            hasBasket: true,
-            totalItems: 1
-        },
-        refetch: mockRefetch
-    })
+    useCurrentBasket: jest.fn()
 }))
 
 jest.mock(
     '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
     () => ({
-        useCheckout: jest.fn().mockReturnValue({
-            step: 2, // SHIPPING_ADDRESS step
-            STEPS: {
-                CONTACT_INFO: 0,
-                PICKUP_ADDRESS: 1,
-                SHIPPING_ADDRESS: 2,
-                SHIPPING_OPTIONS: 3
-            },
-            goToStep: mockGoToStep,
-            goToNextStep: mockGoToNextStep,
-            contactPhone: '(727) 555-0000'
-        })
+        useCheckout: jest.fn()
     })
 )
 
@@ -131,21 +102,7 @@ jest.mock(
         function MockShippingAddressSelection({onSubmit}) {
             return (
                 <div data-testid="shipping-address-selection">
-                    <button
-                        onClick={() =>
-                            onSubmit({
-                                addressId: 'test-address',
-                                address1: '123 Test St',
-                                city: 'Test City',
-                                countryCode: 'US',
-                                firstName: 'Test',
-                                lastName: 'User',
-                                phone: '555-0123',
-                                postalCode: '12345',
-                                stateCode: 'CA'
-                            })
-                        }
-                    >
+                    <button onClick={() => onSubmit(mockSubmitAddressData)}>
                         Continue to Shipping Method
                     </button>
                 </div>
@@ -185,10 +142,73 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-item-shipment-management',
     }))
 }))
 
+const defaultCustomerData = {
+    customerId: 'test-customer-id',
+    isRegistered: true,
+    addresses: [
+        {
+            addressId: 'preferred-address',
+            address1: '123 Main St',
+            city: 'Test City',
+            countryCode: 'US',
+            firstName: 'John',
+            lastName: 'Doe',
+            phone: '555-1234',
+            postalCode: '12345',
+            stateCode: 'CA',
+            preferred: true
+        }
+    ]
+}
+
+const defaultCheckoutValue = {
+    step: 2, // SHIPPING_ADDRESS step
+    STEPS: {
+        CONTACT_INFO: 0,
+        PICKUP_ADDRESS: 1,
+        SHIPPING_ADDRESS: 2,
+        SHIPPING_OPTIONS: 3
+    },
+    goToStep: mockGoToStep,
+    goToNextStep: mockGoToNextStep,
+    contactPhone: '(727) 555-0000'
+}
+
 beforeEach(() => {
     jest.clearAllMocks()
-    mockRemoveEmptyShipments.mockClear()
-    mockUpdateItemsToDeliveryShipment.mockClear()
+    mockRemoveEmptyShipments.mockResolvedValue({})
+    mockUpdateItemsToDeliveryShipment.mockResolvedValue({})
+
+    useCurrentCustomer.mockReturnValue({data: defaultCustomerData})
+    useCurrentBasket.mockReturnValue({
+        data: {
+            basketId: 'test-basket-id',
+            shipments: [
+                {
+                    shippingAddress: null
+                }
+            ]
+        },
+        derivedData: {
+            hasBasket: true,
+            totalItems: 1
+        },
+        refetch: mockRefetch
+    })
+    useCheckout.mockReturnValue(defaultCheckoutValue)
+
+    mockSubmitAddressData = {
+        addressId: 'test-address',
+        address1: '123 Test St',
+        city: 'Test City',
+        countryCode: 'US',
+        firstName: 'Test',
+        lastName: 'User',
+        phone: '555-0123',
+        postalCode: '12345',
+        stateCode: 'CA'
+    }
+
     // Stub background product-lists calls that can 403 and keep Jest open with retries
     global.server.use(
         rest.get('*/customers/:customerId/product-lists', (req, res, ctx) => {
@@ -361,46 +381,31 @@ describe('ShippingAddress Component', () => {
     })
 
     test('targets delivery shipment id when saving address in mixed cart', async () => {
-        jest.resetModules()
         const deliveryId = 'delivery-1'
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    shipments: [
-                        // Pickup shipment
-                        {
-                            shipmentId: 'pickup-1',
-                            shippingAddress: null,
-                            shippingMethod: {c_storePickupEnabled: true}
-                        },
-                        // Delivery shipment
-                        {
-                            shipmentId: deliveryId,
-                            shippingAddress: null,
-                            shippingMethod: {c_storePickupEnabled: false}
-                        }
-                    ]
-                },
-                derivedData: {hasBasket: true, totalItems: 1},
-                refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
-            })
-        }))
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
-        const {user} = localRenderWithProviders(<Component />)
-        {
-            const steps = screen.getAllByTestId('sf-toggle-card-step-1')
-            const sel = within(steps[0]).getByTestId('shipping-address-selection')
-            await user.click(
-                within(sel).getByRole('button', {name: /Continue to Shipping Method/i})
-            )
-        }
+        useCurrentBasket.mockReturnValue({
+            data: {
+                basketId: 'test-basket-id',
+                shipments: [
+                    {
+                        shipmentId: 'pickup-1',
+                        shippingAddress: null,
+                        shippingMethod: {c_storePickupEnabled: true}
+                    },
+                    {
+                        shipmentId: deliveryId,
+                        shippingAddress: null,
+                        shippingMethod: {c_storePickupEnabled: false}
+                    }
+                ]
+            },
+            derivedData: {hasBasket: true, totalItems: 1},
+            refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
+        })
+
+        const {user} = renderWithProviders(<ShippingAddress />)
+        const steps = screen.getAllByTestId('sf-toggle-card-step-1')
+        const sel = within(steps[0]).getByTestId('shipping-address-selection')
+        await user.click(within(sel).getByRole('button', {name: /Continue to Shipping Method/i}))
         const last = mockUpdateShippingAddress.mutateAsync.mock.calls.pop()?.[0]
         expect(last.parameters).toMatchObject({shipmentId: deliveryId})
     })
@@ -449,94 +454,19 @@ describe('ShippingAddress Component', () => {
     })
 
     test('submits shipping address with phone for guest (from contact info context)', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    customerId: null,
-                    isRegistered: false
-                }
-            })
-        }))
-        // Re-mock current basket after reset to provide basket id and shipments
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    shipments: [
-                        {
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {
-                    hasBasket: true,
-                    totalItems: 1
-                },
-                refetch: mockRefetch
-            })
-        }))
-        // Re-mock the inner ShippingAddressSelection component to ensure onSubmit path is deterministic
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection',
-            () => {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                const PropTypes = require('prop-types')
-                function MockShippingAddressSelection({onSubmit}) {
-                    return (
-                        <div data-testid="shipping-address-selection">
-                            <button
-                                onClick={() =>
-                                    onSubmit({
-                                        addressId: 'test-address',
-                                        address1: '123 Test St',
-                                        city: 'Test City',
-                                        countryCode: 'US',
-                                        firstName: 'Test',
-                                        lastName: 'User',
-                                        phone: '555-0123',
-                                        postalCode: '12345',
-                                        stateCode: 'CA'
-                                    })
-                                }
-                            >
-                                Continue to Shipping Method
-                            </button>
-                        </div>
-                    )
-                }
-                MockShippingAddressSelection.propTypes = {onSubmit: PropTypes.func}
-                return MockShippingAddressSelection
+        useCurrentCustomer.mockReturnValue({
+            data: {
+                customerId: null,
+                isRegistered: false
             }
-        )
-        // Ensure mutation resolves for this test
+        })
+        useCheckout.mockReturnValue({
+            ...defaultCheckoutValue,
+            contactPhone: '(727) 555-9999'
+        })
         mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-            () => ({
-                useCheckout: jest.fn().mockReturnValue({
-                    step: 2,
-                    STEPS: {
-                        CONTACT_INFO: 0,
-                        PICKUP_ADDRESS: 1,
-                        SHIPPING_ADDRESS: 2,
-                        SHIPPING_OPTIONS: 3
-                    },
-                    goToStep: mockGoToStep,
-                    goToNextStep: mockGoToNextStep,
-                    contactPhone: '(727) 555-9999'
-                })
-            })
-        )
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
-        const {user} = localRenderWithProviders(<Component />)
-        // Scope click to the first step container to avoid duplicates
+
+        const {user} = renderWithProviders(<ShippingAddress />)
         const stepContainers = screen.getAllByTestId('sf-toggle-card-step-1')
         const submitBtn = within(stepContainers[0]).getByText('Continue to Shipping Method')
         await act(async () => {
@@ -569,42 +499,33 @@ describe('ShippingAddress Component', () => {
         renderWithProviders(<ShippingAddress />)
 
         // Basic rendering test - component should render main elements
-        expect(screen.getByText('Shipping Address')).toBeInTheDocument()
+        const stepContainers = screen.getAllByTestId('sf-toggle-card-step-1')
+        expect(within(stepContainers[0]).getByText('Shipping Address')).toBeInTheDocument()
     })
 
     test('shows multiship header action and toggles to multi-address view', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    productItems: [
-                        {itemId: 'i1', shipmentId: 'me'},
-                        {itemId: 'i2', shipmentId: 'me'}
-                    ],
-                    shipments: [
-                        {
-                            shipmentId: 'me',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {hasBasket: true, totalItems: 2},
-                refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
-            })
-        }))
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
+        useCurrentBasket.mockReturnValue({
+            data: {
+                basketId: 'test-basket-id',
+                productItems: [
+                    {itemId: 'i1', shipmentId: 'me'},
+                    {itemId: 'i2', shipmentId: 'me'}
+                ],
+                shipments: [
+                    {
+                        shipmentId: 'me',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
+                        },
+                        shippingAddress: null
+                    }
+                ]
+            },
+            derivedData: {hasBasket: true, totalItems: 2},
+            refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
+        })
 
-        const {user} = localRenderWithProviders(<Component />)
+        const {user} = renderWithProviders(<ShippingAddress />)
 
         const multishipLink = screen.getByRole('button', {
             name: 'Ship to multiple addresses'
@@ -617,46 +538,37 @@ describe('ShippingAddress Component', () => {
 
         expect(screen.getByRole('button', {name: 'Ship items to one address'})).toBeInTheDocument()
     })
-    test('should consolidate multiple shipments when shipping to single address', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    productItems: [
-                        {itemId: 'i1', shipmentId: 'me'},
-                        {itemId: 'i2', shipmentId: 'delivery-shipment'}
-                    ],
-                    shipments: [
-                        {
-                            shipmentId: 'me',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
-                        },
-                        {
-                            shipmentId: 'delivery-shipment',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {hasBasket: true, totalItems: 2},
-                refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
-            })
-        }))
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
 
-        const {user} = localRenderWithProviders(<Component />)
+    test('should consolidate multiple shipments when shipping to single address', async () => {
+        useCurrentBasket.mockReturnValue({
+            data: {
+                basketId: 'test-basket-id',
+                productItems: [
+                    {itemId: 'i1', shipmentId: 'me'},
+                    {itemId: 'i2', shipmentId: 'delivery-shipment'}
+                ],
+                shipments: [
+                    {
+                        shipmentId: 'me',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
+                        },
+                        shippingAddress: null
+                    },
+                    {
+                        shipmentId: 'delivery-shipment',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
+                        },
+                        shippingAddress: null
+                    }
+                ]
+            },
+            derivedData: {hasBasket: true, totalItems: 2},
+            refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
+        })
+
+        const {user} = renderWithProviders(<ShippingAddress />)
 
         //only get first
         const continueButton = screen.getAllByRole('button', {
@@ -673,52 +585,41 @@ describe('ShippingAddress Component', () => {
     })
 
     test('does not show multiship option when only one delivery item exists with pickup items', async () => {
-        jest.resetModules()
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    productItems: [
-                        {itemId: 'i1', shipmentId: 'delivery-shipment'},
-                        {itemId: 'i2', shipmentId: 'pickup-shipment'}
-                    ],
-                    shipments: [
-                        {
-                            shipmentId: 'delivery-shipment',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
+        useCurrentBasket.mockReturnValue({
+            data: {
+                basketId: 'test-basket-id',
+                productItems: [
+                    {itemId: 'i1', shipmentId: 'delivery-shipment'},
+                    {itemId: 'i2', shipmentId: 'pickup-shipment'}
+                ],
+                shipments: [
+                    {
+                        shipmentId: 'delivery-shipment',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
                         },
-                        {
-                            shipmentId: 'pickup-shipment',
-                            shippingMethod: {
-                                c_storePickupEnabled: true
-                            },
-                            c_fromStoreId: 'store-123'
-                        }
-                    ]
-                },
-                derivedData: {hasBasket: true, totalItems: 2},
-                refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
-            })
-        }))
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
+                        shippingAddress: null
+                    },
+                    {
+                        shipmentId: 'pickup-shipment',
+                        shippingMethod: {
+                            c_storePickupEnabled: true
+                        },
+                        c_fromStoreId: 'store-123'
+                    }
+                ]
+            },
+            derivedData: {hasBasket: true, totalItems: 2},
+            refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
+        })
 
-        localRenderWithProviders(<Component />)
+        renderWithProviders(<ShippingAddress />)
 
         // Should not show multiship link because only 1 delivery item
         expect(screen.queryByTestId('edit-action-button')).not.toBeInTheDocument()
     })
 
     test('auto-selects preferred address for multi-shipment orders and consolidates items', async () => {
-        jest.resetModules()
         mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
         mockUpdateItemsToDeliveryShipment.mockResolvedValue({
             basketId: 'test-basket-id',
@@ -734,133 +635,35 @@ describe('ShippingAddress Component', () => {
         })
         mockRemoveEmptyShipments.mockResolvedValue({})
 
-        const preferredAddress = {
-            addressId: 'preferred-address',
-            address1: '123 Main St',
-            city: 'Test City',
-            countryCode: 'US',
-            firstName: 'John',
-            lastName: 'Doe',
-            phone: '555-1234',
-            postalCode: '12345',
-            stateCode: 'CA',
-            preferred: true
-        }
-
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    customerId: 'test-customer-id',
-                    isRegistered: true,
-                    addresses: [preferredAddress]
-                }
-            })
-        }))
-
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    productItems: [
-                        {itemId: 'i1', shipmentId: 'me'},
-                        {itemId: 'i2', shipmentId: 'delivery-shipment-2'}
-                    ],
-                    shipments: [
-                        {
-                            shipmentId: 'me',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
+        useCurrentBasket.mockReturnValue({
+            data: {
+                basketId: 'test-basket-id',
+                productItems: [
+                    {itemId: 'i1', shipmentId: 'me'},
+                    {itemId: 'i2', shipmentId: 'delivery-shipment-2'}
+                ],
+                shipments: [
+                    {
+                        shipmentId: 'me',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
                         },
-                        {
-                            shipmentId: 'delivery-shipment-2',
-                            shippingMethod: {
-                                c_storePickupEnabled: false
-                            },
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {hasBasket: true, totalItems: 2},
-                refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
-            })
-        }))
-
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-            () => ({
-                useCheckout: jest.fn().mockReturnValue({
-                    step: 2, // SHIPPING_ADDRESS step
-                    STEPS: {
-                        CONTACT_INFO: 0,
-                        PICKUP_ADDRESS: 1,
-                        SHIPPING_ADDRESS: 2,
-                        SHIPPING_OPTIONS: 3
+                        shippingAddress: null
                     },
-                    goToStep: mockGoToStep,
-                    goToNextStep: mockGoToNextStep,
-                    contactPhone: '(727) 555-0000'
-                })
-            })
-        )
-
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-multiship', () => ({
-            useMultiship: jest.fn(() => ({
-                removeEmptyShipments: mockRemoveEmptyShipments
-            }))
-        }))
-
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-item-shipment-management', () => ({
-            useItemShipmentManagement: jest.fn(() => ({
-                updateItemsToDeliveryShipment: mockUpdateItemsToDeliveryShipment
-            }))
-        }))
-
-        jest.doMock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => ({
-            getConfig: jest.fn(() => ({
-                app: {
-                    ...mockConfig.app,
-                    multishipEnabled: true
-                }
-            }))
-        }))
-
-        jest.doMock('@salesforce/commerce-sdk-react', () => {
-            const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
-            return {
-                ...originalModule,
-                useShopperBasketsMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'updateShippingAddressForShipment')
-                        return mockUpdateShippingAddress
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShopperCustomersMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'createCustomerAddress') return mockCreateCustomerAddress
-                    if (mutationType === 'updateCustomerAddress') return mockUpdateCustomerAddress
-                    if (mutationType === 'createCustomerProductList')
-                        return mockCreateCustomerProductList
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShippingMethodsForShipment: jest.fn().mockReturnValue({
-                    refetch: jest.fn().mockResolvedValue({
-                        data: {
-                            applicableShippingMethods: []
-                        }
-                    })
-                })
-            }
+                    {
+                        shipmentId: 'delivery-shipment-2',
+                        shippingMethod: {
+                            c_storePickupEnabled: false
+                        },
+                        shippingAddress: null
+                    }
+                ]
+            },
+            derivedData: {hasBasket: true, totalItems: 2},
+            refetch: jest.fn().mockResolvedValue({data: {basketId: 'test-basket-id'}})
         })
 
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
-
-        localRenderWithProviders(<Component />)
+        renderWithProviders(<ShippingAddress />)
 
         // Wait for auto-selection to complete
         await waitFor(
@@ -928,145 +731,28 @@ describe('ShippingAddress Component', () => {
     })
 
     test('saves address for existing registered users when enableUserRegistration is false', async () => {
-        jest.resetModules()
-        // Re-mock commerce-sdk-react to provide mutations
-        jest.doMock('@salesforce/commerce-sdk-react', () => {
-            const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
-            return {
-                ...originalModule,
-                useShopperBasketsMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'updateShippingAddressForShipment')
-                        return mockUpdateShippingAddress
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShopperCustomersMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'createCustomerAddress') return mockCreateCustomerAddress
-                    if (mutationType === 'updateCustomerAddress') return mockUpdateCustomerAddress
-                    if (mutationType === 'createCustomerProductList')
-                        return mockCreateCustomerProductList
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShippingMethodsForShipment: jest.fn().mockReturnValue({
-                    refetch: jest.fn().mockResolvedValue({
-                        data: {
-                            applicableShippingMethods: []
-                        }
-                    })
-                })
+        useCurrentCustomer.mockReturnValue({
+            data: {
+                customerId: 'test-customer-id',
+                isRegistered: true,
+                addresses: []
             }
         })
-        // Re-mock customer as registered user
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    customerId: 'test-customer-id',
-                    isRegistered: true,
-                    addresses: []
-                }
-            })
-        }))
-        // Re-mock current basket
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    shipments: [
-                        {
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {
-                    hasBasket: true,
-                    totalItems: 1
-                },
-                refetch: mockRefetch
-            })
-        }))
-        // Mock ShippingAddressSelection to submit address without addressId (new address)
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection',
-            () => {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                const PropTypes = require('prop-types')
-                function MockShippingAddressSelection({onSubmit}) {
-                    return (
-                        <div data-testid="shipping-address-selection">
-                            <button
-                                onClick={() =>
-                                    onSubmit({
-                                        // No addressId - this is a new address
-                                        address1: '123 Test St',
-                                        city: 'Test City',
-                                        countryCode: 'US',
-                                        firstName: 'Test',
-                                        lastName: 'User',
-                                        phone: '555-0123',
-                                        postalCode: '12345',
-                                        stateCode: 'CA'
-                                    })
-                                }
-                            >
-                                Continue to Shipping Method
-                            </button>
-                        </div>
-                    )
-                }
-                MockShippingAddressSelection.propTypes = {onSubmit: PropTypes.func}
-                return MockShippingAddressSelection
-            }
-        )
-        // Re-mock checkout context
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-            () => ({
-                useCheckout: jest.fn().mockReturnValue({
-                    step: 2,
-                    STEPS: {
-                        CONTACT_INFO: 0,
-                        PICKUP_ADDRESS: 1,
-                        SHIPPING_ADDRESS: 2,
-                        SHIPPING_OPTIONS: 3
-                    },
-                    goToStep: mockGoToStep,
-                    goToNextStep: mockGoToNextStep,
-                    contactPhone: '(727) 555-0000'
-                })
-            })
-        )
-        // Re-mock multiship and item shipment management hooks
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-multiship', () => ({
-            useMultiship: jest.fn(() => ({
-                removeEmptyShipments: mockRemoveEmptyShipments
-            }))
-        }))
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-item-shipment-management', () => ({
-            useItemShipmentManagement: jest.fn(() => ({
-                updateItemsToDeliveryShipment: mockUpdateItemsToDeliveryShipment
-            }))
-        }))
-        // Re-mock getConfig
-        jest.doMock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => ({
-            getConfig: jest.fn(() => ({
-                ...mockConfig,
-                app: {
-                    ...mockConfig.app,
-                    multishipEnabled: true
-                }
-            }))
-        }))
-
+        // Submit address without addressId so the create-address path is taken
+        mockSubmitAddressData = {
+            address1: '123 Test St',
+            city: 'Test City',
+            countryCode: 'US',
+            firstName: 'Test',
+            lastName: 'User',
+            phone: '555-0123',
+            postalCode: '12345',
+            stateCode: 'CA'
+        }
         mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
         mockCreateCustomerAddress.mutateAsync.mockResolvedValue({})
 
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
-        const {user} = localRenderWithProviders(<Component enableUserRegistration={false} />)
+        const {user} = renderWithProviders(<ShippingAddress enableUserRegistration={false} />)
 
         const stepContainers = screen.getAllByTestId('sf-toggle-card-step-1')
         const selection = within(stepContainers[0]).getByTestId('shipping-address-selection')
@@ -1089,145 +775,28 @@ describe('ShippingAddress Component', () => {
     })
 
     test('saves address for existing registered users when enableUserRegistration prop is not provided', async () => {
-        jest.resetModules()
-        // Re-mock commerce-sdk-react to provide mutations
-        jest.doMock('@salesforce/commerce-sdk-react', () => {
-            const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
-            return {
-                ...originalModule,
-                useShopperBasketsMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'updateShippingAddressForShipment')
-                        return mockUpdateShippingAddress
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShopperCustomersMutation: jest.fn().mockImplementation((mutationType) => {
-                    if (mutationType === 'createCustomerAddress') return mockCreateCustomerAddress
-                    if (mutationType === 'updateCustomerAddress') return mockUpdateCustomerAddress
-                    if (mutationType === 'createCustomerProductList')
-                        return mockCreateCustomerProductList
-                    return {mutateAsync: jest.fn()}
-                }),
-                useShippingMethodsForShipment: jest.fn().mockReturnValue({
-                    refetch: jest.fn().mockResolvedValue({
-                        data: {
-                            applicableShippingMethods: []
-                        }
-                    })
-                })
+        useCurrentCustomer.mockReturnValue({
+            data: {
+                customerId: 'test-customer-id',
+                isRegistered: true,
+                addresses: []
             }
         })
-        // Re-mock customer as registered user
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-            useCurrentCustomer: () => ({
-                data: {
-                    customerId: 'test-customer-id',
-                    isRegistered: true,
-                    addresses: []
-                }
-            })
-        }))
-        // Re-mock current basket
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-            useCurrentBasket: () => ({
-                data: {
-                    basketId: 'test-basket-id',
-                    shipments: [
-                        {
-                            shippingAddress: null
-                        }
-                    ]
-                },
-                derivedData: {
-                    hasBasket: true,
-                    totalItems: 1
-                },
-                refetch: mockRefetch
-            })
-        }))
-        // Mock ShippingAddressSelection to submit address without addressId (new address)
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address-selection',
-            () => {
-                // eslint-disable-next-line @typescript-eslint/no-var-requires
-                const PropTypes = require('prop-types')
-                function MockShippingAddressSelection({onSubmit}) {
-                    return (
-                        <div data-testid="shipping-address-selection">
-                            <button
-                                onClick={() =>
-                                    onSubmit({
-                                        // No addressId - this is a new address
-                                        address1: '123 Test St',
-                                        city: 'Test City',
-                                        countryCode: 'US',
-                                        firstName: 'Test',
-                                        lastName: 'User',
-                                        phone: '555-0123',
-                                        postalCode: '12345',
-                                        stateCode: 'CA'
-                                    })
-                                }
-                            >
-                                Continue to Shipping Method
-                            </button>
-                        </div>
-                    )
-                }
-                MockShippingAddressSelection.propTypes = {onSubmit: PropTypes.func}
-                return MockShippingAddressSelection
-            }
-        )
-        // Re-mock checkout context
-        jest.doMock(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-            () => ({
-                useCheckout: jest.fn().mockReturnValue({
-                    step: 2,
-                    STEPS: {
-                        CONTACT_INFO: 0,
-                        PICKUP_ADDRESS: 1,
-                        SHIPPING_ADDRESS: 2,
-                        SHIPPING_OPTIONS: 3
-                    },
-                    goToStep: mockGoToStep,
-                    goToNextStep: mockGoToNextStep,
-                    contactPhone: '(727) 555-0000'
-                })
-            })
-        )
-        // Re-mock multiship and item shipment management hooks
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-multiship', () => ({
-            useMultiship: jest.fn(() => ({
-                removeEmptyShipments: mockRemoveEmptyShipments
-            }))
-        }))
-        jest.doMock('@salesforce/retail-react-app/app/hooks/use-item-shipment-management', () => ({
-            useItemShipmentManagement: jest.fn(() => ({
-                updateItemsToDeliveryShipment: mockUpdateItemsToDeliveryShipment
-            }))
-        }))
-        // Re-mock getConfig
-        jest.doMock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => ({
-            getConfig: jest.fn(() => ({
-                ...mockConfig,
-                app: {
-                    ...mockConfig.app,
-                    multishipEnabled: true
-                }
-            }))
-        }))
-
+        // Submit address without addressId so the create-address path is taken
+        mockSubmitAddressData = {
+            address1: '123 Test St',
+            city: 'Test City',
+            countryCode: 'US',
+            firstName: 'Test',
+            lastName: 'User',
+            phone: '555-0123',
+            postalCode: '12345',
+            stateCode: 'CA'
+        }
         mockUpdateShippingAddress.mutateAsync.mockResolvedValue({})
         mockCreateCustomerAddress.mutateAsync.mockResolvedValue({})
 
-        const {renderWithProviders: localRenderWithProviders} = await import(
-            '@salesforce/retail-react-app/app/utils/test-utils'
-        )
-        const module = await import(
-            '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-address'
-        )
-        const Component = module.default
-        const {user} = localRenderWithProviders(<Component />)
+        const {user} = renderWithProviders(<ShippingAddress />)
 
         const stepContainers = screen.getAllByTestId('sf-toggle-card-step-1')
         const selection = within(stepContainers[0]).getByTestId('shipping-address-selection')

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options.test.js
@@ -8,6 +8,10 @@ import React from 'react'
 import {screen, waitFor, within} from '@testing-library/react'
 import ShippingOptions from '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import {
+    useShopperBasketsMutation,
+    useShippingMethodsForShipment
+} from '@salesforce/commerce-sdk-react'
 
 // Stub UI modal providers that are irrelevant for these tests to reduce act() noise
 jest.mock('@salesforce/retail-react-app/app/hooks/use-add-to-cart-modal', () => ({
@@ -20,6 +24,17 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-bonus-product-selection-mo
 const mockGoToNextStep = jest.fn()
 const mockGoToStep = jest.fn()
 const mockUpdateShippingMethod = {mutateAsync: jest.fn()}
+const mockUseCurrentCustomer = jest.fn()
+const mockUseCurrentBasket = jest.fn()
+const mockUseCheckout = jest.fn()
+
+const MOCK_STEPS = {
+    CONTACT_INFO: 0,
+    PICKUP_ADDRESS: 1,
+    SHIPPING_ADDRESS: 2,
+    SHIPPING_OPTIONS: 3,
+    PAYMENT: 4
+}
 
 const mockShippingMethods = {
     defaultShippingMethodId: 'standard-shipping',
@@ -39,6 +54,21 @@ const mockShippingMethods = {
     ]
 }
 
+const defaultCustomerData = {customerId: 'test-customer-id', isRegistered: true}
+const defaultBasketData = {
+    data: {
+        basketId: 'test-basket-id',
+        shipments: [
+            {
+                shippingAddress: {address1: '123 Main St', city: 'Test City'},
+                shippingMethod: null
+            }
+        ],
+        shippingItems: [{price: 5.99, priceAdjustments: []}]
+    },
+    derivedData: {hasBasket: true, totalItems: 1}
+}
+
 jest.mock('@salesforce/commerce-sdk-react', () => {
     const originalModule = jest.requireActual('@salesforce/commerce-sdk-react')
     return {
@@ -54,56 +84,17 @@ jest.mock('@salesforce/commerce-sdk-react', () => {
 })
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-    useCurrentCustomer: () => ({
-        data: {
-            customerId: 'test-customer-id',
-            isRegistered: true
-        }
-    })
+    useCurrentCustomer: (...args) => mockUseCurrentCustomer(...args)
 }))
 
 jest.mock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-    useCurrentBasket: () => ({
-        data: {
-            basketId: 'test-basket-id',
-            shipments: [
-                {
-                    shippingAddress: {
-                        address1: '123 Main St',
-                        city: 'Test City'
-                    },
-                    shippingMethod: null
-                }
-            ],
-            shippingItems: [
-                {
-                    price: 5.99,
-                    priceAdjustments: []
-                }
-            ]
-        },
-        derivedData: {
-            hasBasket: true,
-            totalItems: 1
-        }
-    })
+    useCurrentBasket: (...args) => mockUseCurrentBasket(...args)
 }))
 
 jest.mock(
     '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
     () => ({
-        useCheckout: jest.fn().mockReturnValue({
-            step: 3, // SHIPPING_OPTIONS step
-            STEPS: {
-                CONTACT_INFO: 0,
-                PICKUP_ADDRESS: 1,
-                SHIPPING_ADDRESS: 2,
-                SHIPPING_OPTIONS: 3,
-                PAYMENT: 4
-            },
-            goToStep: mockGoToStep,
-            goToNextStep: mockGoToNextStep
-        })
+        useCheckout: (...args) => mockUseCheckout(...args)
     })
 )
 
@@ -121,15 +112,21 @@ jest.mock('@salesforce/retail-react-app/app/hooks/use-toast', () => ({
 
 beforeEach(() => {
     jest.clearAllMocks()
-    // Default mutation to resolve to avoid leakage from tests that override it
     mockUpdateShippingMethod.mutateAsync.mockResolvedValue({})
     mockShowToast.mockReset()
-})
-
-afterEach(() => {
-    // Ensure any module-level mocks from jest.doMock are cleared between tests
-    jest.resetModules()
-    jest.clearAllMocks()
+    mockUseCurrentCustomer.mockReturnValue({data: defaultCustomerData})
+    mockUseCurrentBasket.mockReturnValue(defaultBasketData)
+    mockUseCheckout.mockReturnValue({
+        step: 3,
+        STEPS: MOCK_STEPS,
+        goToStep: mockGoToStep,
+        goToNextStep: mockGoToNextStep
+    })
+    useShopperBasketsMutation.mockImplementation((mutationType) => {
+        if (mutationType === 'updateShippingMethodForShipment') return mockUpdateShippingMethod
+        return {mutateAsync: jest.fn()}
+    })
+    useShippingMethodsForShipment.mockReturnValue({data: mockShippingMethods})
 })
 
 describe('ShippingOptions Component', () => {
@@ -199,13 +196,12 @@ describe('ShippingOptions Component', () => {
         })
 
         test('shows error toast and hides controls when no shipping methods are available', async () => {
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockImplementation((_params, opts) => {
-                const payload = {applicableShippingMethods: [], defaultShippingMethodId: 'std'}
+            const noMethodsPayload = {applicableShippingMethods: [], defaultShippingMethodId: 'std'}
+            useShippingMethodsForShipment.mockImplementation((_params, opts) => {
                 if (opts && typeof opts.onSuccess === 'function') {
-                    opts.onSuccess(payload)
+                    opts.onSuccess(noMethodsPayload)
                 }
-                return {data: payload}
+                return {data: noMethodsPayload}
             })
             mockUpdateShippingMethod.mutateAsync.mockResolvedValue({})
 
@@ -219,48 +215,28 @@ describe('ShippingOptions Component', () => {
     })
 
     describe('for guest users', () => {
-        let localRenderWithProviders
-        let Component
-
-        beforeEach(async () => {
-            jest.resetModules()
-
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {
-                        customerId: null,
-                        isRegistered: false
-                    }
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '123 Main St', city: 'Test City'},
-                                shippingMethod: null
-                            }
-                        ],
-                        shippingItems: [{price: 5.99, priceAdjustments: []}]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
-                })
-            }))
-
-            const testUtils = await import('@salesforce/retail-react-app/app/utils/test-utils')
-            localRenderWithProviders = testUtils.renderWithProviders
-
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-            Component = module.default
+        beforeEach(() => {
+            mockUseCurrentCustomer.mockReturnValue({
+                data: {customerId: null, isRegistered: false}
+            })
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '123 Main St', city: 'Test City'},
+                            shippingMethod: null
+                        }
+                    ],
+                    shippingItems: [{price: 5.99, priceAdjustments: []}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
+            })
         })
 
         test('displays shipping method options with prices and allows selection', async () => {
-            const {user} = localRenderWithProviders(<Component />)
+            const {user} = renderWithProviders(<ShippingOptions />)
 
             expect(screen.getByText('Standard Shipping')).toBeInTheDocument()
             expect(screen.getByText('Express Shipping')).toBeInTheDocument()
@@ -274,7 +250,7 @@ describe('ShippingOptions Component', () => {
         })
 
         test('does not trigger auto-selection of shipping method', async () => {
-            localRenderWithProviders(<Component />)
+            renderWithProviders(<ShippingOptions />)
 
             await new Promise((resolve) => setTimeout(resolve, 150))
 
@@ -285,7 +261,7 @@ describe('ShippingOptions Component', () => {
         test('submits form with selected shipping method and proceeds to next step', async () => {
             mockUpdateShippingMethod.mutateAsync.mockResolvedValue({})
 
-            const {user} = localRenderWithProviders(<Component />)
+            const {user} = renderWithProviders(<ShippingOptions />)
 
             const standardRadios = screen.getAllByRole('radio', {name: /Standard Shipping/i})
             await user.click(standardRadios[0])
@@ -331,10 +307,9 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: methodsWithPromos})
+            useShippingMethodsForShipment.mockReturnValue({data: methodsWithPromos})
 
-            localRenderWithProviders(<Component />)
+            renderWithProviders(<ShippingOptions />)
 
             expect(screen.getByText('Free shipping on orders over $75!')).toBeInTheDocument()
         })
@@ -342,38 +317,22 @@ describe('ShippingOptions Component', () => {
 
     describe('for registered users with auto-selection', () => {
         test('skips shipping method update when existing method is still valid and stays on edit view', async () => {
-            jest.resetModules()
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '456 New St', city: 'New City'},
+                            shippingMethod: {id: 'standard-shipping', name: 'Standard Shipping'}
+                        }
+                    ],
+                    shippingItems: [{price: 5.99, priceAdjustments: []}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
+            })
 
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '456 New St', city: 'New City'},
-                                shippingMethod: {id: 'standard-shipping', name: 'Standard Shipping'}
-                            }
-                        ],
-                        shippingItems: [{price: 5.99, priceAdjustments: []}]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
-                })
-            }))
-
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             await waitFor(() => {
                 expect(mockUpdateShippingMethod.mutateAsync).not.toHaveBeenCalled()
@@ -387,40 +346,24 @@ describe('ShippingOptions Component', () => {
         })
 
         test('auto-selects default method when existing method is no longer valid', async () => {
-            jest.resetModules()
-
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '456 New St', city: 'New City'},
-                                shippingMethod: {id: 'old-method', name: 'Old Method'}
-                            }
-                        ],
-                        shippingItems: [{price: 5.99, priceAdjustments: []}]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
-                })
-            }))
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '456 New St', city: 'New City'},
+                            shippingMethod: {id: 'old-method', name: 'Old Method'}
+                        }
+                    ],
+                    shippingItems: [{price: 5.99, priceAdjustments: []}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 5.99}
+            })
 
             mockUpdateShippingMethod.mutateAsync.mockResolvedValue({})
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             await waitFor(() => {
                 expect(mockUpdateShippingMethod.mutateAsync).toHaveBeenCalledWith({
@@ -436,155 +379,79 @@ describe('ShippingOptions Component', () => {
     })
 
     describe('in summary view (PAYMENT step)', () => {
-        test('renders SingleShipmentSummary without price adjustments and strikethrough price', async () => {
-            jest.resetModules()
+        beforeEach(() => {
+            mockUseCheckout.mockReturnValue({
+                step: 4,
+                STEPS: MOCK_STEPS,
+                goToStep: mockGoToStep,
+                goToNextStep: mockGoToNextStep
+            })
+        })
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 4,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '123 Main St', city: 'Test City'},
-                                shippingMethod: {
-                                    id: 'standard-shipping',
-                                    name: 'Standard Shipping',
-                                    description: '5-7 business days'
-                                }
+        test('renders SingleShipmentSummary without price adjustments and strikethrough price', () => {
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '123 Main St', city: 'Test City'},
+                            shippingMethod: {
+                                id: 'standard-shipping',
+                                name: 'Standard Shipping',
+                                description: '5-7 business days'
                             }
-                        ],
-                        shippingItems: [
-                            {
-                                price: 9.99,
-                                priceAfterItemDiscount: 4.99,
-                                priceAdjustments: [
-                                    {
-                                        priceAdjustmentId: 'promo-1',
-                                        itemText: '50% off shipping!'
-                                    }
-                                ]
-                            }
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 4.99}
-                })
-            }))
+                        }
+                    ],
+                    shippingItems: [
+                        {
+                            price: 9.99,
+                            priceAfterItemDiscount: 4.99,
+                            priceAdjustments: [
+                                {priceAdjustmentId: 'promo-1', itemText: '50% off shipping!'}
+                            ]
+                        }
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 4.99}
+            })
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             expect(screen.getAllByText('Standard Shipping').length).toBeGreaterThan(0)
             expect(screen.getAllByText('5-7 business days').length).toBeGreaterThan(0)
-            // Verify promotion text is NOT shown in summary view
             expect(screen.queryByText('50% off shipping!')).not.toBeInTheDocument()
-            // Verify only the final price is shown (no strikethrough)
-            // Price is formatted with currency code (US$4.99)
             expect(screen.getByText(/4\.99/)).toBeInTheDocument()
-            // Verify original price with strikethrough is NOT shown
             expect(screen.queryByText(/9\.99/)).not.toBeInTheDocument()
         })
 
-        test('renders only final price in summary view when price differs from original', async () => {
-            jest.resetModules()
-
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 4,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '123 Main St', city: 'Test City'},
-                                shippingMethod: {
-                                    id: 'standard-shipping',
-                                    name: 'Standard Shipping',
-                                    description: '5-7 business days'
-                                }
+        test('renders only final price in summary view when price differs from original', () => {
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '123 Main St', city: 'Test City'},
+                            shippingMethod: {
+                                id: 'standard-shipping',
+                                name: 'Standard Shipping',
+                                description: '5-7 business days'
                             }
-                        ],
-                        shippingItems: [
-                            {
-                                price: 9.99,
-                                priceAfterItemDiscount: 0,
-                                priceAdjustments: []
-                            }
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 0}
-                })
-            }))
+                        }
+                    ],
+                    shippingItems: [{price: 9.99, priceAfterItemDiscount: 0, priceAdjustments: []}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 0}
+            })
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
+            renderWithProviders(<ShippingOptions />)
 
-            localRenderWithProviders(<module.default />)
-
-            // Verify "Free" is shown (final price is 0)
-            // There may be multiple instances (edit view and summary view), so use getAllByText
             expect(screen.getAllByText('Free').length).toBeGreaterThan(0)
-            // Verify original price is NOT shown
             expect(screen.queryByText(/9\.99/)).not.toBeInTheDocument()
         })
 
-        test('renders "Free" label when shipping cost is zero', async () => {
-            jest.resetModules()
-
-            // Mock shipping methods to include a free shipping option
+        test('renders "Free" label when shipping cost is zero', () => {
             const freeShippingMethods = {
                 defaultShippingMethodId: 'free-shipping',
                 applicableShippingMethods: [
@@ -597,68 +464,29 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 4,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'me',
-                                shippingAddress: {address1: '123 Main St', city: 'Test City'},
-                                shippingMethod: {
-                                    id: 'free-shipping',
-                                    name: 'Free Standard Shipping',
-                                    description: 'Free for orders over $50'
-                                }
+            useShippingMethodsForShipment.mockReturnValue({data: freeShippingMethods})
+
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'me',
+                            shippingAddress: {address1: '123 Main St', city: 'Test City'},
+                            shippingMethod: {
+                                id: 'free-shipping',
+                                name: 'Free Standard Shipping',
+                                description: 'Free for orders over $50'
                             }
-                        ],
-                        shippingItems: [
-                            {
-                                price: 0,
-                                priceAfterItemDiscount: 0,
-                                priceAdjustments: []
-                            }
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 0}
-                })
-            }))
+                        }
+                    ],
+                    shippingItems: [{price: 0, priceAfterItemDiscount: 0, priceAdjustments: []}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1, totalShippingCost: 0}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: freeShippingMethods})
+            renderWithProviders(<ShippingOptions />)
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
-
-            // There may be multiple instances (edit view and summary view), so use getAllByText
             expect(screen.getAllByText('Free').length).toBeGreaterThan(0)
         })
     })
@@ -700,84 +528,53 @@ describe('ShippingOptions Component', () => {
         }
 
         test('renders per-shipment methods and allows updating by shipment', async () => {
-            jest.resetModules()
-
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: null, isRegistered: false}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'Oscar',
-                                    lastName: 'Robertson',
-                                    address1: '333 South Street Station',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: null
+            mockUseCurrentCustomer.mockReturnValue({
+                data: {customerId: null, isRegistered: false}
+            })
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'Oscar',
+                                lastName: 'Robertson',
+                                address1: '333 South Street Station',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Lee',
-                                    lastName: 'Robertson',
-                                    address1: '158 South Street Station',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: null
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 0}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2}
-                })
-            }))
+                            shippingMethod: null
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Lee',
+                                lastName: 'Robertson',
+                                address1: '158 South Street Station',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
+                            },
+                            shippingMethod: null
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 0}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockImplementation(({parameters}) => {
+            useShippingMethodsForShipment.mockImplementation(({parameters}) => {
                 if (parameters.shipmentId === 'ship1') return {data: multiShipMethods1}
                 if (parameters.shipmentId === 'ship2') return {data: multiShipMethods2}
                 return {data: multiShipMethods1}
             })
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            const {user} = localRenderWithProviders(<module.default />)
+            const {user} = renderWithProviders(<ShippingOptions />)
 
             expect(screen.getAllByText('Shipping Options').length).toBeGreaterThan(0)
             expect(screen.getByText('Shipment 1:')).toBeInTheDocument()
@@ -802,85 +599,51 @@ describe('ShippingOptions Component', () => {
             expect(screen.getByText('Continue to Payment')).toBeInTheDocument()
         })
 
-        test('multi-shipment edit view shows shipping options for each shipment', async () => {
-            jest.resetModules()
-
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'Oscar',
-                                    lastName: 'Robertson',
-                                    address1: '333 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: {id: 'std', name: 'Standard'}
+        test('multi-shipment edit view shows shipping options for each shipment', () => {
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'Oscar',
+                                lastName: 'Robertson',
+                                address1: '333 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Lee',
-                                    lastName: 'Robertson',
-                                    address1: '158 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: {id: 'std2', name: 'Standard 2'}
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 0}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
-                })
-            }))
+                            shippingMethod: {id: 'std', name: 'Standard'}
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Lee',
+                                lastName: 'Robertson',
+                                address1: '158 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
+                            },
+                            shippingMethod: {id: 'std2', name: 'Standard 2'}
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 0}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockImplementation(({parameters}) => {
+            useShippingMethodsForShipment.mockImplementation(({parameters}) => {
                 if (parameters.shipmentId === 'ship1') return {data: multiShipMethods1}
                 if (parameters.shipmentId === 'ship2') return {data: multiShipMethods2}
                 return {data: multiShipMethods1}
             })
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             const cards = screen.getAllByTestId('sf-toggle-card-step-2')
             expect(cards.length).toBeGreaterThan(0)
@@ -890,8 +653,6 @@ describe('ShippingOptions Component', () => {
         })
 
         test('auto-selects default method when no method is set on shipment', async () => {
-            jest.resetModules()
-
             const methods1 = {
                 defaultShippingMethodId: 'std',
                 applicableShippingMethods: [
@@ -907,69 +668,44 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'Oscar',
-                                    lastName: 'Robertson',
-                                    address1: '333 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: null
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'Oscar',
+                                lastName: 'Robertson',
+                                address1: '333 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Lee',
-                                    lastName: 'Robertson',
-                                    address1: '158 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: null
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 0}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
-                })
-            }))
+                            shippingMethod: null
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Lee',
+                                lastName: 'Robertson',
+                                address1: '158 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
+                            },
+                            shippingMethod: null
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 0}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockImplementation(({parameters}) => {
+            useShippingMethodsForShipment.mockImplementation(({parameters}) => {
                 if (parameters.shipmentId === 'ship1') return {data: methods1}
                 if (parameters.shipmentId === 'ship2') return {data: methods2}
                 return {data: methods1}
@@ -977,14 +713,7 @@ describe('ShippingOptions Component', () => {
 
             mockUpdateShippingMethod.mutateAsync.mockResolvedValue({})
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             await waitFor(() => {
                 expect(mockUpdateShippingMethod.mutateAsync).toHaveBeenCalledWith({
@@ -1002,8 +731,6 @@ describe('ShippingOptions Component', () => {
         })
 
         test('continue button calls goToNextStep when clicked', async () => {
-            jest.resetModules()
-
             const methods1 = {
                 defaultShippingMethodId: 'std',
                 applicableShippingMethods: [
@@ -1011,78 +738,49 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: false}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'Oscar',
-                                    lastName: 'Robertson',
-                                    address1: '333 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: {id: 'std', name: 'Standard'}
+            mockUseCurrentCustomer.mockReturnValue({
+                data: {customerId: 'test-customer-id', isRegistered: false}
+            })
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'Oscar',
+                                lastName: 'Robertson',
+                                address1: '333 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Lee',
-                                    lastName: 'Robertson',
-                                    address1: '158 South St',
-                                    city: 'West Lafayette',
-                                    stateCode: 'IN',
-                                    postalCode: '98103'
-                                },
-                                shippingMethod: {id: 'std', name: 'Standard'}
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 0}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
-                })
-            }))
+                            shippingMethod: {id: 'std', name: 'Standard'}
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Lee',
+                                lastName: 'Robertson',
+                                address1: '158 South St',
+                                city: 'West Lafayette',
+                                stateCode: 'IN',
+                                postalCode: '98103'
+                            },
+                            shippingMethod: {id: 'std', name: 'Standard'}
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 0}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: methods1})
+            useShippingMethodsForShipment.mockReturnValue({data: methods1})
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            const {user} = localRenderWithProviders(<module.default />)
+            const {user} = renderWithProviders(<ShippingOptions />)
 
             const continueButtons = screen.getAllByRole('button', {name: /continue to payment/i})
             await user.click(continueButtons[0])
@@ -1090,9 +788,7 @@ describe('ShippingOptions Component', () => {
             expect(mockGoToNextStep).toHaveBeenCalled()
         })
 
-        test('displays address line for each shipment', async () => {
-            jest.resetModules()
-
+        test('displays address line for each shipment', () => {
             const methods1 = {
                 defaultShippingMethodId: 'std',
                 applicableShippingMethods: [
@@ -1100,78 +796,49 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: null, isRegistered: false}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'John',
-                                    lastName: 'Smith',
-                                    address1: '789 Elm Street',
-                                    city: 'Portland',
-                                    stateCode: 'OR',
-                                    postalCode: '97201'
-                                },
-                                shippingMethod: {id: 'std', name: 'Standard'}
+            mockUseCurrentCustomer.mockReturnValue({
+                data: {customerId: null, isRegistered: false}
+            })
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'John',
+                                lastName: 'Smith',
+                                address1: '789 Elm Street',
+                                city: 'Portland',
+                                stateCode: 'OR',
+                                postalCode: '97201'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Jane',
-                                    lastName: 'Doe',
-                                    address1: '456 Oak Avenue',
-                                    city: 'Seattle',
-                                    stateCode: 'WA',
-                                    postalCode: '98101'
-                                },
-                                shippingMethod: {id: 'std', name: 'Standard'}
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 0}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
-                })
-            }))
+                            shippingMethod: {id: 'std', name: 'Standard'}
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Jane',
+                                lastName: 'Doe',
+                                address1: '456 Oak Avenue',
+                                city: 'Seattle',
+                                stateCode: 'WA',
+                                postalCode: '98101'
+                            },
+                            shippingMethod: {id: 'std', name: 'Standard'}
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 0}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 0}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: methods1})
+            useShippingMethodsForShipment.mockReturnValue({data: methods1})
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             expect(
                 screen.getByText('John Smith, 789 Elm Street, Portland, OR, 97201')
@@ -1181,9 +848,7 @@ describe('ShippingOptions Component', () => {
             ).toBeInTheDocument()
         })
 
-        test('displays shipping promotions in edit view for multi-shipment', async () => {
-            jest.resetModules()
-
+        test('displays shipping promotions in edit view for multi-shipment', () => {
             const methodsWithPromos = {
                 defaultShippingMethodId: 'std',
                 applicableShippingMethods: [
@@ -1193,10 +858,7 @@ describe('ShippingOptions Component', () => {
                         description: '4-5 days',
                         price: 5.99,
                         shippingPromotions: [
-                            {
-                                promotionId: 'promo1',
-                                calloutMsg: 'Free Shipping Amount Above 50'
-                            }
+                            {promotionId: 'promo1', calloutMsg: 'Free Shipping Amount Above 50'}
                         ]
                     },
                     {
@@ -1209,242 +871,149 @@ describe('ShippingOptions Component', () => {
                 ]
             }
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 3,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: null, isRegistered: false}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'John',
-                                    lastName: 'Smith',
-                                    address1: '789 Elm Street',
-                                    city: 'Portland',
-                                    stateCode: 'OR',
-                                    postalCode: '97201'
-                                },
-                                shippingMethod: null
-                            }
-                        ],
-                        shippingItems: [{shipmentId: 'ship1', price: 0}]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 1}
-                })
-            }))
+            mockUseCurrentCustomer.mockReturnValue({
+                data: {customerId: null, isRegistered: false}
+            })
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'John',
+                                lastName: 'Smith',
+                                address1: '789 Elm Street',
+                                city: 'Portland',
+                                stateCode: 'OR',
+                                postalCode: '97201'
+                            },
+                            shippingMethod: null
+                        }
+                    ],
+                    shippingItems: [{shipmentId: 'ship1', price: 0}]
+                },
+                derivedData: {hasBasket: true, totalItems: 1}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: methodsWithPromos})
+            useShippingMethodsForShipment.mockReturnValue({data: methodsWithPromos})
 
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
+            renderWithProviders(<ShippingOptions />)
 
-            localRenderWithProviders(<module.default />)
-
-            // Verify promotion text is shown in edit view
             expect(screen.getByText('Free Shipping Amount Above 50')).toBeInTheDocument()
         })
     })
 
     describe('multi-shipment summary view', () => {
-        test('renders total shipping cost for multiple shipments', async () => {
-            jest.resetModules()
+        beforeEach(() => {
+            mockUseCheckout.mockReturnValue({
+                step: 4,
+                STEPS: MOCK_STEPS,
+                goToStep: mockGoToStep,
+                goToNextStep: mockGoToNextStep
+            })
+        })
 
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 4,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'John',
-                                    lastName: 'Doe',
-                                    address1: '123 Main St',
-                                    city: 'Test City',
-                                    stateCode: 'CA',
-                                    postalCode: '12345'
-                                },
-                                shippingMethod: {
-                                    id: 'standard-shipping',
-                                    name: 'Standard Shipping',
-                                    description: '5-7 business days'
-                                },
-                                shippingTotal: 5.99
+        test('renders total shipping cost for multiple shipments', () => {
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'John',
+                                lastName: 'Doe',
+                                address1: '123 Main St',
+                                city: 'Test City',
+                                stateCode: 'CA',
+                                postalCode: '12345'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Jane',
-                                    lastName: 'Doe',
-                                    address1: '456 Oak Ave',
-                                    city: 'Other City',
-                                    stateCode: 'NY',
-                                    postalCode: '67890'
-                                },
-                                shippingMethod: {
-                                    id: 'express-shipping',
-                                    name: 'Express Shipping',
-                                    description: '2-3 business days'
-                                },
-                                shippingTotal: 12.99
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 5.99},
-                            {shipmentId: 'ship2', price: 12.99}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 18.98}
-                })
-            }))
+                            shippingMethod: {
+                                id: 'standard-shipping',
+                                name: 'Standard Shipping',
+                                description: '5-7 business days'
+                            },
+                            shippingTotal: 5.99
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Jane',
+                                lastName: 'Doe',
+                                address1: '456 Oak Ave',
+                                city: 'Other City',
+                                stateCode: 'NY',
+                                postalCode: '67890'
+                            },
+                            shippingMethod: {
+                                id: 'express-shipping',
+                                name: 'Express Shipping',
+                                description: '2-3 business days'
+                            },
+                            shippingTotal: 12.99
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 5.99},
+                        {shipmentId: 'ship2', price: 12.99}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 18.98}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: mockShippingMethods})
-
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             expect(screen.getAllByText('Standard Shipping').length).toBeGreaterThan(0)
             expect(screen.getAllByText('Express Shipping').length).toBeGreaterThan(0)
             expect(screen.getByText('Total Shipping')).toBeInTheDocument()
         })
 
-        test('renders "No shipping method selected" when method is null', async () => {
-            jest.resetModules()
-
-            jest.doMock(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/util/checkout-context',
-                () => ({
-                    useCheckout: jest.fn().mockReturnValue({
-                        step: 4,
-                        STEPS: {
-                            CONTACT_INFO: 0,
-                            PICKUP_ADDRESS: 1,
-                            SHIPPING_ADDRESS: 2,
-                            SHIPPING_OPTIONS: 3,
-                            PAYMENT: 4
-                        },
-                        goToStep: mockGoToStep,
-                        goToNextStep: mockGoToNextStep
-                    })
-                })
-            )
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-customer', () => ({
-                useCurrentCustomer: () => ({
-                    data: {customerId: 'test-customer-id', isRegistered: true}
-                })
-            }))
-            jest.doMock('@salesforce/retail-react-app/app/hooks/use-current-basket', () => ({
-                useCurrentBasket: () => ({
-                    data: {
-                        basketId: 'test-basket-id',
-                        shipments: [
-                            {
-                                shipmentId: 'ship1',
-                                shippingAddress: {
-                                    firstName: 'John',
-                                    lastName: 'Doe',
-                                    address1: '123 Main St',
-                                    city: 'Test City',
-                                    stateCode: 'CA',
-                                    postalCode: '12345'
-                                },
-                                shippingMethod: null,
-                                shippingTotal: 0
+        test('renders "No shipping method selected" when method is null', () => {
+            mockUseCurrentBasket.mockReturnValue({
+                data: {
+                    basketId: 'test-basket-id',
+                    shipments: [
+                        {
+                            shipmentId: 'ship1',
+                            shippingAddress: {
+                                firstName: 'John',
+                                lastName: 'Doe',
+                                address1: '123 Main St',
+                                city: 'Test City',
+                                stateCode: 'CA',
+                                postalCode: '12345'
                             },
-                            {
-                                shipmentId: 'ship2',
-                                shippingAddress: {
-                                    firstName: 'Jane',
-                                    lastName: 'Doe',
-                                    address1: '456 Oak Ave',
-                                    city: 'Other City',
-                                    stateCode: 'NY',
-                                    postalCode: '67890'
-                                },
-                                shippingMethod: {
-                                    id: 'express-shipping',
-                                    name: 'Express Shipping',
-                                    description: '2-3 business days'
-                                },
-                                shippingTotal: 12.99
-                            }
-                        ],
-                        shippingItems: [
-                            {shipmentId: 'ship1', price: 0},
-                            {shipmentId: 'ship2', price: 12.99}
-                        ]
-                    },
-                    derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 12.99}
-                })
-            }))
+                            shippingMethod: null,
+                            shippingTotal: 0
+                        },
+                        {
+                            shipmentId: 'ship2',
+                            shippingAddress: {
+                                firstName: 'Jane',
+                                lastName: 'Doe',
+                                address1: '456 Oak Ave',
+                                city: 'Other City',
+                                stateCode: 'NY',
+                                postalCode: '67890'
+                            },
+                            shippingMethod: {
+                                id: 'express-shipping',
+                                name: 'Express Shipping',
+                                description: '2-3 business days'
+                            },
+                            shippingTotal: 12.99
+                        }
+                    ],
+                    shippingItems: [
+                        {shipmentId: 'ship1', price: 0},
+                        {shipmentId: 'ship2', price: 12.99}
+                    ]
+                },
+                derivedData: {hasBasket: true, totalItems: 2, totalShippingCost: 12.99}
+            })
 
-            const sdk = await import('@salesforce/commerce-sdk-react')
-            sdk.useShippingMethodsForShipment.mockReturnValue({data: mockShippingMethods})
-
-            const {renderWithProviders: localRenderWithProviders} = await import(
-                '@salesforce/retail-react-app/app/utils/test-utils'
-            )
-            const module = await import(
-                '@salesforce/retail-react-app/app/pages/checkout-one-click/partials/one-click-shipping-options'
-            )
-
-            localRenderWithProviders(<module.default />)
+            renderWithProviders(<ShippingOptions />)
 
             expect(screen.getByText('No shipping method selected')).toBeInTheDocument()
         })


### PR DESCRIPTION
Summary of bug: When a guest user enters a custom billing address (different from shipping) and then registers via OTP during one-click checkout, the order is placed with the shipping address as the billing address instead of the custom one the shopper entered.

# Description

Root cause: After OTP registration, the checkout step advances to REVIEW_ORDER, which toggles the payment ToggleCard to summary mode and unmounts the billing ShippingAddressSelection component. When onPlaceOrder calls setIsEditingPayment(true), the component remounts and its mount effect resets the billing form to the customer's preferred saved address (the shipping address), overwriting the custom billing values. onBillingSubmit then reads the reset form and sends the shipping address to the API.

Fix: Snapshot the billing form values in onPlaceOrder before any payment mutations, and restore them in onBillingSubmit before validation. Additionally, keep CheckoutOneClick mounted during auth transitions using a ref guard in CheckoutContainer, and use a ref mirror of billingSameAsShipping to prevent stale closure reads in the async Place Order flow.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

The actual fix relies on the three remaining changes:
billingSameAsShippingRef -- reads the latest value in async flows
Billing form snapshot in onPlaceOrder -- captures values before payment mutations
onBillingSubmit(billingFormSnapshot) -- restores the snapshot before validation
hasRenderedCheckoutRef in CheckoutContainer -- keeps the component mounted during auth transitions

# How to Test-Drive This PR

Newly registered shoppers via OTP in 1CC in 2 scenarios:
-- Enter a custom billing address -> Register with OTP -> See the custom billing address retained -> Place Order
-- Keep billing address same as shipping -> Register with OTP -> Enter a custom billing address -> Place Order

Returning shoppers + Guest shoppers behavior should be the same.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
