### PR TITLE
@W-21198710 Remove passkey nickname in passkey registration flow

### DIFF
--- a/packages/template-retail-react-app/app/components/passkey-registration-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/passkey-registration-modal/index.jsx
@@ -5,26 +5,12 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import React, {useState, useEffect} from 'react'
+import React, {useEffect} from 'react'
 import PropTypes from 'prop-types'
 import {useIntl} from 'react-intl'
 
 // Components
 import OtpAuth from '@salesforce/retail-react-app/app/components/otp-auth'
-import {
-    Button,
-    FormControl,
-    FormLabel,
-    Input,
-    Modal,
-    ModalBody,
-    ModalCloseButton,
-    ModalContent,
-    ModalHeader,
-    ModalOverlay,
-    Alert,
-    AlertIcon
-} from '@salesforce/retail-react-app/app/components/shared/ui'
 
 // Hooks
 import {useForm} from 'react-hook-form'
@@ -44,15 +30,11 @@ import {
 } from '@salesforce/retail-react-app/app/constants'
 
 /**
- * Modal for registering a new passkey with a nickname
+ * Modal for registering a new passkey
  */
 const PasskeyRegistrationModal = ({isOpen, onClose}) => {
     const {data: customer} = useCurrentCustomer()
     const {formatMessage} = useIntl()
-    const [passkeyNickname, setPasskeyNickname] = useState('')
-    const [isLoading, setIsLoading] = useState(false)
-    const [error, setError] = useState(null)
-    const [isOtpAuthOpen, setIsOtpAuthOpen] = useState(false)
 
     const form = useForm()
 
@@ -63,9 +45,6 @@ const PasskeyRegistrationModal = ({isOpen, onClose}) => {
     const finishWebauthnUserRegistration = useAuthHelper(AuthHelpers.FinishWebauthnUserRegistration)
 
     const handleRegisterPasskey = async () => {
-        setIsLoading(true)
-        setError(null)
-
         try {
             await authorizeWebauthnRegistration.mutateAsync({
                 user_id: customer.email,
@@ -74,28 +53,18 @@ const PasskeyRegistrationModal = ({isOpen, onClose}) => {
                     callback_uri: webauthnConfig.callbackURI
                 })
             })
-
-            // Open OTP auth modal
-            onClose()
-            setIsOtpAuthOpen(true)
         } catch (err) {
-            // Set error message for the passkey registration modal
-            setError(formatMessage(API_ERROR_MESSAGE))
-        } finally {
-            setIsLoading(false)
+            // TODO: Propogate error to OTP modal
+            form.setError('global', {type: 'manual', message: formatMessage(API_ERROR_MESSAGE)})
         }
     }
 
     const handleOtpVerification = async (code) => {
-        setIsLoading(true)
-        setError(null)
-
         try {
             // Step 1: Start WebAuthn registration
             const response = await startWebauthnUserRegistration.mutateAsync({
                 user_id: customer.email,
-                pwd_action_token: code,
-                ...(passkeyNickname && {nick_name: passkeyNickname})
+                pwd_action_token: code
             })
 
             // Step 2: Convert response to WebAuthn PublicKeyCredentialCreationOptions format
@@ -144,8 +113,7 @@ const PasskeyRegistrationModal = ({isOpen, onClose}) => {
                 pwd_action_token: code
             })
 
-            // Step 6: Close OTP modal and main modal on success
-            setIsOtpAuthOpen(false)
+            // Step 6: Close on success
             onClose()
 
             return {success: true}
@@ -160,94 +128,26 @@ const PasskeyRegistrationModal = ({isOpen, onClose}) => {
                 success: false,
                 error: message
             }
-        } finally {
-            setIsLoading(false)
         }
     }
 
