### PR TITLE
@W-21615557 feat: use contentLinkUuid field from SCAPI getPage for PD

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v5.2.0-dev (Mar 20, 2026)
+- Add contentLinkUuid support to Page Designer components to fix duplicate React key issues with Content Blocks [#3791] (https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3791)
 - Allow auth related cookies domain to be set via config [#3782](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3782)
 
 ## v5.1.1 (Mar 20, 2026)

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Component/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Component/index.test.tsx
@@ -128,4 +128,44 @@ describe('Component', () => {
 
         expect((receivedProps.designMetadata as {name: string | undefined}).name).toBeUndefined()
     })
+
+    test('includes contentLinkUuid in designMetadata when present', () => {
+        const componentWithUuid = {
+            ...mockComponent,
+            contentLinkUuid: '0e1f329d4ac66ff2c3bbf70301'
+        } as unknown as ComponentProps['component']
+        const receivedProps: Record<string, unknown> = {}
+        const MockDynamicComponent = (props: Record<string, unknown>) => {
+            Object.assign(receivedProps, props)
+            return <div data-testid="dynamic-component">Test</div>
+        }
+        mockRegistry.getComponent.mockReturnValue(MockDynamicComponent)
+        mockRegistry.getFallback.mockReturnValue(null)
+
+        render(<Component component={componentWithUuid} regionId="test-region" />)
+
+        expect(receivedProps.designMetadata).toEqual({
+            name: 'Test Component',
+            isFragment: false,
+            isVisible: true,
+            isLocalized: false,
+            id: 'test-component-id',
+            contentLinkUuid: '0e1f329d4ac66ff2c3bbf70301'
+        })
+    })
+
+    test('omits contentLinkUuid from designMetadata when not present', () => {
+        const receivedProps: Record<string, unknown> = {}
+        const MockDynamicComponent = (props: Record<string, unknown>) => {
+            Object.assign(receivedProps, props)
+            return <div data-testid="dynamic-component">Test</div>
+        }
+        mockRegistry.getComponent.mockReturnValue(MockDynamicComponent)
+        mockRegistry.getFallback.mockReturnValue(null)
+
+        render(<Component component={mockComponent} regionId="test-region" />)
+
+        const designMetadata = receivedProps.designMetadata as Record<string, unknown>
+        expect(designMetadata).not.toHaveProperty('contentLinkUuid')
+    })
 })

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Component/index.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Component/index.tsx
@@ -49,13 +49,17 @@ export const Component = memo(function Component({
     const componentWithRuntimeProps = component as ComponentType & {
         visible?: boolean
         localized?: boolean
+        contentLinkUuid?: string
     }
     const designMetadata: ComponentDesignMetadata = {
         name: component.designMetadata?.name,
         isFragment: false,
         isVisible: Boolean(componentWithRuntimeProps.visible),
         isLocalized: Boolean(componentWithRuntimeProps.localized),
-        id: component.id
+        id: component.id,
+        ...(componentWithRuntimeProps.contentLinkUuid && {
+            contentLinkUuid: componentWithRuntimeProps.contentLinkUuid
+        })
     }
 
     // Cast DynamicComponent to accept our props since registry returns unknown type

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.test.tsx
@@ -255,9 +255,7 @@ describe('Region', () => {
                 regions: [
                     {
                         id: 'main-region',
-                        components: [
-                            {id: 'comp-1', typeId: 'commerce_assets.banner', data: {}}
-                        ]
+                        components: [{id: 'comp-1', typeId: 'commerce_assets.banner', data: {}}]
                     }
                 ]
             } as unknown as PageWithDesignMetadata

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.test.tsx
@@ -39,13 +39,30 @@ describe('Region', () => {
                 {
                     id: 'main-region',
                     components: [
-                        {id: 'comp-1', typeId: 'commerce_assets.banner', data: {}},
-                        {id: 'comp-2', typeId: 'commerce_assets.carousel', data: {}}
+                        {
+                            id: 'comp-1',
+                            typeId: 'commerce_assets.banner',
+                            data: {},
+                            contentLinkUuid: '0e1f329d4ac66ff2c3bbf70301'
+                        },
+                        {
+                            id: 'comp-2',
+                            typeId: 'commerce_assets.carousel',
+                            data: {},
+                            contentLinkUuid: '1f2g430e5bd77gg3d4ccg80402'
+                        }
                     ]
                 },
                 {
                     id: 'sidebar-region',
-                    components: [{id: 'comp-3', typeId: 'commerce_assets.promo', data: {}}]
+                    components: [
+                        {
+                            id: 'comp-3',
+                            typeId: 'commerce_assets.promo',
+                            data: {},
+                            contentLinkUuid: '2g3h541f6ce88hh4e5ddh91503'
+                        }
+                    ]
                 },
                 {
                     id: 'empty-region',
@@ -126,8 +143,18 @@ describe('Region', () => {
                 {
                     id: 'nested-region',
                     components: [
-                        {id: 'nested-comp-1', typeId: 'commerce_assets.text', data: {}},
-                        {id: 'nested-comp-2', typeId: 'commerce_assets.image', data: {}}
+                        {
+                            id: 'nested-comp-1',
+                            typeId: 'commerce_assets.text',
+                            data: {},
+                            contentLinkUuid: '3h4i652g7df99ii5f6eei02604'
+                        },
+                        {
+                            id: 'nested-comp-2',
+                            typeId: 'commerce_assets.image',
+                            data: {},
+                            contentLinkUuid: '4i5j763h8eg00jj6g7ffj13705'
+                        }
                     ]
                 }
             ],
@@ -181,6 +208,63 @@ describe('Region', () => {
             )
 
             expect(container.firstChild).toBeNull()
+        })
+    })
+
+    describe('Content Link UUID', () => {
+        test('handles duplicate fragments with same id but different contentLinkUuid', () => {
+            const mockPageWithDuplicates = {
+                id: 'test-page',
+                regions: [
+                    {
+                        id: 'main-region',
+                        components: [
+                            {
+                                id: 'hero-fragment', // Same ID
+                                typeId: 'commerce_assets.hero',
+                                data: {},
+                                contentLinkUuid: 'uuid-first-instance-001'
+                            },
+                            {
+                                id: 'hero-fragment', // Same ID (reused fragment)
+                                typeId: 'commerce_assets.hero',
+                                data: {},
+                                contentLinkUuid: 'uuid-second-instance-002'
+                            },
+                            {
+                                id: 'hero-fragment', // Same ID (reused fragment)
+                                typeId: 'commerce_assets.hero',
+                                data: {},
+                                contentLinkUuid: 'uuid-third-instance-003'
+                            }
+                        ]
+                    }
+                ]
+            } as unknown as PageWithDesignMetadata
+
+            render(<Region page={mockPageWithDuplicates} regionId="main-region" />)
+
+            const components = screen.getAllByTestId(/^component-hero-fragment$/)
+            expect(components).toHaveLength(3)
+        })
+
+        test('falls back to id when contentLinkUuid is not present', () => {
+            // Test backward compatibility
+            const mockPageWithoutUuid = {
+                id: 'test-page',
+                regions: [
+                    {
+                        id: 'main-region',
+                        components: [
+                            {id: 'comp-1', typeId: 'commerce_assets.banner', data: {}}
+                        ]
+                    }
+                ]
+            } as unknown as PageWithDesignMetadata
+
+            render(<Region page={mockPageWithoutUuid} regionId="main-region" />)
+
+            expect(screen.getByTestId('component-comp-1')).toBeInTheDocument()
         })
     })
 

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.tsx
@@ -94,16 +94,18 @@ function renderRegionContent(
             designMetadata={getDesignMetadata(regionId, metadata)}
             {...rest}
         >
-            {region.components?.map(
-                (comp) =>
+            {region.components?.map((comp) => {
+                const key = (comp as any).contentLinkUuid || comp.id
+                return (
                     comp.id && (
                         <Component
-                            key={comp.id}
+                            key={key}
                             component={comp as ComponentType}
                             regionId={region.id}
                         />
                     )
-            )}
+                )
+            })}
         </RegionWrapper>
     )
 }

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/index.tsx
@@ -17,6 +17,7 @@ import type {
     ComponentDesignMetadata,
     RegionDesignMetadata
 } from '@salesforce/storefront-next-runtime/design/react'
+import type {Region as ExtendedRegion} from '../types'
 
 export type {RegionDesignMetadata}
 
@@ -81,7 +82,7 @@ function getDesignMetadata(regionId: string, metadata?: RegionDesignMetadata) {
 
 // Helper: Render region wrapper with components
 function renderRegionContent(
-    region: ShopperExperience.schemas['Region'],
+    region: ExtendedRegion,
     regionId: string,
     metadata: RegionDesignMetadata | undefined,
     className: string,
@@ -95,7 +96,7 @@ function renderRegionContent(
             {...rest}
         >
             {region.components?.map((comp) => {
-                const key = (comp as any).contentLinkUuid || comp.id
+                const key = comp.contentLinkUuid || comp.id
                 return (
                     comp.id && (
                         <Component

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.test.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.test.tsx
@@ -205,6 +205,57 @@ describe('RegionWrapper', () => {
 
             expect(screen.getByTestId('child-content')).toBeInTheDocument()
         })
+
+        test('uses contentLinkUuid for componentIds when present', () => {
+            const regionWithUuids = {
+                id: 'test-region',
+                components: [
+                    {id: 'comp-1', typeId: 'banner', contentLinkUuid: 'uuid-001'},
+                    {id: 'comp-2', typeId: 'carousel', contentLinkUuid: 'uuid-002'}
+                ]
+            }
+
+            render(
+                <RegionWrapper region={regionWithUuids}>
+                    <div data-testid="child-content">Content</div>
+                </RegionWrapper>
+            )
+
+            expect(screen.getByTestId('child-content')).toBeInTheDocument()
+        })
+
+        test('falls back to id when contentLinkUuid is not present', () => {
+            const regionWithoutUuids = {
+                id: 'test-region',
+                components: [{id: 'comp-1', typeId: 'banner'}]
+            }
+
+            render(
+                <RegionWrapper region={regionWithoutUuids}>
+                    <div data-testid="child-content">Content</div>
+                </RegionWrapper>
+            )
+
+            expect(screen.getByTestId('child-content')).toBeInTheDocument()
+        })
+
+        test('handles mixed components with and without contentLinkUuid', () => {
+            const regionMixed = {
+                id: 'test-region',
+                components: [
+                    {id: 'comp-1', typeId: 'banner', contentLinkUuid: 'uuid-001'},
+                    {id: 'comp-2', typeId: 'carousel'} // No UUID
+                ]
+            }
+
+            render(
+                <RegionWrapper region={regionMixed}>
+                    <div data-testid="child-content">Content</div>
+                </RegionWrapper>
+            )
+
+            expect(screen.getByTestId('child-content')).toBeInTheDocument()
+        })
     })
 
     describe('Props Forwarding', () => {

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.tsx
@@ -65,7 +65,10 @@ export function RegionWrapper({
     const fullDesignMetadata = React.useMemo(
         () => ({
             id: region.id,
-            componentIds: region?.components?.map((cmp: any) => cmp.id) || [],
+            // Use contentLinkUuid for unique identification (important for fragments)
+            // Fall back to id for backward compatibility when UUID not present
+            componentIds:
+                region?.components?.map((cmp: any) => cmp.contentLinkUuid || cmp.id) || [],
             componentTypeExclusions: designMetadata?.componentTypeExclusions || [],
             componentTypeInclusions: designMetadata?.componentTypeInclusions || []
         }),

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.tsx
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/Region/region-wrapper.tsx
@@ -65,8 +65,6 @@ export function RegionWrapper({
     const fullDesignMetadata = React.useMemo(
         () => ({
             id: region.id,
-            // Use contentLinkUuid for unique identification (important for fragments)
-            // Fall back to id for backward compatibility when UUID not present
             componentIds:
                 region?.components?.map((cmp: any) => cmp.contentLinkUuid || cmp.id) || [],
             componentTypeExclusions: designMetadata?.componentTypeExclusions || [],

--- a/packages/commerce-sdk-react/src/components/ShopperExperienceV2/types.ts
+++ b/packages/commerce-sdk-react/src/components/ShopperExperienceV2/types.ts
@@ -18,9 +18,16 @@ type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
 
 export type Page = DataType<Client['getPage']>
 
-export type Region = ArrayElement<NonNullable<Page['regions']>>
+type BaseRegion = ArrayElement<NonNullable<Page['regions']>>
+type BaseComponent = ArrayElement<NonNullable<BaseRegion['components']>>
 
-export type Component = ArrayElement<NonNullable<Region['components']>>
+export type Component = BaseComponent & {
+    contentLinkUuid?: string
+}
+
+export type Region = Omit<BaseRegion, 'components'> & {
+    components?: Component[]
+}
 
 /**
  * Extended Page type with design metadata and component data


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- Extended Component & Region types to include optional contentLinkUuid field for unique identification of fragment components
- Updated React keys to use contentLinkUuid when available, falling back to component id
- Updated RegionWrapper to track child components by contentLinkUuid instead of id
- Unit tests

# How to Test-Drive This PR

[Test plan](https://docs.google.com/spreadsheets/d/1SHOIZyZlbZAwn9y-qzv428WdXpidKYJLt92212_gTuw/edit?gid=2136611132#gid=2136611132)

- Through BM open page designer that's has preview of pwa-kit store 
- Open dev console > network tab > getPage response should include content-link-uuid in page region/component data

<img width="1733" height="1178" alt="Screenshot 2026-04-28 at 4 43 18 PM" src="https://github.com/user-attachments/assets/a48b002d-c701-4610-9e9d-e505c4cda7dd" />


# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [x] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
