### PR TITLE
Add HttpOnly session cookie support for SLAS public clients

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -3,6 +3,7 @@
 - use nightly release of isomorphic sdk that supports httponly cookies [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
 - Handle refresh token flow for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
+- Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 
 ## v5.2.0-dev (Mar 20, 2026)
 

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1511,6 +1511,34 @@ describe('HttpOnly Session Cookies', () => {
         jest.clearAllMocks()
     })
 
+    test('routes SLAS calls through publicClientProxyEndpoint when httpOnly enabled and private client disabled', () => {
+        const {ShopperLogin} = require('commerce-sdk-isomorphic')
+        ShopperLogin.mockClear()
+        new Auth({
+            ...config,
+            enableHttpOnlySessionCookies: true,
+            enablePWAKitPrivateClient: false,
+            publicClientProxyEndpoint: '/mobify/slas/public'
+        })
+        expect(ShopperLogin).toHaveBeenCalledWith(
+            expect.objectContaining({proxy: '/mobify/slas/public'})
+        )
+    })
+
+    test('routes SLAS calls through standard proxy when httpOnly disabled', () => {
+        const {ShopperLogin} = require('commerce-sdk-isomorphic')
+        ShopperLogin.mockClear()
+        new Auth({
+            ...config,
+            enableHttpOnlySessionCookies: false,
+            enablePWAKitPrivateClient: false,
+            publicClientProxyEndpoint: '/mobify/slas/public'
+        })
+        expect(ShopperLogin).toHaveBeenCalledWith(
+            expect.objectContaining({proxy: 'proxy'})
+        )
+    })
+
     test('loginGuestUser does not store tokens when HttpOnly cookies are enabled', async () => {
         const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
         const loginGuestMock = helpers.loginGuestUser as jest.Mock

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -7,7 +7,12 @@
 import Auth, {AuthData} from './'
 import {waitFor} from '@testing-library/react'
 import jwt from 'jsonwebtoken'
-import {helpers, ShopperCustomersTypes, ShopperCustomers} from 'commerce-sdk-isomorphic'
+import {
+    helpers,
+    ShopperCustomersTypes,
+    ShopperCustomers,
+    ShopperLogin
+} from 'commerce-sdk-isomorphic'
 import * as utils from '../utils'
 import {SLAS_SECRET_PLACEHOLDER, X_GRANT_TYPE} from '../constant'
 import {ShopperLoginTypes} from 'commerce-sdk-isomorphic'
@@ -1512,31 +1517,29 @@ describe('HttpOnly Session Cookies', () => {
     })
 
     test('routes SLAS calls through publicClientProxyEndpoint when httpOnly enabled and private client disabled', () => {
-        const {ShopperLogin} = require('commerce-sdk-isomorphic')
-        ShopperLogin.mockClear()
+        const ShopperLoginMock = ShopperLogin as unknown as jest.Mock
+        ShopperLoginMock.mockClear()
         new Auth({
             ...config,
             enableHttpOnlySessionCookies: true,
             enablePWAKitPrivateClient: false,
             publicClientProxyEndpoint: '/mobify/slas/public'
         })
-        expect(ShopperLogin).toHaveBeenCalledWith(
+        expect(ShopperLoginMock).toHaveBeenCalledWith(
             expect.objectContaining({proxy: '/mobify/slas/public'})
         )
     })
 
     test('routes SLAS calls through standard proxy when httpOnly disabled', () => {
-        const {ShopperLogin} = require('commerce-sdk-isomorphic')
-        ShopperLogin.mockClear()
+        const ShopperLoginMock = ShopperLogin as unknown as jest.Mock
+        ShopperLoginMock.mockClear()
         new Auth({
             ...config,
             enableHttpOnlySessionCookies: false,
             enablePWAKitPrivateClient: false,
             publicClientProxyEndpoint: '/mobify/slas/public'
         })
-        expect(ShopperLogin).toHaveBeenCalledWith(
-            expect.objectContaining({proxy: 'proxy'})
-        )
+        expect(ShopperLoginMock).toHaveBeenCalledWith(expect.objectContaining({proxy: 'proxy'}))
     })
 
     test('loginGuestUser does not store tokens when HttpOnly cookies are enabled', async () => {

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -44,6 +44,7 @@ interface AuthConfig extends ApiClientConfigParams {
     proxy: string
     headers?: Record<string, string>
     privateClientProxyEndpoint?: string
+    publicClientProxyEndpoint?: string
     fetchOptions?: FetchOptions
     fetchedToken?: string
     enablePWAKitPrivateClient?: boolean
@@ -305,6 +306,8 @@ class Auth {
         this.client = new ShopperLogin({
             proxy: config.enablePWAKitPrivateClient
                 ? config.privateClientProxyEndpoint
+                : config.enableHttpOnlySessionCookies
+                ? config.publicClientProxyEndpoint
                 : config.proxy,
             headers: config.headers || {},
             parameters: {
@@ -361,7 +364,7 @@ class Auth {
 
         /*
          * There are 2 ways to enable SLAS private client mode.
-         * If enablePWAKitPrivateClient=true, we route SLAS calls to /mobify/slas/private
+         * If enablePWAKitPrivateClient=true, we route SLAS calls to
          * and set an internal placeholder as the client secret. The proxy will override the placeholder
          * with the actual client secret so any truthy value as the placeholder works here.
          *

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -364,7 +364,7 @@ class Auth {
 
         /*
          * There are 2 ways to enable SLAS private client mode.
-         * If enablePWAKitPrivateClient=true, we route SLAS calls to
+         * If enablePWAKitPrivateClient=true, we route SLAS calls to /mobify/slas/private
          * and set an internal placeholder as the client secret. The proxy will override the placeholder
          * with the actual client secret so any truthy value as the placeholder works here.
          *

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -283,6 +283,16 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             fetchOptions: effectiveFetchOptions
         }
 
+        // Determine the proxy endpoint for ShopperLogin based on the client mode:
+        // - Private client mode uses a dedicated private proxy endpoint
+        // - HttpOnly session cookies mode uses a public proxy endpoint
+        // - Otherwise, fall back to the default proxy
+        const shopperLoginProxy = enablePWAKitPrivateClient
+            ? privateClientProxyEndpoint
+            : enableHttpOnlySessionCookies
+            ? publicClientProxyEndpoint
+            : config.proxy
+
         return {
             shopperBaskets: new ShopperBaskets(config),
             shopperBasketsV2: new ShopperBasketsV2(config),
@@ -294,11 +304,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             shopperGiftCertificates: new ShopperGiftCertificates(config),
             shopperLogin: new ShopperLogin({
                 ...config,
-                proxy: enablePWAKitPrivateClient
-                    ? privateClientProxyEndpoint
-                    : enableHttpOnlySessionCookies
-                    ? publicClientProxyEndpoint
-                    : config.proxy
+                proxy: shopperLoginProxy
             }),
             shopperOrders: new ShopperOrders(config),
             shopperPayments: new ShopperPayments(config),
@@ -318,7 +324,11 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
         locale,
         currency,
         headers?.['correlation-id'],
-        apiClients
+        apiClients,
+        enablePWAKitPrivateClient,
+        privateClientProxyEndpoint,
+        publicClientProxyEndpoint,
+        enableHttpOnlySessionCookies
     ])
 
     // Initialize the session

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -47,6 +47,7 @@ export interface CommerceApiProviderProps extends ApiClientConfigParams {
     fetchedToken?: string
     enablePWAKitPrivateClient?: boolean
     privateClientProxyEndpoint?: string
+    publicClientProxyEndpoint?: string
     clientSecret?: string
     silenceWarnings?: boolean
     logger?: Logger
@@ -148,6 +149,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
         fetchedToken,
         enablePWAKitPrivateClient,
         privateClientProxyEndpoint,
+        publicClientProxyEndpoint,
         clientSecret,
         silenceWarnings,
         logger,
@@ -186,6 +188,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             fetchedToken,
             enablePWAKitPrivateClient,
             privateClientProxyEndpoint,
+            publicClientProxyEndpoint,
             clientSecret,
             silenceWarnings,
             logger: configLogger,
@@ -208,6 +211,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
         fetchedToken,
         enablePWAKitPrivateClient,
         privateClientProxyEndpoint,
+        publicClientProxyEndpoint,
         clientSecret,
         silenceWarnings,
         configLogger,
@@ -290,7 +294,11 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             shopperGiftCertificates: new ShopperGiftCertificates(config),
             shopperLogin: new ShopperLogin({
                 ...config,
-                proxy: enablePWAKitPrivateClient ? privateClientProxyEndpoint : config.proxy
+                proxy: enablePWAKitPrivateClient
+                    ? privateClientProxyEndpoint
+                    : enableHttpOnlySessionCookies
+                    ? publicClientProxyEndpoint
+                    : config.proxy
             }),
             shopperOrders: new ShopperOrders(config),
             shopperPayments: new ShopperPayments(config),

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -6,6 +6,7 @@
 - updated package-lock [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
 - Handle refresh token flow and consolidate `x-site-id` header usage for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
+- Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -51,7 +51,8 @@ import {
     proxyBasePath,
     bundleBasePath,
     healthCheckPath,
-    slasPrivateProxyPath
+    slasPrivateProxyPath,
+    slasPublicProxyPath
 } from '../../utils/ssr-namespace-paths'
 import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
 import expressLogging from 'morgan'
@@ -273,7 +274,18 @@ export const RemoteServerFactory = {
             // Custom callbacks must not rely on token fields in the response body in that case; read from
             // response headers (e.g. Set-Cookie) if needed.
             // Signature: (responseBuffer, proxyRes, req, res) => Buffer
-            onSLASPrivateProxyRes: undefined
+            onSLASPrivateProxyRes: undefined,
+
+            // Custom callback to modify the SLAS public client proxy request. This callback is invoked
+            // after the built-in proxy request handling. Users can provide additional
+            // request modifications (e.g., custom headers).
+            // Signature: (proxyRequest, incomingRequest, res) => void
+            onSLASPublicProxyReq: undefined,
+
+            // Custom callback to modify the SLAS public client proxy response. This callback is invoked
+            // after the built-in proxy response handling (including HttpOnly session cookie handling).
+            // Signature: (responseBuffer, proxyRes, req, res) => Buffer
+            onSLASPublicProxyRes: undefined
         }
 
         options = Object.assign({}, defaults, options)
@@ -370,7 +382,12 @@ export const RemoteServerFactory = {
      * @private
      */
     _getSlasEndpoint(options) {
-        if (!options.useSLASPrivateClient) return undefined
+        if (
+            !options.useSLASPrivateClient &&
+            process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES !== 'true'
+        ) {
+            return undefined
+        }
         const shortCode = options.mobify?.app?.commerceAPI?.parameters?.shortCode
         return `${shortCode}.api.commercecloud.salesforce.com`
     },
@@ -523,7 +540,12 @@ export const RemoteServerFactory = {
         this._setupHealthcheck(app)
         this._setupProxying(app, options)
 
-        this._setupSlasPrivateClientProxy(app, options)
+        const httpOnlyCookiesEnabled = process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true'
+        if (options.useSLASPrivateClient) {
+            this._setupSlasPrivateClientProxy(app, options, httpOnlyCookiesEnabled)
+        } else if (httpOnlyCookiesEnabled) {
+            this._setupSlasPublicClientProxy(app, options, httpOnlyCookiesEnabled)
+        }
         this._setupHybridProxy(app, options)
 
         // Beyond this point, we know that this is not a proxy request
@@ -988,44 +1010,34 @@ export const RemoteServerFactory = {
     /**
      * @private
      */
-    _setupSlasPrivateClientProxy(app, options) {
-        if (!options.useSLASPrivateClient) {
-            return
-        }
+    /**
+     * Shared proxy middleware factory used by both private and public SLAS client proxies.
+     * @private
+     */
+    _createSlasProxyMiddleware(app, options, proxyConfig) {
+        const {
+            proxyPath,
+            logNamespace,
+            isPrivateClient,
+            httpOnlyCookiesEnabled,
+            encodedCredentials,
+            onCustomProxyReq,
+            onCustomProxyRes
+        } = proxyConfig
 
-        // This is the full path to the SLAS trusted-system endpoint
-        // We want to throw an error if the regex defined options.applySLASPrivateClientToEndpoints
-        // matches this path as an early warning to developers that they should update their regex
-        // in ssr.js to exclude this path.
-        const trustedSystemPath = '/shopper/auth/v1/oauth2/trusted-system/token'
-        if (trustedSystemPath.match(options.applySLASPrivateClientToEndpoints)) {
-            throw new Error(
-                'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'
-            )
-        }
-
-        localDevLog(`Proxying ${slasPrivateProxyPath} to ${options.slasTarget}`)
-
-        const clientId = options.mobify?.app?.commerceAPI?.parameters?.clientId
-        const clientSecret = process.env.PWA_KIT_SLAS_CLIENT_SECRET
-        if (!clientSecret) {
-            this._handleMissingSlasPrivateEnvVar(app, slasPrivateProxyPath)
-            return
-        }
-
-        const encodedSlasCredentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+        localDevLog(`Proxying ${proxyPath} to ${options.slasTarget}`)
 
         app.use(
-            slasPrivateProxyPath,
+            proxyPath,
             (req, res, next) => {
                 // Check if the request should be blocked before it reaches the proxy
-                // We run this outside of the proxy middleware because modifying the response
-                // to send a 403 in the proxy causes issues with the response interceptor.
                 if (
                     !req.path?.match(options.slasApiPath) ||
-                    req.path?.match(/\/oauth2\/trusted-system/)
+                    (isPrivateClient && req.path?.match(/\/oauth2\/trusted-system/))
                 ) {
-                    const message = `Request to ${req.path} is not allowed through the SLAS Private Client Proxy`
+                    const message = `Request to ${req.path} is not allowed through the SLAS ${
+                        isPrivateClient ? 'Private' : 'Public'
+                    } Client Proxy`
                     logger.error(message)
                     return res.status(403).json({
                         message: message
@@ -1037,13 +1049,9 @@ export const RemoteServerFactory = {
                 target: options.slasTarget,
                 changeOrigin: true,
 
-                // http-proxy-middleware uses the original incoming request path to determine
-                // both proxyRequest and incomingRequest paths.
-                // This cannot be modified by any express middleware
-                // So we need to use the built in pathRewrite to remove the base path
                 pathRewrite: (path) => {
                     const basePathRegexEntry = getEnvBasePath() ? `${getEnvBasePath()}?` : ''
-                    const regex = new RegExp(`^${basePathRegexEntry}${slasPrivateProxyPath}`)
+                    const regex = new RegExp(`^${basePathRegexEntry}${proxyPath}`)
                     return path.replace(regex, '')
                 },
                 selfHandleResponse: true,
@@ -1052,64 +1060,58 @@ export const RemoteServerFactory = {
                         applyProxyRequestHeaders({
                             proxyRequest,
                             incomingRequest,
-                            proxyPath: slasPrivateProxyPath,
+                            proxyPath: proxyPath,
                             targetHost: options.slasHostName,
                             targetProtocol: 'https'
                         })
 
-                        if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
-                            // /oauth2/trusted-agent/token endpoint auth header comes from Account Manager
-                            // so the SLAS private client is sent via this special header
-                            proxyRequest.setHeader('_sfdc_client_auth', encodedSlasCredentials)
-                        } else if (
-                            incomingRequest.path?.match(options.applySLASPrivateClientToEndpoints)
-                        ) {
-                            // We pattern match and add client secrets only to endpoints that
-                            // match the regex specified by options.applySLASPrivateClientToEndpoints.
-                            //
-                            // Other SLAS endpoints, ie. SLAS authenticate (/oauth2/login) and
-                            // SLAS logout (/oauth2/logout), use the Authorization header for a different
-                            // purpose so we don't want to overwrite the header for those calls.
-                            proxyRequest.setHeader(
-                                'Authorization',
-                                `Basic ${encodedSlasCredentials}`
-                            )
-
-                            // When HttpOnly session cookies are enabled, inject the refresh token
-                            // from the HttpOnly cookie as the sfdc_refresh_token header. SLAS uses
-                            // this header as a fallback for grant_type=refresh_token requests when
-                            // the refresh_token body parameter is empty.
-                            // The SDK sends x-grant-type: refresh_token to signal this is a refresh request.
-                            if (
-                                process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
-                                incomingRequest.headers[X_GRANT_TYPE] === 'refresh_token'
+                        if (isPrivateClient) {
+                            // Private client: inject client secret headers
+                            if (incomingRequest.path?.match(/\/oauth2\/trusted-agent\/token/)) {
+                                proxyRequest.setHeader('_sfdc_client_auth', encodedCredentials)
+                            } else if (
+                                incomingRequest.path?.match(
+                                    options.applySLASPrivateClientToEndpoints
+                                )
                             ) {
-                                setRefreshTokenHeader(proxyRequest, incomingRequest)
-                                // Remove the signal header — it's only for our proxy, not SLAS.
-                                proxyRequest.removeHeader(X_GRANT_TYPE)
+                                proxyRequest.setHeader(
+                                    'Authorization',
+                                    `Basic ${encodedCredentials}`
+                                )
                             }
-                        } else if (
-                            process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true' &&
+                        }
+
+                        // When HttpOnly session cookies are enabled, inject the refresh token
+                        // from the HttpOnly cookie for refresh_token grant requests.
+                        if (
+                            httpOnlyCookiesEnabled &&
+                            incomingRequest.headers[X_GRANT_TYPE] === 'refresh_token'
+                        ) {
+                            setRefreshTokenHeader(proxyRequest, incomingRequest)
+                            proxyRequest.removeHeader(X_GRANT_TYPE)
+                        }
+
+                        // Handle logout: inject tokens from HttpOnly cookies
+                        if (
+                            httpOnlyCookiesEnabled &&
                             incomingRequest.path?.match(SLAS_LOGOUT_ENDPOINT)
                         ) {
                             setTokensInLogoutRequest(proxyRequest, incomingRequest)
                         }
 
                         // Strip internal headers that are only used by our proxy, not by SLAS.
-                        if (process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true') {
+                        if (httpOnlyCookiesEnabled) {
                             proxyRequest.removeHeader(X_SITE_ID)
                         }
 
-                        // Allow users to apply additional custom modifications to the proxy request
-                        if (typeof options.onSLASPrivateProxyReq === 'function') {
+                        // Allow users to apply additional custom modifications
+                        if (typeof onCustomProxyReq === 'function') {
                             try {
-                                options.onSLASPrivateProxyReq(proxyRequest, incomingRequest, res)
+                                onCustomProxyReq(proxyRequest, incomingRequest, res)
                             } catch (error) {
-                                logger.error('Error in custom onSLASPrivateProxyReq callback', {
-                                    namespace: '_setupSlasPrivateClientProxy',
-                                    additionalProperties: {
-                                        error: error
-                                    }
+                                logger.error(`Error in custom proxy request callback`, {
+                                    namespace: logNamespace,
+                                    additionalProperties: {error}
                                 })
                             }
                         }
@@ -1126,22 +1128,20 @@ export const RemoteServerFactory = {
                             }
                             return
                         }
-                        logger.error('Error in SLAS private proxy request handling', {
-                            namespace: '_setupSlasPrivateClientProxy',
-                            additionalProperties: {
-                                error: error
-                            }
+                        logger.error(`Error in SLAS proxy request handling`, {
+                            namespace: logNamespace,
+                            additionalProperties: {error}
                         })
                         if (!res.headersSent) {
                             res.status(500).json({
-                                message: 'Error preparing SLAS private proxy request'
+                                message: `Error preparing SLAS proxy request`
                             })
                         }
                     }
                 },
                 onError: (error, req, res) => {
-                    logger.error('Error in SLAS private proxy', {
-                        namespace: '_setupSlasPrivateClientProxy',
+                    logger.error(`Error in SLAS proxy`, {
+                        namespace: logNamespace,
                         additionalProperties: {
                             error: error,
                             path: req?.url
@@ -1149,21 +1149,16 @@ export const RemoteServerFactory = {
                     })
                     if (!res.headersSent) {
                         res.status(500).json({
-                            message: 'Error in SLAS private proxy request'
+                            message: `Error in SLAS proxy request`
                         })
                     }
                 },
                 onProxyRes: responseInterceptor((responseBuffer, proxyRes, req, res) => {
                     let workingBuffer = responseBuffer
                     try {
-                        // When HttpOnly session cookies are enabled and response is 200 from a token endpoint,
-                        // set tokens as HttpOnly cookies and strip from body.
-                        // Check against tokenResponseEndpoints regex (configurable in ssr.js)
                         const isTokenEndpoint = req.path?.match(options.tokenResponseEndpoints)
-                        const httpOnlySessionCookiesEnabled =
-                            process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true'
                         if (
-                            httpOnlySessionCookiesEnabled &&
+                            httpOnlyCookiesEnabled &&
                             proxyRes.statusCode === 200 &&
                             isTokenEndpoint
                         ) {
@@ -1176,11 +1171,10 @@ export const RemoteServerFactory = {
                                     options
                                 )
                             } catch (error) {
-                                // HttpOnly configuration errors should fail the request (do not leak tokens)
                                 res.statusCode = 500
                                 res.statusMessage = 'Internal Server Error'
                                 logger.error('Error applying HttpOnly session cookies', {
-                                    namespace: '_setupSlasPrivateClientProxy',
+                                    namespace: logNamespace,
                                     additionalProperties: {
                                         error: error.message || error
                                     }
@@ -1197,44 +1191,35 @@ export const RemoteServerFactory = {
                             }
                         }
 
-                        // If the passwordless login endpoint returns a 404, which corresponds to a user
-                        // email not being found, we mask it with a 200 OK response so that it is not
-                        // obvious that the user does not exist.
-                        // We do this to prevent user enumeration.
+                        // Mask passwordless login 404 to prevent user enumeration
                         if (
                             req.path?.match(/\/oauth2\/passwordless\/login/) &&
                             proxyRes.statusCode === 404
                         ) {
                             res.statusCode = 200
                             res.statusMessage = 'OK'
-
-                            // When a /passwordless/login endpoint response returns 200, it has no body
-                            // so we return an empty body here to match an actual 200 response.
                             workingBuffer = Buffer.from('', 'utf8')
                         }
 
-                        // Allow users to apply additional custom modifications to the proxy response
-                        if (typeof options.onSLASPrivateProxyRes === 'function') {
+                        // Allow users to apply additional custom modifications
+                        if (typeof onCustomProxyRes === 'function') {
                             try {
-                                const customBuffer = options.onSLASPrivateProxyRes(
+                                const customBuffer = onCustomProxyRes(
                                     workingBuffer,
                                     proxyRes,
                                     req,
                                     res
                                 )
-                                // Only use the custom buffer if it was returned
                                 if (customBuffer !== undefined) {
                                     workingBuffer = customBuffer
                                 }
                             } catch (error) {
                                 logger.error(
-                                    'Error in custom onSLASPrivateProxyRes callback',
+                                    `Error in custom proxy response callback`,
                                     /* istanbul ignore next */
                                     {
-                                        namespace: '_setupSlasPrivateClientProxy',
-                                        additionalProperties: {
-                                            error: error
-                                        }
+                                        namespace: logNamespace,
+                                        additionalProperties: {error}
                                     }
                                 )
                             }
@@ -1245,7 +1230,7 @@ export const RemoteServerFactory = {
                         logger.error(
                             'There is an error processing the response from SLAS. Returning original response.',
                             {
-                                namespace: '_setupSlasPrivateClientProxy',
+                                namespace: logNamespace,
                                 additionalProperties: {
                                     error: error,
                                     statusCode: proxyRes?.statusCode,
@@ -1258,6 +1243,51 @@ export const RemoteServerFactory = {
                 })
             })
         )
+    },
+
+    /**
+     * @private
+     */
+    _setupSlasPrivateClientProxy(app, options, httpOnlyCookiesEnabled) {
+        const trustedSystemPath = '/shopper/auth/v1/oauth2/trusted-system/token'
+        if (trustedSystemPath.match(options.applySLASPrivateClientToEndpoints)) {
+            throw new Error(
+                'It is not allowed to include /oauth2/trusted-system endpoints in `applySLASPrivateClientToEndpoints`'
+            )
+        }
+
+        const clientId = options.mobify?.app?.commerceAPI?.parameters?.clientId
+        const clientSecret = process.env.PWA_KIT_SLAS_CLIENT_SECRET
+        if (!clientSecret) {
+            this._handleMissingSlasPrivateEnvVar(app, slasPrivateProxyPath)
+            return
+        }
+
+        const encodedCredentials = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+
+        this._createSlasProxyMiddleware(app, options, {
+            proxyPath: slasPrivateProxyPath,
+            logNamespace: '_setupSlasPrivateClientProxy',
+            isPrivateClient: true,
+            httpOnlyCookiesEnabled,
+            encodedCredentials,
+            onCustomProxyReq: options.onSLASPrivateProxyReq,
+            onCustomProxyRes: options.onSLASPrivateProxyRes
+        })
+    },
+
+    /**
+     * @private
+     */
+    _setupSlasPublicClientProxy(app, options, httpOnlyCookiesEnabled) {
+        this._createSlasProxyMiddleware(app, options, {
+            proxyPath: slasPublicProxyPath,
+            logNamespace: '_setupSlasPublicClientProxy',
+            isPrivateClient: false,
+            httpOnlyCookiesEnabled,
+            onCustomProxyReq: options.onSLASPublicProxyReq,
+            onCustomProxyRes: options.onSLASPublicProxyRes
+        })
     },
 
     /**

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -1159,9 +1159,7 @@ describe('SLAS public proxy', () => {
 
         RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
 
-        const response = await request(app).get(
-            '/mobify/slas/public/shopper/products/v1'
-        )
+        const response = await request(app).get('/mobify/slas/public/shopper/products/v1')
 
         expect(response.status).toBe(403)
     })

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -204,30 +204,6 @@ describe('SLAS private proxy', () => {
         delete process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES
     })
 
-    test('returns 404 when useSLASPrivateClient is false', async () => {
-        const app = mockExpress()
-        const options = {
-            useSLASPrivateClient: false,
-            mobify: {
-                app: {
-                    commerceAPI: {
-                        parameters: {
-                            shortCode: 'test',
-                            clientId: 'test-client-id'
-                        }
-                    }
-                }
-            }
-        }
-
-        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
-
-        // Attempt to access the SLAS private proxy path
-        const response = await request(app).get('/mobify/slas/private/shopper/auth/v1/oauth2/token')
-
-        expect(response.status).toBe(404)
-    })
-
     test('returns 501 when useSLASPrivateClient is true but no secret is set', async () => {
         const app = mockExpress()
         const options = RemoteServerFactory._configure({
@@ -245,7 +221,7 @@ describe('SLAS private proxy', () => {
             }
         })
 
-        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
         const response = await request(app).get('/mobify/slas/private/shopper/auth/v1/oauth2/token')
 
@@ -271,7 +247,7 @@ describe('SLAS private proxy', () => {
 
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
         const response = await request(app).get('/mobify/slas/private/shopper/products/v1')
 
@@ -297,7 +273,7 @@ describe('SLAS private proxy', () => {
 
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
         const response = await request(app).post(
             '/mobify/slas/private/shopper/auth/v1/oauth2/trusted-system/token'
@@ -352,7 +328,7 @@ describe('SLAS private proxy', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
             const response = await request(app).post(
                 '/mobify/slas/private/shopper/auth/v1/oauth2/token'
@@ -408,7 +384,7 @@ describe('SLAS private proxy', () => {
                 throw new Error('boom')
             })
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
             const response = await request(app).post(
                 '/mobify/slas/private/shopper/auth/v1/oauth2/token'
@@ -416,10 +392,10 @@ describe('SLAS private proxy', () => {
 
             expect(response.status).toBe(500)
             expect(response.body).toEqual({
-                message: 'Error preparing SLAS private proxy request'
+                message: 'Error preparing SLAS proxy request'
             })
             expect(logger.error).toHaveBeenCalledWith(
-                'Error in SLAS private proxy request handling',
+                'Error in SLAS proxy request handling',
                 expect.objectContaining({
                     namespace: '_setupSlasPrivateClientProxy'
                 })
@@ -449,7 +425,7 @@ describe('SLAS private proxy', () => {
 
         process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-        RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+        RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
         const response = await request(app).post(
             '/mobify/slas/private/shopper/auth/v1/oauth2/token'
@@ -457,10 +433,10 @@ describe('SLAS private proxy', () => {
 
         expect(response.status).toBe(500)
         expect(response.body).toEqual({
-            message: 'Error in SLAS private proxy request'
+            message: 'Error in SLAS proxy request'
         })
         expect(logger.error).toHaveBeenCalledWith(
-            'Error in SLAS private proxy',
+            'Error in SLAS proxy',
             expect.objectContaining({
                 namespace: '_setupSlasPrivateClientProxy'
             })
@@ -518,7 +494,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, false)
 
             const response = await request(app).post(
                 '/mobify/slas/private/shopper/auth/v1/oauth2/token'
@@ -570,7 +546,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app).post(
                 '/mobify/slas/private/shopper/auth/v1/oauth2/token'
@@ -620,7 +596,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/logout')
@@ -677,7 +653,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             // Cookies are keyed to 'othersite', and x-site-id header says 'othersite'
             const response = await request(app)
@@ -736,7 +712,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
@@ -792,7 +768,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
@@ -846,7 +822,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/passwordless/token')
@@ -907,7 +883,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/token')
@@ -968,7 +944,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             // Send refresh_token request with NO cookies at all
             const response = await request(app)
@@ -1019,7 +995,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             // Has cookies but NOT the refresh token cookie
             const response = await request(app)
@@ -1078,7 +1054,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             // Regular token request (e.g. guest login) — no x-grant-type header
             const response = await request(app)
@@ -1130,7 +1106,7 @@ describe('HttpOnly session cookies', () => {
 
             process.env.PWA_KIT_SLAS_CLIENT_SECRET = 'test-secret'
 
-            RemoteServerFactory._setupSlasPrivateClientProxy(app, options)
+            RemoteServerFactory._setupSlasPrivateClientProxy(app, options, true)
 
             const response = await request(app)
                 .post('/mobify/slas/private/shopper/auth/v1/oauth2/logout')
@@ -1143,6 +1119,270 @@ describe('HttpOnly session cookies', () => {
             expect(response.status).toBe(200)
             // x-site-id should be stripped from the outgoing request
             expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+})
+
+describe('SLAS public proxy', () => {
+    let request
+    let mockExpress
+
+    beforeEach(() => {
+        mockExpress = require('express')
+        request = require('supertest')
+    })
+
+    afterEach(() => {
+        delete process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES
+    })
+
+    test('returns 403 for non-SLAS auth paths', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        const app = mockExpress()
+        const options = RemoteServerFactory._configure({
+            useSLASPrivateClient: false,
+            mobify: {
+                app: {
+                    commerceAPI: {
+                        parameters: {
+                            shortCode: 'test',
+                            organizationId: 'f_ecom_test',
+                            clientId: 'test-client-id'
+                        }
+                    }
+                }
+            }
+        })
+
+        RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
+
+        const response = await request(app).get(
+            '/mobify/slas/public/shopper/products/v1'
+        )
+
+        expect(response.status).toBe(403)
+    })
+
+    test('sets HttpOnly cookies on token response and strips tokens from body', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            const accessToken = makeJWT({
+                iat: 1000,
+                isb: 'uido:ecom::upn:Guest::uidn:Guest::gcid:g1::rcid:r1::chid:testsite'
+            })
+            res.status(200).json({
+                access_token: accessToken,
+                expires_in: 1800,
+                refresh_token: 'mock-refresh-token'
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: false,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
+
+            const response = await request(app)
+                .post('/mobify/slas/public/shopper/auth/v1/oauth2/token')
+                .set(X_SITE_ID, 'testsite')
+
+            expect(response.status).toBe(200)
+            // Tokens stripped from body
+            expect(response.body).not.toHaveProperty('access_token')
+            expect(response.body).not.toHaveProperty('refresh_token')
+
+            // HttpOnly cookies set
+            expect(response.headers['set-cookie']).toBeDefined()
+            const cookies = response.headers['set-cookie']
+            expect(cookies.some((c) => c.includes('cc-at_testsite'))).toBe(true)
+            expect(cookies.some((c) => c.includes('cc-at-expires_testsite'))).toBe(true)
+            expect(cookies.some((c) => c.includes('cc-nx-g_testsite'))).toBe(true)
+            expect(cookies.some((c) => c.includes('cc-nx-exists_testsite=1'))).toBe(true)
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('does NOT inject client secret headers', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        let capturedHeaders
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            capturedHeaders = req.headers
+            const accessToken = makeJWT({
+                iat: 1000,
+                isb: 'uido:ecom::upn:Guest::uidn:Guest::gcid:g1::rcid:r1::chid:testsite'
+            })
+            res.status(200).json({
+                access_token: accessToken,
+                expires_in: 1800,
+                refresh_token: 'mock-refresh-token'
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: false,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
+
+            const response = await request(app)
+                .post('/mobify/slas/public/shopper/auth/v1/oauth2/token')
+                .set(X_SITE_ID, 'testsite')
+
+            expect(response.status).toBe(200)
+            // No Authorization or _sfdc_client_auth headers should be injected
+            expect(capturedHeaders['authorization']).toBeUndefined()
+            expect(capturedHeaders['_sfdc_client_auth']).toBeUndefined()
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('injects refresh token from HttpOnly cookie for refresh_token requests', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        let capturedHeaders
+        const mockSlasServer = mockExpress()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            capturedHeaders = req.headers
+            const accessToken = makeJWT({
+                iat: 1000,
+                isb: 'uido:ecom::upn:Guest::uidn:Guest::gcid:g1::rcid:r1::chid:testsite'
+            })
+            res.status(200).json({
+                access_token: accessToken,
+                expires_in: 1800,
+                refresh_token: 'new-refresh-token'
+            })
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: false,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
+
+            const response = await request(app)
+                .post('/mobify/slas/public/shopper/auth/v1/oauth2/token')
+                .set('Cookie', 'cc-nx-g_testsite=mock-guest-refresh-token')
+                .set(X_SITE_ID, 'testsite')
+                .set(X_GRANT_TYPE, 'refresh_token')
+
+            expect(response.status).toBe(200)
+            // sfdc_refresh_token header was injected
+            expect(capturedHeaders['sfdc_refresh_token']).toBe('mock-guest-refresh-token')
+            // x-grant-type and x-site-id were stripped
+            expect(capturedHeaders[X_GRANT_TYPE]).toBeUndefined()
+            expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+        } finally {
+            mockSlasServerInstance.close()
+        }
+    })
+
+    test('returns 401 when refresh token cookie is missing on a refresh_token request', async () => {
+        process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES = 'true'
+
+        const mockSlasServer = mockExpress()
+        const slasHit = jest.fn()
+        mockSlasServer.post('/shopper/auth/v1/oauth2/token', (req, res) => {
+            slasHit()
+            res.status(200).json({access_token: 'should-not-reach'})
+        })
+
+        const mockSlasServerInstance = mockSlasServer.listen(0)
+        const mockSlasPort = mockSlasServerInstance.address().port
+
+        try {
+            const app = mockExpress()
+            const options = RemoteServerFactory._configure({
+                useSLASPrivateClient: false,
+                slasTarget: `http://localhost:${mockSlasPort}`,
+                mobify: {
+                    app: {
+                        commerceAPI: {
+                            parameters: {
+                                shortCode: 'test',
+                                organizationId: 'f_ecom_test',
+                                clientId: 'test-client-id',
+                                siteId: 'testsite'
+                            }
+                        }
+                    }
+                }
+            })
+
+            RemoteServerFactory._setupSlasPublicClientProxy(app, options, true)
+
+            const response = await request(app)
+                .post('/mobify/slas/public/shopper/auth/v1/oauth2/token')
+                .set(X_SITE_ID, 'testsite')
+                .set(X_GRANT_TYPE, 'refresh_token')
+
+            expect(response.status).toBe(401)
+            expect(response.body.message).toBe('invalid refresh_token')
+            expect(slasHit).not.toHaveBeenCalled()
         } finally {
             mockSlasServerInstance.close()
         }

--- a/packages/pwa-kit-runtime/src/utils/ssr-namespace-paths.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-namespace-paths.js
@@ -20,6 +20,7 @@ const BUNDLE_PATH_BASE = `${MOBIFY_PATH}/bundle`
 const CACHING_PATH_BASE = `${MOBIFY_PATH}/caching`
 const HEALTHCHECK_PATH = `${MOBIFY_PATH}/ping`
 const SLAS_PRIVATE_CLIENT_PROXY_PATH = `${MOBIFY_PATH}/slas/private`
+const SLAS_PUBLIC_CLIENT_PROXY_PATH = `${MOBIFY_PATH}/slas/public`
 
 /*
  * Returns the base path. This is prepended to a /mobify path.
@@ -69,6 +70,7 @@ export const bundleBasePath = BUNDLE_PATH_BASE
 export const cachingBasePath = CACHING_PATH_BASE
 export const healthCheckPath = HEALTHCHECK_PATH
 export const slasPrivateProxyPath = SLAS_PRIVATE_CLIENT_PROXY_PATH
+export const slasPublicProxyPath = SLAS_PUBLIC_CLIENT_PROXY_PATH
 
 /**
  * @deprecated This variable is no longer used. This variable has always been an empty string.

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add `x-site-id` request header to read HttpOnly cookies on the server [#3700](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3700)
 - Rename the configuration flag `disableHttpOnlySessionCookies` to `enableHttpOnlySessionCookies` [#3723](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3723)
 - Increase msxSize for vendor.js [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
+- Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 
 ## v9.2.0-dev (Mar 20, 2026)
 

--- a/packages/template-retail-react-app/app/components/_app-config/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app-config/index.jsx
@@ -31,7 +31,8 @@ import {
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {
     getEnvBasePath,
-    slasPrivateProxyPath
+    slasPrivateProxyPath,
+    slasPublicProxyPath
 } from '@salesforce/pwa-kit-runtime/utils/ssr-namespace-paths'
 import {createUrlTemplate} from '@salesforce/retail-react-app/app/utils/url'
 import createLogger from '@salesforce/pwa-kit-runtime/utils/logger-factory'
@@ -93,6 +94,7 @@ const AppConfig = ({children, locals = {}}) => {
     const redirectURI = `${appOrigin}${getEnvBasePath()}/callback`
     const proxy = `${appOrigin}${getEnvBasePath()}${commerceApiConfig.proxyPath}`
     const slasPrivateClientProxyEndpoint = `${appOrigin}${getEnvBasePath()}${slasPrivateProxyPath}`
+    const slasPublicClientProxyEndpoint = `${appOrigin}${getEnvBasePath()}${slasPublicProxyPath}`
 
     const pageDesignerParams = locals.pageDesignerParams || {}
 
@@ -113,6 +115,7 @@ const AppConfig = ({children, locals = {}}) => {
             // Make sure to also enable useSLASPrivateClient in ssr.js when enabling this setting.
             enablePWAKitPrivateClient={false}
             privateClientProxyEndpoint={slasPrivateClientProxyEndpoint}
+            publicClientProxyEndpoint={slasPublicClientProxyEndpoint}
             // Uncomment 'hybridAuthEnabled' if the current site has Hybrid Auth enabled. Do NOT set this flag for hybrid storefronts using Plugin SLAS.
             // hybridAuthEnabled={true}
             enableHttpOnlySessionCookies={

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -121,7 +121,7 @@ module.exports = {
     ssrParameters: {
         ssrFunctionNodeVersion: '24.x',
         // Store the session cookies as HttpOnly for enhanced security.
-        enableHttpOnlySessionCookies: false,
+        enableHttpOnlySessionCookies: true,
         proxyConfigs: [
             {
                 host: 'kv7kzm78.api.commercecloud.salesforce.com',


### PR DESCRIPTION
**Summary**                                                                                                           
                             
  - Adds a new /mobify/slas/public proxy endpoint that enables HttpOnly session cookies for SLAS public clients (no 
  client_secret required), complementing the existing /mobify/slas/private proxy for private clients
  - Refactors the SLAS proxy middleware into a shared _createSlasProxyMiddleware factory used by both private and   
  public client proxies, eliminating code duplication                                                               
  - When enableHttpOnlySessionCookies=true and useSLASPrivateClient=false, the SDK routes SLAS calls through the
  public proxy, which handles cookie-based token storage, refresh token injection, and logout — all without         
  injecting client credentials

**Demo**
         

https://github.com/user-attachments/assets/b8a3c969-4ab7-4927-ba96-6d2eaccd91d6

**Note:** We have a separate story for request de-duplication
                                                                                                           
  **Changes**                                                                                                           
   
  - pwa-kit-runtime: New _setupSlasPublicClientProxy and shared _createSlasProxyMiddleware; new /mobify/slas/public 
  namespace path; _getSlasEndpoint now resolves even without private client enabled when HttpOnly cookies are on
  - commerce-sdk-react: Auth and CommerceApiProvider accept publicClientProxyEndpoint prop; SLAS SDK proxy routes to
   /mobify/slas/public when HttpOnly enabled but private client disabled                                            
  - template-retail-react-app: Wires up publicClientProxyEndpoint; defaults enableHttpOnlySessionCookies: true
                                                                                                                    
  **Test plan**                                                                                                         
                                                                                                                    
  - Verify public client guest and registered login sets HttpOnly cookies (cc-at_*, cc-nx-g_*, cc-at-expires_*) and strips tokens  
  from body                  
  - Verify public client refresh token flow reads refresh token from HttpOnly cookie                                
