### PR TITLE
@W-22434715@ - Stabilize e2e cart/wishlist cleanup

### DIFF
--- a/e2e/config.js
+++ b/e2e/config.js
@@ -12,6 +12,8 @@ module.exports = {
         process.env.RETAIL_APP_HOME ||
         'https://scaffold-pwa-e2e-tests-pwa-kit.mobify-storefront.com',
     RETAIL_APP_HOME_SITE: 'RefArch',
+    RETAIL_APP_HOME_ORGANIZATION_ID:
+        process.env.RETAIL_APP_HOME_ORGANIZATION_ID || 'f_ecom_zzrf_002',
     /**
      * We need to write the environment details and status to a file so that other steps in the workflow can use it.
      * Propagating outputs from node to composite actions to workflow is not robust enough.

--- a/e2e/scripts/cleanup.js
+++ b/e2e/scripts/cleanup.js
@@ -45,24 +45,29 @@ async function clearCartAndWishlist(page) {
     const orgId = config.RETAIL_APP_HOME_ORGANIZATION_ID
     const headers = {Authorization: `Bearer ${session.accessToken}`}
 
-    // 1. Active basket -> delete
-    const basketRes = await safeRequest('GET baskets', () =>
+    // 1. Active baskets -> delete
+    // shopper-baskets has no list endpoint, so list via shopper-customers
+    // (works for guest and registered customers since SLAS issues a
+    // customer_id for both).
+    const basketsRes = await safeRequest('GET customer baskets', () =>
         page.request.get(
-            `${baseUrl}/checkout/shopper-baskets/v1/organizations/${orgId}/baskets?siteId=${siteId}`,
+            `${baseUrl}/customer/shopper-customers/v1/organizations/${orgId}/customers/${session.customerId}/baskets?siteId=${siteId}`,
             {headers}
         )
     )
-    if (basketRes?.ok()) {
-        const body = await safeRequest('parse baskets', () => basketRes.json())
-        const basketId = body?.baskets?.[0]?.basketId || body?.basketId
-        if (basketId) {
-            await safeRequest('DELETE basket', () =>
-                page.request.delete(
-                    `${baseUrl}/checkout/shopper-baskets/v1/organizations/${orgId}/baskets/${basketId}?siteId=${siteId}`,
-                    {headers}
+    if (basketsRes?.ok()) {
+        const body = await safeRequest('parse customer baskets', () => basketsRes.json())
+        const basketIds = (body?.baskets ?? []).map((b) => b?.basketId).filter(Boolean)
+        await Promise.all(
+            basketIds.map((basketId) =>
+                safeRequest(`DELETE basket ${basketId}`, () =>
+                    page.request.delete(
+                        `${baseUrl}/checkout/shopper-baskets/v1/organizations/${orgId}/baskets/${basketId}?siteId=${siteId}`,
+                        {headers}
+                    )
                 )
             )
-        }
+        )
     }
 
     // 2. Wishlist items -> delete each

--- a/e2e/scripts/cleanup.js
+++ b/e2e/scripts/cleanup.js
@@ -10,6 +10,12 @@ const config = require('../config.js')
 // commerce-sdk-react stores tokens in localStorage with the siteId as suffix:
 // e.g. `access_token_RefArch`, `customer_id_RefArch`. Match by prefix so the
 // helper works regardless of the active siteId.
+//
+// NOTE: When SLAS tokens migrate from localStorage to httpOnly cookies, this
+// helper will silently no-op (no access_token/customer_id in localStorage →
+// readSession returns null → cleanup skips). Follow-up: switch to reading
+// the session from cookies, or call cookie-authed /mobify/slas/private/*
+// endpoints. Tracked separately from this PR.
 const readSession = (page) =>
     page.evaluate(() => {
         const entries = Object.entries(window.localStorage)

--- a/e2e/scripts/cleanup.js
+++ b/e2e/scripts/cleanup.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const config = require('../config.js')
+
+// commerce-sdk-react stores tokens in localStorage with the siteId as suffix:
+// e.g. `access_token_RefArch`, `customer_id_RefArch`. Match by prefix so the
+// helper works regardless of the active siteId.
+const readSession = (page) =>
+    page.evaluate(() => {
+        const entries = Object.entries(window.localStorage)
+        const accessToken = entries.find(([k]) => k.startsWith('access_token'))?.[1]
+        const customerId = entries.find(([k]) => k.startsWith('customer_id'))?.[1]
+        return accessToken && customerId ? {accessToken, customerId} : null
+    })
+
+const safeRequest = async (label, fn) => {
+    try {
+        return await fn()
+    } catch (error) {
+        console.warn(`[e2e cleanup] ${label} failed: ${error.message}`)
+        return null
+    }
+}
+
+/**
+ * Empty the active basket and wishlist for the currently logged-in shopper.
+ * Reads the session from localStorage and calls SCAPI directly via the
+ * storefront's /mobify/proxy/api path, so cookies/SLAS auth match the test
+ * browser's existing session.
+ *
+ * Always best-effort: a missing session, a failed call, or a missing
+ * wishlist must never fail the test that just ran.
+ */
+async function clearCartAndWishlist(page) {
+    const session = await safeRequest('readSession', () => readSession(page))
+    if (!session) return
+
+    const baseUrl = `${config.RETAIL_APP_HOME}/mobify/proxy/api`
+    const siteId = config.RETAIL_APP_HOME_SITE
+    const orgId = config.RETAIL_APP_HOME_ORGANIZATION_ID
+    const headers = {Authorization: `Bearer ${session.accessToken}`}
+
+    // 1. Active basket -> delete
+    const basketRes = await safeRequest('GET baskets', () =>
+        page.request.get(
+            `${baseUrl}/checkout/shopper-baskets/v1/organizations/${orgId}/baskets?siteId=${siteId}`,
+            {headers}
+        )
+    )
+    if (basketRes?.ok()) {
+        const body = await safeRequest('parse baskets', () => basketRes.json())
+        const basketId = body?.baskets?.[0]?.basketId || body?.basketId
+        if (basketId) {
+            await safeRequest('DELETE basket', () =>
+                page.request.delete(
+                    `${baseUrl}/checkout/shopper-baskets/v1/organizations/${orgId}/baskets/${basketId}?siteId=${siteId}`,
+                    {headers}
+                )
+            )
+        }
+    }
+
+    // 2. Wishlist items -> delete each
+    const listsRes = await safeRequest('GET customer-product-lists', () =>
+        page.request.get(
+            `${baseUrl}/customer/shopper-customers/v1/organizations/${orgId}/customers/${session.customerId}/customer-product-lists?siteId=${siteId}`,
+            {headers}
+        )
+    )
+    if (!listsRes?.ok()) return
+    const body = await safeRequest('parse customer-product-lists', () => listsRes.json())
+    const wishlist = body?.data?.find((l) => l.type === 'wish_list')
+    const items = wishlist?.customerProductListItems
+    if (!items?.length) return
+
+    await Promise.all(
+        items.map((item) =>
+            safeRequest(`DELETE wishlist item ${item.id}`, () =>
+                page.request.delete(
+                    `${baseUrl}/customer/shopper-customers/v1/organizations/${orgId}/customers/${session.customerId}/customer-product-lists/${wishlist.id}/items/${item.id}?siteId=${siteId}`,
+                    {headers}
+                )
+            )
+        )
+    )
+}
+
+module.exports = {clearCartAndWishlist}

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -24,23 +24,36 @@ const {getCreditCardExpiry, runAccessibilityTest} = require('../scripts/utils.js
  * @param {Boolean} dnt - Do Not Track value to answer the form. False to enable tracking, True to disable tracking.
  */
 export const answerConsentTrackingForm = async (page, dnt = false) => {
+    const consentForm = page.locator('text=Tracking Consent')
+
+    // Probe for the form: if it doesn't appear, assume the preference is
+    // already set and return. With httpOnly cookies, auth initialization
+    // can be slow so we allow up to 10s for it to render.
     try {
-        const consentForm = page.locator('text=Tracking Consent')
-
-        // Wait for the consent form to appear. With httpOnly cookies, auth initialization
-        // may be slower so the form can take longer to render after page.goto resolves.
         await consentForm.waitFor({state: 'visible', timeout: 10000})
+    } catch {
+        return
+    }
 
-        const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
-        const button = page
-            .locator(`button[aria-label="${ariaLabel}"]`)
-            .and(page.locator(':visible'))
-        await button.first().click()
+    const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
+    const button = page.locator(`button[aria-label="${ariaLabel}"]`).and(page.locator(':visible'))
 
-        // Wait for the consent form to fully disappear from the DOM
-        await consentForm.waitFor({state: 'hidden', timeout: 5000})
-    } catch (error) {
-        // Consent form may not appear (e.g. preference already set) — continue silently
+    // The consent modal is rendered into a chakra-portal anchored to the
+    // bottom of the viewport. While it is visible, its inner Stack of
+    // buttons intercepts pointer events on any element that overlaps it
+    // (e.g. Sign In, Add Bundle to Cart). If the first dismissal click
+    // doesn't make the modal disappear within 5s, retry once before giving
+    // up — this is more robust than a single click + long wait, and avoids
+    // the misleading 60s waitForResponse timeouts we see when a stale modal
+    // intercepts a later click in the test.
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            await button.first().click()
+            await consentForm.waitFor({state: 'hidden', timeout: 5000})
+            return
+        } catch {
+            // fall through and retry
+        }
     }
 }
 
