### PR TITLE
Centralize HttpOnly session cookie config

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
+- Centralize HttpOnly session cookie config [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Handle missing refresh token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3771)
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
-- Centralize HttpOnly session cookie config [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
+- Centralize HttpOnly session cookie config [#3792](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3792)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -21,6 +21,11 @@ import {
     X_GRANT_TYPE
 } from './constants'
 import {SESSION_COOKIE_CONFIG, getCookieName, getSiteId} from './httponly-cookie-config'
+const {
+    refreshTokenRegistered,
+    refreshTokenGuest,
+    accessToken: accessTokenConfig
+} = SESSION_COOKIE_CONFIG
 import {
     catchAndLog,
     getHashForString,
@@ -137,8 +142,8 @@ export const setRefreshTokenHeader = (proxyRequest, incomingRequest) => {
 
     // Try registered refresh token first, then guest
     const refreshToken =
-        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId)] ||
-        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, siteId)]
+        cookies[getCookieName(refreshTokenRegistered, siteId)] ||
+        cookies[getCookieName(refreshTokenGuest, siteId)]
     if (!refreshToken) {
         throw new RefreshTokenNotFoundError(
             'Refresh token cookie not found. Cannot proceed with refresh token flow.'
@@ -170,21 +175,20 @@ export const setTokensInLogoutRequest = (proxyRequest, incomingRequest) => {
     }
 
     // Inject Bearer token from access token cookie
-    const accessToken = cookies[getCookieName(SESSION_COOKIE_CONFIG.accessToken, siteId)]
+    const accessToken = cookies[getCookieName(accessTokenConfig, siteId)]
     if (accessToken) {
         proxyRequest.setHeader('Authorization', `Bearer ${accessToken}`)
     }
 
     // Inject refresh_token into query string from HttpOnly cookie
-    const refreshToken =
-        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId)]
+    const refreshToken = cookies[getCookieName(refreshTokenRegistered, siteId)]
     if (refreshToken) {
         const separator = proxyRequest.path.includes('?') ? '&' : '?'
         proxyRequest.path += `${separator}refresh_token=${encodeURIComponent(refreshToken)}`
     } else {
         logger.warn(
             `Refresh token cookie (${getCookieName(
-                SESSION_COOKIE_CONFIG.refreshTokenRegistered,
+                refreshTokenRegistered,
                 siteId
             )}) not found for ${incomingRequest.path}. The logout request may fail.`,
             {namespace: 'setTokensInLogoutRequest'}

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -20,6 +20,7 @@ import {
     X_SITE_ID,
     X_GRANT_TYPE
 } from './constants'
+import {SESSION_COOKIE_CONFIG, getCookieName, getSiteId} from './httponly-cookie-config'
 import {
     catchAndLog,
     getHashForString,
@@ -125,7 +126,7 @@ export const setRefreshTokenHeader = (proxyRequest, incomingRequest) => {
     }
 
     const cookies = cookie.parse(cookieHeader)
-    const siteId = incomingRequest.headers[X_SITE_ID]
+    const siteId = getSiteId(incomingRequest)
     if (!siteId) {
         throw new RefreshTokenNotFoundError(
             'x-site-id header is missing on SLAS token request. ' +
@@ -135,7 +136,9 @@ export const setRefreshTokenHeader = (proxyRequest, incomingRequest) => {
     }
 
     // Try registered refresh token first, then guest
-    const refreshToken = cookies[`cc-nx_${siteId}`] || cookies[`cc-nx-g_${siteId}`]
+    const refreshToken =
+        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId)] ||
+        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, siteId)]
     if (!refreshToken) {
         throw new RefreshTokenNotFoundError(
             'Refresh token cookie not found. Cannot proceed with refresh token flow.'
@@ -155,7 +158,7 @@ export const setTokensInLogoutRequest = (proxyRequest, incomingRequest) => {
     if (!cookieHeader) return
 
     const cookies = cookie.parse(cookieHeader)
-    const siteId = incomingRequest.headers[X_SITE_ID]
+    const siteId = getSiteId(incomingRequest)
     if (!siteId) {
         logger.warn(
             'x-site-id header is missing on SLAS logout request. ' +
@@ -167,19 +170,23 @@ export const setTokensInLogoutRequest = (proxyRequest, incomingRequest) => {
     }
 
     // Inject Bearer token from access token cookie
-    const accessToken = cookies[`cc-at_${siteId}`]
+    const accessToken = cookies[getCookieName(SESSION_COOKIE_CONFIG.accessToken, siteId)]
     if (accessToken) {
         proxyRequest.setHeader('Authorization', `Bearer ${accessToken}`)
     }
 
     // Inject refresh_token into query string from HttpOnly cookie
-    const refreshToken = cookies[`cc-nx_${siteId}`]
+    const refreshToken =
+        cookies[getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId)]
     if (refreshToken) {
         const separator = proxyRequest.path.includes('?') ? '&' : '?'
         proxyRequest.path += `${separator}refresh_token=${encodeURIComponent(refreshToken)}`
     } else {
         logger.warn(
-            `Refresh token cookie (cc-nx_${siteId}) not found for ${incomingRequest.path}. The logout request may fail.`,
+            `Refresh token cookie (${getCookieName(
+                SESSION_COOKIE_CONFIG.refreshTokenRegistered,
+                siteId
+            )}) not found for ${incomingRequest.path}. The logout request may fail.`,
             {namespace: 'setTokensInLogoutRequest'}
         )
     }

--- a/packages/pwa-kit-runtime/src/ssr/server/constants.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/constants.js
@@ -38,5 +38,6 @@ export const SLAS_LOGOUT_ENDPOINT = /\/oauth2\/logout/
 
 // Custom headers used by the proxy layer for HttpOnly session cookie support.
 // These are internal to our proxy and stripped before forwarding to SLAS/SCAPI.
+export const DWSID_COOKIE_NAME = 'dwsid'
 export const X_SITE_ID = 'x-site-id'
 export const X_GRANT_TYPE = 'x-grant-type'

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {X_SITE_ID, DWSID_COOKIE_NAME} from './constants'
+
+export const SESSION_COOKIE_CONFIG = {
+    accessToken: {
+        key: 'cc-at',
+        attributes: {httpOnly: true, secure: true, sameSite: 'lax', path: '/'}
+    },
+    accessTokenExpires: {
+        key: 'cc-at-expires',
+        attributes: {httpOnly: false, secure: true, sameSite: 'lax', path: '/'}
+    },
+    accessTokenDnt: {
+        key: 'cc-at-dnt',
+        attributes: {httpOnly: false, secure: true, sameSite: 'lax', path: '/'}
+    },
+    uido: {key: 'uido', attributes: {httpOnly: false, secure: true, sameSite: 'lax', path: '/'}},
+    idpAccessToken: {
+        key: 'idp_access_token',
+        attributes: {httpOnly: true, secure: true, sameSite: 'lax', path: '/'}
+    },
+    refreshTokenGuest: {
+        key: 'cc-nx-g',
+        attributes: {httpOnly: true, secure: true, sameSite: 'lax', path: '/'}
+    },
+    refreshTokenRegistered: {
+        key: 'cc-nx',
+        attributes: {httpOnly: true, secure: true, sameSite: 'lax', path: '/'}
+    },
+    refreshTokenExists: {
+        key: 'cc-nx-exists',
+        attributes: {httpOnly: false, secure: true, sameSite: 'lax', path: '/'}
+    }
+}
+
+export const getSiteId = (request) => request.headers?.[X_SITE_ID]
+
+export const getCookieName = (config, siteId) => `${config.key}_${siteId}`
+
+export const getCookieNamesToStripFromProxy = (siteId) => [
+    getCookieName(SESSION_COOKIE_CONFIG.accessToken, siteId),
+    getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, siteId),
+    getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId),
+    DWSID_COOKIE_NAME
+]

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {
+    SESSION_COOKIE_CONFIG,
+    getSiteId,
+    getCookieName,
+    getCookieNamesToStripFromProxy
+} from './httponly-cookie-config'
+import {X_SITE_ID} from './constants'
+
+describe('SESSION_COOKIE_CONFIG', () => {
+    it('defines the correct key prefixes', () => {
+        expect(SESSION_COOKIE_CONFIG.accessToken.key).toBe('cc-at')
+        expect(SESSION_COOKIE_CONFIG.accessTokenExpires.key).toBe('cc-at-expires')
+        expect(SESSION_COOKIE_CONFIG.accessTokenDnt.key).toBe('cc-at-dnt')
+        expect(SESSION_COOKIE_CONFIG.uido.key).toBe('uido')
+        expect(SESSION_COOKIE_CONFIG.idpAccessToken.key).toBe('idp_access_token')
+        expect(SESSION_COOKIE_CONFIG.refreshTokenGuest.key).toBe('cc-nx-g')
+        expect(SESSION_COOKIE_CONFIG.refreshTokenRegistered.key).toBe('cc-nx')
+        expect(SESSION_COOKIE_CONFIG.refreshTokenExists.key).toBe('cc-nx-exists')
+    })
+
+    it('marks sensitive token cookies as httpOnly', () => {
+        expect(SESSION_COOKIE_CONFIG.accessToken.attributes.httpOnly).toBe(true)
+        expect(SESSION_COOKIE_CONFIG.idpAccessToken.attributes.httpOnly).toBe(true)
+        expect(SESSION_COOKIE_CONFIG.refreshTokenGuest.attributes.httpOnly).toBe(true)
+        expect(SESSION_COOKIE_CONFIG.refreshTokenRegistered.attributes.httpOnly).toBe(true)
+    })
+
+    it('marks client-readable cookies as non-httpOnly', () => {
+        expect(SESSION_COOKIE_CONFIG.accessTokenExpires.attributes.httpOnly).toBe(false)
+        expect(SESSION_COOKIE_CONFIG.accessTokenDnt.attributes.httpOnly).toBe(false)
+        expect(SESSION_COOKIE_CONFIG.uido.attributes.httpOnly).toBe(false)
+        expect(SESSION_COOKIE_CONFIG.refreshTokenExists.attributes.httpOnly).toBe(false)
+    })
+
+    it('sets secure, sameSite lax, and path / on all cookies', () => {
+        Object.values(SESSION_COOKIE_CONFIG).forEach((config) => {
+            expect(config.attributes.secure).toBe(true)
+            expect(config.attributes.sameSite).toBe('lax')
+            expect(config.attributes.path).toBe('/')
+        })
+    })
+})
+
+describe('getSiteId', () => {
+    it('extracts siteId from x-site-id header', () => {
+        const request = {headers: {[X_SITE_ID]: 'RefArch'}}
+        expect(getSiteId(request)).toBe('RefArch')
+    })
+
+    it('returns undefined when header is missing', () => {
+        const request = {headers: {}}
+        expect(getSiteId(request)).toBeUndefined()
+    })
+
+    it('returns undefined when headers is undefined', () => {
+        const request = {}
+        expect(getSiteId(request)).toBeUndefined()
+    })
+})
+
+describe('getCookieName', () => {
+    it('combines config key with siteId', () => {
+        expect(getCookieName(SESSION_COOKIE_CONFIG.accessToken, 'RefArch')).toBe('cc-at_RefArch')
+        expect(getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, 'MySite')).toBe(
+            'cc-nx-g_MySite'
+        )
+    })
+})
+
+describe('getCookieNamesToStripFromProxy', () => {
+    it('returns access token, both refresh tokens, and dwsid', () => {
+        const names = getCookieNamesToStripFromProxy('RefArch')
+        expect(names).toEqual([
+            'cc-at_RefArch',
+            'cc-nx-g_RefArch',
+            'cc-nx_RefArch',
+            'dwsid'
+        ])
+    })
+
+    it('always includes dwsid regardless of siteId', () => {
+        const names = getCookieNamesToStripFromProxy(undefined)
+        expect(names).toContain('dwsid')
+    })
+})

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
@@ -76,12 +76,7 @@ describe('getCookieName', () => {
 describe('getCookieNamesToStripFromProxy', () => {
     it('returns access token, both refresh tokens, and dwsid', () => {
         const names = getCookieNamesToStripFromProxy('RefArch')
-        expect(names).toEqual([
-            'cc-at_RefArch',
-            'cc-nx-g_RefArch',
-            'cc-nx_RefArch',
-            'dwsid'
-        ])
+        expect(names).toEqual(['cc-at_RefArch', 'cc-nx-g_RefArch', 'cc-nx_RefArch', 'dwsid'])
     })
 
     it('always includes dwsid regardless of siteId', () => {

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
@@ -6,7 +6,8 @@
  */
 import {jwtDecode} from 'jwt-decode'
 import {cookieAsString} from '../../utils/ssr-proxying'
-import {SET_COOKIE, X_SITE_ID} from './constants'
+import {SET_COOKIE} from './constants'
+import {SESSION_COOKIE_CONFIG, getCookieName, getSiteId} from './httponly-cookie-config'
 import logger from '../../utils/logger-instance'
 
 // Refresh token cookie TTL defaults (seconds). Must stay in sync with commerce-sdk-react auth constants.
@@ -68,7 +69,7 @@ function getTokenClaims(accessToken) {
  * @private
  */
 export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, options) {
-    const siteId = req.headers?.[X_SITE_ID]
+    const siteId = getSiteId(req)
     if (!siteId) {
         throw new Error(
             'HttpOnly session cookies are enabled but siteId is missing. ' +
@@ -84,30 +85,31 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
     }
 
     const site = siteId
+    const {
+        accessToken,
+        accessTokenExpires,
+        accessTokenDnt,
+        uido,
+        idpAccessToken,
+        refreshTokenGuest,
+        refreshTokenRegistered,
+        refreshTokenExists
+    } = SESSION_COOKIE_CONFIG
 
     // Decode JWT and extract claims
     let isGuest = true
     if (parsed.access_token) {
-        const {
-            accessExpires,
-            expiresAt,
-            dnt,
-            uido,
-            isGuest: guest
-        } = getTokenClaims(parsed.access_token)
-        isGuest = guest
+        const tokenClaims = getTokenClaims(parsed.access_token)
+        isGuest = tokenClaims.isGuest
 
         // Access token (HttpOnly)
         res.append(
             SET_COOKIE,
             cookieAsString({
-                name: `cc-at_${site}`,
+                name: getCookieName(accessToken, site),
                 value: parsed.access_token,
-                path: '/',
-                secure: true,
-                sameSite: 'lax',
-                httpOnly: true,
-                expires: accessExpires
+                expires: tokenClaims.accessExpires,
+                ...accessToken.attributes
             })
         )
 
@@ -115,44 +117,35 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
         res.append(
             SET_COOKIE,
             cookieAsString({
-                name: `cc-at-expires_${site}`,
-                value: String(expiresAt),
-                path: '/',
-                secure: true,
-                sameSite: 'lax',
-                httpOnly: false,
-                expires: accessExpires
+                name: getCookieName(accessTokenExpires, site),
+                value: String(tokenClaims.expiresAt),
+                expires: tokenClaims.accessExpires,
+                ...accessTokenExpires.attributes
             })
         )
 
         // Do-not-track flag from JWT (non-HttpOnly so client can read it)
-        if (dnt !== undefined) {
+        if (tokenClaims.dnt !== undefined) {
             res.append(
                 SET_COOKIE,
                 cookieAsString({
-                    name: `cc-at-dnt_${site}`,
-                    value: String(dnt),
-                    path: '/',
-                    secure: true,
-                    sameSite: 'lax',
-                    httpOnly: false,
-                    expires: accessExpires
+                    name: getCookieName(accessTokenDnt, site),
+                    value: String(tokenClaims.dnt),
+                    expires: tokenClaims.accessExpires,
+                    ...accessTokenDnt.attributes
                 })
             )
         }
 
         // uido: IDP origin (e.g. "slas", "ecom"); non-HttpOnly so client can read for useCustomerType/isExternal
-        if (uido) {
+        if (tokenClaims.uido) {
             res.append(
                 SET_COOKIE,
                 cookieAsString({
-                    name: `uido_${site}`,
-                    value: uido,
-                    path: '/',
-                    secure: true,
-                    sameSite: 'lax',
-                    httpOnly: false,
-                    expires: accessExpires
+                    name: getCookieName(uido, site),
+                    value: tokenClaims.uido,
+                    expires: tokenClaims.accessExpires,
+                    ...uido.attributes
                 })
             )
         }
@@ -162,13 +155,10 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
             res.append(
                 SET_COOKIE,
                 cookieAsString({
-                    name: `idp_access_token_${site}`,
+                    name: getCookieName(idpAccessToken, site),
                     value: parsed.idp_access_token,
-                    path: '/',
-                    secure: true,
-                    sameSite: 'lax',
-                    httpOnly: true,
-                    expires: accessExpires
+                    expires: tokenClaims.accessExpires,
+                    ...idpAccessToken.attributes
                 })
             )
         }
@@ -183,18 +173,15 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
             commerceAPI
         )
         const refreshExpires = new Date(Date.now() + refreshTTL * 1000)
-        const refreshCookieName = isGuest ? `cc-nx-g_${site}` : `cc-nx_${site}`
+        const refreshConfig = isGuest ? refreshTokenGuest : refreshTokenRegistered
 
         res.append(
             SET_COOKIE,
             cookieAsString({
-                name: refreshCookieName,
+                name: getCookieName(refreshConfig, site),
                 value: parsed.refresh_token,
-                path: '/',
-                secure: true,
-                sameSite: 'lax',
-                httpOnly: true,
-                expires: refreshExpires
+                expires: refreshExpires,
+                ...refreshConfig.attributes
             })
         )
 
@@ -203,30 +190,24 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
         res.append(
             SET_COOKIE,
             cookieAsString({
-                name: `cc-nx-exists_${site}`,
+                name: getCookieName(refreshTokenExists, site),
                 value: '1',
-                path: '/',
-                secure: true,
-                sameSite: 'lax',
-                httpOnly: false,
-                expires: refreshExpires
+                expires: refreshExpires,
+                ...refreshTokenExists.attributes
             })
         )
 
         // Delete the opposite refresh token cookie to mirror client-side behavior:
         // Login (guest → registered): delete guest cookie cc-nx-g
         // Logout (registered → guest): delete registered cookie cc-nx
-        const staleCookieName = isGuest ? `cc-nx_${site}` : `cc-nx-g_${site}`
+        const staleRefreshConfig = isGuest ? refreshTokenRegistered : refreshTokenGuest
         res.append(
             SET_COOKIE,
             cookieAsString({
-                name: staleCookieName,
+                name: getCookieName(staleRefreshConfig, site),
                 value: '',
-                path: '/',
-                secure: true,
-                sameSite: 'lax',
-                httpOnly: true,
-                expires: new Date(0)
+                expires: new Date(0),
+                ...staleRefreshConfig.attributes
             })
         )
     }

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -12,7 +12,13 @@ import {processExpressResponse} from './process-express-response'
 import {isRemote, localDevLog, verboseProxyLogging, isScapiDomain} from './utils'
 import logger from '../logger-instance'
 import {getEnvBasePath} from '../ssr-namespace-paths'
-import {X_SITE_ID} from '../../ssr/server/constants'
+import {X_SITE_ID, DWSID_COOKIE_NAME} from '../../ssr/server/constants'
+import {
+    SESSION_COOKIE_CONFIG,
+    getCookieName,
+    getCookieNamesToStripFromProxy,
+    getSiteId
+} from '../../ssr/server/httponly-cookie-config'
 
 export const ALLOWED_CACHING_PROXY_REQUEST_METHODS = ['HEAD', 'GET', 'OPTIONS']
 
@@ -52,7 +58,7 @@ export const setScapiAuthRequestHeaders = ({
     targetHost
 }) => {
     const url = incomingRequest.url
-    const resolvedSiteId = incomingRequest.headers?.[X_SITE_ID]
+    const resolvedSiteId = getSiteId(incomingRequest)
 
     // Skip if: caching proxy, not SCAPI domain, or no URL
     if (caching || !isScapiDomain(targetHost) || !url) {
@@ -72,7 +78,7 @@ export const setScapiAuthRequestHeaders = ({
     if (!cookieHeader) return
 
     const cookies = cookie.parse(cookieHeader)
-    const tokenKey = `cc-at_${resolvedSiteId}`
+    const tokenKey = getCookieName(SESSION_COOKIE_CONFIG.accessToken, resolvedSiteId)
     const accessToken = cookies[tokenKey]
 
     if (accessToken) {
@@ -81,8 +87,8 @@ export const setScapiAuthRequestHeaders = ({
     }
 
     // Transform dwsid cookie into sfdc_dwsid header (same as MRT)
-    if (cookies.dwsid) {
-        proxyRequest.setHeader('sfdc_dwsid', cookies.dwsid)
+    if (cookies[DWSID_COOKIE_NAME]) {
+        proxyRequest.setHeader('sfdc_dwsid', cookies[DWSID_COOKIE_NAME])
     }
 
     // Strip session cookies — the proxy has already extracted the tokens
@@ -112,15 +118,10 @@ export const stripSessionCookies = (proxyRequest, incomingRequest) => {
     if (!cookieHeader) return
 
     const cookies = cookie.parse(cookieHeader)
-    const siteId = incomingRequest.headers[X_SITE_ID]
+    const siteId = getSiteId(incomingRequest)
 
     // Build the exact list of cookies to delete, matching MRT's approach
-    const cookiesToDelete = new Set(['dwsid'])
-    if (siteId) {
-        cookiesToDelete.add(`cc-at_${siteId}`)
-        cookiesToDelete.add(`cc-nx-g_${siteId}`)
-        cookiesToDelete.add(`cc-nx_${siteId}`)
-    }
+    const cookiesToDelete = new Set(getCookieNamesToStripFromProxy(siteId))
 
     const filtered = Object.entries(cookies).filter(([name]) => !cookiesToDelete.has(name))
 


### PR DESCRIPTION
**Summary**

- Extracted all HttpOnly session cookie name definitions and attributes into a new httponly-cookie-config.js module with SESSION_COOKIE_CONFIG, getCookieName, getSiteId, and getCookieNamesToStripFromProxy
 - Replaced ~16 inline template literals and repeated path/secure/sameSite/httpOnly attribute blocks across process-token-response.js, configure-proxy.js, and build-remote-server.js
 - Cookie attributes are now spreadable via ...config.attributes, eliminating duplicated cookie config at each call site
 - Moved DWSID_COOKIE_NAME to constants.js as a general-purpose constant

  **Test plan**
  - Existing unit tests pass unchanged (97 tests across process-token-response.test.js, build-remote-server.test.js, configure-proxy.basic.test.js)
  - New httponly-cookie-config.test.js validates key prefixes, httpOnly flags, shared attributes, helper functions (10 tests)
  - npm start runs without errors
  - Grep confirms no remaining inline cc-at_/cc-nx_/cookies.dwsid patterns in non-test source files

