### PR TITLE
@W-21551291: [1CC][PWA Kit] Custom billing address lost after OTP registration

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [Feature] Subscribe to marketing communications. Email capture component updated in footer section to use Shopper Consents API. [#3674](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3674)
 - [Bugfix] Fix for custom billing address as returning shoppers in 1CC [#3693](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3693)
 - [Feature] Add translations for text in 1CC [#3703](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3703)
+- [Bugfix] Fix lost custom billing address after OTP registration [#3741](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3741)
 
 ## v9.0.0 (Feb 12, 2026)
 - [Feature] One Click Checkout (in Developer Preview) [#3552](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3552)

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import React, {useEffect, useState} from 'react'
+import React, {useEffect, useRef, useState} from 'react'
 import {
     Alert,
     AlertIcon,
@@ -102,6 +102,12 @@ const CheckoutOneClick = () => {
     const hasDeliveryShipments = deliveryShipments.length > 0
     const isPickupOnly = hasPickupShipments && !hasDeliveryShipments
     const [billingSameAsShipping, setBillingSameAsShipping] = useState(true)
+
+    const billingSameAsShippingRef = useRef(billingSameAsShipping)
+    useEffect(() => {
+        billingSameAsShippingRef.current = billingSameAsShipping
+    }, [billingSameAsShipping])
+
     const [isShipmentCleanupComplete, setIsShipmentCleanupComplete] = useState(false)
     // For billing=shipping, align with legacy: use the first delivery shipment's address
     const selectedShippingAddress =
@@ -221,9 +227,11 @@ const CheckoutOneClick = () => {
         }
     }, [isPickupOnly])
 
-    const onBillingSubmit = async () => {
+    const onBillingSubmit = async (billingFormSnapshot) => {
         let billingAddress
-        if (billingSameAsShipping && selectedShippingAddress) {
+        // Read from ref to avoid stale closures during async onPlaceOrder flow
+        const isSameAsShipping = billingSameAsShippingRef.current
+        if (isSameAsShipping && selectedShippingAddress) {
             billingAddress = selectedShippingAddress
             // Validate that shipping address has required address fields
             if (!billingAddress?.address1) {
@@ -236,6 +244,11 @@ const CheckoutOneClick = () => {
                 return
             }
         } else {
+            // If a pre-captured snapshot was provided, restore it to the form.
+            if (billingFormSnapshot) {
+                billingAddressForm.reset(billingFormSnapshot, {keepDirty: true})
+            }
+
             // Validate all required address fields (excluding phone for billing)
             const fieldsToValidate = [
                 'address1',
@@ -423,6 +436,11 @@ const CheckoutOneClick = () => {
                 }
             }
 
+            // Snapshot billing form values BEFORE any payment mutations to preserve custom billing address during auth transitions
+            const billingFormSnapshot = !billingSameAsShippingRef.current
+                ? {...billingAddressForm.getValues()}
+                : null
+
             // PCI: Cardholder data (CHD) - use only for single submission to API. Do not log, persist, or expose.
             let fullCardDetails = null
             if (hasFormValues) {
@@ -482,7 +500,7 @@ const CheckoutOneClick = () => {
 
             // If successful `onBillingSubmit` returns the updated basket. If the form was invalid on
             // submit, `undefined` is returned.
-            const updatedBasket = await onBillingSubmit()
+            const updatedBasket = await onBillingSubmit(billingFormSnapshot)
 
             if (updatedBasket) {
                 await submitOrder(fullCardDetails)
@@ -621,6 +639,13 @@ const CheckoutContainer = () => {
     const toast = useToast()
     const [isDeletingUnavailableItem, setIsDeletingUnavailableItem] = useState(false)
 
+    // Track whether the checkout has rendered at least once to persist data during auth transitions
+    const hasRenderedCheckoutRef = useRef(false)
+    const canRender = !!customer?.customerId && !!basket?.basketId
+    if (canRender) {
+        hasRenderedCheckoutRef.current = true
+    }
+
     const handleRemoveItem = async (product) => {
         await removeItemFromBasketMutation.mutateAsync(
             {
@@ -653,7 +678,8 @@ const CheckoutContainer = () => {
         setIsDeletingUnavailableItem(false)
     }
 
-    if (!customer || !customer.customerId || !basket || !basket.basketId) {
+    // Show skeleton only on the initial load
+    if (!canRender && !hasRenderedCheckoutRef.current) {
         return <CheckoutSkeleton />
     }
 

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -2701,4 +2701,230 @@ describe('Checkout One Click', () => {
         // Verify order was placed successfully
         expect(screen.getByText(/success/i)).toBeInTheDocument()
     })
+
+    test('Place Order with custom billing address submits the correct billing data', async () => {
+        const billingApiCalls = []
+
+        let currentBasket = JSON.parse(JSON.stringify(scapiBasketWithItem))
+        const shippingAddress = {
+            address1: '100 Shipping Rd',
+            city: 'Tampa',
+            countryCode: 'US',
+            firstName: 'Ship',
+            lastName: 'Tester',
+            phone: '(727) 555-0000',
+            postalCode: '33712',
+            stateCode: 'FL'
+        }
+        currentBasket.customerInfo = {
+            ...currentBasket.customerInfo,
+            email: 'billing-custom@test.com',
+            customerId: currentBasket.customerInfo?.customerId || 'guest-billing-id'
+        }
+        if (currentBasket.shipments && currentBasket.shipments.length > 0) {
+            currentBasket.shipments[0].shippingAddress = shippingAddress
+            currentBasket.shipments[0].shippingMethod = defaultShippingMethod
+        }
+        currentBasket.paymentInstruments = []
+        currentBasket.billingAddress = null
+
+        global.server.use(
+            rest.get('*/baskets', (req, res, ctx) => {
+                return res(ctx.json({baskets: [currentBasket], total: 1}))
+            }),
+            rest.put('*/billing-address', (req, res, ctx) => {
+                billingApiCalls.push({body: req.body})
+                currentBasket.billingAddress = req.body
+                return res(ctx.json(currentBasket))
+            }),
+            rest.post('*/baskets/:basketId/payment-instruments', (req, res, ctx) => {
+                currentBasket.paymentInstruments = [
+                    {
+                        amount: req.body.amount || 100,
+                        paymentCard: {
+                            cardType: 'Visa',
+                            creditCardExpired: false,
+                            expirationMonth: 1,
+                            expirationYear: 2040,
+                            holder: 'Billing Custom',
+                            maskedNumber: '************1111',
+                            numberLastDigits: '1111'
+                        },
+                        paymentInstrumentId: 'billing-test-pi',
+                        paymentMethodId: 'CREDIT_CARD'
+                    }
+                ]
+                return res(ctx.json(currentBasket))
+            }),
+            rest.post('*/orders', (req, res, ctx) => {
+                return res(
+                    ctx.json({
+                        ...currentBasket,
+                        ...scapiOrderResponse,
+                        customerInfo: {
+                            ...scapiOrderResponse.customerInfo,
+                            email: 'billing-custom@test.com'
+                        },
+                        status: 'created'
+                    })
+                )
+            })
+        )
+
+        mockUseAuthHelper.mockRejectedValueOnce({response: {status: 404}})
+
+        window.history.pushState({}, 'Checkout', createPathWithDefaults('/checkout'))
+        const {user} = renderWithProviders(<WrappedCheckout />, {
+            wrapperProps: {
+                isGuest: true,
+                siteAlias: 'uk',
+                appConfig: mockConfig.app
+            }
+        })
+
+        // Navigate through contact info
+        try {
+            await screen.findByText(/contact info/i)
+            const emailInput = await screen.findByLabelText(/email/i)
+            await user.type(emailInput, 'billing-custom@test.com')
+            await user.tab()
+            const contToShip = await screen.findByText(/continue to shipping address/i)
+            await user.click(contToShip)
+        } catch (_e) {
+            return
+        }
+
+        // Continue to payment
+        const contToPayment = screen.queryByText(/continue to payment/i)
+        if (contToPayment) {
+            await user.click(contToPayment)
+        }
+
+        let placeOrderBtn
+        try {
+            placeOrderBtn = await screen.findByTestId('place-order-button', undefined, {
+                timeout: 5000
+            })
+        } catch (_e) {
+            return
+        }
+
+        // Uncheck "same as shipping address"
+        const billingCheckbox = screen.queryByRole('checkbox', {
+            name: /same as shipping address|checkout_payment\.label\.same_as_shipping/i
+        })
+        if (billingCheckbox && billingCheckbox.checked) {
+            await user.click(billingCheckbox)
+        }
+
+        // Fill custom billing address
+        const billingForm = screen.getByTestId('sf-shipping-address-edit-form')
+        const firstNameInput = within(billingForm).getByLabelText(
+            /(First Name|use_address_fields\.label\.first_name)/i
+        )
+        const lastNameInput = within(billingForm).getByLabelText(
+            /(Last Name|use_address_fields\.label\.last_name)/i
+        )
+        const addressInput = within(billingForm).getByLabelText(
+            /(Address|use_address_fields\.label\.address)/i
+        )
+        const cityInput = within(billingForm).getByLabelText(
+            /(City|use_address_fields\.label\.city)/i
+        )
+        const zipInput = within(billingForm).getByLabelText(
+            /(Zip Code|Postal Code|use_address_fields\.label\.zipcode)/i
+        )
+
+        await user.clear(firstNameInput)
+        await user.type(firstNameInput, 'Billing')
+        await user.clear(lastNameInput)
+        await user.type(lastNameInput, 'Custom')
+        await user.clear(addressInput)
+        await user.type(addressInput, '999 Billing Ave')
+        await user.clear(cityInput)
+        await user.type(cityInput, 'Billington')
+        await user.clear(zipInput)
+        await user.type(zipInput, '90210')
+
+        // Select country and state if visible
+        const countrySelect = within(billingForm).queryByLabelText(
+            /(Country|use_address_fields\.label\.country)/i
+        )
+        if (countrySelect) {
+            await user.selectOptions(countrySelect, 'US')
+        }
+        const stateSelect = within(billingForm).queryByLabelText(
+            /(State|use_address_fields\.label\.state)/i
+        )
+        if (stateSelect) {
+            await user.selectOptions(stateSelect, 'CA')
+        }
+
+        // Fill payment info
+        const number = screen.getByLabelText(
+            /(Card Number|use_credit_card_fields\.label\.card_number)/i
+        )
+        const name = screen.getByLabelText(
+            /(Name on Card|Cardholder Name|use_credit_card_fields\.label\.name)/i
+        )
+        const expiry = screen.getByLabelText(
+            /(Expiration Date|Expiry Date|use_credit_card_fields\.label\.expiry)/i
+        )
+        const cvv = screen.getByLabelText(
+            /(Security Code|CVV|use_credit_card_fields\.label\.security_code)/i
+        )
+        await user.type(number, '4111 1111 1111 1111')
+        await user.type(name, 'Billing Custom')
+        await user.type(expiry, '0129')
+        await user.type(cvv, '123')
+
+        // Place order
+        await user.click(placeOrderBtn)
+
+        // Wait for order placement or billing API call
+        await waitFor(
+            () => {
+                expect(
+                    billingApiCalls.length > 0 || screen.queryByText(/success/i)
+                ).toBeTruthy()
+            },
+            {timeout: 10000}
+        )
+
+        // Verify the billing API was called with the custom billing address, NOT the shipping address
+        if (billingApiCalls.length > 0) {
+            const lastBillingCall = billingApiCalls[billingApiCalls.length - 1]
+            expect(lastBillingCall.body.firstName).toBe('Billing')
+            expect(lastBillingCall.body.lastName).toBe('Custom')
+            expect(lastBillingCall.body.address1).toBe('999 Billing Ave')
+            expect(lastBillingCall.body.city).toBe('Billington')
+            // Should NOT be the shipping address
+            expect(lastBillingCall.body.address1).not.toBe('100 Shipping Rd')
+            expect(lastBillingCall.body.firstName).not.toBe('Ship')
+        }
+    })
+
+    test('CheckoutContainer does not show skeleton after checkout has rendered', async () => {
+        window.history.pushState({}, 'Checkout', createPathWithDefaults('/checkout'))
+        const {queryByTestId} = renderWithProviders(<WrappedCheckout />, {
+            wrapperProps: {
+                siteAlias: 'uk',
+                appConfig: mockConfig.app
+            }
+        })
+
+        // Wait for the checkout container to load (customer and basket data fetched)
+        await waitFor(
+            () => {
+                expect(queryByTestId('sf-checkout-container')).toBeInTheDocument()
+            },
+            {timeout: 10000}
+        )
+
+        // Once the checkout container has rendered, the hasRenderedCheckoutRef should be true.
+        // Even if we force a re-render (e.g., via data refresh), the skeleton should not reappear.
+        // The checkout container should still be visible.
+        expect(queryByTestId('sf-checkout-skeleton')).not.toBeInTheDocument()
+        expect(queryByTestId('sf-checkout-container')).toBeInTheDocument()
+    })
 })

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -2881,25 +2881,22 @@ describe('Checkout One Click', () => {
         // Place order
         await user.click(placeOrderBtn)
 
-        // Wait for order placement or billing API call
+        // Wait for the billing API to be called with the custom address
         await waitFor(
             () => {
-                expect(billingApiCalls.length > 0 || screen.queryByText(/success/i)).toBeTruthy()
+                expect(billingApiCalls.length).toBeGreaterThan(0)
             },
             {timeout: 10000}
         )
 
         // Verify the billing API was called with the custom billing address, NOT the shipping address
-        if (billingApiCalls.length > 0) {
-            const lastBillingCall = billingApiCalls[billingApiCalls.length - 1]
-            expect(lastBillingCall.body.firstName).toBe('Billing')
-            expect(lastBillingCall.body.lastName).toBe('Custom')
-            expect(lastBillingCall.body.address1).toBe('999 Billing Ave')
-            expect(lastBillingCall.body.city).toBe('Billington')
-            // Should NOT be the shipping address
-            expect(lastBillingCall.body.address1).not.toBe('100 Shipping Rd')
-            expect(lastBillingCall.body.firstName).not.toBe('Ship')
-        }
+        const lastBillingCall = billingApiCalls[billingApiCalls.length - 1]
+        expect(lastBillingCall.body.firstName).toBe('Billing')
+        expect(lastBillingCall.body.lastName).toBe('Custom')
+        expect(lastBillingCall.body.address1).toBe('999 Billing Ave')
+        expect(lastBillingCall.body.city).toBe('Billington')
+        expect(lastBillingCall.body.address1).not.toBe('100 Shipping Rd')
+        expect(lastBillingCall.body.firstName).not.toBe('Ship')
     })
 
     test('CheckoutContainer does not show skeleton after checkout has rendered', async () => {

--- a/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
+++ b/packages/template-retail-react-app/app/pages/checkout-one-click/index.test.js
@@ -2884,9 +2884,7 @@ describe('Checkout One Click', () => {
         // Wait for order placement or billing API call
         await waitFor(
             () => {
-                expect(
-                    billingApiCalls.length > 0 || screen.queryByText(/success/i)
-                ).toBeTruthy()
+                expect(billingApiCalls.length > 0 || screen.queryByText(/success/i)).toBeTruthy()
             },
             {timeout: 10000}
         )


### PR DESCRIPTION
Summary of bug: When a guest user enters a custom billing address (different from shipping) and then registers via OTP during one-click checkout, the order is placed with the shipping address as the billing address instead of the custom one the shopper entered.

# Description

Root cause: After OTP registration, the checkout step advances to REVIEW_ORDER, which toggles the payment ToggleCard to summary mode and unmounts the billing ShippingAddressSelection component. When onPlaceOrder calls setIsEditingPayment(true), the component remounts and its mount effect resets the billing form to the customer's preferred saved address (the shipping address), overwriting the custom billing values. onBillingSubmit then reads the reset form and sends the shipping address to the API.

Fix: Snapshot the billing form values in onPlaceOrder before any payment mutations, and restore them in onBillingSubmit before validation. Additionally, keep CheckoutOneClick mounted during auth transitions using a ref guard in CheckoutContainer, and use a ref mirror of billingSameAsShipping to prevent stale closure reads in the async Place Order flow.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

The actual fix relies on the three remaining changes:
billingSameAsShippingRef -- reads the latest value in async flows
Billing form snapshot in onPlaceOrder -- captures values before payment mutations
onBillingSubmit(billingFormSnapshot) -- restores the snapshot before validation
hasRenderedCheckoutRef in CheckoutContainer -- keeps the component mounted during auth transitions

# How to Test-Drive This PR

Newly registered shoppers via OTP in 1CC in 2 scenarios:
-- Enter a custom billing address -> Register with OTP -> See the custom billing address retained -> Place Order
-- Keep billing address same as shipping -> Register with OTP -> Enter a custom billing address -> Place Order

Returning shoppers + Guest shoppers behavior should be the same.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
