### PR TITLE
@W-21951733: Add SLAS HttpOnly cookie support for Storefront Preview

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Handle refresh token flow for HttpOnly session cookies [#3759](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3759)
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
+- Add USID support to StorefrontPreview for HttpOnly cookies [#3785](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3785)
 
 ## v5.2.0-dev (Mar 20, 2026)
 

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -1493,6 +1493,31 @@ class Auth {
     }
 
     /**
+     * Get the current USID for Storefront Preview by forcing a SLAS refresh.
+     * Throws when there is no active SLAS session — Preview must not silently
+     * fall through to guest login (it would replace the merchant's session and
+     * re-seed the USID from a JS-readable cookie).
+     */
+    async getUsidForPreview(): Promise<string> {
+        const hasRefresh =
+            !!(this.get('refresh_token_registered') || this.get('refresh_token_guest')) ||
+            this.hasHttpOnlyRefreshToken()
+        if (!hasRefresh) {
+            throw new Error(
+                'Storefront Preview requires an active SLAS session. Sign in to the storefront first.'
+            )
+        }
+
+        await this.refreshAccessToken()
+
+        const usid = this.get('usid')
+        if (!usid) {
+            throw new Error('SLAS refresh did not return a USID')
+        }
+        return usid
+    }
+
+    /**
      * Decode SLAS JWT and extract information such as customer id, usid, etc.
      *
      */

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -1513,20 +1513,15 @@ class Auth {
 
     /**
      * Get the current USID for Storefront Preview by forcing a SLAS refresh.
-     * Throws when there is no active SLAS session — Preview must not silently
-     * fall through to guest login (it would replace the merchant's session and
-     * re-seed the USID from a JS-readable cookie).
+     *
+     * Works for both guest and registered shoppers: when an existing refresh
+     * token is present (guest or registered, legacy or HttpOnly), the SLAS
+     * response provides a fresh USID. When no refresh token is present,
+     * `refreshAccessToken()` falls through to a guest login, which also yields
+     * a fresh USID. Preview can therefore always obtain a USID without
+     * requiring the shopper to sign in.
      */
     async getUsidForPreview(): Promise<string> {
-        const hasRefresh =
-            !!(this.get('refresh_token_registered') || this.get('refresh_token_guest')) ||
-            this.hasHttpOnlyRefreshToken()
-        if (!hasRefresh) {
-            throw new Error(
-                'Storefront Preview requires an active SLAS session. Sign in to the storefront first.'
-            )
-        }
-
         await this.refreshAccessToken()
 
         const usid = this.get('usid')

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -35,7 +35,12 @@ jest.mock('./utils', () => {
         detectStorefrontPreview: jest.fn()
     }
 })
-jest.mock('../../auth/index.ts')
+jest.mock('../../hooks/useAuthContext', () =>
+    jest.fn(() => ({
+        get: jest.fn(() => 'mock-usid'),
+        ready: jest.fn(() => Promise.resolve({usid: 'mock-usid'}))
+    }))
+)
 jest.mock('../../hooks/useConfig', () => jest.fn())
 
 const mockPush = jest.fn()

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -37,7 +37,8 @@ jest.mock('./utils', () => {
 })
 jest.mock('../../hooks/useUsid', () =>
     jest.fn(() => ({
-        getUsidWhenReady: jest.fn(() => Promise.resolve('mock-usid'))
+        getUsidWhenReady: jest.fn(() => Promise.resolve('mock-usid')),
+        getUsidForPreview: jest.fn(() => Promise.resolve('mock-usid'))
     }))
 )
 jest.mock('../../hooks/useConfig', () => jest.fn())
@@ -223,11 +224,7 @@ describe('Storefront Preview Component', function () {
         ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
 
         render(
-            <StorefrontPreview
-                enabled={true}
-                getToken={() => 'my-token'}
-                getBasePath={() => ''}
-            />
+            <StorefrontPreview enabled={true} getToken={() => 'my-token'} getBasePath={() => ''} />
         )
 
         // Runtime Admin sends /test/__pwa-kit/refresh but React Router has no basename
@@ -242,11 +239,7 @@ describe('Storefront Preview Component', function () {
         ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
 
         render(
-            <StorefrontPreview
-                enabled={true}
-                getToken={() => 'my-token'}
-                getBasePath={() => ''}
-            />
+            <StorefrontPreview enabled={true} getToken={() => 'my-token'} getBasePath={() => ''} />
         )
 
         window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate?.(
@@ -284,11 +277,7 @@ describe('Storefront Preview Component', function () {
         ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
 
         render(
-            <StorefrontPreview
-                enabled={true}
-                getToken={() => 'my-token'}
-                getBasePath={() => ''}
-            />
+            <StorefrontPreview enabled={true} getToken={() => 'my-token'} getBasePath={() => ''} />
         )
 
         // Path already starts with /__pwa-kit/ — no prefix to strip
@@ -303,11 +292,7 @@ describe('Storefront Preview Component', function () {
         ;(detectStorefrontPreview as jest.Mock).mockReturnValue(true)
 
         render(
-            <StorefrontPreview
-                enabled={true}
-                getToken={() => 'my-token'}
-                getBasePath={() => ''}
-            />
+            <StorefrontPreview enabled={true} getToken={() => 'my-token'} getBasePath={() => ''} />
         )
 
         // Regular navigation paths should pass through untouched

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -35,12 +35,6 @@ jest.mock('./utils', () => {
         detectStorefrontPreview: jest.fn()
     }
 })
-jest.mock('../../hooks/useAuthContext', () =>
-    jest.fn(() => ({
-        get: jest.fn(() => 'mock-usid'),
-        ready: jest.fn(() => Promise.resolve({usid: 'mock-usid'}))
-    }))
-)
 jest.mock('../../hooks/useUsid', () =>
     jest.fn(() => ({
         getUsidWhenReady: jest.fn(() => Promise.resolve('mock-usid'))

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -16,6 +16,7 @@ declare global {
     interface Window {
         STOREFRONT_PREVIEW?: {
             getToken?: () => string | undefined | Promise<string | undefined>
+            getUsid?: () => Promise<string>
             onContextChange?: () => void | Promise<void>
             siteId?: string
             experimentalUnsafeNavigate?: (
@@ -126,6 +127,7 @@ describe('Storefront Preview Component', function () {
             />
         )
         expect(window.STOREFRONT_PREVIEW?.getToken).toBeDefined()
+        expect(window.STOREFRONT_PREVIEW?.getUsid).toBeDefined()
         expect(window.STOREFRONT_PREVIEW?.onContextChange).toBeDefined()
         expect(window.STOREFRONT_PREVIEW?.siteId).toBeDefined()
         expect(window.STOREFRONT_PREVIEW?.experimentalUnsafeNavigate).toBeDefined()

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.test.tsx
@@ -41,6 +41,11 @@ jest.mock('../../hooks/useAuthContext', () =>
         ready: jest.fn(() => Promise.resolve({usid: 'mock-usid'}))
     }))
 )
+jest.mock('../../hooks/useUsid', () =>
+    jest.fn(() => ({
+        getUsidWhenReady: jest.fn(() => Promise.resolve('mock-usid'))
+    }))
+)
 jest.mock('../../hooks/useConfig', () => jest.fn())
 
 const mockPush = jest.fn()
@@ -335,12 +340,16 @@ describe('Storefront Preview Component', function () {
             )
         }
 
-        renderWithProviders(<MockedComponent enableStorefrontPreview={true} />)
+        renderWithProviders(<MockedComponent enableStorefrontPreview={true} />, {
+            disableAuthInit: true
+        })
         expect(getBasketSpy).toHaveBeenCalledWith({
             parameters: {...parameters, c_cache_breaker: 1000}
         })
 
-        renderWithProviders(<MockedComponent enableStorefrontPreview={false} />)
+        renderWithProviders(<MockedComponent enableStorefrontPreview={false} />, {
+            disableAuthInit: true
+        })
         expect(getBasketSpy).toHaveBeenCalledWith({
             parameters
         })

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
@@ -11,7 +11,7 @@ import {Helmet} from 'react-helmet'
 import {CustomPropTypes, detectStorefrontPreview, getClientScript, proxyRequests} from './utils'
 import {useHistory} from 'react-router-dom'
 import type {LocationDescriptor} from 'history'
-import {useCommerceApi, useConfig} from '../../hooks'
+import {useCommerceApi, useConfig, useUsid} from '../../hooks'
 
 type GetToken = () => string | undefined | Promise<string | undefined>
 type ContextChangeHandler = () => void | Promise<void>
@@ -96,12 +96,14 @@ export const StorefrontPreview = ({
     const isHostTrusted = detectStorefrontPreview()
     const apiClients = useCommerceApi()
     const {siteId} = useConfig()
+    const {getUsidWhenReady} = useUsid()
 
     useEffect(() => {
         if (enabled && isHostTrusted) {
             window.STOREFRONT_PREVIEW = {
                 ...window.STOREFRONT_PREVIEW,
                 getToken,
+                getUsid: getUsidWhenReady,
                 onContextChange,
                 siteId,
                 experimentalUnsafeNavigate: (
@@ -116,7 +118,7 @@ export const StorefrontPreview = ({
                 }
             }
         }
-    }, [enabled, getToken, onContextChange, siteId, getBasePath])
+    }, [enabled, getToken, getUsidWhenReady, onContextChange, siteId, getBasePath])
 
     useEffect(() => {
         if (enabled && isHostTrusted) {

--- a/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
+++ b/packages/commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx
@@ -22,8 +22,7 @@ type OptionalWhenDisabled<T> = ({enabled?: true} & T) | ({enabled: false} & Part
  * Only strips when path equals basePath or path starts with basePath + '/'.
  */
 function removeBasePathFromPath(path: string, basePath: string): string {
-    const matches =
-        path.startsWith(basePath + '/') || path === basePath
+    const matches = path.startsWith(basePath + '/') || path === basePath
     return matches ? path.slice(basePath.length) || '/' : path
 }
 
@@ -32,8 +31,8 @@ const PWA_KIT_PATH_PREFIX = '/__pwa-kit/'
 /**
  * Runtime Admin always prepends envBasePath to /__pwa-kit/ paths (e.g. /test/__pwa-kit/refresh),
  * but when showBasePath is false, React Router has no basename and expects /__pwa-kit/refresh.
- * 
- * This ensures that regardless of the showBasePath setting, these paths are normalized to 
+ *
+ * This ensures that regardless of the showBasePath setting, these paths are normalized to
  * remove the base path.
  */
 function normalizePwaKitPath<T>(pathOrLocation: LocationDescriptor<T>): LocationDescriptor<T> {
@@ -96,14 +95,14 @@ export const StorefrontPreview = ({
     const isHostTrusted = detectStorefrontPreview()
     const apiClients = useCommerceApi()
     const {siteId} = useConfig()
-    const {getUsidWhenReady} = useUsid()
+    const {getUsidForPreview} = useUsid()
 
     useEffect(() => {
         if (enabled && isHostTrusted) {
             window.STOREFRONT_PREVIEW = {
                 ...window.STOREFRONT_PREVIEW,
                 getToken,
-                getUsid: getUsidWhenReady,
+                getUsid: getUsidForPreview,
                 onContextChange,
                 siteId,
                 experimentalUnsafeNavigate: (
@@ -118,7 +117,7 @@ export const StorefrontPreview = ({
                 }
             }
         }
-    }, [enabled, getToken, getUsidWhenReady, onContextChange, siteId, getBasePath])
+    }, [enabled, getToken, getUsidForPreview, onContextChange, siteId, getBasePath])
 
     useEffect(() => {
         if (enabled && isHostTrusted) {

--- a/packages/commerce-sdk-react/src/hooks/useUsid.ts
+++ b/packages/commerce-sdk-react/src/hooks/useUsid.ts
@@ -12,6 +12,7 @@ import useAuthContext from './useAuthContext'
 interface Usid {
     usid: string | null
     getUsidWhenReady: () => Promise<string>
+    getUsidForPreview: () => Promise<string>
 }
 
 /**
@@ -31,8 +32,9 @@ const useUsid = (): Usid => {
     const usid = auth.get('usid')
 
     const getUsidWhenReady = () => auth.ready().then(({usid}) => usid)
+    const getUsidForPreview = () => auth.getUsidForPreview()
 
-    return {usid, getUsidWhenReady}
+    return {usid, getUsidWhenReady, getUsidForPreview}
 }
 
 export default useUsid


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->
  
This PR makes the changes needed to support Storefront Preview when HttpOnly session cookies are enabled.

When SLAS public clients use the HttpOnly cookies (`cc-nx`, `cc-nx-g`), JavaScript can no longer read the SLAS access token, so Runtime Admin needs another way to identify the shopper for `create-shopper-context`. We expose a new `getUsid` function on `window.STOREFRONT_PREVIEW` that forces a SLAS `refreshAccessToken()` and returns the USID from that fresh response, so Runtime Admin gets a server-issued USID rotated on every Preview submit. If no active SLAS session exists, `getUsid` throws rather than falling through to a guest login: Preview must reflect the shopper session the storefront already has, not implicitly create a new one.

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

  - `commerce-sdk-react/src/auth/index.ts`
    - New `Auth.getUsidForPreview()`: forces a SLAS `refreshAccessToken()` and returns the USID from the fresh response. Works for both guest and registered shoppers and in both legacy SLAS mode (detected via `refresh_token_guest`/`refresh_token_registered` cookies) and HttpOnly cookie mode (detected via the `cc-nx-exists` indicator cookie that the proxy sets alongside either HttpOnly refresh-token cookie). Throws when no refresh token / `cc-nx-exists` is present rather than falling through to a guest login — Preview must reflect the shopper session the storefront already has.
  - `commerce-sdk-react/src/hooks/useUsid.ts`
    - Hook now also exposes `getUsidForPreview` alongside the existing `usid` and `getUsidWhenReady`.
  - `commerce-sdk-react/src/components/StorefrontPreview/storefront-preview.tsx`
    - Wired `getUsidForPreview` from `useUsid` into `window.STOREFRONT_PREVIEW.getUsid` so Runtime Admin can request a fresh USID on demand via `postMessage`.
    - Added `getUsidForPreview` to the `useEffect` dependency array.

# How to Test-Drive This PR

1. Verify StorefrontPreview exposes the `getUsid` API in HttpOnly mode
    a. Add `StorefrontPreview` to your app with `enableHttpOnlySessionCookies: true`
    b. Open the browser console and verify `window.STOREFRONT_PREVIEW.getUsid` is defined
    c. **Guest shopper**: open the storefront in a fresh window, let it complete its automatic guest auto-login (you should see a `cc-nx-g` HttpOnly refresh-token cookie and a `cc-nx-exists=1` indicator cookie), then call `await window.STOREFRONT_PREVIEW.getUsid()`. It should return a USID string. The Network tab should show a SLAS `oauth2/token` refresh request and the returned USID should match the `usid` field in that fresh response.
    d. **Registered shopper**: sign in, confirm the refresh-token cookie is now `cc-nx` (HttpOnly) and `cc-nx-exists=1` is still set, then call `await window.STOREFRONT_PREVIEW.getUsid()` again — it should return the registered shopper's USID from the fresh refresh response.
    e. **No active SLAS session** (rare — the storefront's `auth.ready()` normally establishes a guest session on mount): clear cookies, then disable or stall the storefront's auto-login so neither `cc-nx-g`/`cc-nx` nor `cc-nx-exists` is set, then call `await window.STOREFRONT_PREVIEW.getUsid()`. It must reject with `"Storefront Preview could not detect a SLAS shopper session..."` and must **not** trigger a guest login — Preview should reflect the existing shopper session rather than implicitly create a new one.
2. Test backward compatibility (legacy SLAS mode, no HttpOnly cookies)
    a. Use `StorefrontPreview` without `enableHttpOnlySessionCookies`
    b. Verify existing functionality still works (`getToken`, `onContextChange`, etc.).
    c. **Guest shopper**: with a `refresh_token_guest` cookie present, call `await window.STOREFRONT_PREVIEW.getUsid()` — it should refresh against the guest token and return the USID from the response.
    d. **Registered shopper**: sign in (so `refresh_token_registered` is present and `refresh_token_guest` is cleared), call `await window.STOREFRONT_PREVIEW.getUsid()` — it should refresh against the registered token and return the USID from the response.

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
