### PR TITLE
Fix MRT Data Store env var names in generated config and README

### DIFF
--- a/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/bootstrap/js/config/default.js.hbs
@@ -23,8 +23,8 @@ module.exports = {
         // MRT Data Store (opt-in): when true, SSR resolves prefs and serializes `__MRT_DATA_STORE__` in
         // `#mobify-data`; when false, that key is omitted. See `isMrtDataStoreEnabled` in pwa-kit-runtime.
         // Set `PWAKIT_MRT_DATA_STORE_ENABLED=true|false` to override without editing files.
-        // Local dev without DynamoDB: `PWAKIT_MRT_DATA_STORE_DEFAULTS` (JSON map of full DAL keys → objects),
-        // `PWAKIT_MRT_DATA_STORE_ALLOW_LOCAL=true` when NODE_ENV is production, optional `PWAKIT_MRT_DATA_STORE_WARN_ON_MISSING=false`.
+        // Local dev without DynamoDB: `MRT_DATA_STORE_DEFAULTS` (JSON map of full DAL keys → objects),
+        // optional `MRT_DATA_STORE_WARN_ON_MISSING=false` to silence missing-key warnings.
         mrtDataStore: {
             enabled: false
         },

--- a/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
+++ b/packages/pwa-kit-create-app/assets/templates/@salesforce/retail-react-app/config/default.js.hbs
@@ -23,8 +23,8 @@ module.exports = {
         // MRT Data Store (opt-in): when true, SSR resolves prefs and serializes `__MRT_DATA_STORE__` in
         // `#mobify-data`; when false, that key is omitted. See `isMrtDataStoreEnabled` in pwa-kit-runtime.
         // Set `PWAKIT_MRT_DATA_STORE_ENABLED=true|false` to override without editing files.
-        // Local dev without DynamoDB: `PWAKIT_MRT_DATA_STORE_DEFAULTS` (JSON map of full DAL keys → objects),
-        // `PWAKIT_MRT_DATA_STORE_ALLOW_LOCAL=true` when NODE_ENV is production, optional `PWAKIT_MRT_DATA_STORE_WARN_ON_MISSING=false`.
+        // Local dev without DynamoDB: `MRT_DATA_STORE_DEFAULTS` (JSON map of full DAL keys → objects),
+        // optional `MRT_DATA_STORE_WARN_ON_MISSING=false` to silence missing-key warnings.
         mrtDataStore: {
             enabled: false
         },

--- a/packages/template-retail-react-app/README.md
+++ b/packages/template-retail-react-app/README.md
@@ -44,13 +44,13 @@ The Retail React App's configuration files are located in the `app/config` folde
 You can resolve **MRT Data Store** custom preferences during SSR without DynamoDB by using the in-memory provider from **`@salesforce/pwa-kit-dev`** (loaded by `@salesforce/pwa-kit-runtime` when you are **not** in a full Managed Runtime process).
 
 - **Turn the feature on:** set **`app.mrtDataStore.enabled`** in `config/default.js`, and/or **`PWAKIT_MRT_DATA_STORE_ENABLED=true`** (use `false` to force off without editing files).
-- **Use local defaults:** set **`PWAKIT_MRT_DATA_STORE_DEFAULTS`** to a JSON object whose keys are **full DAL keys** and values are plain objects. For example, site preferences use `<siteId>-custom-site-preferences` (such as `RefArch-custom-site-preferences`); global preferences use **`custom-global-preferences`**.
+- **Use local defaults:** set **`MRT_DATA_STORE_DEFAULTS`** to a JSON object whose keys are **full DAL keys** and values are plain objects. For example, site preferences use `<siteId>-custom-site-preferences` (such as `RefArch-custom-site-preferences`); global preferences use **`custom-global-preferences`**.
 - **Use the local provider, not DynamoDB:** in development, keep **`AWS_REGION`**, **`MOBIFY_PROPERTY_ID`**, and **`DEPLOY_TARGET`** unset for the dev server. If all three are set, the runtime uses the **real** Data Store instead of your defaults map.
-- **Optional:** **`PWAKIT_MRT_DATA_STORE_WARN_ON_MISSING=false`** silences console warnings when a key is missing. Use **`PWAKIT_MRT_DATA_STORE_ALLOW_LOCAL=true`** if you need the local provider while **`NODE_ENV=production`** locally.
+- **Optional:** **`MRT_DATA_STORE_WARN_ON_MISSING=false`** silences console warnings when a key is missing.
 
 ```bash
 export PWAKIT_MRT_DATA_STORE_ENABLED=true
-export PWAKIT_MRT_DATA_STORE_DEFAULTS='{"RefArch-custom-site-preferences":{},"custom-global-preferences":{}}'
+export MRT_DATA_STORE_DEFAULTS='{"RefArch-custom-site-preferences":{},"custom-global-preferences":{}}'
 npm start
 ```
 


### PR DESCRIPTION
## Summary
- The generator templates and the retail-react-app README referenced `PWAKIT_MRT_DATA_STORE_DEFAULTS` and `PWAKIT_MRT_DATA_STORE_WARN_ON_MISSING`, but `@salesforce/mrt-utilities` actually reads the unprefixed `MRT_DATA_STORE_DEFAULTS` and `MRT_DATA_STORE_WARN_ON_MISSING`. Renamed in the comments and the README so copy-pasting from generated projects works.
- Removed the reference to `PWAKIT_MRT_DATA_STORE_ALLOW_LOCAL`, which is not consumed anywhere in this repo or in `@salesforce/mrt-utilities`.
- Aligns the generator/README with the rename already noted in the `@salesforce/pwa-kit-runtime` 3.18.0 changelog.

Found while validating PWA Kit 3.18.0-preview.1: setting the `PWAKIT_*`-prefixed defaults env vars produced no `__MRT_DATA_STORE__` data because the names didn't match what `mrt-utilities/dist/*/data-store/development.js` reads.

## Test plan
Run from a freshly generated 3.18 project:
```bash
PWAKIT_MRT_DATA_STORE_ENABLED=true \
MRT_DATA_STORE_DEFAULTS='{"custom-global-preferences":{"testFeature":true},"RefArch-custom-site-preferences":{"storeName":"Test Store RefArch"}}' \
npm start
```

- [ ] `view-source:http://localhost:3000/RefArch/` includes `__MRT_DATA_STORE__` under `#mobify-data` with the seeded values.
- [ ] Default-off path: without `PWAKIT_MRT_DATA_STORE_ENABLED`, the key is omitted (regression check).
- [ ] No runtime files touched — comments and README only.