### PR TITLE
Handle Refresh Token Flow for HttpOnly Session Cookies

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 - Add HttpOnly session cookies for SLAS private client proxy [#3680](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3680)
 - use nightly release of isomorphic sdk that supports httponly cookies [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
+- Handle refresh token flow for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 
 ## v5.2.0-dev (Mar 12, 2026)
 - Update storefront preview to support base paths [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1538,7 +1538,13 @@ describe('HttpOnly Session Cookies', () => {
         const loginGuestMock = helpers.loginGuestUser as jest.Mock
         loginGuestMock.mockResolvedValueOnce(httpOnlyTokenResponse)
 
-        // First call: triggers loginGuestUser
+        // With HttpOnly cookies enabled, the first ready() attempts a refresh (since JS
+        // can't read the HttpOnly refresh token cookie). On a fresh session there's no
+        // refresh token cookie, so SLAS rejects — then it falls through to loginGuestUser.
+        const refreshMock = helpers.refreshAccessToken as jest.Mock
+        refreshMock.mockRejectedValueOnce(new Error('no refresh token'))
+
+        // First call: refresh fails, falls through to loginGuestUser
         await auth.ready()
 
         // Set cc-at-expires cookie (as server would via Set-Cookie header)

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -9,7 +9,7 @@ import {waitFor} from '@testing-library/react'
 import jwt from 'jsonwebtoken'
 import {helpers, ShopperCustomersTypes, ShopperCustomers} from 'commerce-sdk-isomorphic'
 import * as utils from '../utils'
-import {SLAS_SECRET_PLACEHOLDER} from '../constant'
+import {SLAS_SECRET_PLACEHOLDER, X_GRANT_TYPE} from '../constant'
 import {ShopperLoginTypes} from 'commerce-sdk-isomorphic'
 import {
     DEFAULT_SLAS_REFRESH_TOKEN_REGISTERED_TTL,
@@ -62,6 +62,7 @@ jest.mock('commerce-sdk-isomorphic', () => {
                     clientId: 'clientId',
                     siteId: 'siteId'
                 },
+                headers: config?.headers || {},
                 fetchOptions: {
                     credentials: config?.fetchOptions?.credentials || 'same-origin'
                 }
@@ -1615,5 +1616,90 @@ describe('HttpOnly Session Cookies', () => {
         expect(auth.get('access_token')).toBe(TOKEN_RESPONSE.access_token)
         expect(auth.get('refresh_token_guest')).toBe(TOKEN_RESPONSE.refresh_token)
         onClientMock.mockReturnValue(true)
+    })
+
+    test('refreshAccessToken sets x-grant-type header during the call and cleans it up after', async () => {
+        const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
+
+        // Simulate an expired access token with a valid refresh token
+        const expiredTime = Math.floor(Date.now() / 1000) - 100
+        // @ts-expect-error private method
+        auth.set('cc-at-expires', String(expiredTime))
+        // @ts-expect-error private method
+        auth.set('refresh_token_guest', 'refresh_token')
+        // @ts-expect-error private method
+        auth.set('customer_type', 'guest')
+        // @ts-expect-error private method
+        auth.set('access_token', JWTExpired)
+
+        // Capture the header value during the refresh call
+        let headerDuringCall: string | undefined
+        const refreshMock = helpers.refreshAccessToken as jest.Mock
+        refreshMock.mockImplementationOnce((options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
+            headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
+            return Promise.resolve(TOKEN_RESPONSE)
+        })
+
+        await auth.ready()
+
+        // x-grant-type was set to 'refresh_token' during the call
+        expect(headerDuringCall).toBe('refresh_token')
+        // x-grant-type is cleaned up after the call
+        // @ts-expect-error private property
+        expect(auth.client.clientConfig.headers[X_GRANT_TYPE]).toBeUndefined()
+    })
+
+    test('refreshAccessToken cleans up x-grant-type header even when the call fails', async () => {
+        const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
+
+        const expiredTime = Math.floor(Date.now() / 1000) - 100
+        // @ts-expect-error private method
+        auth.set('cc-at-expires', String(expiredTime))
+        // @ts-expect-error private method
+        auth.set('refresh_token_guest', 'refresh_token')
+        // @ts-expect-error private method
+        auth.set('customer_type', 'guest')
+        // @ts-expect-error private method
+        auth.set('access_token', JWTExpired)
+
+        // Mock a failure with an 'invalid refresh_token' response
+        const refreshMock = helpers.refreshAccessToken as jest.Mock
+        refreshMock.mockRejectedValueOnce(
+            Object.assign(new Error('invalid refresh_token'), {
+                response: {json: () => Promise.resolve({message: 'invalid refresh_token'})}
+            })
+        )
+        // After refresh fails, it falls through to loginGuestUser
+        const loginGuestMock = helpers.loginGuestUser as jest.Mock
+        loginGuestMock.mockResolvedValueOnce(httpOnlyTokenResponse)
+
+        await auth.ready()
+
+        // x-grant-type is cleaned up despite the failure
+        // @ts-expect-error private property
+        expect(auth.client.clientConfig.headers[X_GRANT_TYPE]).toBeUndefined()
+        expect(refreshMock).toHaveBeenCalled()
+    })
+
+    test('refreshAccessToken does not set x-grant-type header when httpOnly cookies are disabled', async () => {
+        const auth = new Auth({...config, enableHttpOnlySessionCookies: false})
+
+        // @ts-expect-error private method
+        auth.set('access_token', JWTExpired)
+        // @ts-expect-error private method
+        auth.set('refresh_token_guest', 'refresh_token')
+
+        let headerDuringCall: string | undefined
+        const refreshMock = helpers.refreshAccessToken as jest.Mock
+        refreshMock.mockImplementationOnce((options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
+            headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
+            return Promise.resolve(TOKEN_RESPONSE)
+        })
+
+        await auth.ready()
+
+        expect(headerDuringCall).toBeUndefined()
+        // @ts-expect-error private property
+        expect(auth.client.clientConfig.headers[X_GRANT_TYPE]).toBeUndefined()
     })
 })

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1635,10 +1635,12 @@ describe('HttpOnly Session Cookies', () => {
         // Capture the header value during the refresh call
         let headerDuringCall: string | undefined
         const refreshMock = helpers.refreshAccessToken as jest.Mock
-        refreshMock.mockImplementationOnce((options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
-            headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
-            return Promise.resolve(TOKEN_RESPONSE)
-        })
+        refreshMock.mockImplementationOnce(
+            (options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
+                headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
+                return Promise.resolve(TOKEN_RESPONSE)
+            }
+        )
 
         await auth.ready()
 
@@ -1691,10 +1693,12 @@ describe('HttpOnly Session Cookies', () => {
 
         let headerDuringCall: string | undefined
         const refreshMock = helpers.refreshAccessToken as jest.Mock
-        refreshMock.mockImplementationOnce((options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
-            headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
-            return Promise.resolve(TOKEN_RESPONSE)
-        })
+        refreshMock.mockImplementationOnce(
+            (options: {slasClient: {clientConfig: {headers: Record<string, string>}}}) => {
+                headerDuringCall = options.slasClient.clientConfig.headers[X_GRANT_TYPE]
+                return Promise.resolve(TOKEN_RESPONSE)
+            }
+        )
 
         await auth.ready()
 

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -745,14 +745,24 @@ class Auth {
         const refreshTokenRegistered = this.get('refresh_token_registered')
         const refreshTokenGuest = this.get('refresh_token_guest')
         const refreshToken = refreshTokenRegistered || refreshTokenGuest
-        if (refreshToken) {
+
+        // When HttpOnly session cookies are enabled on the client, the refresh token is in an
+        // HttpOnly cookie that JavaScript cannot read. We still attempt the refresh request —
+        // the SLAS private proxy injects the refresh token via the sfdc_refresh_token header.
+        const hasHttpOnlyRefreshToken =
+            !refreshToken &&
+            this.enableHttpOnlySessionCookies &&
+            onClient()
+
+        if (refreshToken || hasHttpOnlyRefreshToken) {
             try {
+                const isGuest = this.get('customer_type') !== 'registered'
                 return await this.queueRequest(
                     () =>
                         helpers.refreshAccessToken({
                             slasClient: this.client,
                             parameters: {
-                                refreshToken,
+                                refreshToken: refreshToken || '',
                                 dnt: dntPref
                             },
                             credentials: {
@@ -760,7 +770,7 @@ class Auth {
                             },
                             enableHttpOnlySessionCookies: this.enableHttpOnlySessionCookies
                         }),
-                    !!refreshTokenGuest
+                    isGuest
                 )
             } catch (error) {
                 // If the refresh token is invalid, we need to re-login the user

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -30,7 +30,8 @@ import {
     SLAS_SECRET_OVERRIDE_MSG,
     DNT_COOKIE_NAME,
     DWSID_COOKIE_NAME,
-    SLAS_REFRESH_TOKEN_COOKIE_TTL_OVERRIDE_MSG
+    SLAS_REFRESH_TOKEN_COOKIE_TTL_OVERRIDE_MSG,
+    X_GRANT_TYPE
 } from '../constant'
 
 import {Logger} from '../types'
@@ -750,13 +751,16 @@ class Auth {
         // HttpOnly cookie that JavaScript cannot read. We still attempt the refresh request —
         // the SLAS private proxy injects the refresh token via the sfdc_refresh_token header.
         const hasHttpOnlyRefreshToken =
-            !refreshToken &&
-            this.enableHttpOnlySessionCookies &&
-            onClient()
+            !refreshToken && this.enableHttpOnlySessionCookies && onClient()
 
         if (refreshToken || hasHttpOnlyRefreshToken) {
             try {
                 const isGuest = this.get('customer_type') !== 'registered'
+                // Signal the proxy that this is a refresh token request so it can
+                // inject the HttpOnly refresh token cookie as the sfdc_refresh_token header.
+                if (this.enableHttpOnlySessionCookies) {
+                    this.client.clientConfig.headers[X_GRANT_TYPE] = 'refresh_token'
+                }
                 return await this.queueRequest(
                     () =>
                         helpers.refreshAccessToken({
@@ -784,6 +788,8 @@ class Auth {
                         this.clearStorage()
                     }
                 }
+            } finally {
+                delete this.client.clientConfig.headers[X_GRANT_TYPE]
             }
         }
 

--- a/packages/commerce-sdk-react/src/constant.ts
+++ b/packages/commerce-sdk-react/src/constant.ts
@@ -44,6 +44,9 @@ export const EXCLUDE_COOKIE_SUFFIX = [DWSID_COOKIE_NAME, DNT_COOKIE_NAME]
  */
 export const SERVER_AFFINITY_HEADER_KEY = 'sfdc_dwsid'
 
+// Custom header sent by the SDK to signal a refresh token request to the proxy.
+export const X_GRANT_TYPE = 'x-grant-type'
+
 export const CLIENT_KEYS = {
     SHOPPER_BASKETS: 'shopperBaskets',
     SHOPPER_BASKETS_V2: 'shopperBasketsV2',

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `x-site-id` request header to read HttpOnly cookies on the server [#3700](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3700)
 - Rename the configuration flag `disableHttpOnlySessionCookies` to `enableHttpOnlySessionCookies` [#3723](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3723)
 - updated package-lock [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
+- Handle refresh token flow and consolidate `x-site-id` header usage for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 
 ## v3.18.0-dev (Mar 12, 2026)
 - Add base path prefix to support multiple MRT environments under 1 domain [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -95,6 +95,36 @@ export const isBinary = (headers) => {
 }
 
 /**
+ * Inject the refresh token from HttpOnly cookies as the sfdc_refresh_token header.
+ * SLAS uses sfdc_refresh_token as a fallback when the refresh_token body parameter is
+ * missing or empty (which is the case when HttpOnly session cookies are enabled, because
+ * client-side JavaScript cannot read the HttpOnly refresh token cookie).
+ * @private
+ */
+export const setRefreshTokenHeader = (proxyRequest, incomingRequest) => {
+    const cookieHeader = incomingRequest.headers.cookie
+    if (!cookieHeader) return
+
+    const cookies = cookie.parse(cookieHeader)
+    const siteId = incomingRequest.headers['x-site-id']
+    if (!siteId) {
+        logger.warn(
+            'x-site-id header is missing on SLAS token request. ' +
+                'Refresh token header injection skipped. ' +
+                'Ensure the x-site-id header is set in CommerceApiProvider headers.',
+            {namespace: 'setRefreshTokenHeader'}
+        )
+        return
+    }
+
+    // Try registered refresh token first, then guest
+    const refreshToken = cookies[`cc-nx_${siteId}`] || cookies[`cc-nx-g_${siteId}`]
+    if (refreshToken) {
+        proxyRequest.setHeader('sfdc_refresh_token', refreshToken)
+    }
+}
+
+/**
  * Inject Bearer token and refresh token from HttpOnly cookies for the SLAS logout endpoint.
  * Reads the access token and refresh token from cookies keyed by siteId (from the x-site-id header),
  * sets the Authorization header, and appends refresh_token to the query string.
@@ -1002,6 +1032,17 @@ export const RemoteServerFactory = {
                         // SLAS logout (/oauth2/logout), use the Authorization header for a different
                         // purpose so we don't want to overwrite the header for those calls.
                         proxyRequest.setHeader('Authorization', `Basic ${encodedSlasCredentials}`)
+
+                        // When HttpOnly session cookies are enabled, inject the refresh token
+                        // from the HttpOnly cookie as the sfdc_refresh_token header. SLAS uses
+                        // this header as a fallback for grant_type=refresh_token requests when
+                        // the refresh_token body parameter is empty.
+                        if (
+                            process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
+                            incomingRequest.path?.match(/\/oauth2\/token$/)
+                        ) {
+                            setRefreshTokenHeader(proxyRequest, incomingRequest)
+                        }
                     } else if (
                         process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
                         incomingRequest.path?.match(SLAS_LOGOUT_ENDPOINT)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -16,7 +16,9 @@ import {
     X_ENCODED_HEADERS,
     CONTENT_SECURITY_POLICY,
     SLAS_TOKEN_RESPONSE_ENDPOINTS,
-    SLAS_LOGOUT_ENDPOINT
+    SLAS_LOGOUT_ENDPOINT,
+    X_SITE_ID,
+    X_GRANT_TYPE
 } from './constants'
 import {
     catchAndLog,
@@ -106,7 +108,7 @@ export const setRefreshTokenHeader = (proxyRequest, incomingRequest) => {
     if (!cookieHeader) return
 
     const cookies = cookie.parse(cookieHeader)
-    const siteId = incomingRequest.headers['x-site-id']
+    const siteId = incomingRequest.headers[X_SITE_ID]
     if (!siteId) {
         logger.warn(
             'x-site-id header is missing on SLAS token request. ' +
@@ -135,7 +137,7 @@ export const setTokensInLogoutRequest = (proxyRequest, incomingRequest) => {
     if (!cookieHeader) return
 
     const cookies = cookie.parse(cookieHeader)
-    const siteId = incomingRequest.headers['x-site-id']
+    const siteId = incomingRequest.headers[X_SITE_ID]
     if (!siteId) {
         logger.warn(
             'x-site-id header is missing on SLAS logout request. ' +
@@ -1037,17 +1039,25 @@ export const RemoteServerFactory = {
                         // from the HttpOnly cookie as the sfdc_refresh_token header. SLAS uses
                         // this header as a fallback for grant_type=refresh_token requests when
                         // the refresh_token body parameter is empty.
+                        // The SDK sends x-grant-type: refresh_token to signal this is a refresh request.
                         if (
                             process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
-                            incomingRequest.path?.match(/\/oauth2\/token$/)
+                            incomingRequest.headers[X_GRANT_TYPE] === 'refresh_token'
                         ) {
                             setRefreshTokenHeader(proxyRequest, incomingRequest)
+                            // Remove the signal header — it's only for our proxy, not SLAS.
+                            proxyRequest.removeHeader(X_GRANT_TYPE)
                         }
                     } else if (
                         process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
                         incomingRequest.path?.match(SLAS_LOGOUT_ENDPOINT)
                     ) {
                         setTokensInLogoutRequest(proxyRequest, incomingRequest)
+                    }
+
+                    // Strip internal headers that are only used by our proxy, not by SLAS.
+                    if (process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true') {
+                        proxyRequest.removeHeader(X_SITE_ID)
                     }
 
                     // Allow users to apply additional custom modifications to the proxy request

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {isBinary, once, RemoteServerFactory} from './build-remote-server'
-import {X_ENCODED_HEADERS} from './constants'
+import {X_ENCODED_HEADERS, X_SITE_ID, X_GRANT_TYPE} from './constants'
 import {default as createEvent} from '@serverless/event-mocks'
 import logger from '../../utils/logger-instance'
 import {catchAndLog, parseRequestUrl} from '../../utils/ssr-server'
@@ -527,7 +527,7 @@ describe('HttpOnly session cookies', () => {
                     'Cookie',
                     'cc-at_testsite=mock-access-token; cc-nx_testsite=mock-refresh-token'
                 )
-                .set('x-site-id', 'testsite')
+                .set(X_SITE_ID, 'testsite')
 
             expect(response.status).toBe(200)
             expect(response.body.success).toBe(true)
@@ -585,7 +585,7 @@ describe('HttpOnly session cookies', () => {
                     'Cookie',
                     'cc-at_othersite=other-access-token; cc-nx_othersite=other-refresh-token'
                 )
-                .set('x-site-id', 'othersite')
+                .set(X_SITE_ID, 'othersite')
 
             expect(response.status).toBe(200)
             expect(capturedAuthHeader).toBe('Bearer other-access-token')
@@ -639,7 +639,7 @@ describe('HttpOnly session cookies', () => {
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
-                .set('x-site-id', 'testsite')
+                .set(X_SITE_ID, 'testsite')
 
             expect(response.status).toBe(200)
             expect(response.body).not.toHaveProperty('access_token')
@@ -695,7 +695,7 @@ describe('HttpOnly session cookies', () => {
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
-                .set('x-site-id', 'testsite')
+                .set(X_SITE_ID, 'testsite')
 
             expect(response.status).toBe(500)
             expect(response.body.error).toBe('Internal server error')
@@ -749,7 +749,7 @@ describe('HttpOnly session cookies', () => {
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/passwordless/token')
-                .set('x-site-id', 'testsite')
+                .set(X_SITE_ID, 'testsite')
 
             expect(response.status).toBe(200)
             expect(response.body).not.toHaveProperty('access_token')
@@ -759,6 +759,190 @@ describe('HttpOnly session cookies', () => {
             const cookies = response.headers['set-cookie']
             expect(cookies.some((c) => c.includes('cc-at_testsite'))).toBe(true)
             expect(cookies.some((c) => c.includes('cc-at-expires_testsite'))).toBe(true)
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('injects sfdc_refresh_token header and strips x-grant-type and x-site-id when x-grant-type is refresh_token', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        let capturedHeaders
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            capturedHeaders = req.headers
+            const accessToken = makeJWT({
+                iat: 1000,
+                isb: 'uido:ecom::upn:Guest::uidn:Guest::gcid:g1::rcid:r1::chid:testsite'
+            })
+            res.status(200).json({
+                access_token: accessToken,
+                expires_in: 1800,
+                refresh_token: 'new-refresh-token'
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: true,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+            const response = await request(app)
+                .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
+                .set(
+                    'Cookie',
+                    'cc-nx-g_testsite=mock-guest-refresh-token'
+                )
+                .set(X_SITE_ID, 'testsite')
+                .set(X_GRANT_TYPE, 'refresh_token')
+
+            expect(response.status).toBe(200)
+            // sfdc_refresh_token header was injected with the refresh token from the cookie
+            expect(capturedHeaders['sfdc_refresh_token']).toBe('mock-guest-refresh-token')
+            // x-grant-type and x-site-id were stripped from the outgoing request
+            expect(capturedHeaders[X_GRANT_TYPE]).toBeUndefined()
+            expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+            // HttpOnly cookies are set on the response
+            expect(response.headers['set-cookie']).toBeDefined()
+            const cookies = response.headers['set-cookie']
+            expect(cookies.some((c) => c.includes('cc-at_testsite'))).toBe(true)
+            expect(cookies.some((c) => c.includes('cc-nx-g_testsite'))).toBe(true)
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('does not inject sfdc_refresh_token header when x-grant-type is not refresh_token', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        let capturedHeaders
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            capturedHeaders = req.headers
+            const accessToken = makeJWT({
+                iat: 1000,
+                isb: 'uido:ecom::upn:Guest::uidn:Guest::gcid:g1::rcid:r1::chid:testsite'
+            })
+            res.status(200).json({
+                access_token: accessToken,
+                expires_in: 1800,
+                refresh_token: 'mock-refresh-token'
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: true,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+            // Regular token request (e.g. guest login) — no x-grant-type header
+            const response = await request(app)
+                .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
+                .set(
+                    'Cookie',
+                    'cc-nx-g_testsite=mock-guest-refresh-token'
+                )
+                .set(X_SITE_ID, 'testsite')
+
+            expect(response.status).toBe(200)
+            // sfdc_refresh_token should NOT be injected for non-refresh requests
+            expect(capturedHeaders['sfdc_refresh_token']).toBeUndefined()
+            // x-site-id should still be stripped
+            expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('strips x-site-id from logout requests', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        let capturedHeaders
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/logout', (req, res) => {
+            capturedHeaders = req.headers
+            res.status(200).json({success: true})
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: true,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
+
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+
+            const response = await request(app)
+                .post('/mobify/slas/private/shopper/auth/v1/oauth2/logout')
+                .set(
+                    'Cookie',
+                    'cc-at_testsite=mock-access-token; cc-nx_testsite=mock-refresh-token'
+                )
+                .set(X_SITE_ID, 'testsite')
+
+            expect(response.status).toBe(200)
+            // x-site-id should be stripped from the outgoing request
+            expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
         } finally {
             mockSlasServerInstance.close()
         }

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -810,10 +810,7 @@ describe('HttpOnly session cookies', () => {
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
-                .set(
-                    'Cookie',
-                    'cc-nx-g_testsite=mock-guest-refresh-token'
-                )
+                .set('Cookie', 'cc-nx-g_testsite=mock-guest-refresh-token')
                 .set(X_SITE_ID, 'testsite')
                 .set(X_GRANT_TYPE, 'refresh_token')
 
@@ -880,10 +877,7 @@ describe('HttpOnly session cookies', () => {
             // Regular token request (e.g. guest login) — no x-grant-type header
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
-                .set(
-                    'Cookie',
-                    'cc-nx-g_testsite=mock-guest-refresh-token'
-                )
+                .set('Cookie', 'cc-nx-g_testsite=mock-guest-refresh-token')
                 .set(X_SITE_ID, 'testsite')
 
             expect(response.status).toBe(200)

--- a/packages/pwa-kit-runtime/src/ssr/server/constants.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/constants.js
@@ -35,3 +35,8 @@ export const SLAS_TOKEN_RESPONSE_ENDPOINTS = /\/oauth2\/(token|passwordless\/tok
 // to inject Bearer token and refresh token from HttpOnly cookies.
 // Users can override this in their project's ssr.js options.
 export const SLAS_LOGOUT_ENDPOINT = /\/oauth2\/logout/
+
+// Custom headers used by the proxy layer for HttpOnly session cookie support.
+// These are internal to our proxy and stripped before forwarding to SLAS/SCAPI.
+export const X_SITE_ID = 'x-site-id'
+export const X_GRANT_TYPE = 'x-grant-type'

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
@@ -6,7 +6,7 @@
  */
 import {jwtDecode} from 'jwt-decode'
 import {cookieAsString} from '../../utils/ssr-proxying'
-import {SET_COOKIE} from './constants'
+import {SET_COOKIE, X_SITE_ID} from './constants'
 import logger from '../../utils/logger-instance'
 
 // Refresh token cookie TTL defaults (seconds). Must stay in sync with commerce-sdk-react auth constants.
@@ -68,7 +68,7 @@ function getTokenClaims(accessToken) {
  * @private
  */
 export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, options) {
-    const siteId = req.headers?.['x-site-id']
+    const siteId = req.headers?.[X_SITE_ID]
     if (!siteId) {
         throw new Error(
             'HttpOnly session cookies are enabled but siteId is missing. ' +

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
@@ -5,6 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {getRefreshTokenCookieTTL, setHttpOnlySessionCookies} from './process-token-response'
+import {X_SITE_ID} from './constants'
 import {parse as parseSetCookie} from 'set-cookie-parser'
 
 jest.mock('../../utils/logger-instance', () => ({
@@ -25,7 +26,7 @@ function makeJWT(payload) {
 }
 
 function makeReq(siteId = 'testsite') {
-    return {headers: {'x-site-id': siteId}}
+    return {headers: {[X_SITE_ID]: siteId}}
 }
 
 function makeRes() {

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
@@ -9,6 +9,7 @@ import {
     setScapiAuthRequestHeaders,
     configureProxy
 } from './configure-proxy'
+import {X_SITE_ID} from '../../ssr/server/constants'
 import * as ssrProxying from '../ssr-proxying'
 import * as utils from './utils'
 import cookie from 'cookie'
@@ -121,7 +122,7 @@ describe('setScapiAuthRequestHeaders', () => {
             url: '/shopper/products/v1/products',
             headers: {
                 cookie: 'cc-at_RefArch=test-access-token',
-                'x-site-id': 'RefArch'
+                [X_SITE_ID]: 'RefArch'
             }
         }
 
@@ -149,7 +150,7 @@ describe('setScapiAuthRequestHeaders', () => {
             url: '/shopper/products/v1/products',
             headers: {
                 cookie: 'cc-at_RefArch=test-access-token',
-                'x-site-id': 'RefArch'
+                [X_SITE_ID]: 'RefArch'
             }
         }
 
@@ -201,7 +202,7 @@ describe('setScapiAuthRequestHeaders', () => {
             url: '/api/products',
             headers: {
                 cookie: 'cc-at_RefArch=test-access-token',
-                'x-site-id': 'RefArch'
+                [X_SITE_ID]: 'RefArch'
             }
         }
 
@@ -224,7 +225,7 @@ describe('setScapiAuthRequestHeaders', () => {
         }
         const incomingRequest = {
             url: '/shopper/products/v1/products',
-            headers: {'x-site-id': 'RefArch'}
+            headers: {[X_SITE_ID]: 'RefArch'}
         }
 
         setScapiAuthRequestHeaders({
@@ -249,7 +250,7 @@ describe('setScapiAuthRequestHeaders', () => {
             url: '/shopper/products/v1/products',
             headers: {
                 cookie: 'cc-at_OtherSite=other-access-token',
-                'x-site-id': 'OtherSite'
+                [X_SITE_ID]: 'OtherSite'
             }
         }
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -12,6 +12,7 @@ import {processExpressResponse} from './process-express-response'
 import {isRemote, localDevLog, verboseProxyLogging, isScapiDomain} from './utils'
 import logger from '../logger-instance'
 import {getEnvBasePath} from '../ssr-namespace-paths'
+import {X_SITE_ID} from '../../ssr/server/constants'
 
 export const ALLOWED_CACHING_PROXY_REQUEST_METHODS = ['HEAD', 'GET', 'OPTIONS']
 
@@ -51,7 +52,7 @@ export const setScapiAuthRequestHeaders = ({
     targetHost
 }) => {
     const url = incomingRequest.url
-    const resolvedSiteId = incomingRequest.headers?.['x-site-id']
+    const resolvedSiteId = incomingRequest.headers?.[X_SITE_ID]
 
     // Skip if: caching proxy, not SCAPI domain, or no URL
     if (caching || !isScapiDomain(targetHost) || !url) {
@@ -268,6 +269,8 @@ export const configureProxy = ({
                     caching,
                     targetHost
                 })
+                // Strip internal header — only used by our proxy, not by SCAPI.
+                proxyRequest.removeHeader(X_SITE_ID)
             }
         },
 


### PR DESCRIPTION
**Summary**                                                                                                                                           
                                                                                                                                                    
  - Refresh token flow on the client: When HttpOnly session cookies are enabled, the client-side JavaScript cannot read the refresh token cookie. The SDK now detects this scenario and still attempts the refresh request by sending an x-grant-type: refresh_token signal header to the proxy, which injects the refresh token from the HttpOnly cookie as the sfdc_refresh_token header that SLAS uses as a fallback.                           
  - New setRefreshTokenHeader proxy handler: The SLAS private proxy intercepts grant_type=refresh_token requests, reads the cc-nx_{siteId} (registered) or cc-nx-g_{siteId} (guest) refresh token from HttpOnly cookies, and forwards it to SLAS via the sfdc_refresh_token header.          
  - x-grant-type header lifecycle: The SDK sets x-grant-type: refresh_token on the shared SLAS client before the refresh call and removes it in a finally block to prevent it from leaking into subsequent SLAS calls (e.g., getAccessToken, logout).                                               
  - x-site-id header cleanup: Previously, the x-site-id internal header was only stripped from SCAPI proxy requests (configure-proxy.js). It is now also stripped from SLAS private proxy requests in build-remote-server.js, and all hardcoded 'x-site-id' string references have been replaced with the X_SITE_ID constant for consistency.
      

https://github.com/user-attachments/assets/e2e8e142-0c5e-4a38-a4ac-1842046b6dc5


                                                                                                                                                    
  Test Plan       

  - Verify guest user refresh token flow works with HttpOnly session cookies enabled                                                                
  - Verify registered user refresh token flow works with HttpOnly session cookies enabled
  - Verify x-grant-type header does not leak to non-refresh SLAS calls                                                                              
  - Verify x-site-id header is stripped from both SLAS and SCAPI proxy requests                                                                     
  - Verify refresh flow still works when HttpOnly session cookies are disabled (backward compatibility)                                             
  - Run unit tests in auth/index.test.ts and build-remote-server.test.js        