-    const resetState = () => {
-        setPasskeyNickname('')
-        setError(null)
-    }
-
-    const handleClose = () => {
-        resetState()
-        onClose()
-    }
-
-    // Reset state when modal opens
+    // Trigger registration automatically when modal opens
     useEffect(() => {
         if (isOpen) {
-            resetState()
+            handleRegisterPasskey()
         }
     }, [isOpen])
 
     return (
-        <>
-            <Modal isOpen={isOpen} onClose={handleClose} size="md">
-                <ModalOverlay />
-                <ModalContent>
-                    <ModalHeader>
-                        {formatMessage({
-                            defaultMessage: 'Create Passkey',
-                            id: 'passkey_registration.modal.title'
-                        })}
-                    </ModalHeader>
-                    <ModalCloseButton
-                        aria-label={formatMessage({
-                            id: 'passkey_registration.modal.button.close.assistive_msg',
-                            defaultMessage: 'Close passkey form'
-                        })}
-                        data-testid="passkey-registration-modal-close-button"
-                    />
-                    <ModalBody pb={6}>
-                        {error && (
-                            <Alert status="error" mb={4}>
-                                <AlertIcon />
-                                {error}
-                            </Alert>
-                        )}
-
-                        <FormControl>
-                            <FormLabel>
-                                {formatMessage({
-                                    defaultMessage: 'Passkey Nickname (optional)',
-                                    id: 'passkey_registration.modal.label.nickname'
-                                })}
-                            </FormLabel>
-                            <Input
-                                placeholder="e.g., 'iPhone', 'Personal Laptop'"
-                                value={passkeyNickname}
-                                onChange={(e) => setPasskeyNickname(e.target.value)}
-                                mb={4}
-                                isDisabled={isLoading}
-                            />
-                            <Button
-                                width="full"
-                                colorScheme="blue"
-                                onClick={handleRegisterPasskey}
-                                isLoading={isLoading}
-                                loadingText="Registering..."
-                            >
-                                {formatMessage({
-                                    defaultMessage: 'Register Passkey',
-                                    id: 'passkey_registration.modal.button.register'
-                                })}
-                            </Button>
-                        </FormControl>
-                    </ModalBody>
-                </ModalContent>
-            </Modal>
-            <OtpAuth
-                isOpen={isOtpAuthOpen}
-                onClose={() => setIsOtpAuthOpen(false)}
-                form={form}
-                handleSendEmailOtp={handleRegisterPasskey}
-                handleOtpVerification={handleOtpVerification}
-                isPasskeyRegistration={true}
-                hideCheckoutAsGuestButton={true}
-            />
-        </>
+        <OtpAuth
+            isOpen={isOpen}
+            onClose={onClose}
+            form={form}
+            handleSendEmailOtp={handleRegisterPasskey}
+            handleOtpVerification={handleOtpVerification}
+            isPasskeyRegistration={true}
+            hideCheckoutAsGuestButton={true}
+        />
     )
 }
 

--- a/packages/template-retail-react-app/app/components/passkey-registration-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/passkey-registration-modal/index.jsx
@@ -54,7 +54,6 @@ const PasskeyRegistrationModal = ({isOpen, onClose}) => {
                 })
             })
         } catch (err) {
-            // TODO: Propogate error to OTP modal
             form.setError('global', {type: 'manual', message: formatMessage(API_ERROR_MESSAGE)})
         }
     }

