### PR TITLE
Update CI PWA Kit deploy workflow (@W-22221739@)

### DIFF
--- a/.github/workflows/deploy_latest_release.yml
+++ b/.github/workflows/deploy_latest_release.yml
@@ -100,6 +100,6 @@ jobs:
           CWD: ${{ steps.generate_app.outputs.project_path }}
           TARGET: ${{ matrix.environment.target }}
           PROJECT: ${{ matrix.environment.project }}
-          MESSAGE: ${{ env.BUNDLE_NAME }})
+          MESSAGE: ${{ env.BUNDLE_NAME }}
           CLOUD_ORIGIN: ${{ matrix.environment.cloud_origin }}
           FLAGS: ${{ matrix.environment.flags }}

--- a/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/ssr.js.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/overrides/app/ssr.js.hbs
@@ -317,7 +317,15 @@ export async function jwksCaching(req, res, options) {
             .json({error: 'Bad request parameters: Tenant ID or short code is invalid.'})
     try {
         const JWKS_URI = `https://${shortCode}.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/f_ecom_${tenantId}/oauth2/jwks`
+        {{#if answers.project.privateFeatures.jwksUserAgentEnabled}}
+        const jwksUserAgent = process.env.PWA_KIT_JWKS_USER_AGENT
+        const response = await fetch(
+            JWKS_URI,
+            jwksUserAgent ? {headers: {'User-Agent': jwksUserAgent}} : undefined
+        )
+        {{else}}
         const response = await fetch(JWKS_URI)
+        {{/if}}
 
         if (!response.ok) {
             throw new Error('Request failed with status: ' + response.status)

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/ssr.js.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/app/ssr.js.hbs
@@ -317,7 +317,15 @@ export async function jwksCaching(req, res, options) {
             .json({error: 'Bad request parameters: Tenant ID or short code is invalid.'})
     try {
         const JWKS_URI = `https://${shortCode}.api.commercecloud.salesforce.com/shopper/auth/v1/organizations/f_ecom_${tenantId}/oauth2/jwks`
+        {{#if answers.project.privateFeatures.jwksUserAgentEnabled}}
+        const jwksUserAgent = process.env.PWA_KIT_JWKS_USER_AGENT
+        const response = await fetch(
+            JWKS_URI,
+            jwksUserAgent ? {headers: {'User-Agent': jwksUserAgent}} : undefined
+        )
+        {{else}}
         const response = await fetch(JWKS_URI)
+        {{/if}}
 
         if (!response.ok) {
             throw new Error('Request failed with status: ' + response.status)

--- a/packages/pwa-kit-create-app/program.json
+++ b/packages/pwa-kit-create-app/program.json
@@ -406,7 +406,7 @@
             {
                 "id": "retail-react-app-bug-bounty",
                 "name": "Retail React App Bug Bounty Project",
-                "description": "",
+                "description": "Internal preset used by CI to build the PWA Kit bundle deployed to the bug-bounty test environment. Connects to the staging-001 instance, uses the bug-bounty private SLAS client, and reads the JWKS fetch User-Agent from the PWA_KIT_JWKS_USER_AGENT env variable (set at the MRT environment level) so SLAS access-token validation passes the WAF allowlist. Not for customer use.",
                 "templateId": "retail-react-app",
                 "answers": {
                     "project.extend": true,
@@ -422,7 +422,8 @@
                     "project.einstein.siteId": "aaij-MobileFirst",
                     "project.dataCloud.appSourceId": "7ae070a6-f4ec-4def-a383-d9cacc3f20a1",
                     "project.dataCloud.tenantId": "g82wgnrvm-ywk9dggrrw8mtggy.pc-rnd",
-                    "project.demo.enableDemoSettings": false
+                    "project.demo.enableDemoSettings": false,
+                    "project.privateFeatures.jwksUserAgentEnabled": true
                 },
                 "private": true
             },


### PR DESCRIPTION
## Summary

Makes the PWA Kit Bug Bounty bundle reproducible from CI on every release.

## Changes

- **`program.json`** – Extends the preset with two flags:
  - `project.privateFeatures.loginFlowsEnabled` – enables passwordless / social / reset-password login.
  - `project.privateFeatures.jwksUserAgentEnabled` – opts the bundle into reading the JWKS `User-Agent` header from an MRT env variable at runtime.
- **`create-mobify-app.js`** – Registers a small `or` Handlebars helper used to flatten the conditionals in the templates.
- **Bootstrap `default.js.hbs`** – Enables passwordless/social login when either `enableDemoSettings` or `privateFeatures.loginFlowsEnabled` is set. Existing presets are unaffected.
- **`ssr.js.hbs` (bootstrap override + retail-react-app template)** – When `privateFeatures.jwksUserAgentEnabled` is set, the JWKS fetch reads the `User-Agent` from an env variable; the actual value lives on the MRT environment, not in this repo. Otherwise emits the original `fetch(JWKS_URI)`.


## Test plan

- [ ] Run the generator locally with the preset and inspect `config/default.js` – passwordless / social / reset password `enabled: true`.
- [ ] Inspect `overrides/app/ssr.js` – JWKS `fetch` reads the env variable and only sends the header when it is set.
- [ ] Start the bundle locally with the MRT env variables set and confirm SLAS flows.
- [ ] Trigger the workflow on the test branch and verify the bundle is published to the internal bug-bounty environment.
- [ ] Regenerate other presets and confirm output is byte-for-byte identical to pre-change output.