### PR TITLE
@W-21201751@ Http-only - Handle missing HttpOnly access token cookie (cc-at)

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Ensure client-side refresh token requests are deduped [#3786](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3786/)
+- Handle missing access token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 
 ## v5.2.0-dev (Mar 20, 2026)
 

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -553,6 +553,19 @@ class Auth {
     }
 
     /**
+     * Clears the non-HttpOnly access token expiry cookie (cc-at-expires).
+     *
+     * This is needed when SCAPI returns a 401 because the HttpOnly access token cookie
+     * (cc-at_{siteId}) was deleted externally while the expiry cookie remained valid.
+     * Clearing the expiry cookie ensures isAccessTokenExpired() returns true, so
+     * subsequent calls to ready() will trigger a refresh instead of assuming the token
+     * is still valid.
+     */
+    clearAccessTokenExpiry(): void {
+        this.delete('cc-at-expires')
+    }
+
+    /**
      * Returns whether the access token is expired. When enableHttpOnlySessionCookies is true,
      * uses cc-at-expires cookie from store; otherwise decodes the JWT from getAccessToken().
      */

--- a/packages/commerce-sdk-react/src/hooks/helpers.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/helpers.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {handleInvalidToken} from './helpers'
+import Auth from '../auth'
+
+const mockLogger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+    debug: jest.fn()
+}
+
+const createMock401Error = (responseBody: Record<string, unknown>) => ({
+    response: {
+        status: 401,
+        json: () => responseBody
+    }
+})
+
+describe('handleInvalidToken', () => {
+    let mockAuth: jest.Mocked<
+        Pick<Auth, 'logout' | 'clearAccessTokenExpiry' | 'refreshAccessToken'>
+    >
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        mockAuth = {
+            logout: jest.fn().mockResolvedValue({access_token: 'new_guest_token'}),
+            clearAccessTokenExpiry: jest.fn(),
+            refreshAccessToken: jest.fn().mockResolvedValue({access_token: 'refreshed_token'})
+        }
+    })
+
+    test('re-throws non-401 errors', async () => {
+        const error = {response: {status: 500}}
+        await expect(handleInvalidToken(error, mockAuth as any, mockLogger)).rejects.toEqual(error)
+    })
+
+    test('calls auth.logout() when detail is "Customer credentials changed after token was issued."', async () => {
+        const error = createMock401Error({
+            detail: 'Customer credentials changed after token was issued.'
+        })
+
+        const result = await handleInvalidToken(error, mockAuth as any, mockLogger)
+
+        expect(mockAuth.logout).toHaveBeenCalled()
+        expect(result).toEqual({access_token: 'new_guest_token'})
+    })
+
+    test('clears access token expiry and refreshes when proxy reports missing access token cookie', async () => {
+        const error = createMock401Error({
+            message: 'access_token_cookie_missing'
+        })
+
+        const result = await handleInvalidToken(error, mockAuth as any, mockLogger)
+
+        expect(mockAuth.clearAccessTokenExpiry).toHaveBeenCalled()
+        expect(mockAuth.refreshAccessToken).toHaveBeenCalled()
+        expect(result).toEqual({access_token: 'refreshed_token'})
+        expect(mockLogger.info).toHaveBeenCalledWith(
+            expect.stringContaining('Access token cookie missing')
+        )
+    })
+
+    test('re-throws 401 with unrecognized response body', async () => {
+        const error = createMock401Error({
+            detail: 'Some other SCAPI error.'
+        })
+
+        await expect(handleInvalidToken(error, mockAuth as any, mockLogger)).rejects.toEqual(error)
+
+        expect(mockAuth.logout).not.toHaveBeenCalled()
+        expect(mockAuth.clearAccessTokenExpiry).not.toHaveBeenCalled()
+    })
+})

--- a/packages/commerce-sdk-react/src/hooks/helpers.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/helpers.test.ts
@@ -16,9 +16,9 @@ const mockLogger = {
     debug: jest.fn()
 }
 
