### PR TITLE
@W-21581300@ Harden SLAS private proxy error handling

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## v3.18.0-dev (Mar 12, 2026)
-- Add additional logging and error handling for SLAS error handling.
+- Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750).
 - Add base path prefix to support multiple MRT environments under 1 domain [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)
 
 ## v3.17.0 (Mar 12, 2026)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.18.0-dev (Mar 12, 2026)
+- Add additional logging and error handling for SLAS error handling.
 - Add base path prefix to support multiple MRT environments under 1 domain [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)
 
 ## v3.17.0 (Mar 12, 2026)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -923,42 +923,73 @@ export const RemoteServerFactory = {
                 },
                 selfHandleResponse: true,
                 onProxyReq: (proxyRequest, incomingRequest, res) => {
-                    applyProxyRequestHeaders({
-                        proxyRequest,
-                        incomingRequest,
-                        proxyPath: slasPrivateProxyPath,
-                        targetHost: options.slasHostName,
-                        targetProtocol: 'https'
-                    })
+                    try {
+                        applyProxyRequestHeaders({
+                            proxyRequest,
+                            incomingRequest,
+                            proxyPath: slasPrivateProxyPath,
+                            targetHost: options.slasHostName,
+                            targetProtocol: 'https'
+                        })
 
-                    if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
-                        // /oauth2/trusted-agent/token endpoint auth header comes from Account Manager
-                        // so the SLAS private client is sent via this special header
-                        proxyRequest.setHeader('_sfdc_client_auth', encodedSlasCredentials)
-                    } else if (
-                        incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints)
-                    ) {
-                        // We pattern match and add client secrets only to endpoints that
-                        // match the regex specified by options.applySLASPrivateClientToEndpoints.
-                        //
-                        // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
-                        // SLAS logout (/oauth2/logout), use the Authorization header for a different
-                        // purpose so we don't want to overwrite the header for those calls.
-                        proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
-                    }
+                        if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
+                            // /oauth2/trusted-agent/token endpoint auth header comes from Account Manager
+                            // so the SLAS private client is sent via this special header
+                            proxyRequest.setHeader('_sfdc_client_auth', encodedSlasCredentials)
+                        } else if (
+                            incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints)
+                        ) {
+                            // We pattern match and add client secrets only to endpoints that
+                            // match the regex specified by options.applySLASPrivateClientToEndpoints.
+                            //
+                            // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
+                            // SLAS logout (/oauth2/logout), use the Authorization header for a different
+                            // purpose so we don't want to overwrite the header for those calls.
+                            proxyRequest.setHeader(
+                                'Authorization',
+                                `Basic ${encodedSlasCredentials}`
+                            )
+                        }
 
