### PR TITLE
@W-21201751@ Handle scenario where SDK sets auth header instead of through cc-at

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
 - Handle missing access token for HttpOnly session cookies [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
-- Fix missing access token logic so error is not thrown when `Authorization` header is set by the SDK 
+- Fix missing access token logic so error is not thrown when `Authorization` header is set by the SDK [#3793](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3793)
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add HttpOnly session cookies for SLAS public client [#3774](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3774)
 - Do not forward sesssion cookies to SCAPI [#3783](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3783)
 - Handle missing access token for HttpOnly session cookies [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
+- Fix missing access token logic so error is not thrown when `Authorization` header is set by the SDK 
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.basic.test.js
@@ -250,6 +250,36 @@ describe('setScapiAuthRequestHeaders', () => {
         expect(proxyRequest.setHeader).not.toHaveBeenCalledWith('authorization', expect.any(String))
     })
 
+    it('does not throw when access token cookie is missing but Authorization header exists (SSR)', () => {
+        utils.isScapiDomain.mockReturnValue(true)
+        cookie.parse.mockReturnValue({}) // No access token cookie
+
+        const proxyRequest = {
+            setHeader: jest.fn(),
+            removeHeader: jest.fn()
+        }
+        const incomingRequest = {
+            url: '/shopper/products/v1/products',
+            headers: {
+                cookie: 'some-other-cookie=value',
+                authorization: 'Bearer server-side-token',
+                [X_SITE_ID]: 'RefArch'
+            }
+        }
+
+        expect(() =>
+            setScapiAuthRequestHeaders({
+                proxyRequest,
+                incomingRequest,
+                caching: false,
+                targetHost: 'abc-001.api.commercecloud.salesforce.com'
+            })
+        ).not.toThrow()
+
+        // Should not override the existing Authorization header
+        expect(proxyRequest.setHeader).not.toHaveBeenCalledWith('authorization', expect.any(String))
+    })
+
     it('uses x-site-id header to resolve correct cookie', () => {
         utils.isScapiDomain.mockReturnValue(true)
         cookie.parse.mockReturnValue({'cc-at_OtherSite': 'other-access-token'})

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -88,13 +88,20 @@ export const setScapiAuthRequestHeaders = ({
     const accessToken = cookies[tokenKey]
 
     if (!accessToken) {
-        throw new AccessTokenNotFoundError(
-            'Access token cookie not found. Cannot proceed with SCAPI request.'
-        )
+        // During SSR, the SDK sets the Authorization header directly (onClient() is false),
+        // so the cookie won't be present on the server-side loopback request. Only throw
+        // when there is no existing Authorization header — meaning the client relied on
+        // the proxy to inject it from the cookie, but the cookie is missing.
+        const hasExistingAuth = incomingRequest.headers.authorization
+        if (!hasExistingAuth) {
+            throw new AccessTokenNotFoundError(
+                'Access token cookie not found. Cannot proceed with SCAPI request.'
+            )
+        }
+    } else {
+        // Cookie-based auth takes precedence over any existing header
+        proxyRequest.setHeader('authorization', `Bearer ${accessToken}`)
     }
-
-    // Always override - cookie-based auth takes precedence
-    proxyRequest.setHeader('authorization', `Bearer ${accessToken}`)
 
     // Transform dwsid cookie into sfdc_dwsid header (same as MRT)
     if (cookies.dwsid) {


### PR DESCRIPTION
Follow up to #3790 

This fixes an error that appears when the SDK sets the Authorization header directly on the request rather than sending a cc-at token through to the proxy. This occurs during SSR when a PDP or PLP is accessed directly without first loading the home page.

Testing the changes:

Start the app
On a new tab (not the one that loaded the home page), open a PLP (http://localhost:3000/global/en-GB/category/womens) or PDP directly (http://localhost:3000/global/en-GB/product/25720076M?color=JJD99XX&pid=013742003314M)
The page should load (before, the page would return an HTTP 400 due to the missing cc-at cookie)