@@ -325,6 +338,13 @@ export const loginShopper = async ({page, userCredentials, allowFallback = true}
 
         await page.locator('input#email').fill(userCredentials.email)
         await page.locator('input#password').fill(userCredentials.password)
+
+        // The DNT consent modal is portaled to the bottom of the viewport.
+        // If it is still visible when we click Sign In, its container
+        // intercepts the click — the form never submits and waitForResponse
+        // below times out at 60s with a misleading message. Make the failure
+        // explicit instead.
+        await expect(page.locator('text=Tracking Consent')).toBeHidden({timeout: 10000})
 
         const loginResponsePromise = page.waitForResponse(
             '**/shopper/auth/v1/organizations/**/oauth2/login'

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -318,7 +318,7 @@ export const validateWishlist = async ({page, a11y = {}}) => {
  *
  * @return {Boolean} - denotes whether or not login was successful
  */
-export const loginShopper = async ({page, userCredentials}) => {
+export const loginShopper = async ({page, userCredentials, allowFallback = true}) => {
     try {
         await page.goto(config.RETAIL_APP_HOME + '/login')
         await answerConsentTrackingForm(page)
@@ -345,6 +345,8 @@ export const loginShopper = async ({page, userCredentials}) => {
         await expect(page.getByText(userCredentials.email)).toBeVisible()
         return true
     } catch (error) {
+        console.error('[e2e] loginShopper failed:', error.message)
+        if (!allowFallback) throw error
         return false
     }
 }

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -24,24 +24,24 @@ const {getCreditCardExpiry, runAccessibilityTest} = require('../scripts/utils.js
  * @param {Boolean} dnt - Do Not Track value to answer the form. False to enable tracking, True to disable tracking.
  */
 export const answerConsentTrackingForm = async (page, dnt = false) => {
-    const consentForm = page.locator('text=Tracking Consent')
-
-    // Probe for the form rather than waiting+catching: if it isn't rendered
-    // within the probe window we assume the preference is already set and
-    // skip silently. If it IS rendered, dismiss it and propagate any failure
-    // — a stuck consent form blocks every subsequent click and produces
-    // confusing 60s timeouts elsewhere in the test.
     try {
-        await consentForm.waitFor({state: 'visible', timeout: 15000})
-    } catch {
-        return
+        const consentForm = page.locator('text=Tracking Consent')
+
+        // Wait for the consent form to appear. With httpOnly cookies, auth initialization
+        // may be slower so the form can take longer to render after page.goto resolves.
+        await consentForm.waitFor({state: 'visible', timeout: 10000})
+
+        const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
+        const button = page
+            .locator(`button[aria-label="${ariaLabel}"]`)
+            .and(page.locator(':visible'))
+        await button.first().click()
+
+        // Wait for the consent form to fully disappear from the DOM
+        await consentForm.waitFor({state: 'hidden', timeout: 5000})
+    } catch (error) {
+        // Consent form may not appear (e.g. preference already set) — continue silently
     }
-
-    const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
-    const button = page.locator(`button[aria-label="${ariaLabel}"]`).and(page.locator(':visible'))
-    await button.first().click()
-
-    await consentForm.waitFor({state: 'hidden', timeout: 10000})
 }
 
 /**

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -38,9 +38,7 @@ export const answerConsentTrackingForm = async (page, dnt = false) => {
     }
 
     const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
-    const button = page
-        .locator(`button[aria-label="${ariaLabel}"]`)
-        .and(page.locator(':visible'))
+    const button = page.locator(`button[aria-label="${ariaLabel}"]`).and(page.locator(':visible'))
     await button.first().click()
 
     await consentForm.waitFor({state: 'hidden', timeout: 10000})

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -328,13 +328,10 @@ export const validateWishlist = async ({page, a11y = {}}) => {
  *      - lastName
  *      - email
  *      - password
- * @param {Boolean} [options.allowFallback=true] - When false, rethrows the underlying error
- *      instead of returning false. Use this to surface real SLAS failures in tests that
- *      shouldn't fall through to register-then-relogin against polluted state.
  *
  * @return {Boolean} - denotes whether or not login was successful
  */
-export const loginShopper = async ({page, userCredentials, allowFallback = true}) => {
+export const loginShopper = async ({page, userCredentials}) => {
     let loginResponse
     let tokenResponse
     try {
@@ -375,7 +372,6 @@ export const loginShopper = async ({page, userCredentials, allowFallback = true}
             ? ` (last SLAS response: ${lastResponse.status()} ${lastResponse.url()})`
             : ''
         console.error(`[e2e] loginShopper failed${responseContext}:`, error.message)
-        if (!allowFallback) throw error
         return false
     }
 }

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -328,10 +328,15 @@ export const validateWishlist = async ({page, a11y = {}}) => {
  *      - lastName
  *      - email
  *      - password
+ * @param {Boolean} [options.allowFallback=true] - When false, rethrows the underlying error
+ *      instead of returning false. Use this to surface real SLAS failures in tests that
+ *      shouldn't fall through to register-then-relogin against polluted state.
  *
  * @return {Boolean} - denotes whether or not login was successful
  */
 export const loginShopper = async ({page, userCredentials, allowFallback = true}) => {
+    let loginResponse
+    let tokenResponse
     try {
         await page.goto(config.RETAIL_APP_HOME + '/login')
         await answerConsentTrackingForm(page)
@@ -354,10 +359,10 @@ export const loginShopper = async ({page, userCredentials, allowFallback = true}
         )
         await page.getByRole('button', {name: /Sign In/i}).click()
 
-        const loginResponse = await loginResponsePromise
+        loginResponse = await loginResponsePromise
         expect(loginResponse.status()).toBe(303) // Login returns a 303 redirect to /callback with authCode and usid
 
-        const tokenResponse = await tokenResponsePromise
+        tokenResponse = await tokenResponsePromise
         expect(tokenResponse.status()).toBe(200)
 
         await page.waitForURL(/.*\/account.*/, {timeout: 10000})
@@ -365,7 +370,11 @@ export const loginShopper = async ({page, userCredentials, allowFallback = true}
         await expect(page.getByText(userCredentials.email)).toBeVisible()
         return true
     } catch (error) {
-        console.error('[e2e] loginShopper failed:', error.message)
+        const lastResponse = tokenResponse || loginResponse
+        const responseContext = lastResponse
+            ? ` (last SLAS response: ${lastResponse.status()} ${lastResponse.url()})`
+            : ''
+        console.error(`[e2e] loginShopper failed${responseContext}:`, error.message)
         if (!allowFallback) throw error
         return false
     }

--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -24,24 +24,26 @@ const {getCreditCardExpiry, runAccessibilityTest} = require('../scripts/utils.js
  * @param {Boolean} dnt - Do Not Track value to answer the form. False to enable tracking, True to disable tracking.
  */
 export const answerConsentTrackingForm = async (page, dnt = false) => {
+    const consentForm = page.locator('text=Tracking Consent')
+
+    // Probe for the form rather than waiting+catching: if it isn't rendered
+    // within the probe window we assume the preference is already set and
+    // skip silently. If it IS rendered, dismiss it and propagate any failure
+    // — a stuck consent form blocks every subsequent click and produces
+    // confusing 60s timeouts elsewhere in the test.
     try {
-        const consentForm = page.locator('text=Tracking Consent')
-
-        // Wait for the consent form to appear. With httpOnly cookies, auth initialization
-        // may be slower so the form can take longer to render after page.goto resolves.
-        await consentForm.waitFor({state: 'visible', timeout: 10000})
-
-        const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
-        const button = page
-            .locator(`button[aria-label="${ariaLabel}"]`)
-            .and(page.locator(':visible'))
-        await button.first().click()
-
-        // Wait for the consent form to fully disappear from the DOM
-        await consentForm.waitFor({state: 'hidden', timeout: 5000})
-    } catch (error) {
-        // Consent form may not appear (e.g. preference already set) — continue silently
+        await consentForm.waitFor({state: 'visible', timeout: 15000})
+    } catch {
+        return
     }
+
+    const ariaLabel = dnt ? 'Decline tracking' : 'Accept tracking'
+    const button = page
+        .locator(`button[aria-label="${ariaLabel}"]`)
+        .and(page.locator(':visible'))
+    await button.first().click()
+
+    await consentForm.waitFor({state: 'hidden', timeout: 10000})
 }
 
 /**

--- a/e2e/tests/desktop/guest-shopper.spec.js
+++ b/e2e/tests/desktop/guest-shopper.spec.js
@@ -8,8 +8,13 @@
 const {test, expect} = require('@playwright/test')
 const {generateUserCredentials} = require('../../scripts/utils.js')
 const {addProductToCart, searchProduct, checkoutProduct} = require('../../scripts/pageHelpers.js')
+const {clearCartAndWishlist} = require('../../scripts/cleanup.js')
 
 const GUEST_USER_CREDENTIALS = generateUserCredentials()
+
+test.afterEach(async ({page}) => {
+    await clearCartAndWishlist(page)
+})
 
 /**
  * Test that guest shoppers can add a product to cart and go through the entire checkout process,

--- a/e2e/tests/desktop/registered-shopper.spec.js
+++ b/e2e/tests/desktop/registered-shopper.spec.js
@@ -14,11 +14,16 @@ const {
     registeredUserHappyPath
 } = require('../../scripts/pageHelpers')
 const {generateUserCredentials} = require('../../scripts/utils.js')
+const {clearCartAndWishlist} = require('../../scripts/cleanup.js')
 let registeredUserCredentials = {}
 
 test.beforeAll(async () => {
     // Generate credentials once and use throughout tests to avoid creating a new account
     registeredUserCredentials = generateUserCredentials()
+})
+
+test.afterEach(async ({page}) => {
+    await clearCartAndWishlist(page)
 })
 
 /**

--- a/e2e/tests/homepage.spec.js
+++ b/e2e/tests/homepage.spec.js
@@ -21,14 +21,15 @@ test.describe('Retail app home page loads', () => {
 
     test('get started link', async ({page}) => {
         const getStartedLink = page.getByRole('link', {name: 'Get started'})
-        await expect(getStartedLink).toBeVisible()
+        await expect(getStartedLink).toBeVisible({timeout: 15000})
+        await getStartedLink.scrollIntoViewIfNeeded()
 
-        const popupPromise = page.waitForEvent('popup', {timeout: 30000})
-        await getStartedLink.click()
+        const [getStartedPage] = await Promise.all([
+            page.waitForEvent('popup', {timeout: 30000}),
+            getStartedLink.click()
+        ])
 
-        const getStartedPage = await popupPromise
         await expect(getStartedPage).toHaveURL(/.*getting-started/, {timeout: 15000})
-
         await expect(getStartedPage.getByRole('heading').first()).toBeVisible({timeout: 10000})
     })
 })

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -8,8 +8,13 @@
 const {test, expect} = require('@playwright/test')
 const {addProductToCart, searchProduct, checkoutProduct} = require('../../scripts/pageHelpers')
 const {generateUserCredentials, getCreditCardExpiry} = require('../../scripts/utils.js')
+const {clearCartAndWishlist} = require('../../scripts/cleanup.js')
 
 const GUEST_USER_CREDENTIALS = generateUserCredentials()
+
+test.afterEach(async ({page}) => {
+    await clearCartAndWishlist(page)
+})
 
 /**
  * Test that guest shoppers can add a product to cart and go through the entire checkout process,

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -6,7 +6,12 @@
  */
 
 const {test, expect} = require('@playwright/test')
-const {addProductToCart, searchProduct, checkoutProduct} = require('../../scripts/pageHelpers')
+const {
+    addProductToCart,
+    answerConsentTrackingForm,
+    searchProduct,
+    checkoutProduct
+} = require('../../scripts/pageHelpers')
 const {generateUserCredentials, getCreditCardExpiry} = require('../../scripts/utils.js')
 const {clearCartAndWishlist} = require('../../scripts/cleanup.js')
 
@@ -143,12 +148,18 @@ test('Guest shopper can checkout product bundle', async ({page}) => {
 
     await page.waitForLoadState()
 
+    // The DNT consent modal can re-appear after navigations on mobile when
+    // the dnt cookie isn't yet set, and it intercepts clicks on the bottom
+    // of the viewport (where Add Bundle to Cart sits).
+    await answerConsentTrackingForm(page)
+
     await expect(page.getByRole('heading', {name: /Turquoise Jewelry Bundle/i})).toBeVisible({
         timeout: 30000
     })
 
     const addBundleToCart = page.getByRole('button', {name: /Add Bundle to Cart/i})
     await expect(addBundleToCart).toBeEnabled({timeout: 30000})
+    await expect(page.locator('text=Tracking Consent')).toBeHidden({timeout: 10000})
     await addBundleToCart.click()
 
     const addedToCartModal = page.getByText(/1 item added to cart/i)

--- a/e2e/tests/mobile/guest-shopper.spec.js
+++ b/e2e/tests/mobile/guest-shopper.spec.js
@@ -129,6 +129,10 @@ test('Guest shopper can edit product item in cart', async ({page}) => {
  * Test that guest shoppers can add product bundle to cart and successfully checkout
  */
 test('Guest shopper can checkout product bundle', async ({page}) => {
+    // PLP/PDP and bundle render are noticeably slower on mobile-chrome and
+    // the default 60s test budget is regularly insufficient.
+    test.setTimeout(120000)
+
     await searchProduct({page, query: 'bundle', isMobile: true})
 
     await page
@@ -139,9 +143,13 @@ test('Guest shopper can checkout product bundle', async ({page}) => {
 
     await page.waitForLoadState()
 
-    await expect(page.getByRole('heading', {name: /Turquoise Jewelry Bundle/i})).toBeVisible()
+    await expect(page.getByRole('heading', {name: /Turquoise Jewelry Bundle/i})).toBeVisible({
+        timeout: 30000
+    })
 
-    await page.getByRole('button', {name: /Add Bundle to Cart/i}).click()
+    const addBundleToCart = page.getByRole('button', {name: /Add Bundle to Cart/i})
+    await expect(addBundleToCart).toBeEnabled({timeout: 30000})
+    await addBundleToCart.click()
 
     const addedToCartModal = page.getByText(/1 item added to cart/i)
     await addedToCartModal.waitFor()

--- a/e2e/tests/mobile/registered-shopper.spec.js
+++ b/e2e/tests/mobile/registered-shopper.spec.js
@@ -16,12 +16,17 @@ const {
     answerConsentTrackingForm
 } = require('../../scripts/pageHelpers')
 const {generateUserCredentials, getCreditCardExpiry} = require('../../scripts/utils.js')
+const {clearCartAndWishlist} = require('../../scripts/cleanup.js')
 
 let registeredUserCredentials = {}
 
 test.beforeAll(async () => {
     // Generate credentials once and use throughout tests to avoid creating a new account
     registeredUserCredentials = generateUserCredentials()
+})
+
+test.afterEach(async ({page}) => {
+    await clearCartAndWishlist(page)
 })
 
 /**

--- a/packages/template-retail-react-app/app/utils/locale.test.js
+++ b/packages/template-retail-react-app/app/utils/locale.test.js
@@ -23,7 +23,11 @@ jest.mock('cross-fetch', () => {
         }
 
         const locale = matched[1]
-        const json = await import(`../static/translations/compiled/${locale}.json`)
+        const imported = await import(`../static/translations/compiled/${locale}.json`)
+        // Dynamic JSON import returns a namespace ({default}) under Node 24 ESM
+        // semantics but the bare object under babel's CJS interop. Unwrap so the
+        // mock returns the same shape as a real fetch().json() in either case.
+        const json = imported.default ?? imported
 
         return {
             ok: true,


### PR DESCRIPTION
## Summary

- Adds `e2e/scripts/cleanup.js` with `clearCartAndWishlist(page)` that uses Playwright's `page.request` to call SCAPI through `/mobify/proxy/api` and delete the active basket + every wishlist item for the logged-in shopper.
- Wires `test.afterEach(clearCartAndWishlist)` into all four shopper specs (`{desktop,mobile}/{registered,guest}-shopper.spec.js`) so leftover state never bleeds into the next test or retry.
- Makes `loginShopper` log the error and rethrow (gated by `allowFallback`, defaults to existing silent-fallback behavior) so future tests can opt into surfacing real SLAS failures instead of falling through to register-then-relogin against polluted state.
- Adds `RETAIL_APP_HOME_ORGANIZATION_ID` to `e2e/config.js` (defaults to `f_ecom_zzrf_002`, env-overridable).

## Why

`e2e.yml` has been failing nightly since 2026-04-30. The reliable repro is `Registered shopper can add master product from wishlist to cart`:

```
strict mode violation: getByRole('heading', { name: /Cotton Turtleneck Sweater/i })
  resolved to 2 elements:
    sf-cart-item-701642838739M  (variant w/ size L)
    sf-cart-item-25518241M      (master product, no size)
```

Two preceding tests add Cotton Turtleneck Sweater to the wishlist (one as a sized variant, one as the master product) for the same `registeredUserCredentials` generated in `beforeAll`, with **zero `afterEach`/`afterAll` cleanup hooks anywhere** in `e2e/tests/`. On Playwright retries the same SCAPI customer is reused, so the second test sees both items. This isn't a new regression — `46784a8b9` flipped pass/fail across 04-22 → 04-27, well before the recent SLAS proxy refactor / HttpOnly merge.

Initial suspicion was the new `enableHttpOnlySessionCookies` feature, but it's `false` on `develop` and gated by `MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true'` (never set on the e2e MRT targets), so it's not exercised.

No runtime/production code is touched.

Test run: https://github.com/SalesforceCommerceCloud/pwa-kit/actions/runs/25917410571

GUS: @W-22434715@