### PR TITLE
Fix TS build error in ShopperConsents mutation tests

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v5.2.0-dev (Mar 12, 2026)
 - Update storefront preview to support base paths [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)
+- Fix TS build error in ShopperConsents mutation tests [#3752](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3752)
 
 ## v5.1.0
 - Add Page Designer Support [#3727](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3727)

--- a/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperConsents/mutation.test.ts
@@ -39,7 +39,7 @@ const baseSubscriptionResponse: ShopperConsentsTypes.ConsentSubscriptionResponse
     data: [
         {
             subscriptionId: 'test-subscription',
-            channels: ['email' as ShopperConsentsTypes.ChannelType],
+            channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
             contactPointValue: 'test@example.com'
         }
     ]
@@ -125,7 +125,7 @@ describe('Cache update behavior', () => {
                 data: [
                     {
                         subscriptionId: 'test-subscription',
-                        channels: ['email' as ShopperConsentsTypes.ChannelType],
+                        channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
                         contactPointValue: 'test@example.com'
                     }
                 ]
@@ -211,12 +211,12 @@ describe('Cache update behavior', () => {
                 data: [
                     {
                         subscriptionId: 'test-subscription',
-                        channels: ['email' as ShopperConsentsTypes.ChannelType],
+                        channels: new Set(['email' as ShopperConsentsTypes.ChannelType]),
                         contactPointValue: 'test@example.com'
                     },
                     {
                         subscriptionId: 'test-subscription-2',
-                        channels: ['sms' as ShopperConsentsTypes.ChannelType],
+                        channels: new Set(['sms' as ShopperConsentsTypes.ChannelType]),
                         contactPointValue: '+15551234567'
                     }
                 ]


### PR DESCRIPTION
Fix build error in commerce-sdk-react

# Description

commerce-sdk-isomorphic@5.1.0 changed the channels property type from ChannelType[] to Set<ChannelType>, breaking the commerce-sdk-react build. Updated 4 occurrences in mutation.test.ts to use new Set([...]).

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->


- [X] **Other changes** (non-breaking changes that does not fit any of the above)