-                    // Allow users to apply additional custom modifications to the proxy request
-                    if (typeof options.onSLASPrivateProxyReq === 'function') {
-                        try {
-                            options.onSLASPrivateProxyReq(proxyRequest, incomingRequest, res)
-                        } catch (error) {
-                            logger.error('Error in custom onSLASPrivateProxyReq callback', {
-                                namespace: '_setupSlasPrivateClientProxy',
-                                additionalProperties: {
-                                    error: error
-                                }
+                        // Allow users to apply additional custom modifications to the proxy request
+                        if (typeof options.onSLASPrivateProxyReq === 'function') {
+                            try {
+                                options.onSLASPrivateProxyReq(proxyRequest, incomingRequest, res)
+                            } catch (error) {
+                                logger.error('Error in custom onSLASPrivateProxyReq callback', {
+                                    namespace: '_setupSlasPrivateClientProxy',
+                                    additionalProperties: {
+                                        error: error
+                                    }
+                                })
+                            }
+                        }
+                    } catch (error) {
+                        logger.error('Error in SLAS private proxy request handling', {
+                            namespace: '_setupSlasPrivateClientProxy',
+                            additionalProperties: {
+                                error: error
+                            }
+                        })
+                        if (!res.headersSent) {
+                            res.status(500).json({
+                                message: 'Error preparing SLAS private proxy request'
                             })
                         }
+                    }
+                },
+                onError: (error, req, res) => {
+                    logger.error('Error in SLAS private proxy', {
+                        namespace: '_setupSlasPrivateClientProxy',
+                        additionalProperties: {
+                            error: error,
+                            path: req?.url
+                        }
+                    })
+                    if (!res.headersSent) {
+                        res.status(500).json({
+                            message: 'Error in SLAS private proxy request'
+                        })
                     }
                 },
                 onProxyRes: responseInterceptor((responseBuffer, proxyRes, req, res) => {
@@ -1009,9 +1040,16 @@ export const RemoteServerFactory = {
 
                         return workingBuffer
                     } catch (error) {
-                        console.error(
+                        logger.error(
                             'There is an error processing the response from SLAS. Returning original response.',
-                            error
+                            {
+                                namespace: '_setupSlasPrivateClientProxy',
+                                additionalProperties: {
+                                    error: error,
+                                    statusCode: proxyRes?.statusCode,
+                                    path: req?.url
+                                }
+                            }
                         )
                         return workingBuffer
                     }

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -9,6 +9,7 @@ import {X_ENCODED_HEADERS} from './constants'
 import {default as createEvent} from '@serverless/event-mocks'
 import logger from '../../utils/logger-instance'
 import {catchAndLog, parseRequestUrl} from '../../utils/ssr-server'
+import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
 
 jest.mock('../../utils/ssr-config', () => {
     return {
@@ -28,6 +29,13 @@ jest.mock('../../utils/logger-instance', () => ({
         error: jest.fn()
     }
 }))
+jest.mock('../../utils/ssr-server/configure-proxy', () => {
+    const actual = jest.requireActual('../../utils/ssr-server/configure-proxy')
+    return {
+        ...actual,
+        applyProxyRequestHeaders: jest.fn(actual.applyProxyRequestHeaders)
+    }
+})
 
 describe('the once function', () => {
     test('should prevent a function being called more than once', () => {
@@ -180,6 +188,7 @@ describe('SLAS private proxy', () => {
         // Mock express application
         mockExpress = require('express')
         request = require('supertest')
+        logger.error.mockClear()
     })
 
     afterEach(() => {
@@ -356,6 +365,98 @@ describe('SLAS private proxy', () => {
         } finally {
             mockSlasServerInstance.close()
         }
+    })
+
+    test('returns 500 when onProxyReq logic throws', async () => {
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            res.status(200).json({access_token: 'mock-token'})
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: true,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id'
+                            }
+                        }
+                    }
+                }
+            })
+
+            process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+            applyProxyRequestHeaders.mockImplementationOnce(() => {
+                throw new Error('boom')
+            })
+
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+            const response = await request(app).post(
+                '/mobify/slas/private/shopper/auth/v1/oauth2/token'
+            )
+
+            expect(response.status).toBe(500)
+            expect(response.body).toEqual({
+                message: 'Error preparing SLAS private proxy request'
+            })
+            expect(logger.error).toHaveBeenCalledWith(
+                'Error in SLAS private proxy request handling',
+                expect.objectContaining({
+                    namespace: '_setupSlasPrivateClientProxy'
+                })
+            )
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('returns 500 when proxy emits an error', async () => {
+        const app = mockExpress()
+        const options = RemoteServerFactory._configure({
+            useSLASPrivateClient: true,
+            slasTarget: 'http://127.0.0.1:1',
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            organizationId: 'f_ecom_test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        })
+
+        process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+        const response = await request(app).post(
+            '/mobify/slas/private/shopper/auth/v1/oauth2/token'
+        )
+
+        expect(response.status).toBe(500)
+        expect(response.body).toEqual({
+            message: 'Error in SLAS private proxy request'
+        })
+        expect(logger.error).toHaveBeenCalledWith(
+            'Error in SLAS private proxy',
+            expect.objectContaining({
+                namespace: '_setupSlasPrivateClientProxy'
+            })
+        )
     })
 })
 


### PR DESCRIPTION
# Summary

- Wrap SLAS private onProxyReq logic in a try/catch to prevent uncaught exceptions and return a 500 with logging.
- Add explicit onError handler for SLAS private proxy failures.
- Use structured logging (with status/path context) for SLAS response processing errors.

# Test plan

- Not run (runtime-only change).