### PR TITLE
Re-add cookieDomain to Auth constructor

### DIFF
--- a/packages/commerce-sdk-react/src/provider.test.tsx
+++ b/packages/commerce-sdk-react/src/provider.test.tsx
@@ -89,6 +89,18 @@ describe('provider', () => {
         expect(authInstance.ready).toHaveBeenCalledTimes(1)
     })
 
+    test('passes cookieDomain to Auth constructor', () => {
+        renderWithProviders(<h1>test</h1>, {
+            cookieDomain: '.example.com'
+        })
+        expect(Auth).toHaveBeenCalledTimes(1)
+        expect(Auth).toHaveBeenCalledWith(
+            expect.objectContaining({
+                cookieDomain: '.example.com'
+            })
+        )
+    })
+
     test('passes enableHttpOnlySessionCookies to Auth constructor', () => {
         renderWithProviders(<h1>HttpOnly cookies enabled!</h1>, {
             enableHttpOnlySessionCookies: true

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -214,6 +214,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             refreshTokenRegisteredCookieTTL,
             refreshTokenGuestCookieTTL,
             hybridAuthEnabled,
+            cookieDomain,
             enableHttpOnlySessionCookies
         })
     }, [


### PR DESCRIPTION
This PR re-adds a line that was lost on merge that sets the configured cookie domain in the Auth object.