-const createMock401Error = (responseBody: Record<string, unknown>) => ({
+const createMockError = (status: number, responseBody: Record<string, unknown>) => ({
     response: {
-        status: 401,
+        status,
         json: () => responseBody
     }
 })
@@ -43,7 +43,7 @@ describe('handleInvalidToken', () => {
     })
 
     test('calls auth.logout() when detail is "Customer credentials changed after token was issued."', async () => {
-        const error = createMock401Error({
+        const error = createMockError(401, {
             detail: 'Customer credentials changed after token was issued.'
         })
 
@@ -54,7 +54,7 @@ describe('handleInvalidToken', () => {
     })
 
     test('clears access token expiry and refreshes when proxy reports missing access token cookie', async () => {
-        const error = createMock401Error({
+        const error = createMockError(400, {
             message: 'access_token_cookie_missing'
         })
 
@@ -63,13 +63,23 @@ describe('handleInvalidToken', () => {
         expect(mockAuth.clearAccessTokenExpiry).toHaveBeenCalled()
         expect(mockAuth.refreshAccessToken).toHaveBeenCalled()
         expect(result).toEqual({access_token: 'refreshed_token'})
-        expect(mockLogger.info).toHaveBeenCalledWith(
+        expect(mockLogger.warn).toHaveBeenCalledWith(
             expect.stringContaining('Access token cookie missing')
         )
     })
 
+    test('re-throws 400 with unrecognized response body', async () => {
+        const error = createMockError(400, {
+            detail: 'Some other error.'
+        })
+
+        await expect(handleInvalidToken(error, mockAuth as any, mockLogger)).rejects.toEqual(error)
+
+        expect(mockAuth.clearAccessTokenExpiry).not.toHaveBeenCalled()
+    })
+
     test('re-throws 401 with unrecognized response body', async () => {
-        const error = createMock401Error({
+        const error = createMockError(401, {
             detail: 'Some other SCAPI error.'
         })
 

--- a/packages/commerce-sdk-react/src/hooks/helpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/helpers.ts
@@ -23,11 +23,23 @@ export const handleInvalidToken = async (error: any, auth: Auth, logger: Logger)
     }
 
     const response = await error?.response?.json()
-    if (response?.detail !== 'Customer credentials changed after token was issued.') {
-        throw error
+    if (response?.detail === 'Customer credentials changed after token was issued.') {
+        logger.info('Login was invalidated. Clearing login state.')
+        return await auth.logout()
     }
-    logger.info('Login was invalidated. Clearing login state.')
-    return await auth.logout()
+
+    // The proxy returns this message when the HttpOnly access token cookie (cc-at_{siteId})
+    // is missing. This can happen if the cookie was deleted externally (e.g. via dev tools)
+    // while the non-HttpOnly expiry cookie (cc-at-expires) remained valid, causing
+    // isAccessTokenExpired() to incorrectly report the token as not expired. Clear the
+    // stale expiry cookie and trigger a token refresh.
+    if (response?.message === 'access_token_cookie_missing') {
+        logger.info('Access token cookie missing. Clearing expiry and refreshing token.')
+        auth.clearAccessTokenExpiry()
+        return await auth.refreshAccessToken()
+    }
+
+    throw error
 }
 
 /**

--- a/packages/commerce-sdk-react/src/hooks/helpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/helpers.ts
@@ -18,6 +18,20 @@ import {onClient} from '../utils'
  * @returns a new guest access token
  */
 export const handleInvalidToken = async (error: any, auth: Auth, logger: Logger) => {
+    // The proxy returns a 400 with this message when the HttpOnly access token cookie
+    // (cc-at_{siteId}) is missing. This can happen if the cookie was deleted externally
+    // (e.g. via dev tools) while the non-HttpOnly expiry cookie (cc-at-expires) remained
+    // valid, causing isAccessTokenExpired() to incorrectly report the token as not expired.
+    // Clear the stale expiry cookie and trigger a token refresh.
+    if (error?.response?.status === 400) {
+        const response = await error?.response?.json()
+        if (response?.message === 'access_token_cookie_missing') {
+            logger.warn('Access token cookie missing. Clearing expiry and refreshing token.')
+            auth.clearAccessTokenExpiry()
+            return await auth.refreshAccessToken()
+        }
+    }
+
     if (error?.response?.status !== 401) {
         throw error
     }
@@ -26,17 +40,6 @@ export const handleInvalidToken = async (error: any, auth: Auth, logger: Logger)
     if (response?.detail === 'Customer credentials changed after token was issued.') {
         logger.info('Login was invalidated. Clearing login state.')
         return await auth.logout()
-    }
-
-    // The proxy returns this message when the HttpOnly access token cookie (cc-at_{siteId})
-    // is missing. This can happen if the cookie was deleted externally (e.g. via dev tools)
-    // while the non-HttpOnly expiry cookie (cc-at-expires) remained valid, causing
-    // isAccessTokenExpired() to incorrectly report the token as not expired. Clear the
-    // stale expiry cookie and trigger a token refresh.
-    if (response?.message === 'access_token_cookie_missing') {
-        logger.info('Access token cookie missing. Clearing expiry and refreshing token.')
-        auth.clearAccessTokenExpiry()
-        return await auth.refreshAccessToken()
     }
 
     throw error

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
+- Handle missing access token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
-- Handle missing access token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
+- Handle missing access token for HttpOnly session cookies [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
@@ -8,7 +8,8 @@ import {
     applyProxyRequestHeaders,
     setScapiAuthRequestHeaders,
     stripSessionCookies,
-    configureProxy
+    configureProxy,
+    AccessTokenNotFoundError
 } from './configure-proxy'
 import {X_SITE_ID} from '../../ssr/server/constants'
 import * as ssrProxying from '../ssr-proxying'
@@ -130,7 +131,7 @@ describe('setScapiAuthRequestHeaders', () => {
             }
         }
 
-        const result = setScapiAuthRequestHeaders({
+        setScapiAuthRequestHeaders({
             proxyRequest,
             incomingRequest,
             caching: false,
@@ -142,7 +143,6 @@ describe('setScapiAuthRequestHeaders', () => {
             'Bearer test-access-token'
         )
         expect(proxyRequest.setHeader).toHaveBeenCalledWith('sfdc_dwsid', 'test-session-id')
-        expect(result).toBe(true)
     })
 
     it('does not apply Bearer token when caching is true', () => {
@@ -222,7 +222,7 @@ describe('setScapiAuthRequestHeaders', () => {
         expect(proxyRequest.setHeader).not.toHaveBeenCalled()
     })
 
-    it('returns false when access token cookie is not present', () => {
+    it('throws AccessTokenNotFoundError when access token cookie is not present', () => {
         utils.isScapiDomain.mockReturnValue(true)
         cookie.parse.mockReturnValue({}) // No access token cookie
 
@@ -238,15 +238,16 @@ describe('setScapiAuthRequestHeaders', () => {
             }
         }
 
-        const result = setScapiAuthRequestHeaders({
-            proxyRequest,
-            incomingRequest,
-            caching: false,
-            targetHost: 'abc-001.api.commercecloud.salesforce.com'
-        })
+        expect(() =>
+            setScapiAuthRequestHeaders({
+                proxyRequest,
+                incomingRequest,
+                caching: false,
+                targetHost: 'abc-001.api.commercecloud.salesforce.com'
+            })
+        ).toThrow(AccessTokenNotFoundError)
 
         expect(proxyRequest.setHeader).not.toHaveBeenCalledWith('authorization', expect.any(String))
-        expect(result).toBe(false)
     })
 
     it('uses x-site-id header to resolve correct cookie', () => {

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
@@ -130,7 +130,7 @@ describe('setScapiAuthRequestHeaders', () => {
             }
         }
 
-        setScapiAuthRequestHeaders({
+        const result = setScapiAuthRequestHeaders({
             proxyRequest,
             incomingRequest,
             caching: false,
@@ -142,6 +142,7 @@ describe('setScapiAuthRequestHeaders', () => {
             'Bearer test-access-token'
         )
         expect(proxyRequest.setHeader).toHaveBeenCalledWith('sfdc_dwsid', 'test-session-id')
+        expect(result).toBe(true)
     })
 
     it('does not apply Bearer token when caching is true', () => {
@@ -221,26 +222,31 @@ describe('setScapiAuthRequestHeaders', () => {
         expect(proxyRequest.setHeader).not.toHaveBeenCalled()
     })
 
-    it('does not apply Bearer token when cookie is not present', () => {
+    it('returns false when access token cookie is not present', () => {
         utils.isScapiDomain.mockReturnValue(true)
         cookie.parse.mockReturnValue({}) // No access token cookie
 
         const proxyRequest = {
-            setHeader: jest.fn()
+            setHeader: jest.fn(),
+            removeHeader: jest.fn()
         }
         const incomingRequest = {
             url: '/shopper/products/v1/products',
-            headers: {[X_SITE_ID]: 'RefArch'}
+            headers: {
+                cookie: 'some-other-cookie=value',
+                [X_SITE_ID]: 'RefArch'
+            }
         }
 
-        setScapiAuthRequestHeaders({
+        const result = setScapiAuthRequestHeaders({
             proxyRequest,
             incomingRequest,
             caching: false,
             targetHost: 'abc-001.api.commercecloud.salesforce.com'
         })
 
-        expect(proxyRequest.setHeader).not.toHaveBeenCalled()
+        expect(proxyRequest.setHeader).not.toHaveBeenCalledWith('authorization', expect.any(String))
+        expect(result).toBe(false)
     })
 
     it('uses x-site-id header to resolve correct cookie', () => {

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -14,6 +14,17 @@ import logger from '../logger-instance'
 import {getEnvBasePath} from '../ssr-namespace-paths'
 import {X_SITE_ID} from '../../ssr/server/constants'
 
+/**
+ * Error thrown when the access token HttpOnly cookie is not found on an SCAPI proxy request.
+ * Handled in onProxyReq to return a 400 instead of forwarding an unauthenticated request to SCAPI.
+ */
+export class AccessTokenNotFoundError extends Error {
+    constructor(message) {
+        super(message)
+        this.name = 'AccessTokenNotFoundError'
+    }
+}
+
 export const ALLOWED_CACHING_PROXY_REQUEST_METHODS = ['HEAD', 'GET', 'OPTIONS']
 
 /**
@@ -46,8 +57,7 @@ const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
  * @param targetHost {String} the target hostname (host+port)
  */
 /**
- * @returns {boolean} false if this is an SCAPI request and the access token cookie is missing,
- *   true otherwise (including non-SCAPI requests where auth injection is not applicable).
+ * @throws {AccessTokenNotFoundError} If this is an SCAPI request and the access token cookie is missing.
  */
 export const setScapiAuthRequestHeaders = ({
     proxyRequest,
@@ -60,7 +70,7 @@ export const setScapiAuthRequestHeaders = ({
 
     // Skip if: caching proxy, not SCAPI domain, or no URL
     if (caching || !isScapiDomain(targetHost) || !url) {
-        return true
+        return
     }
 
     if (!resolvedSiteId) {
@@ -68,7 +78,7 @@ export const setScapiAuthRequestHeaders = ({
             'x-site-id header is missing on SCAPI proxy request. Bearer token injection skipped.',
             {namespace: 'configureProxy.setScapiAuthRequestHeaders'}
         )
-        return true
+        return
     }
 
     // Get access token from HttpOnly cookie
@@ -77,10 +87,14 @@ export const setScapiAuthRequestHeaders = ({
     const tokenKey = `cc-at_${resolvedSiteId}`
     const accessToken = cookies[tokenKey]
 
-    if (accessToken) {
-        // Always override - cookie-based auth takes precedence
-        proxyRequest.setHeader('authorization', `Bearer ${accessToken}`)
+    if (!accessToken) {
+        throw new AccessTokenNotFoundError(
+            'Access token cookie not found. Cannot proceed with SCAPI request.'
+        )
     }
+
+    // Always override - cookie-based auth takes precedence
+    proxyRequest.setHeader('authorization', `Bearer ${accessToken}`)
 
     // Transform dwsid cookie into sfdc_dwsid header (same as MRT)
     if (cookies.dwsid) {
@@ -92,8 +106,6 @@ export const setScapiAuthRequestHeaders = ({
     stripSessionCookies(proxyRequest, incomingRequest)
     // Strip internal header — only used by our proxy, not by SCAPI.
     proxyRequest.removeHeader(X_SITE_ID)
-
-    return !!accessToken
 }
 
 /**
@@ -324,20 +336,27 @@ export const configureProxy = ({
             // inject auth headers from cookies, strip session cookies, and
             // remove internal headers. Non-SCAPI proxies are left untouched.
             if (process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true') {
-                const hasAccessToken = setScapiAuthRequestHeaders({
-                    proxyRequest,
-                    incomingRequest,
-                    caching,
-                    targetHost
-                })
-
-                // If the access token cookie is missing, short-circuit instead of
-                // forwarding an unauthenticated request to SCAPI.
-                if (!hasAccessToken && !res.headersSent) {
-                    proxyRequest.destroy()
-                    res.status(401).json({
-                        message: 'access_token_cookie_missing'
+                try {
+                    setScapiAuthRequestHeaders({
+                        proxyRequest,
+                        incomingRequest,
+                        caching,
+                        targetHost
                     })
+                } catch (error) {
+                    if (error instanceof AccessTokenNotFoundError) {
+                        logger.warn(error.message, {
+                            namespace: 'configureProxy.setScapiAuthRequestHeaders'
+                        })
+                        if (!res.headersSent) {
+                            proxyRequest.destroy()
+                            res.status(400).json({
+                                message: 'access_token_cookie_missing'
+                            })
+                        }
+                        return
+                    }
+                    throw error
                 }
             }
         },

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -45,6 +45,10 @@ const generalProxyPathRE = /^\/mobify\/proxy\/([^/]+)(\/.*)$/
  * @param caching {Boolean} true for a caching proxy, false for a standard proxy
  * @param targetHost {String} the target hostname (host+port)
  */
+/**
+ * @returns {boolean} false if this is an SCAPI request and the access token cookie is missing,
+ *   true otherwise (including non-SCAPI requests where auth injection is not applicable).
+ */
 export const setScapiAuthRequestHeaders = ({
     proxyRequest,
     incomingRequest,
@@ -56,7 +60,7 @@ export const setScapiAuthRequestHeaders = ({
 
     // Skip if: caching proxy, not SCAPI domain, or no URL
     if (caching || !isScapiDomain(targetHost) || !url) {
-        return
+        return true
     }
 
     if (!resolvedSiteId) {
@@ -64,14 +68,12 @@ export const setScapiAuthRequestHeaders = ({
             'x-site-id header is missing on SCAPI proxy request. Bearer token injection skipped.',
             {namespace: 'configureProxy.setScapiAuthRequestHeaders'}
         )
-        return
+        return true
     }
 
     // Get access token from HttpOnly cookie
     const cookieHeader = incomingRequest.headers.cookie
-    if (!cookieHeader) return
-
-    const cookies = cookie.parse(cookieHeader)
+    const cookies = cookieHeader ? cookie.parse(cookieHeader) : {}
     const tokenKey = `cc-at_${resolvedSiteId}`
     const accessToken = cookies[tokenKey]
 
@@ -90,6 +92,8 @@ export const setScapiAuthRequestHeaders = ({
     stripSessionCookies(proxyRequest, incomingRequest)
     // Strip internal header — only used by our proxy, not by SCAPI.
     proxyRequest.removeHeader(X_SITE_ID)
+
+    return !!accessToken
 }
 
 /**
@@ -303,7 +307,7 @@ export const configureProxy = ({
          * @param incomingRequest {http.IncomingMessage} the request made to
          * this Express app that prompted the proxying
          */
-        onProxyReq: (proxyRequest, incomingRequest) => {
+        onProxyReq: (proxyRequest, incomingRequest, res) => {
             // First, apply standard proxy headers (Host, Origin, etc.)
             applyProxyRequestHeaders({
                 proxyRequest,
@@ -318,12 +322,21 @@ export const configureProxy = ({
             // inject auth headers from cookies, strip session cookies, and
             // remove internal headers. Non-SCAPI proxies are left untouched.
             if (process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true') {
-                setScapiAuthRequestHeaders({
+                const hasAccessToken = setScapiAuthRequestHeaders({
                     proxyRequest,
                     incomingRequest,
                     caching,
                     targetHost
                 })
+
+                // If the access token cookie is missing, short-circuit instead of
+                // forwarding an unauthenticated request to SCAPI.
+                if (!hasAccessToken && !res.headersSent) {
+                    proxyRequest.destroy()
+                    res.status(401).json({
+                        message: 'access_token_cookie_missing'
+                    })
+                }
             }
         },
 

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -286,10 +286,12 @@ export const configureProxy = ({
                 })
             }
 
-            res.writeHead(500, {
-                'Content-Type': 'text/plain'
-            })
-            res.end(`Error in proxy request to ${req.url}: ${err}`)
+            if (!res.headersSent) {
+                res.writeHead(500, {
+                    'Content-Type': 'text/plain'
+                })
+                res.end(`Error in proxy request to ${req.url}: ${err}`)
+            }
         },
 
         /**

--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Increase msxSize for vendor.js [#3754](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3754)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 
+
 ## v9.2.0-dev (Mar 20, 2026)
 
 ## v9.1.1 (Mar 20, 2026)

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -110,7 +110,7 @@
     },
     {
       "path": "build/vendor.js",
-      "maxSize": "393 kB"
+      "maxSize": "395 kB"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Issue addressed: When HttpOnly session cookies are enabled, the access token lives in an HttpOnly cookie (cc-at_{siteId}) that JavaScript cannot read. If this cookie is deleted externally (e.g. via browser dev tools) while the non-HttpOnly expiry cookie (cc-at-expires) remains valid, isAccessTokenExpired() incorrectly reports the token as not expired. The client then makes an SCAPI request through the proxy without a valid access token.
- Solution: The proxy now detects the missing cc-at cookie in setScapiAuthRequestHeaders and short-circuits with a 401 { message: 'access_token_cookie_missing' } response instead of forwarding an unauthenticated request to SCAPI.
- On the client, handleInvalidToken recognizes this specific proxy response, clears the stale cc-at-expires cookie via a new auth.clearAccessTokenExpiry() method, and triggers a token refresh. The existing retry logic at each call site then retries the original request with the new token.

The approach taken is slightly different compared to how the refresh token (`cc-nx(-g)`) is handled because they have different usage patterns:

- Refresh token (cc-nx) — preventive, client-side gate:
The refresh token has a companion non-HttpOnly indicator cookie (cc-nx-exists) set with the same expiry. Before attempting a refresh, the client checks cc-nx-exists === '1' — if absent, it skips the refresh flow entirely and falls through to guest login with no network round-trip. As a backstop, if cc-nx-exists is stale, the proxy throws RefreshTokenNotFoundError and returns a 401.

- Access token (cc-at) — reactive, proxy-side catch:
The access token has no equivalent indicator cookie — only cc-at-expires for the expiry timestamp. An cc-at-exists indicator cookie would not help here because browsers don't selectively clear HttpOnly vs non-HttpOnly cookies (if a user clears cc-at, cc-at-exists would still be '1'). Instead, the proxy detects the missing cookie at request time and returns a specific 401 that the client handles by clearing stale state and refreshing.


## Testing
- Enable HttpOnly cookies and start the site
- Once the site is finished authenticating, clear the cc-at cookie
- Try navigating to a PDP or PLP to make a call to SCAPI

Before the change:
- See that there is an HTTP 401 and no follow up token request

After the change:
- See that there is an HTTP 401 with the message `access_token_cookie_missing` and a follow up token request to restore the session