### PR TITLE
Extract reusable SLAS proxy helpers

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add additional logging and error handling for SLAS error handling [#3750](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3750)
 - Harden the SLAS private-client proxy with a path-and-method allow-list and path normalization. The legacy `applySLASPrivateClientToEndpoints` option is no longer used; the allow-list can be overridden via `slasPrivateClientAllowList` [#3802](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3802) [#3806](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3806)
 - Fix SSR QueryClient memory retention across warm Lambda invocations [#3795](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3795)
+- Refactor: Extract reusable SLAS proxy helpers [#3812](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3812)
 
 ## v3.17.1 (Mar 20, 2026)
 - Add base path prefix to support multiple MRT environments under 1 domain [#3614](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3614)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -1064,6 +1064,49 @@ export const RemoteServerFactory = {
     },
 
     /**
+     * Strip the proxy base path and normalize the SLAS path for forwarding.
+     * Normalizes only the path portion so that URLs in query parameters
+     * (e.g. redirect_uri=http://localhost:3000/callback) are not mangled
+     * by posixPath.normalize collapsing `://` to `:/`.
+     * @private
+     */
+    _rewriteSlasProxyPath(rawPath, proxyPath) {
+        const basePathRegexEntry = getEnvBasePath() ? `${getEnvBasePath()}?` : ''
+        const regex = new RegExp(`^${basePathRegexEntry}${proxyPath}`)
+        const stripped = rawPath.replace(regex, '')
+        const [pathname, ...queryParts] = stripped.split('?')
+        const normalizedPath = this._normalizeSlasPath(pathname)
+        return queryParts.length ? `${normalizedPath}?${queryParts.join('?')}` : normalizedPath
+    },
+
+    /**
+     * Express middleware that gates requests against the SLAS allowlist.
+     * Normalizes the path, matches it against the allowlist, and returns 403
+     * for unmatched requests. Stashes the match on `req` for downstream use.
+     * @private
+     */
+    _createSlasAllowlistGuard(allowList, proxyLabel) {
+        return (req, res, next) => {
+            const normalizedPath = this._normalizeSlasPath(req.path)
+            const allowedEntry = this._matchSlasAllowlistEntry(
+                normalizedPath,
+                req.method,
+                allowList
+            )
+
+            if (!allowedEntry) {
+                const message = `Request to ${req.path} is not allowed through the SLAS ${proxyLabel} Client Proxy`
+                logger.error(message)
+                return res.status(403).json({message})
+            }
+
+            req._normalizedSlasPath = normalizedPath
+            req._slasAllowlistEntry = allowedEntry
+            next()
+        }
+    },
+
+    /**
      * @private
      */
     _setupSlasPrivateClientProxy(app, options) {
@@ -1113,26 +1156,7 @@ export const RemoteServerFactory = {
 
         app.use(
             slasPrivateProxyPath,
-            (req, res, next) => {
-                const normalizedPath = this._normalizeSlasPath(req.path)
-                const allowedEntry = this._matchSlasAllowlistEntry(
-                    normalizedPath,
-                    req.method,
-                    allowList
-                )
-
-                if (!allowedEntry) {
-                    const message = `Request to ${req.path} is not allowed through the SLAS Private Client Proxy`
-                    logger.error(message)
-                    return res.status(403).json({
-                        message
-                    })
-                }
-
-                req._normalizedSlasPath = normalizedPath
-                req._slasAllowlistEntry = allowedEntry
-                next()
-            },
+            this._createSlasAllowlistGuard(allowList, 'Private'),
             createProxyMiddleware({
                 target: options.slasTarget,
                 changeOrigin: true,
@@ -1141,15 +1165,7 @@ export const RemoteServerFactory = {
                 // both proxyRequest and incomingRequest paths.
                 // This cannot be modified by any express middleware
                 // So we need to use the built in pathRewrite to remove the base path
-                pathRewrite: (path) => {
-                    const basePathRegexEntry = getEnvBasePath() ? `${getEnvBasePath()}?` : ''
-                    const regex = new RegExp(`^${basePathRegexEntry}${slasPrivateProxyPath}`)
-                    const stripped = path.replace(regex, '')
-                    // Normalize the forwarded path so SLAS sees exactly what
-                    // our guards evaluated — no encoded traversals or
-                    // characters that could route differently upstream.
-                    return this._normalizeSlasPath(stripped)
-                },
+                pathRewrite: (path) => this._rewriteSlasProxyPath(path, slasPrivateProxyPath),
                 selfHandleResponse: true,
                 onProxyReq: (proxyRequest, incomingRequest, res) => {
                     try {

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -1076,6 +1076,7 @@ export const RemoteServerFactory = {
         const stripped = rawPath.replace(regex, '')
         const [pathname, ...queryParts] = stripped.split('?')
         const normalizedPath = this._normalizeSlasPath(pathname)
+        if (normalizedPath === null) return null
         return queryParts.length ? `${normalizedPath}?${queryParts.join('?')}` : normalizedPath
     },
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -115,6 +115,56 @@ describe('_normalizeSlasPath', () => {
     })
 })
 
+describe('_rewriteSlasProxyPath', () => {
+    const proxyPath = '/mobify/slas/private'
+
+    test('strips proxy prefix and normalizes the path', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/token',
+            proxyPath
+        )
+        expect(result).toBe('/shopper/auth/v1/organizations/org1/oauth2/token')
+    })
+
+    test('preserves query strings containing URLs', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/authorize?redirect_uri=http://localhost:3000/callback&response_type=code',
+            proxyPath
+        )
+        expect(result).toBe(
+            '/shopper/auth/v1/organizations/org1/oauth2/authorize?redirect_uri=http://localhost:3000/callback&response_type=code'
+        )
+    })
+
+    test('preserves query strings with multiple question marks', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/authorize?redirect_uri=http://example.com/cb?foo=bar&code=abc',
+            proxyPath
+        )
+        expect(result).toBe(
+            '/shopper/auth/v1/organizations/org1/oauth2/authorize?redirect_uri=http://example.com/cb?foo=bar&code=abc'
+        )
+    })
+
+    test('handles paths without query strings', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/logout',
+            proxyPath
+        )
+        expect(result).toBe('/shopper/auth/v1/organizations/org1/oauth2/logout')
+    })
+
+    test('normalizes encoded path traversals but preserves query string', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/token/%2E%2E/passwordless/login?client_id=abc',
+            proxyPath
+        )
+        expect(result).toBe(
+            '/shopper/auth/v1/organizations/org1/oauth2/passwordless/login?client_id=abc'
+        )
+    })
+})
+
 describe('_matchSlasAllowlistEntry', () => {
     const ORG = 'f_ecom_zzrf_001'
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -154,6 +154,14 @@ describe('_rewriteSlasProxyPath', () => {
         expect(result).toBe('/shopper/auth/v1/organizations/org1/oauth2/logout')
     })
 
+    test('returns null when path contains malformed encoding', () => {
+        const result = RemoteServerFactory._rewriteSlasProxyPath(
+            '/mobify/slas/private/shopper/auth/%E0%A4%A/oauth2/token?x=1',
+            proxyPath
+        )
+        expect(result).toBeNull()
+    })
+
     test('normalizes encoded path traversals but preserves query string', () => {
         const result = RemoteServerFactory._rewriteSlasProxyPath(
             '/mobify/slas/private/shopper/auth/v1/organizations/org1/oauth2/token/%2E%2E/passwordless/login?client_id=abc',
@@ -162,6 +170,108 @@ describe('_rewriteSlasProxyPath', () => {
         expect(result).toBe(
             '/shopper/auth/v1/organizations/org1/oauth2/passwordless/login?client_id=abc'
         )
+    })
+})
+
+describe('_createSlasAllowlistGuard', () => {
+    const allowList = [
+        {segments: ['oauth2', 'token'], methods: ['POST']},
+        {segments: ['oauth2', 'authorize'], methods: ['GET']},
+        {segments: ['oauth2', 'logout'], methods: ['GET', 'POST']}
+    ]
+
+    const mockRes = () => {
+        const res = {
+            status: jest.fn().mockReturnThis(),
+            json: jest.fn().mockReturnThis()
+        }
+        return res
+    }
+
+    test('calls next for an allowed endpoint', () => {
+        const guard = RemoteServerFactory._createSlasAllowlistGuard(allowList, 'Private')
+        const req = {
+            path: '/shopper/auth/v1/organizations/org1/oauth2/token',
+            method: 'POST'
+        }
+        const res = mockRes()
+        const next = jest.fn()
+
+        guard(req, res, next)
+
+        expect(next).toHaveBeenCalled()
+        expect(res.status).not.toHaveBeenCalled()
+        expect(req._slasAllowlistEntry).toEqual({
+            segments: ['oauth2', 'token'],
+            methods: ['POST']
+        })
+        expect(req._normalizedSlasPath).toBe(
+            '/shopper/auth/v1/organizations/org1/oauth2/token'
+        )
+    })
+
+    test('returns 403 for a disallowed endpoint', () => {
+        const guard = RemoteServerFactory._createSlasAllowlistGuard(allowList, 'Public')
+        const req = {
+            path: '/shopper/auth/v1/organizations/org1/oauth2/trusted-system/token',
+            method: 'POST'
+        }
+        const res = mockRes()
+        const next = jest.fn()
+
+        guard(req, res, next)
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledWith(403)
+        expect(res.json).toHaveBeenCalledWith({
+            message: expect.stringContaining('SLAS Public Client Proxy')
+        })
+    })
+
+    test('returns 403 when method does not match', () => {
+        const guard = RemoteServerFactory._createSlasAllowlistGuard(allowList, 'Private')
+        const req = {
+            path: '/shopper/auth/v1/organizations/org1/oauth2/token',
+            method: 'GET'
+        }
+        const res = mockRes()
+        const next = jest.fn()
+
+        guard(req, res, next)
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    test('returns 403 for malformed percent-encoded paths', () => {
+        const guard = RemoteServerFactory._createSlasAllowlistGuard(allowList, 'Private')
+        const req = {
+            path: '/shopper/auth/%E0%A4%A/organizations/org1/oauth2/token',
+            method: 'POST'
+        }
+        const res = mockRes()
+        const next = jest.fn()
+
+        guard(req, res, next)
+
+        expect(next).not.toHaveBeenCalled()
+        expect(res.status).toHaveBeenCalledWith(403)
+    })
+
+    test('includes proxyLabel in the 403 error message', () => {
+        const guard = RemoteServerFactory._createSlasAllowlistGuard(allowList, 'MyLabel')
+        const req = {
+            path: '/shopper/auth/v1/organizations/org1/oauth2/unknown',
+            method: 'POST'
+        }
+        const res = mockRes()
+        const next = jest.fn()
+
+        guard(req, res, next)
+
+        expect(res.json).toHaveBeenCalledWith({
+            message: expect.stringContaining('SLAS MyLabel Client Proxy')
+        })
     })
 })
 

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.test.js
@@ -205,9 +205,7 @@ describe('_createSlasAllowlistGuard', () => {
             segments: ['oauth2', 'token'],
             methods: ['POST']
         })
-        expect(req._normalizedSlasPath).toBe(
-            '/shopper/auth/v1/organizations/org1/oauth2/token'
-        )
+        expect(req._normalizedSlasPath).toBe('/shopper/auth/v1/organizations/org1/oauth2/token')
     })
 
     test('returns 403 for a disallowed endpoint', () => {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title field above -->

# Description

 - Extract _rewriteSlasProxyPath — strips the proxy base path and normalizes the forwarded path, splitting at ? before normalizing so URLs  
  in query parameters (e.g. redirect_uri=http://localhost:3000/callback) are not mangled by posixPath.normalize                              
  - Extract _createSlasAllowlistGuard — reusable Express middleware that gates SLAS proxy requests against an allowlist and stashes the      
  matched entry on req                                                                                                                       
  - _setupSlasPrivateClientProxy now uses both helpers instead of inline logic
# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

