### PR TITLE
Expire HttpOnly session cookies on logout

### DIFF
--- a/docs/httponly-cookies-architecture.md
+++ b/docs/httponly-cookies-architecture.md
@@ -186,9 +186,6 @@ The logout call is awaited so the browser processes the Set-Cookie response head
 HttpOnly session cookies) before the subsequent guest login sets fresh cookies. The proxy expires
 cookies on SLAS logout response, regardless of whether SLAS returned success or failure.
 
-> **Note:** When `enableHttpOnlySessionCookies=false`, logout is fire-and-forget because the client
-> can expire all cookies directly.
-
 ```
 Browser                       Express App (SLAS Proxy)                    SLAS
   │                                     │                                  │

--- a/docs/httponly-cookies-architecture.md
+++ b/docs/httponly-cookies-architecture.md
@@ -182,7 +182,12 @@ Browser                       Express App (SLAS Proxy)                    SLAS
 
 ### 4. Logout
 
-Handled directly by the Express app (not CloudFront). Same flow for both client types.
+The logout call is awaited so the browser processes the Set-Cookie response headers (which expire the
+HttpOnly session cookies) before the subsequent guest login sets fresh cookies. The proxy expires
+cookies on SLAS logout response, regardless of whether SLAS returned success or failure.
+
+> **Note:** When `enableHttpOnlySessionCookies=false`, logout is fire-and-forget because the client
+> can expire all cookies directly.
 
 ```
 Browser                       Express App (SLAS Proxy)                    SLAS
@@ -211,7 +216,12 @@ Browser                       Express App (SLAS Proxy)                    SLAS
   │                                     │  (no session cookies forwarded)  │
   │                                     │ ───────────────────────────────► │
   │                                     │◄───────────────────────────────  │
+  │                                     │                                  │
+  │                                     │  Expire HttpOnly session cookies │
+  │                                     │                                  │
   │◄─────────────────────────────────── │                                  │
