### PR TITLE
@W-21251336 - Fix e2e consent form timing for httpOnly cookie support

### DIFF
--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -25,57 +25,22 @@ const {getCreditCardExpiry, runAccessibilityTest} = require('../scripts/utils.js
  */
 export const answerConsentTrackingForm = async (page, dnt = false) => {
     try {
-        const consentFormVisible = await page
-            .locator('text=Tracking Consent')
-            .isVisible()
-            .catch(() => false)
-        if (!consentFormVisible) {
-            return
-        }
+        const consentForm = page.locator('text=Tracking Consent')
 
-        const buttonText = dnt ? 'Decline' : 'Accept'
-        await page
-            .getByRole('button', {name: new RegExp(buttonText, 'i')})
-            .first()
-            .waitFor({timeout: 3000})
+        // Wait for the consent form to appear. With httpOnly cookies, auth initialization
+        // may be slower so the form can take longer to render after page.goto resolves.
+        await consentForm.waitFor({state: 'visible', timeout: 10000})
 
-        // Find and click consent buttons (handles both mobile and desktop versions existing in the DOM)
-        const clickSuccess = await page.evaluate((targetText) => {
-            // Try aria-label first, then fallback to text content
-            let buttons = Array.from(
-                document.querySelectorAll(`button[aria-label="${targetText} tracking"]`)
-            )
+        const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
+        const button = page
+            .locator(`button[aria-label="${ariaLabel}"]`)
+            .and(page.locator(':visible'))
+        await button.first().click()
 
-            if (buttons.length === 0) {
-                buttons = Array.from(document.querySelectorAll('button')).filter(
-                    (btn) =>
-                        btn.textContent &&
-                        btn.textContent.trim().toLowerCase() === targetText.toLowerCase()
-                )
-            }
-
-            let clickedCount = 0
-            buttons.forEach((button) => {
-                // Only click visible buttons
-                if (button.offsetParent !== null) {
-                    button.click()
-                    clickedCount++
-                }
-            })
-
-            return clickedCount
-        }, buttonText)
-
-        // after clicking an answering button, the tracking consent should not stay in the DOM
-        if (clickSuccess > 0) {
-            await page.waitForTimeout(2000)
-            await page
-                .locator('text=Tracking Consent')
-                .isHidden({timeout: 5000})
-                .catch(() => {})
-        }
+        // Wait for the consent form to fully disappear from the DOM
+        await consentForm.waitFor({state: 'hidden', timeout: 5000})
     } catch (error) {
-        // Silently continue - consent form handling should not break tests
+        // Consent form may not appear (e.g. preference already set) — continue silently
     }
 }
 
@@ -239,7 +204,7 @@ export const addProductToCart = async ({page, isMobile = false}) => {
 
     await addedToCartModal.waitFor()
 
-    await page.getByLabel('Close').click()
+    await page.getByLabel('Close', {exact: true}).click()
 }
 
 /**

--- a/e2e/tests/desktop/guest-shopper.spec.js
+++ b/e2e/tests/desktop/guest-shopper.spec.js
@@ -86,7 +86,7 @@ test('Guest shopper can checkout product bundle', async ({page}) => {
 
     const addedToCartModal = page.getByText(/1 item added to cart/i)
     await addedToCartModal.waitFor()
-    await page.getByLabel('Close').click()
+    await page.getByLabel('Close', {exact: true}).click()
 
     await page.getByLabel(/My cart/i).click()
     await page.waitForLoadState()

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -140,7 +140,7 @@ test('Guest shopper can checkout product bundle', async ({page}) => {
 
     const addedToCartModal = page.getByText(/1 item added to cart/i)
     await addedToCartModal.waitFor()
-    await page.getByLabel('Close').click()
+    await page.getByLabel('Close', {exact: true}).click()
 
     await page.getByLabel(/My cart/i).click()
     await page.waitForLoadState()


### PR DESCRIPTION
## Summary
- Rewrote `answerConsentTrackingForm` to wait for the consent form to render before interacting (up to 10s timeout), fixing race conditions when httpOnly cookies cause slower auth initialization
- Fixed strict mode violations on `getByLabel('Close')` by adding `{exact: true}` to avoid matching both the consent form close button and the add-to-cart modal close button
- Simplified the consent form dismissal logic, replacing `page.evaluate` DOM manipulation with standard Playwright locators

## Why this change is needed
   With the introduction of httpOnly session cookies (#3804), the initial guest auth flow
    now requires a server round-trip to set cookies (`cc-at`, `cc-nx-g`, etc.) before the
    app fully initializes. This makes page hydration slightly slower than before, causing
    a race condition in e2e tests:

   1. `page.goto()` resolves and `answerConsentTrackingForm` runs immediately
   2. The old implementation did an instant `isVisible()` check — a point-in-time
   snapshot
   3. If the consent form hadn't rendered yet (auth still initializing), the function
   returned early
   4. The consent form appeared later during PDP navigation
   5. When the add-to-cart modal opened, both its close button (`aria-label="Close"`) and
    the consent form's close button (`aria-label="Close consent tracking form"`) were in
   the DOM simultaneously
   6. `getByLabel('Close')` matched both → Playwright strict mode violation

   This was never an issue before because without the server round-trip, auth initialized
    fast enough that the consent form always appeared before the snapshot check ran.
