### PR TITLE
Do not forward session cookies to SCAPI

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Handle refresh token flow and consolidate `x-site-id` header usage for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
+- Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -54,7 +54,7 @@ import {
     slasPrivateProxyPath,
     slasPublicProxyPath
 } from '../../utils/ssr-namespace-paths'
-import {applyProxyRequestHeaders} from '../../utils/ssr-server/configure-proxy'
+import {applyProxyRequestHeaders, stripSessionCookies} from '../../utils/ssr-server/configure-proxy'
 import expressLogging from 'morgan'
 import logger from '../../utils/logger-instance'
 import {createProxyMiddleware, responseInterceptor} from 'http-proxy-middleware'
@@ -1099,8 +1099,10 @@ export const RemoteServerFactory = {
                             setTokensInLogoutRequest(proxyRequest, incomingRequest)
                         }
 
-                        // Strip internal headers that are only used by our proxy, not by SLAS.
+                        // Strip internal headers and session cookies that are only used
+                        // by our proxy, not by SLAS.
                         if (httpOnlyCookiesEnabled) {
+                            stripSessionCookies(proxyRequest, incomingRequest)
                             proxyRequest.removeHeader(X_SITE_ID)
                         }
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -565,10 +565,12 @@ describe('HttpOnly session cookies', () => {
 
         let capturedAuthHeader
         let capturedRefreshToken
+        let capturedCookieHeader
         const mockSlasServer = mockExpress()
         mockSlasServer.post('/shopper/auth/v1/oauth2/logout', (req, res) => {
             capturedAuthHeader = req.headers.authorization
             capturedRefreshToken = req.query.refresh_token
+            capturedCookieHeader = req.headers.cookie
             res.status(200).json({success: true})
         })
 
@@ -610,6 +612,8 @@ describe('HttpOnly session cookies', () => {
             expect(response.body.success).toBe(true)
             expect(capturedAuthHeader).toBe('Bearer mock-access-token')
             expect(capturedRefreshToken).toBe('mock-refresh-token')
+            // Session cookies should not be forwarded to SLAS
+            expect(capturedCookieHeader).toBeUndefined()
             expect(response.headers['set-cookie']).toBeUndefined()
         } finally {
             mockSlasServerInstance.close()
@@ -897,6 +901,8 @@ describe('HttpOnly session cookies', () => {
             // x-grant-type and x-site-id were stripped from the outgoing request
             expect(capturedHeaders[X_GRANT_TYPE]).toBeUndefined()
             expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+            // Session cookies should not be forwarded to SLAS
+            expect(capturedHeaders.cookie).toBeUndefined()
             // HttpOnly cookies are set on the response
             expect(response.headers['set-cookie']).toBeDefined()
             const cookies = response.headers['set-cookie']
@@ -1067,6 +1073,8 @@ describe('HttpOnly session cookies', () => {
             expect(capturedHeaders['sfdc_refresh_token']).toBeUndefined()
             // x-site-id should still be stripped
             expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+            // Session cookies should not be forwarded to SLAS
+            expect(capturedHeaders.cookie).toBeUndefined()
         } finally {
             mockSlasServerInstance.close()
         }
@@ -1119,6 +1127,8 @@ describe('HttpOnly session cookies', () => {
             expect(response.status).toBe(200)
             // x-site-id should be stripped from the outgoing request
             expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+            // Session cookies should not be forwarded to SLAS
+            expect(capturedHeaders.cookie).toBeUndefined()
         } finally {
             mockSlasServerInstance.close()
         }
@@ -1334,6 +1344,8 @@ describe('SLAS public proxy', () => {
             // x-grant-type and x-site-id were stripped
             expect(capturedHeaders[X_GRANT_TYPE]).toBeUndefined()
             expect(capturedHeaders[X_SITE_ID]).toBeUndefined()
+            // Session cookies should not be forwarded to SLAS
+            expect(capturedHeaders.cookie).toBeUndefined()
         } finally {
             mockSlasServerInstance.close()
         }

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
@@ -7,6 +7,7 @@
 import {
     applyProxyRequestHeaders,
     setScapiAuthRequestHeaders,
+    stripSessionCookies,
     configureProxy
 } from './configure-proxy'
 import {X_SITE_ID} from '../../ssr/server/constants'
@@ -110,9 +111,12 @@ describe('setScapiAuthRequestHeaders', () => {
         jest.clearAllMocks()
     })
 
-    it('applies Bearer token for non-SLAS Shopper API endpoints', () => {
+    it('applies Bearer token and sfdc_dwsid header for SCAPI endpoints', () => {
         utils.isScapiDomain.mockReturnValue(true)
-        cookie.parse.mockReturnValue({'cc-at_RefArch': 'test-access-token'})
+        cookie.parse.mockReturnValue({
+            'cc-at_RefArch': 'test-access-token',
+            dwsid: 'test-session-id'
+        })
 
         const proxyRequest = {
             setHeader: jest.fn(),
@@ -121,7 +125,7 @@ describe('setScapiAuthRequestHeaders', () => {
         const incomingRequest = {
             url: '/shopper/products/v1/products',
             headers: {
-                cookie: 'cc-at_RefArch=test-access-token',
+                cookie: 'cc-at_RefArch=test-access-token; dwsid=test-session-id',
                 [X_SITE_ID]: 'RefArch'
             }
         }
@@ -137,6 +141,7 @@ describe('setScapiAuthRequestHeaders', () => {
             'authorization',
             'Bearer test-access-token'
         )
+        expect(proxyRequest.setHeader).toHaveBeenCalledWith('sfdc_dwsid', 'test-session-id')
     })
 
     it('does not apply Bearer token when caching is true', () => {
@@ -265,5 +270,76 @@ describe('setScapiAuthRequestHeaders', () => {
             'authorization',
             'Bearer other-access-token'
         )
+    })
+})
+
+describe('stripSessionCookies', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('strips siteId-specific session cookies and dwsid, preserves others', () => {
+        cookie.parse.mockReturnValue({
+            'cc-at_SiteA': 'access-token-a',
+            'cc-at_SiteB': 'access-token-b',
+            'cc-nx-g_SiteA': 'guest-refresh-a',
+            'cc-nx_SiteA': 'registered-refresh-a',
+            dwsid: 'session-id',
+            'custom-cookie': 'keep-me'
+        })
+        cookie.serialize.mockImplementation((name, value) => `${name}=${value}`)
+
+        const proxyRequest = {
+            setHeader: jest.fn(),
+            removeHeader: jest.fn()
+        }
+        const incomingRequest = {
+            headers: {cookie: 'any', [X_SITE_ID]: 'SiteA'}
+        }
+
+        stripSessionCookies(proxyRequest, incomingRequest)
+
+        // Only SiteA cookies are stripped; SiteB cookies are preserved
+        expect(proxyRequest.setHeader).toHaveBeenCalledWith(
+            'cookie',
+            'cc-at_SiteB=access-token-b; custom-cookie=keep-me'
+        )
+        expect(proxyRequest.removeHeader).not.toHaveBeenCalled()
+    })
+
+    it('removes cookie header entirely when all cookies are session cookies', () => {
+        cookie.parse.mockReturnValue({
+            'cc-at_RefArch': 'access-token',
+            'cc-nx-g_RefArch': 'guest-refresh-token',
+            dwsid: 'session-id'
+        })
+
+        const proxyRequest = {
+            setHeader: jest.fn(),
+            removeHeader: jest.fn()
+        }
+        const incomingRequest = {
+            headers: {cookie: 'any', [X_SITE_ID]: 'RefArch'}
+        }
+
+        stripSessionCookies(proxyRequest, incomingRequest)
+
+        expect(proxyRequest.removeHeader).toHaveBeenCalledWith('cookie')
+        expect(proxyRequest.setHeader).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when no cookie header is present', () => {
+        const proxyRequest = {
+            setHeader: jest.fn(),
+            removeHeader: jest.fn()
+        }
+        const incomingRequest = {
+            headers: {}
+        }
+
+        stripSessionCookies(proxyRequest, incomingRequest)
+
+        expect(proxyRequest.setHeader).not.toHaveBeenCalled()
+        expect(proxyRequest.removeHeader).not.toHaveBeenCalled()
     })
 })

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -79,6 +79,53 @@ export const setScapiAuthRequestHeaders = ({
         // Always override - cookie-based auth takes precedence
         proxyRequest.setHeader('authorization', `Bearer ${accessToken}`)
     }
+
+    // Transform dwsid cookie into sfdc_dwsid header (same as MRT)
+    if (cookies.dwsid) {
+        proxyRequest.setHeader('sfdc_dwsid', cookies.dwsid)
+    }
+}
+
+/**
+ * Strip HttpOnly session cookies from a proxy request after the proxy has already
+ * extracted the tokens it needs (e.g., to set Authorization headers).
+ *
+ * This mirrors the MRT CloudFront Lambda@Edge logic in transformHttpOnlyCookies
+ * (cloudfront-proxy-origin-rewriter.js), using exact cookie names based on siteId
+ * rather than prefix matching.
+ *
+ * Removes: cc-at_{siteId}, cc-nx-g_{siteId}, cc-nx_{siteId}, and dwsid.
+ * Any remaining cookies are preserved and forwarded.
+ *
+ * @private
+ * @param proxyRequest {http.ClientRequest} the outgoing proxy request
+ * @param incomingRequest {http.IncomingMessage} the original incoming request
+ */
+export const stripSessionCookies = (proxyRequest, incomingRequest) => {
+    const cookieHeader = incomingRequest.headers.cookie
+    if (!cookieHeader) return
+
+    const cookies = cookie.parse(cookieHeader)
+    const siteId = incomingRequest.headers[X_SITE_ID]
+
+    // Build the exact list of cookies to delete, matching MRT's approach
+    const cookiesToDelete = new Set(['dwsid'])
+    if (siteId) {
+        cookiesToDelete.add(`cc-at_${siteId}`)
+        cookiesToDelete.add(`cc-nx-g_${siteId}`)
+        cookiesToDelete.add(`cc-nx_${siteId}`)
+    }
+
+    const filtered = Object.entries(cookies).filter(([name]) => !cookiesToDelete.has(name))
+
+    if (filtered.length === 0) {
+        proxyRequest.removeHeader('cookie')
+    } else {
+        proxyRequest.setHeader(
+            'cookie',
+            filtered.map(([name, value]) => cookie.serialize(name, value)).join('; ')
+        )
+    }
 }
 
 /**
@@ -269,6 +316,9 @@ export const configureProxy = ({
                     caching,
                     targetHost
                 })
+                // Strip session cookies — the proxy has already extracted the tokens
+                // it needs. These cookies should not be forwarded to SCAPI.
+                stripSessionCookies(proxyRequest, incomingRequest)
                 // Strip internal header — only used by our proxy, not by SCAPI.
                 proxyRequest.removeHeader(X_SITE_ID)
             }

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -84,6 +84,12 @@ export const setScapiAuthRequestHeaders = ({
     if (cookies.dwsid) {
         proxyRequest.setHeader('sfdc_dwsid', cookies.dwsid)
     }
+
+    // Strip session cookies — the proxy has already extracted the tokens
+    // it needs. These cookies should not be forwarded to SCAPI.
+    stripSessionCookies(proxyRequest, incomingRequest)
+    // Strip internal header — only used by our proxy, not by SCAPI.
+    proxyRequest.removeHeader(X_SITE_ID)
 }
 
 /**
@@ -308,7 +314,9 @@ export const configureProxy = ({
                 targetProtocol
             })
 
-            // Apply Authorization header with shopper's access token from HttpOnly cookie
+            // For SCAPI proxy requests with HttpOnly cookies enabled:
+            // inject auth headers from cookies, strip session cookies, and
+            // remove internal headers. Non-SCAPI proxies are left untouched.
             if (process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true') {
                 setScapiAuthRequestHeaders({
                     proxyRequest,
@@ -316,11 +324,6 @@ export const configureProxy = ({
                     caching,
                     targetHost
                 })
-                // Strip session cookies — the proxy has already extracted the tokens
-                // it needs. These cookies should not be forwarded to SCAPI.
-                stripSessionCookies(proxyRequest, incomingRequest)
-                // Strip internal header — only used by our proxy, not by SCAPI.
-                proxyRequest.removeHeader(X_SITE_ID)
             }
         },
 


### PR DESCRIPTION
 **Summary**                                                                                                                                           
                                                                                                                                                    
  - Strip HttpOnly session cookies (cc-at_{siteId}, cc-nx-g_{siteId}, cc-nx_{siteId}, dwsid) from proxy requests before forwarding to SCAPI and  SLAS, aligning local dev behavior with MRT's CloudFront Lambda@Edge transformHttpOnlyCookies logic                                                
  - Transform dwsid cookie into sfdc_dwsid header on SCAPI proxy requests, matching MRT behavior                                                                                           

```
[SCAPI Proxy Debug] {
  url: '/customer/shopper-customers/v1/organizations/f_ecom_zzrf_001/customers/abwrEUk0sXmusRlekZwGYYwrkW/baskets?siteId=RefArchGlobal',
  authorization: 'Bearer ****EKsLmuA==',
  cookie: 'dwanonymous_5eac94f25e98e4dcb13b163dcfcb7651=abwrEUk0sXmusRlekZwGYYwrkW; cc-at-expires_RefArchGlobal=1775863960; cc-at-dnt_RefArchGlobal=1; uido_RefArchGlobal=slas; cc-nx-exists_RefArchGlobal=1; usid_RefArchGlobal=a803e39e-4c5b-4a32-8681-359f5fdb30db; sid=oAQ9EGeNLsart6fXQPDIcFJXqNbowRELUZM',                                                                                                                                            
  xSiteId: undefined
}
```                                                                                                                                                                                                                                        
                                                                                                                                                    
  **Test plan**                                                                                                                                         
                                                                                                                                                                                                                                                         
  - Local dev: confirm SCAPI proxy requests forward Authorization and sfdc_dwsid headers but not cc-at_*, cc-nx-g_*, cc-nx_*, or dwsid cookies      
  - Local dev: confirm SLAS proxy requests (token refresh, logout) do not forward session cookies                                                   
  