### PR TITLE
@W-21671037@ Remove base path from /__pwa-kit requests if showBasePath is false

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v5.1.1-preview.0 (Mar 13, 2026)
 - Update storefront preview to support base paths [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)
+- Remove base path from /__pwa-kit route requests when showBasePath is false [#3758](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3758)
 
 ## v5.1.0 (Mar 12, 2026)
 - Add Page Designer Support [#3727](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3727)

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -213,6 +213,102 @@ describe('Storefront Preview Component', function () {
         expect(mockPush).toHaveBeenCalledWith({pathname: '/product/123', search: '?q=1'})
     })
 
+    test('experimentalUnsafeNavigate strips base path prefix from /__pwa-kit/ paths when getBasePath returns empty (showBasePath false)', () => {
+        ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
+
+        render(
+            <StorefrontPreview
+                enabled={true}
+                getToken={() => 'my-token'}
+                getBasePath={() => ''}
+            />
+        )
+
+        // Runtime Admin sends /test/__pwa-kit/refresh but React Router has no basename
+        window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.(
+            '/test/__pwa-kit/refresh?referrer=/some-page',
+            'replace'
+        )
+        expect(mockReplace).toHaveBeenCalledWith('/__pwa-kit/refresh?referrer=/some-page')
+    })
+
+    test('experimentalUnsafeNavigate strips base path prefix from /__pwa-kit/ location objects when getBasePath returns empty', () => {
+        ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
+
+        render(
+            <StorefrontPreview
+                enabled={true}
+                getToken={() => 'my-token'}
+                getBasePath={() => ''}
+            />
+        )
+
+        window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.(
+            {pathname: '/test/__pwa-kit/refresh', search: '?referrer=/some-page'},
+            'replace'
+        )
+        expect(mockReplace).toHaveBeenCalledWith({
+            pathname: '/__pwa-kit/refresh',
+            search: '?referrer=/some-page'
+        })
+    })
+
+    test('experimentalUnsafeNavigate normalizes /__pwa-kit/ paths and then strips router base path (showBasePath true)', () => {
+        ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
+
+        render(
+            <StorefrontPreview
+                enabled={true}
+                getToken={() => 'my-token'}
+                getBasePath={() => '/test'}
+            />
+        )
+
+        // Runtime Admin sends /test/__pwa-kit/refresh, normalizePwaKitPath strips to
+        // /__pwa-kit/refresh, then removeBasePathFromLocation is a no-op (doesn't start with /test/)
+        // React Router re-adds the basename, so history receives /__pwa-kit/refresh
+        window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.(
+            '/test/__pwa-kit/refresh?referrer=/test/some-page',
+            'replace'
+        )
+        expect(mockReplace).toHaveBeenCalledWith('/__pwa-kit/refresh?referrer=/test/some-page')
+    })
+
+    test('experimentalUnsafeNavigate does not alter /__pwa-kit/ paths that have no prefix', () => {
+        ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
+
+        render(
+            <StorefrontPreview
+                enabled={true}
+                getToken={() => 'my-token'}
+                getBasePath={() => ''}
+            />
+        )
+
+        // Path already starts with /__pwa-kit/ — no prefix to strip
+        window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.(
+            '/__pwa-kit/refresh?referrer=/some-page',
+            'push'
+        )
+        expect(mockPush).toHaveBeenCalledWith('/__pwa-kit/refresh?referrer=/some-page')
+    })
+
+    test('experimentalUnsafeNavigate does not affect non /__pwa-kit/ paths when showBasePath is false', () => {
+        ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
+
+        render(
+            <StorefrontPreview
+                enabled={true}
+                getToken={() => 'my-token'}
+                getBasePath={() => ''}
+            />
+        )
+
+        // Regular navigation paths should pass through untouched
+        window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.('/products/123', 'push')
+        expect(mockPush).toHaveBeenCalledWith('/products/123')
+    })
+
     test('cache breaker is added to the parameters of SCAPI requests, only if in storefront preview', () => {
         ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
         mockQueryEndpoint('baskets/123', {})

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
@@ -27,6 +27,28 @@ function removeBasePathFromPath(path: string, basePath: string): string {
     return matches ? path.slice(basePath.length) || '/' : path
 }
 
+const PWA_KIT_PATH_PREFIX = '/__pwa-kit/'
+
+/**
+ * Runtime Admin always prepends envBasePath to /__pwa-kit/ paths (e.g. /test/__pwa-kit/refresh),
+ * but when showBasePath is false, React Router has no basename and expects /__pwa-kit/refresh.
+ * 
+ * This ensures that regardless of the showBasePath setting, these paths are normalized to 
+ * remove the base path.
+ */
+function normalizePwaKitPath<T>(pathOrLocation: LocationDescriptor<T>): LocationDescriptor<T> {
+    if (typeof pathOrLocation === 'string') {
+        const idx = pathOrLocation.indexOf(PWA_KIT_PATH_PREFIX)
+        return idx > 0 ? pathOrLocation.slice(idx) : pathOrLocation
+    }
+    const pathname = pathOrLocation.pathname ?? '/'
+    const idx = pathname.indexOf(PWA_KIT_PATH_PREFIX)
+    if (idx > 0) {
+        return {...pathOrLocation, pathname: pathname.slice(idx)}
+    }
+    return pathOrLocation
+}
+
 /**
  * Strip the base path from a path
  *
@@ -53,8 +75,8 @@ function removeBasePathFromLocation<T>(
  * @param enabled - flag to turn on/off Storefront Preview feature. By default, it is set to true.
  * This flag only applies if storefront is running in a Runtime Admin iframe.
  * @param getToken - A method that returns the access token for the current user
- * @param getBasePath - A method that returns the router base path of the app. Requird if using
- * base path for router routes (showBasePath is true in url config).
+ * @param getBasePath - A method that returns the router base path of the app.
+ * Required if using a base path for router routes (showBasePath is true in url config).
  */
 export const StorefrontPreview = ({
     children,
@@ -88,7 +110,8 @@ export const StorefrontPreview = ({
                     ...args: unknown[]
                 ) => {
                     const basePath = getBasePath?.() ?? ''
-                    const pathWithoutBase = removeBasePathFromLocation(path, basePath)
+                    const normalizedPath = normalizePwaKitPath(path)
+                    const pathWithoutBase = removeBasePathFromLocation(normalizedPath, basePath)
                     history[action](pathWithoutBase, ...args)
                 }
             }

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.17.1-preview.0 (Mar 13, 2026)
 - Add base path prefix to support multiple MRT environments under 1 domain [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)
+- Remove base path from /__pwa-kit route requests when showBasePath is false [#3758](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3758)
 
 ## v3.17.0 (Mar 12, 2026)
 - Add Node 24 support. Migrate deprecated Node.js `url.parse()` and `url.format()` to the WHATWG `URL` [#3652](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3652)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -54,6 +54,7 @@ import logger from '../../utils/logger-instance'
 import {createProxyMiddleware, responseInterceptor} from 'http-proxy-middleware'
 import {hybridProxy} from '../../utils/ssr-server/hybrid-proxy'
 import {convertExpressRouteToRegex} from '../../utils/ssr-server/convert-express-route'
+import {getConfig} from '../../utils/ssr-config'
 import {ServerlessAdapter} from '@h4ad/serverless-adapter'
 import {DefaultHandler} from '@h4ad/serverless-adapter/lib/handlers/default'
 import {CallbackResolver} from '@h4ad/serverless-adapter/lib/resolvers/callback'
@@ -578,10 +579,16 @@ export const RemoteServerFactory = {
          * If the server receives a request containing the base path, remove it before allowing
          * the request through to the other express endpoints
          *
-         * We scope base path removal to /mobify routes and routes defined by the express app
-         * (For example /callback or /worker.js)
+         * We scope base path removal to /mobify routes, /__pwa-kit routes (when showBasePath
+         * is false), and routes defined by the express app (For example /callback or /worker.js).
          * This is to avoid affecting React Router routes where a site id or locale might be present
          * that is equal to the base path.
+         *
+         * /__pwa-kit routes are a special case. These are internal PWA Kit routes
+         * (e.g. /__pwa-kit/refresh) that are registered as React Router routes and are invoked
+         * by the Storefront Preview code on Runtime Admin (which always appends a base path if set).
+         * When showBasePath is false, React Router has no basename, so the base path must be stripped here.
+         * When showBasePath is true, React Router handles the base path via its basename prop.
          *
          * For example, if you have a base path of /us and a site id of /us we don't want
          * to remove the /us from www.example.com/us/en-US/category/... as this route is handled by
@@ -590,11 +597,18 @@ export const RemoteServerFactory = {
          * @param req {express.req} the incoming request - modified in-place
          * @private
          */
+        const showBasePath = getConfig()?.app?.url?.showBasePath === true
+
         const removeBasePathMiddleware = (req, res, next) => {
             const basePath = getEnvBasePath()
 
             // Fast path: /mobify routes always get the base path removed
-            if (req.path.startsWith(`${basePath}/mobify`)) {
+            // /__pwa-kit routes get the base path removed only when showBasePath is false,
+            // because when showBasePath is true, React Router handles it via basename.
+            if (
+                req.path.startsWith(`${basePath}/mobify`) ||
+                (!showBasePath && req.path.startsWith(`${basePath}/__pwa-kit`))
+            ) {
                 const cleanPath = removeBasePathFromPath(req.path)
                 const {search} = parseRequestUrl(req)
                 req.url = cleanPath + search

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -587,7 +587,9 @@ export const RemoteServerFactory = {
          * /__pwa-kit routes are a special case. These are internal PWA Kit routes
          * (e.g. /__pwa-kit/refresh) that are registered as React Router routes and are invoked
          * by the Storefront Preview code on Runtime Admin (which always appends a base path if set).
-         * When showBasePath is false, React Router has no basename, so the base path must be stripped here.
+         * When showBasePath is false, React Router has no basename, so we redirect to the clean
+         * URL (without base path) so the browser navigates to a path that React Router can match
+         * and hydrate correctly on the client.
          * When showBasePath is true, React Router handles the base path via its basename prop.
          *
          * For example, if you have a base path of /us and a site id of /us we don't want
@@ -603,16 +605,20 @@ export const RemoteServerFactory = {
             const basePath = getEnvBasePath()
 
             // Fast path: /mobify routes always get the base path removed
-            // /__pwa-kit routes get the base path removed only when showBasePath is false,
-            // because when showBasePath is true, React Router handles it via basename.
-            if (
-                req.path.startsWith(`${basePath}/mobify`) ||
-                (!showBasePath && req.path.startsWith(`${basePath}/__pwa-kit`))
-            ) {
+            if (req.path.startsWith(`${basePath}/mobify`)) {
                 const cleanPath = removeBasePathFromPath(req.path)
                 const {search} = parseRequestUrl(req)
                 req.url = cleanPath + search
                 return next()
+            }
+
+            // /__pwa-kit routes: when showBasePath is false, the browser URL still has the
+            // base path but client-side React Router has no basename, so hydration would fail.
+            // Redirect to the clean URL so the browser navigates to a path React Router matches.
+            if (!showBasePath && req.path.startsWith(`${basePath}/__pwa-kit`)) {
+                const cleanPath = removeBasePathFromPath(req.path)
+                const {search} = parseRequestUrl(req)
+                return res.redirect(302, cleanPath + search)
             }
 
             // For other routes, only proceed if path equals basePath or path starts with basePath + '/'

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1397,6 +1397,12 @@ describe('SLAS private client proxy', () => {
 })
 
 describe('Base path tests', () => {
+    beforeEach(() => {
+        // Re-establish the getConfig mock that afterEach's restoreAllMocks clears.
+        // _setupBasePathMiddleware reads getConfig() at setup time.
+        jest.spyOn(ssrConfig, 'getConfig').mockReturnValue({})
+    })
+
     afterEach(() => {
         jest.restoreAllMocks()
     })
@@ -1492,6 +1498,50 @@ describe('Base path tests', () => {
             .then((response) => {
                 expect(response.status).toBe(200)
                 expect(response.body.message).toBe('test')
+            })
+    }, 15000)
+
+    test('should remove base path from /__pwa-kit routes when showBasePath is false', async () => {
+        jest.spyOn(ssrNamespacePaths, 'getEnvBasePath').mockReturnValue('/basepath')
+        jest.spyOn(ssrConfig, 'getConfig').mockReturnValue({
+            app: {url: {showBasePath: false}}
+        })
+
+        const app = RemoteServerFactory._createApp(opts())
+
+        let capturedPath = null
+        app.use((req, res, next) => {
+            capturedPath = req.path
+            next()
+        })
+
+        return request(app)
+            .get('/basepath/__pwa-kit/refresh')
+            .then(() => {
+                // Base path should be stripped since showBasePath is false
+                expect(capturedPath).toBe('/__pwa-kit/refresh')
+            })
+    }, 15000)
+
+    test('should not remove base path from /__pwa-kit routes when showBasePath is true', async () => {
+        jest.spyOn(ssrNamespacePaths, 'getEnvBasePath').mockReturnValue('/basepath')
+        jest.spyOn(ssrConfig, 'getConfig').mockReturnValue({
+            app: {url: {showBasePath: true}}
+        })
+
+        const app = RemoteServerFactory._createApp(opts())
+
+        let capturedPath = null
+        app.use((req, res, next) => {
+            capturedPath = req.path
+            next()
+        })
+
+        return request(app)
+            .get('/basepath/__pwa-kit/refresh')
+            .then(() => {
+                // Base path should NOT be stripped since React Router handles it via basename
+                expect(capturedPath).toBe('/basepath/__pwa-kit/refresh')
             })
     }, 15000)
 })

--- a/packages/pwa-kit-runtime/src/ssr/server/express.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/express.test.js
@@ -1501,7 +1501,7 @@ describe('Base path tests', () => {
             })
     }, 15000)
 
-    test('should remove base path from /__pwa-kit routes when showBasePath is false', async () => {
+    test('should redirect /__pwa-kit routes to clean URL when showBasePath is false', async () => {
         jest.spyOn(ssrNamespacePaths, 'getEnvBasePath').mockReturnValue('/basepath')
         jest.spyOn(ssrConfig, 'getConfig').mockReturnValue({
             app: {url: {showBasePath: false}}
@@ -1509,17 +1509,12 @@ describe('Base path tests', () => {
 
         const app = RemoteServerFactory._createApp(opts())
 
-        let capturedPath = null
-        app.use((req, res, next) => {
-            capturedPath = req.path
-            next()
-        })
-
         return request(app)
-            .get('/basepath/__pwa-kit/refresh')
-            .then(() => {
-                // Base path should be stripped since showBasePath is false
-                expect(capturedPath).toBe('/__pwa-kit/refresh')
+            .get('/basepath/__pwa-kit/refresh?referrer=/some-page')
+            .expect(302)
+            .then((response) => {
+                // Should redirect to the clean URL without base path
+                expect(response.headers.location).toBe('/__pwa-kit/refresh?referrer=/some-page')
             })
     }, 15000)
 


### PR DESCRIPTION
PWA has a toggle, `showBasePath` that determines whether a base path is included in the React Router urls.

Runtime Admin / Storefront Preview, does not have access to showBasePaths. This is 99% not a problem as in all but 1 case, 
Runtime Admin and Storefront Preview are calling /mobify endpoints which will always have the base path if it has been set.

The one exception is when Storefront Preview calls `/__pwa-kit/refresh`. [This is a special React Router route](https://github.com/SalesforceCommerceCloud/pwa-kit/blob/develop/packages/pwa-kit-react-sdk/src/ssr/universal/components/route-component/index.js#L412) that preview invokes to refresh the iframe contents. Because storefront preview will always call /`basepath/__pwa-kit/refresh` even when showBasePaths is false, we always remove the base path from the url because React Router (via the History api) will re-add the base path afterward if showBasePaths is true and leave the url as `/__pwa-kit/refresh` if show basepath is false.


This fix is applied in 2 places: the change in `build-remote-server.js` handles hard navigations to `/basepath/__pwa-kit/refresh` and redirects to `/__pwa-kit/refresh`. The storefront preview component changes handles soft navigations done in storefront preview.