--- a/packages/template-retail-react-app/app/components/passkey-registration-modal/index.test.js
+++ b/packages/template-retail-react-app/app/components/passkey-registration-modal/index.test.js
@@ -41,10 +41,10 @@ jest.mock('@salesforce/retail-react-app/app/components/otp-auth', () => {
     const React = jest.requireActual('react')
     const MockOtpAuth = ({isOpen, handleOtpVerification}) => {
         React.useEffect(() => {
-            if (handleOtpVerification) {
+            if (isOpen && handleOtpVerification) {
                 otpVerificationHandler = handleOtpVerification
             }
-        }, [handleOtpVerification])
+        }, [isOpen, handleOtpVerification])
         return isOpen ? <div data-testid="otp-auth-modal">OTP Auth Modal</div> : null
     }
     MockOtpAuth.propTypes = {
@@ -58,12 +58,6 @@ describe('PasskeyRegistrationModal', () => {
     const mockOnClose = jest.fn()
     const mockCustomer = {
         email: 'test@example.com'
-    }
-
-    function PasskeyRegistrationModalWrapper() {
-        const [isOpen, setIsOpen] = React.useState(true)
-
-        return <PasskeyRegistrationModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
     }
 
     beforeEach(() => {
@@ -111,82 +105,25 @@ describe('PasskeyRegistrationModal', () => {
     })
 
     describe('Rendering', () => {
-        test('renders modal when isOpen is true', () => {
-            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
-                wrapperProps: {appConfig: mockConfig.app}
-            })
-
-            expect(screen.getByText('Create Passkey')).toBeInTheDocument()
-            expect(screen.getByText(/Passkey Nickname/)).toBeInTheDocument()
-            expect(
-                screen.getByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-            ).toBeInTheDocument()
-            expect(screen.getByText('Register Passkey')).toBeInTheDocument()
-        })
-
-        test('does not render modal when isOpen is false', () => {
+        test('does not render OTP modal when isOpen is false', () => {
             renderWithProviders(<PasskeyRegistrationModal isOpen={false} onClose={mockOnClose} />)
 
-            expect(screen.queryByText('Create Passkey')).not.toBeInTheDocument()
-        })
-    })
-
-    describe('User Interactions', () => {
-        test('allows user to type in nickname input', async () => {
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const input = screen.getByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-            await user.type(input, 'My iPhone')
-
-            expect(input).toHaveValue('My iPhone')
+            expect(screen.queryByTestId("Confirm it's you")).not.toBeInTheDocument()
         })
 
-        test('calls onClose when close button is clicked', async () => {
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const closeButton = screen.getByLabelText('Close passkey form')
-            await user.click(closeButton)
-
-            expect(mockOnClose).toHaveBeenCalledTimes(1)
-        })
-
-        test('resets form state when modal opens', async () => {
-            const {user} = renderWithProviders(<PasskeyRegistrationModalWrapper />)
-
-            const input = screen.getByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-            await user.type(input, 'Test Nickname')
-            expect(input).toHaveValue('Test Nickname')
-
-            // Close modal
-            const closeButton = screen.getByTestId('passkey-registration-modal-close-button')
-            await user.click(closeButton)
-
-            await waitFor(() => {
-                expect(
-                    screen.queryByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-                ).not.toBeInTheDocument()
-            })
-
-            // Reopen modal - state should be reset
+        test('renders OTP modal when isOpen is true', () => {
             renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />)
-            const newInput = screen.getByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-            expect(newInput).toHaveValue('')
+
+            expect(screen.getByTestId('otp-auth-modal')).toBeInTheDocument()
         })
     })
 
     describe('Passkey Registration', () => {
-        test('calls authorizeWebauthnRegistration on register button click', async () => {
+        test('calls authorizeWebauthnRegistration automatically on open', async () => {
             mockMutateAsync.mockResolvedValue({})
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(mockMutateAsync).toHaveBeenCalledWith({
@@ -197,49 +134,28 @@ describe('PasskeyRegistrationModal', () => {
             })
         })
 
-        test('closes modal and opens OTP auth modal on successful registration', async () => {
+        test('opens OTP auth modal automatically on successful authorization', async () => {
             mockMutateAsync.mockResolvedValue({})
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
-                expect(mockOnClose).toHaveBeenCalled()
                 expect(screen.getByTestId('otp-auth-modal')).toBeInTheDocument()
             })
         })
 
-        test('displays error message when registration fails', async () => {
-            const errorMessage = 'Registration failed'
-            mockMutateAsync.mockRejectedValue(new Error(errorMessage))
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
-
-            await waitFor(() => {
-                expect(screen.getByText('Something went wrong. Try again!')).toBeInTheDocument()
+        test('does not close when authorization fails', async () => {
+            mockMutateAsync.mockRejectedValue(new Error('Registration failed'))
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
             })
-        })
 
-        test('shows loading state during registration', async () => {
-            mockMutateAsync.mockImplementation(
-                () => new Promise((resolve) => setTimeout(resolve, 100))
-            )
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />
-            )
-
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
-
-            expect(screen.getByText('Registering...')).toBeInTheDocument()
-            expect(registerButton).toBeDisabled()
+            // Auth failure is handled silently — OTP modal stays open
+            await waitFor(() => {
+                expect(screen.getByTestId('otp-auth-modal')).toBeInTheDocument()
+            })
+            expect(mockOnClose).not.toHaveBeenCalled()
         })
     })
 
@@ -314,16 +230,9 @@ describe('PasskeyRegistrationModal', () => {
             global.navigator.credentials.create.mockResolvedValue(mockCredential)
             mockFinishWebauthnRegistration.mockResolvedValue({})
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal first
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(screen.getByTestId('otp-auth-modal')).toBeInTheDocument()
@@ -372,63 +281,9 @@ describe('PasskeyRegistrationModal', () => {
             // Verify success result
             expect(result).toEqual({success: true})
 
-            // Verify modals are closed
+            // Verify modal is closed
             await waitFor(() => {
                 expect(mockOnClose).toHaveBeenCalled()
-            })
-        })
-
-        test('includes nickname in startWebauthnUserRegistration when provided', async () => {
-            const otpCode = '12345678'
-            const nickname = 'My iPhone'
-            const mockStartResponse = {
-                challenge: 'dGVzdA==',
-                rp: {name: 'Test', id: 'example.com'},
-                user: {id: 'dGVzdA==', name: 'test@example.com'},
-                pubKeyCredParams: [],
-                timeout: 60000
-            }
-
-            const mockCredential = {
-                type: 'public-key',
-                id: 'test-id',
-                rawId: new ArrayBuffer(8),
-                response: {
-                    attestationObject: new ArrayBuffer(16),
-                    clientDataJSON: new ArrayBuffer(16)
-                }
-            }
-
-            mockStartWebauthnRegistration.mockResolvedValue(mockStartResponse)
-            global.navigator.credentials.create.mockResolvedValue(mockCredential)
-            mockFinishWebauthnRegistration.mockResolvedValue({})
-
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Set nickname
-            const input = screen.getByPlaceholderText("e.g., 'iPhone', 'Personal Laptop'")
-            await user.type(input, nickname)
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
-
-            await waitFor(() => {
-                expect(otpVerificationHandler).toBeTruthy()
-            })
-
-            await otpVerificationHandler(otpCode)
-
-            // Verify nickname was included
-            expect(mockStartWebauthnRegistration).toHaveBeenCalledWith({
-                user_id: 'test@example.com',
-                pwd_action_token: otpCode,
-                nick_name: nickname
             })
         })
 
@@ -438,16 +293,9 @@ describe('PasskeyRegistrationModal', () => {
 
             mockStartWebauthnRegistration.mockRejectedValue(new Error(errorMessage))
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -460,9 +308,8 @@ describe('PasskeyRegistrationModal', () => {
                 error: 'Something went wrong. Try again!'
             })
 
-            // Verify modals are not closed on error
-            // mockOnClose was called once when opening OTP modal, but not again after error
-            expect(mockOnClose).toHaveBeenCalledTimes(1)
+            // Verify onClose was not called on error
+            expect(mockOnClose).not.toHaveBeenCalled()
         })
 
         test('returns error when WebAuthn API is not available', async () => {
@@ -479,16 +326,9 @@ describe('PasskeyRegistrationModal', () => {
             // Remove credentials API
             delete global.navigator.credentials
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -518,16 +358,9 @@ describe('PasskeyRegistrationModal', () => {
             mockStartWebauthnRegistration.mockResolvedValue(mockStartResponse)
             global.navigator.credentials.create.mockRejectedValue(notAllowedError)
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -554,16 +387,9 @@ describe('PasskeyRegistrationModal', () => {
             mockStartWebauthnRegistration.mockResolvedValue(mockStartResponse)
             global.navigator.credentials.create.mockResolvedValue(null)
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -603,16 +429,9 @@ describe('PasskeyRegistrationModal', () => {
             global.navigator.credentials.create.mockResolvedValue(mockCredential)
             mockFinishWebauthnRegistration.mockRejectedValue(new Error(errorMessage))
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -642,16 +461,9 @@ describe('PasskeyRegistrationModal', () => {
             mockStartWebauthnRegistration.mockResolvedValue(mockStartResponse)
             global.navigator.credentials.create.mockRejectedValue(abortError)
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            // Open OTP modal
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()
@@ -670,15 +482,9 @@ describe('PasskeyRegistrationModal', () => {
 
             mockStartWebauthnRegistration.mockRejectedValue(new Error('401'))
 
-            const {user} = renderWithProviders(
-                <PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />,
-                {
-                    wrapperProps: {appConfig: mockConfig.app}
-                }
-            )
-
-            const registerButton = screen.getByText('Register Passkey')
-            await user.click(registerButton)
+            renderWithProviders(<PasskeyRegistrationModal isOpen={true} onClose={mockOnClose} />, {
+                wrapperProps: {appConfig: mockConfig.app}
+            })
 
             await waitFor(() => {
                 expect(otpVerificationHandler).toBeTruthy()

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -3397,30 +3397,6 @@
       "value": "Previous Page"
     }
   ],
-  "passkey_registration.modal.button.close.assistive_msg": [
-    {
-      "type": 0,
-      "value": "Close passkey form"
-    }
-  ],
-  "passkey_registration.modal.button.register": [
-    {
-      "type": 0,
-      "value": "Register Passkey"
-    }
-  ],
-  "passkey_registration.modal.label.nickname": [
-    {
-      "type": 0,
-      "value": "Passkey Nickname (optional)"
-    }
-  ],
-  "passkey_registration.modal.title": [
-    {
-      "type": 0,
-      "value": "Create Passkey"
-    }
-  ],
   "passkey_registration.toast.button.close.assistive_msg": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -3397,30 +3397,6 @@
       "value": "Previous Page"
     }
   ],
-  "passkey_registration.modal.button.close.assistive_msg": [
-    {
-      "type": 0,
-      "value": "Close passkey form"
-    }
-  ],
-  "passkey_registration.modal.button.register": [
-    {
-      "type": 0,
-      "value": "Register Passkey"
-    }
-  ],
-  "passkey_registration.modal.label.nickname": [
-    {
-      "type": 0,
-      "value": "Passkey Nickname (optional)"
-    }
-  ],
-  "passkey_registration.modal.title": [
-    {
-      "type": 0,
-      "value": "Create Passkey"
-    }
-  ],
   "passkey_registration.toast.button.close.assistive_msg": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -7125,62 +7125,6 @@
       "value": "]"
     }
   ],
-  "passkey_registration.modal.button.close.assistive_msg": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ƈŀǿǿşḗḗ ƥȧȧşşķḗḗẏ ƒǿǿřḿ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
-  "passkey_registration.modal.button.register": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Řḗḗɠīşŧḗḗř Ƥȧȧşşķḗḗẏ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
-  "passkey_registration.modal.label.nickname": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ƥȧȧşşķḗḗẏ Ƞīƈķƞȧȧḿḗḗ (ǿǿƥŧīǿǿƞȧȧŀ)"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
-  "passkey_registration.modal.title": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ƈřḗḗȧȧŧḗḗ Ƥȧȧşşķḗḗẏ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
   "passkey_registration.toast.button.close.assistive_msg": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -1405,18 +1405,6 @@
   "pagination.link.prev.assistive_msg": {
     "defaultMessage": "Previous Page"
   },
-  "passkey_registration.modal.button.close.assistive_msg": {
-    "defaultMessage": "Close passkey form"
-  },
-  "passkey_registration.modal.button.register": {
-    "defaultMessage": "Register Passkey"
-  },
-  "passkey_registration.modal.label.nickname": {
-    "defaultMessage": "Passkey Nickname (optional)"
-  },
-  "passkey_registration.modal.title": {
-    "defaultMessage": "Create Passkey"
-  },
   "passkey_registration.toast.button.close.assistive_msg": {
     "defaultMessage": "Close toast"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -1405,18 +1405,6 @@
   "pagination.link.prev.assistive_msg": {
     "defaultMessage": "Previous Page"
   },
-  "passkey_registration.modal.button.close.assistive_msg": {
-    "defaultMessage": "Close passkey form"
-  },
-  "passkey_registration.modal.button.register": {
-    "defaultMessage": "Register Passkey"
-  },
-  "passkey_registration.modal.label.nickname": {
-    "defaultMessage": "Passkey Nickname (optional)"
-  },
-  "passkey_registration.modal.title": {
-    "defaultMessage": "Create Passkey"
-  },
   "passkey_registration.toast.button.close.assistive_msg": {
     "defaultMessage": "Close toast"
   },


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

To reduce user friction for passkey registration and follow industry standards, we will remove the nickname prompt during the registration flow. Instead SLAS will automatically set the nickname to the name of the passkey provider.

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- remove nickname prompt during passkey registration flow
- automatically call `authorizeWebauthnRegistration` when passkey registration modal is rendered

# How to Test-Drive This PR

- Login to https://wasatch-mrt-passwordless-test.mrt-storefront-staging.com/
- Click the "Create Passkey" button in the toast
- Verify the user is prompted for the OTP and no nickname is prompted
- Check your email and verify an OTP was sent to you

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [x] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [x] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [x] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