+  │  Cookies expired; guest login next  │                                  │
+  │ ───────────────────────────────────►│  (new guest token flow)          │
 ```
 
 ## Configuration

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Ensure client-side refresh token requests are deduped [#3786](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3786/)
 - Handle missing access token for HttpOnly session cookies [#3771](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 - Add USID support to StorefrontPreview for HttpOnly cookies [#3785](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3785)
+- Expire HttpOnly session cookies on SLAS logout [#3794](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3794)
+
 
 ## v5.2.0-dev (Mar 20, 2026)
 

--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Add USID support to StorefrontPreview for HttpOnly cookies [#3785](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3785)
 - Expire HttpOnly session cookies on SLAS logout [#3794](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3794)
 
-
 ## v5.2.0-dev (Mar 20, 2026)
 
 ## v5.1.1 (Mar 20, 2026)

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1204,6 +1204,58 @@ describe('Auth', () => {
         expect(helpers.logout).not.toHaveBeenCalled()
         expect(helpers.loginGuestUser).toHaveBeenCalled()
     })
+    test('logout with enableHttpOnlySessionCookies awaits the logout call', async () => {
+        const logoutMock = helpers.logout as jest.Mock
+        let resolveLogout: Function
+        logoutMock.mockImplementation(
+            () => new Promise((resolve) => (resolveLogout = resolve))
+        )
+        const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
+        // @ts-expect-error private method
+        auth.set('customer_type', 'registered')
+
+        let logoutDone = false
+        const logoutPromise = auth.logout().then(() => (logoutDone = true))
+
+        // logout() should not resolve until the helpers.logout promise resolves
+        await new Promise((r) => setTimeout(r, 10))
+        expect(logoutDone).toBe(false)
+
+        resolveLogout!('')
+        await logoutPromise
+        expect(logoutDone).toBe(true)
+        expect(logoutMock).toHaveBeenCalled()
+    })
+    test('logout with enableHttpOnlySessionCookies swallows SLAS errors', async () => {
+        const logoutMock = helpers.logout as jest.Mock
+        logoutMock.mockRejectedValue(new Error('SLAS error'))
+        const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
+        // @ts-expect-error private method
+        auth.set('customer_type', 'registered')
+
+        // Should not throw
+        await auth.logout()
+        expect(logoutMock).toHaveBeenCalled()
+        expect(helpers.loginGuestUser).toHaveBeenCalled()
+    })
+    test('logout without enableHttpOnlySessionCookies does not await the logout call', async () => {
+        const logoutMock = helpers.logout as jest.Mock
+        let resolveLogout: Function
+        logoutMock.mockImplementation(
+            () => new Promise((resolve) => (resolveLogout = resolve))
+        )
+        const auth = new Auth(config)
+        // @ts-expect-error private method
+        auth.set('customer_type', 'registered')
+
+        // logout() should resolve immediately (fire-and-forget) without waiting for helpers.logout
+        await auth.logout()
+        expect(logoutMock).toHaveBeenCalled()
+        expect(helpers.loginGuestUser).toHaveBeenCalled()
+
+        // Clean up the dangling promise
+        resolveLogout!('')
+    })
     test('updateCustomerPassword calls registered login', async () => {
         jest.spyOn(ShopperCustomers.prototype, 'updateCustomerPassword').mockImplementation()
         const auth = new Auth(config)

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1224,9 +1224,10 @@ describe('Auth', () => {
         expect(logoutDone).toBe(true)
         expect(logoutMock).toHaveBeenCalled()
     })
-    test('logout with enableHttpOnlySessionCookies swallows SLAS errors', async () => {
+    test('logout with enableHttpOnlySessionCookies swallows SLAS errors and logs warning', async () => {
         const logoutMock = helpers.logout as jest.Mock
         logoutMock.mockRejectedValue(new Error('SLAS error'))
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
         const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
         // @ts-expect-error private method
         auth.set('customer_type', 'registered')
@@ -1235,6 +1236,12 @@ describe('Auth', () => {
         await auth.logout()
         expect(logoutMock).toHaveBeenCalled()
         expect(helpers.loginGuestUser).toHaveBeenCalled()
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'SLAS logout failed: SLAS error. The error is ignored and session cookies are still cleared by the proxy.'
+            )
+        )
+        warnSpy.mockRestore()
     })
     test('logout without enableHttpOnlySessionCookies does not await the logout call', async () => {
         const logoutMock = helpers.logout as jest.Mock

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1206,7 +1206,7 @@ describe('Auth', () => {
     })
     test('logout with enableHttpOnlySessionCookies awaits the logout call', async () => {
         const logoutMock = helpers.logout as jest.Mock
-        let resolveLogout: Function
+        let resolveLogout: (value: unknown) => void
         logoutMock.mockImplementation(() => new Promise((resolve) => (resolveLogout = resolve)))
         const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
         // @ts-expect-error private method
@@ -1238,7 +1238,7 @@ describe('Auth', () => {
     })
     test('logout without enableHttpOnlySessionCookies does not await the logout call', async () => {
         const logoutMock = helpers.logout as jest.Mock
-        let resolveLogout: Function
+        let resolveLogout: (value: unknown) => void
         logoutMock.mockImplementation(() => new Promise((resolve) => (resolveLogout = resolve)))
         const auth = new Auth(config)
         // @ts-expect-error private method

--- a/packages/commerce-sdk-react/src/auth/index.test.ts
+++ b/packages/commerce-sdk-react/src/auth/index.test.ts
@@ -1207,9 +1207,7 @@ describe('Auth', () => {
     test('logout with enableHttpOnlySessionCookies awaits the logout call', async () => {
         const logoutMock = helpers.logout as jest.Mock
         let resolveLogout: Function
-        logoutMock.mockImplementation(
-            () => new Promise((resolve) => (resolveLogout = resolve))
-        )
+        logoutMock.mockImplementation(() => new Promise((resolve) => (resolveLogout = resolve)))
         const auth = new Auth({...config, enableHttpOnlySessionCookies: true})
         // @ts-expect-error private method
         auth.set('customer_type', 'registered')
@@ -1241,9 +1239,7 @@ describe('Auth', () => {
     test('logout without enableHttpOnlySessionCookies does not await the logout call', async () => {
         const logoutMock = helpers.logout as jest.Mock
         let resolveLogout: Function
-        logoutMock.mockImplementation(
-            () => new Promise((resolve) => (resolveLogout = resolve))
-        )
+        logoutMock.mockImplementation(() => new Promise((resolve) => (resolveLogout = resolve)))
         const auth = new Auth(config)
         // @ts-expect-error private method
         auth.set('customer_type', 'registered')

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -1256,9 +1256,12 @@ class Auth {
                 // Set-Cookie headers before guest login sets new cookies.
                 try {
                     await logoutPromise
-                } catch {
-                    // The proxy expires cookies regardless of SLAS success/failure,
-                    // so we can safely swallow the error.
+                } catch (error) {
+                    this.logger.warn(
+                        `SLAS logout failed: ${
+                            error instanceof Error ? error.message : String(error)
+                        }. The error is ignored and session cookies are still cleared by the proxy.`
+                    )
                 }
             }
         }

--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -1243,14 +1243,24 @@ class Auth {
      */
     async logout() {
         if (this.get('customer_type') === 'registered') {
-            // Not awaiting on purpose because there isn't much we can do if this fails.
-            void helpers.logout({
+            const logoutPromise = helpers.logout({
                 slasClient: this.client,
                 parameters: {
                     accessToken: this.get('access_token'),
                     refreshToken: this.get('refresh_token_registered')
                 }
             })
+            if (this.enableHttpOnlySessionCookies) {
+                // When HttpOnly cookies are enabled, the proxy expires session cookies
+                // on the logout response. We must await so the browser processes the
+                // Set-Cookie headers before guest login sets new cookies.
+                try {
+                    await logoutPromise
+                } catch {
+                    // The proxy expires cookies regardless of SLAS success/failure,
+                    // so we can safely swallow the error.
+                }
+            }
         }
         this.clearStorage()
         return await this.ready()

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Handle missing access token for HttpOnly session cookies [#3790](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3790)
 - Fix missing access token logic so error is not thrown when `Authorization` header is set by the SDK [#3793](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3793)
 - Centralize HttpOnly session cookie config [#3792](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3792)
+- Expire HttpOnly session cookies on SLAS logout [#3794](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3794)
+
 
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -13,7 +13,6 @@
 - Centralize HttpOnly session cookie config [#3792](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3792)
 - Expire HttpOnly session cookies on SLAS logout [#3794](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3794)
 
-
 ## v3.18.0-dev (Mar 20, 2026)
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -73,7 +73,7 @@ import {CallbackResolver} from '@h4ad/serverless-adapter/lib/resolvers/callback'
 import {ApiGatewayV1Adapter} from '@h4ad/serverless-adapter/lib/adapters/aws'
 import {ExpressFramework} from '@h4ad/serverless-adapter/lib/frameworks/express'
 import {is as typeis} from 'type-is'
-import {setHttpOnlySessionCookies} from './process-token-response'
+import {setHttpOnlySessionCookies, expireHttpOnlySessionCookies} from './process-token-response'
 
 /**
  * An Array of mime-types (Content-Type values) that are considered
@@ -1201,6 +1201,21 @@ export const RemoteServerFactory = {
                                     }),
                                     'utf8'
                                 )
+                            }
+                        }
+
+                        // Expire all HttpOnly session cookies on logout, regardless
+                        // of whether SLAS returned success or failure.
+                        if (httpOnlyCookiesEnabled && req.path?.match(SLAS_LOGOUT_ENDPOINT)) {
+                            try {
+                                expireHttpOnlySessionCookies(req, res)
+                            } catch (error) {
+                                logger.warn('Error expiring HttpOnly session cookies on logout', {
+                                    namespace: logNamespace,
+                                    additionalProperties: {
+                                        error: error.message || error
+                                    }
+                                })
                             }
                         }
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -614,7 +614,10 @@ describe('HttpOnly session cookies', () => {
             expect(capturedRefreshToken).toBe('mock-refresh-token')
             // Session cookies should not be forwarded to SLAS
             expect(capturedCookieHeader).toBeUndefined()
-            expect(response.headers['set-cookie']).toBeUndefined()
+            // Proxy should expire all HttpOnly session cookies on logout
+            const setCookies = response.headers['set-cookie']
+            expect(setCookies).toBeDefined()
+            expect(setCookies.every((c) => c.includes('Expires=Thu, 01 Jan 1970'))).toBe(true)
         } finally {
             mockSlasServerInstance.close()
         }

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
@@ -42,6 +42,8 @@ export const getSiteId = (request) => request.headers?.[X_SITE_ID]
 
 export const getCookieName = (config, siteId) => `${config.key}_${siteId}`
 
+export const getAllCookieConfigs = () => Object.values(SESSION_COOKIE_CONFIG)
+
 export const getCookieNamesToStripFromProxy = (siteId) => [
     getCookieName(SESSION_COOKIE_CONFIG.accessToken, siteId),
     getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, siteId),

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
@@ -7,7 +7,12 @@
 import {jwtDecode} from 'jwt-decode'
 import {cookieAsString} from '../../utils/ssr-proxying'
 import {SET_COOKIE} from './constants'
-import {SESSION_COOKIE_CONFIG, getCookieName, getSiteId} from './httponly-cookie-config'
+import {
+    SESSION_COOKIE_CONFIG,
+    getAllCookieConfigs,
+    getCookieName,
+    getSiteId
+} from './httponly-cookie-config'
 import logger from '../../utils/logger-instance'
 
 // Refresh token cookie TTL defaults (seconds). Must stay in sync with commerce-sdk-react auth constants.
@@ -218,4 +223,34 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
     delete stripped.idp_access_token
     delete stripped.refresh_token
     return Buffer.from(JSON.stringify(stripped), 'utf8')
+}
+
+/**
+ * When a SLAS logout response is received, expire all HttpOnly session cookies so that
+ * stale tokens are not sent with subsequent requests.
+ * @private
+ */
+export function expireHttpOnlySessionCookies(req, res) {
+    const siteId = getSiteId(req)
+    if (!siteId) {
+        throw new Error(
+            'HttpOnly session cookies are enabled but siteId is missing. ' +
+                'Ensure the x-site-id header is set on the request.'
+        )
+    }
+
+    const site = siteId
+    const expired = new Date(0)
+
+    for (const config of getAllCookieConfigs()) {
+        res.append(
+            SET_COOKIE,
+            cookieAsString({
+                name: getCookieName(config, site),
+                value: '',
+                expires: expired,
+                ...config.attributes
+            })
+        )
+    }
 }

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
-import {getRefreshTokenCookieTTL, setHttpOnlySessionCookies} from './process-token-response'
+import {
+    getRefreshTokenCookieTTL,
+    setHttpOnlySessionCookies,
+    expireHttpOnlySessionCookies
+} from './process-token-response'
 import {X_SITE_ID} from './constants'
 import {parse as parseSetCookie} from 'set-cookie-parser'
 
@@ -320,5 +324,69 @@ describe('setHttpOnlySessionCookies', () => {
 
         const atCookie = res.cookies.find((c) => c.includes('cc-at_othersite='))
         expect(atCookie).toBeDefined()
+    })
+})
+
+describe('expireHttpOnlySessionCookies', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('throws when x-site-id header is missing', () => {
+        const res = makeRes()
+        const req = {headers: {}}
+        expect(() => expireHttpOnlySessionCookies(req, res)).toThrow(/siteId is missing/)
+    })
+
+    test('expires all session cookies for the given site', () => {
+        const res = makeRes()
+        expireHttpOnlySessionCookies(makeReq(), res)
+
+        const expectedCookieKeys = [
+            'cc-at_testsite',
+            'cc-at-expires_testsite',
+            'cc-at-dnt_testsite',
+            'uido_testsite',
+            'idp_access_token_testsite',
+            'cc-nx-g_testsite',
+            'cc-nx_testsite',
+            'cc-nx-exists_testsite'
+        ]
+
+        expect(res.cookies).toHaveLength(expectedCookieKeys.length)
+
+        for (const key of expectedCookieKeys) {
+            const cookie = parseCookie(res.cookies.find((c) => c.includes(`${key}=`)))
+            expect(cookie).toBeDefined()
+            expect(cookie.value).toBe('')
+            expect(cookie.expires).toEqual(new Date(0))
+        }
+    })
+
+    test('uses x-site-id header to resolve correct cookie names', () => {
+        const res = makeRes()
+        expireHttpOnlySessionCookies(makeReq('mysite'), res)
+
+        const atCookie = res.cookies.find((c) => c.includes('cc-at_mysite='))
+        expect(atCookie).toBeDefined()
+        expect(res.cookies.find((c) => c.includes('cc-at_testsite='))).toBeUndefined()
+    })
+
+    test('preserves cookie attributes (Secure, HttpOnly, Path) from config', () => {
+        const res = makeRes()
+        expireHttpOnlySessionCookies(makeReq(), res)
+
+        // cc-at should be HttpOnly + Secure
+        const atCookie = parseCookie(res.cookies.find((c) => c.includes('cc-at_testsite=')))
+        expect(atCookie.httpOnly).toBe(true)
+        expect(atCookie.secure).toBe(true)
+        expect(atCookie.path).toBe('/')
+
+        // cc-at-expires should NOT be HttpOnly, but should be Secure
+        const expCookie = parseCookie(
+            res.cookies.find((c) => c.includes('cc-at-expires_testsite='))
+        )
+        expect(expCookie.httpOnly).toBeUndefined()
+        expect(expCookie.secure).toBe(true)
     })
 })


### PR DESCRIPTION
**Summary**                                                                                                                                                              
                                                                                                                                                                     
  - Proxy expires all HttpOnly session cookies on any SLAS logout response (success or failure), preventing stale tokens from being sent with subsequent requests      
  - Client-side Auth.logout() awaits the logout call when enableHttpOnlySessionCookies=true so the browser processes the Set-Cookie headers before guest login sets  fresh cookies                                                                                                                                                        
  - Adds expireHttpOnlySessionCookies to process-token-response.js and getAllCookieConfigs helper to httponly-cookie-config.js                                       
                                                                                                                                                                       
  **Changes**                                                                                                                                                              
                                                                                                                                                                       
  - packages/pwa-kit-runtime/src/ssr/server/process-token-response.js — new expireHttpOnlySessionCookies function                                                      
  - packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js — new getAllCookieConfigs helper                                                               
  - packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js — call expireHttpOnlySessionCookies in onProxyRes for logout endpoints                              
  - packages/commerce-sdk-react/src/auth/index.ts — await logout when HttpOnly cookies enabled, swallow SLAS errors                                                    
  - docs/httponly-cookies-architecture.md — document logout flow                                                                                                       
                                                                                                                                                                       
  **Test plan**                                                                                                                                                            
                                                                                                                                                                       
  - Unit tests for expireHttpOnlySessionCookies (missing siteId, all cookies expired, site-specific names, cookie attributes preserved)                                
  - Unit tests for Auth.logout() (awaits when httpOnly enabled, swallows SLAS errors, fire-and-forget when disabled)                                                 
  - Manual test: login as registered user → logout → verify cookies are cleared in browser DevTools → verify guest session starts cleanly                              
                             