### PR TITLE
@W-22299570 Add /continue route for UCP checkout escalation

### DIFF
--- a/packages/template-retail-react-app/app/pages/continue/index.jsx
+++ b/packages/template-retail-react-app/app/pages/continue/index.jsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React, {useEffect, useState} from 'react'
+import {FormattedMessage, useIntl} from 'react-intl'
+import {
+    Alert,
+    Box,
+    Container,
+    Stack,
+    Text,
+    Spinner
+} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {AlertIcon} from '@salesforce/retail-react-app/app/components/icons'
+import Cookies from 'js-cookie'
+
+import {useAuthHelper, AuthHelpers, useAccessToken, useConfig} from '@salesforce/commerce-sdk-react'
+import {useSearchParams} from '@salesforce/retail-react-app/app/hooks'
+import {API_ERROR_MESSAGE} from '@salesforce/retail-react-app/app/constants'
+
+const UcpContinue = () => {
+    const {formatMessage} = useIntl()
+    const [searchParams] = useSearchParams()
+    const loginGuestUser = useAuthHelper(AuthHelpers.LoginGuestUser)
+    const {getTokenWhenReady} = useAccessToken()
+    const config = useConfig()
+    const {proxy, organizationId, siteId} = config
+
+    const {basketId, usid, merge, overrideExisting} = searchParams
+    const [error, setError] = useState('')
+
+    const hasMissingParams = !basketId || !usid
+    useEffect(() => {
+        if (hasMissingParams) {
+            setError(
+                formatMessage({
+                    id: 'ucp_continue.error.missing_params',
+                    defaultMessage:
+                        'Missing required parameters. A valid basket ID and shopper ID are required.'
+                })
+            )
+            return
+        }
+
+        const continueCheckout = async () => {
+            try {
+                // Set the usid cookie so loginGuestUser picks it up and
+                // establishes a session for the same anonymous shopper.
+                Cookies.set(`usid_${siteId}`, usid)
+                await loginGuestUser.mutateAsync()
+            } catch {
+                setError(formatMessage(API_ERROR_MESSAGE))
+                return
+            }
+
+            try {
+                const accessToken = await getTokenWhenReady()
+                const params = new URLSearchParams({siteId})
+                if (merge) params.set('merge', merge)
+                if (overrideExisting) params.set('overrideExisting', overrideExisting)
+                const promoteUrl = `${proxy}/checkout/shopper-baskets/v2/organizations/${organizationId}/baskets/${basketId}/actions/promote?${params}`
+
+                const res = await fetch(promoteUrl, {
+                    method: 'POST',
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        'Content-Type': 'application/json'
+                    }
+                })
+
+                if (!res.ok) {
+                    if (res.status === 409) {
+                        setError(
+                            formatMessage({
+                                id: 'ucp_continue.error.conflict',
+                                defaultMessage:
+                                    'A basket already exists for this session. Please specify how to resolve the conflict.'
+                            })
+                        )
+                    } else if (res.status === 404) {
+                        setError(
+                            formatMessage({
+                                id: 'ucp_continue.error.basket_not_found',
+                                defaultMessage:
+                                    'The basket was not found or is no longer available.'
+                            })
+                        )
+                    } else {
+                        setError(formatMessage(API_ERROR_MESSAGE))
+                    }
+                    return
+                }
+            } catch {
+                setError(formatMessage(API_ERROR_MESSAGE))
+                return
+            }
+
+            window.location.replace('/checkout')
+        }
+
+        continueCheckout()
+    }, [])
+
+    return (
+        <Box data-testid="ucp-continue-page" bg="gray.50" py={[8, 16]}>
+            <Container
+                paddingTop={16}
+                width={['100%', '407px']}
+                bg="white"
+                paddingBottom={14}
+                marginTop={8}
+                marginBottom={8}
+                borderRadius="base"
+            >
+                {error && (
+                    <Alert status="error" marginBottom={8}>
+                        <AlertIcon color="red.500" boxSize={4} />
+                        <Text fontSize="sm" ml={3}>
+                            {error}
+                        </Text>
+                    </Alert>
+                )}
+                {!error && (
+                    <Stack justify="center" align="center" spacing={8} marginBottom={8}>
+                        <Spinner
+                            opacity={0.85}
+                            color="blue.600"
+                            animationDuration="0.8s"
+                            size="lg"
+                        />
+                        <Text align="center" fontSize="xl" fontWeight="semibold">
+                            <FormattedMessage
+                                id="ucp_continue.message.loading"
+                                defaultMessage="Preparing your checkout..."
+                            />
+                        </Text>
+                    </Stack>
+                )}
+            </Container>
+        </Box>
+    )
+}
+
+UcpContinue.getTemplateName = () => 'continue'
+
+export default UcpContinue

--- a/packages/template-retail-react-app/app/pages/continue/index.test.jsx
+++ b/packages/template-retail-react-app/app/pages/continue/index.test.jsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen, waitFor} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import UcpContinue from '@salesforce/retail-react-app/app/pages/continue/index'
+
+const mockMutateAsync = jest.fn()
+const mockGetTokenWhenReady = jest.fn()
+
+jest.mock('@salesforce/retail-react-app/app/hooks', () => {
+    const original = jest.requireActual('@salesforce/retail-react-app/app/hooks')
+    return {
+        ...original,
+        useSearchParams: jest.fn(() => [{}])
+    }
+})
+
+jest.mock('@salesforce/commerce-sdk-react', () => ({
+    ...jest.requireActual('@salesforce/commerce-sdk-react'),
+    useAuthHelper: jest.fn(() => ({mutateAsync: mockMutateAsync})),
+    AuthHelpers: {LoginGuestUser: 'loginGuestUser'},
+    useAccessToken: jest.fn(() => ({getTokenWhenReady: mockGetTokenWhenReady})),
+    useConfig: jest.fn(() => ({
+        proxy: 'http://localhost/mobify/proxy/api',
+        organizationId: 'f_ecom_test_001',
+        siteId: 'TestSite'
+    }))
+}))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const {useSearchParams} = require('@salesforce/retail-react-app/app/hooks')
+
+const VALID_PARAMS = {basketId: 'test-basket-id', usid: 'test-usid'}
+let mockFetch
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockMutateAsync.mockResolvedValue({access_token: 'mock-token'})
+    mockGetTokenWhenReady.mockResolvedValue('mock-token')
+    mockFetch = jest.fn().mockResolvedValue({ok: true, status: 200})
+    global.fetch = mockFetch
+    delete window.location
+    window.location = {replace: jest.fn()}
+})
+
+test('getTemplateName returns a string', () => {
+    expect(typeof UcpContinue.getTemplateName()).toBe('string')
+})
+
+test('renders loading state when valid params are provided', () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    renderWithProviders(<UcpContinue />)
+    expect(screen.getByText('Preparing your checkout...')).toBeInTheDocument()
+})
+
+test('shows error when required params are missing', async () => {
+    useSearchParams.mockReturnValue([{}])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByText(/Missing required parameters/)).toBeInTheDocument()
+    })
+})
+
+test('shows error when only basketId is missing', async () => {
+    useSearchParams.mockReturnValue([{usid: 'test-usid'}])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByText(/Missing required parameters/)).toBeInTheDocument()
+    })
+})
+
+test('shows error when only usid is missing', async () => {
+    useSearchParams.mockReturnValue([{basketId: 'test-basket-id'}])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByText(/Missing required parameters/)).toBeInTheDocument()
+    })
+})
+
+test('calls loginGuestUser on happy path', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledTimes(1)
+    })
+})
+
+test('calls promote endpoint with correct URL and params', async () => {
+    useSearchParams.mockReturnValue([{...VALID_PARAMS, merge: 'true'}])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('/baskets/test-basket-id/actions/promote'),
+            expect.objectContaining({method: 'POST'})
+        )
+    })
+    const fetchUrl = mockFetch.mock.calls[0][0]
+    expect(fetchUrl).toContain('siteId=TestSite')
+    expect(fetchUrl).toContain('merge=true')
+})
+
+test('forwards overrideExisting param to promote endpoint', async () => {
+    useSearchParams.mockReturnValue([{...VALID_PARAMS, overrideExisting: 'true'}])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+    })
+    const fetchUrl = mockFetch.mock.calls[0][0]
+    expect(fetchUrl).toContain('overrideExisting=true')
+})
+
+test('redirects to /checkout on success', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(window.location.replace).toHaveBeenCalledWith('/checkout')
+    })
+})
+
+test('shows error when SLAS login fails', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    mockMutateAsync.mockRejectedValueOnce(new Error('SLAS failure'))
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    expect(mockFetch).not.toHaveBeenCalled()
+})
+
+test('shows error when promote returns 404', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    mockFetch.mockResolvedValueOnce({ok: false, status: 404})
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByText(/basket was not found/)).toBeInTheDocument()
+    })
+})
+
+test('shows error when promote returns 409', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    mockFetch.mockResolvedValueOnce({ok: false, status: 409})
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByText(/basket already exists/)).toBeInTheDocument()
+    })
+})
+
+test('shows generic error when promote returns unexpected status', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    mockFetch.mockResolvedValueOnce({ok: false, status: 500})
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+})
+
+test('shows error when promote fetch throws network error', async () => {
+    useSearchParams.mockReturnValue([VALID_PARAMS])
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    renderWithProviders(<UcpContinue />)
+    await waitFor(() => {
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+})

--- a/packages/template-retail-react-app/app/routes.jsx
+++ b/packages/template-retail-react-app/app/routes.jsx
@@ -51,6 +51,7 @@ const Wishlist = loadable(() => import('./pages/account/wishlist'), {
     fallback
 })
 const PaymentProcessing = loadable(() => import('./pages/checkout/payment-processing'), {fallback})
+const UcpContinue = loadable(() => import('./pages/continue'), {fallback})
 const PageNotFound = loadable(() => import('./pages/page-not-found'))
 
 export const routes = [
@@ -136,6 +137,9 @@ export default () => {
     const socialRedirectURI = loginConfig?.social?.redirectURI
     const passwordlessLoginEnabled = loginConfig?.passwordless?.enabled
     const passwordlessLoginLandingPath = loginConfig?.passwordless?.landingPath
+    const ucpConfig = config?.app?.ucp
+    const ucpEnabled = ucpConfig?.enabled
+    const ucpContinuePath = ucpConfig?.continuePath
 
     // Add dynamic routes conditionally (only if features are enabled and paths are defined)
     const dynamicRoutes = [
@@ -154,6 +158,12 @@ export default () => {
             socialRedirectURI && {
                 path: socialRedirectURI,
                 component: SocialLoginRedirect,
+                exact: true
+            },
+        ucpEnabled &&
+            ucpContinuePath && {
+                path: ucpContinuePath,
+                component: UcpContinue,
                 exact: true
             }
     ].filter(Boolean)

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -4985,6 +4985,30 @@
       "value": "Edit Shipping Options"
     }
   ],
+  "ucp_continue.error.basket_not_found": [
+    {
+      "type": 0,
+      "value": "The basket was not found or is no longer available."
+    }
+  ],
+  "ucp_continue.error.conflict": [
+    {
+      "type": 0,
+      "value": "A basket already exists for this session. Please specify how to resolve the conflict."
+    }
+  ],
+  "ucp_continue.error.missing_params": [
+    {
+      "type": 0,
+      "value": "Missing required parameters. A valid basket ID and shopper ID are required."
+    }
+  ],
+  "ucp_continue.message.loading": [
+    {
+      "type": 0,
+      "value": "Preparing your checkout..."
+    }
+  ],
   "update_password_fields.button.forgot_password": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -4985,6 +4985,30 @@
       "value": "Edit Shipping Options"
     }
   ],
+  "ucp_continue.error.basket_not_found": [
+    {
+      "type": 0,
+      "value": "The basket was not found or is no longer available."
+    }
+  ],
+  "ucp_continue.error.conflict": [
+    {
+      "type": 0,
+      "value": "A basket already exists for this session. Please specify how to resolve the conflict."
+    }
+  ],
+  "ucp_continue.error.missing_params": [
+    {
+      "type": 0,
+      "value": "Missing required parameters. A valid basket ID and shopper ID are required."
+    }
+  ],
+  "ucp_continue.message.loading": [
+    {
+      "type": 0,
+      "value": "Preparing your checkout..."
+    }
+  ],
   "update_password_fields.button.forgot_password": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -10497,6 +10497,62 @@
       "value": "]"
     }
   ],
+  "ucp_continue.error.basket_not_found": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ŧħḗḗ ƀȧȧşķḗḗŧ ẇȧȧş ƞǿǿŧ ƒǿǿŭŭƞḓ ǿǿř īş ƞǿǿ ŀǿǿƞɠḗḗř ȧȧṽȧȧīŀȧȧƀŀḗḗ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "ucp_continue.error.conflict": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ȧ ƀȧȧşķḗḗŧ ȧȧŀřḗḗȧȧḓẏ ḗḗẋīşŧş ƒǿǿř ŧħīş şḗḗşşīǿǿƞ. Ƥŀḗḗȧȧşḗḗ şƥḗḗƈīƒẏ ħǿǿẇ ŧǿǿ řḗḗşǿǿŀṽḗḗ ŧħḗḗ ƈǿǿƞƒŀīƈŧ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "ucp_continue.error.missing_params": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḿīşşīƞɠ řḗḗɋŭŭīřḗḗḓ ƥȧȧřȧȧḿḗḗŧḗḗřş. Ȧ ṽȧȧŀīḓ ƀȧȧşķḗḗŧ ĪḒ ȧȧƞḓ şħǿǿƥƥḗḗř ĪḒ ȧȧřḗḗ řḗḗɋŭŭīřḗḗḓ."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "ucp_continue.message.loading": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƥřḗḗƥȧȧřīƞɠ ẏǿǿŭŭř ƈħḗḗƈķǿǿŭŭŧ..."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "update_password_fields.button.forgot_password": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/config/default.js
+++ b/packages/template-retail-react-app/config/default.js
@@ -118,6 +118,10 @@ module.exports = {
         },
         googleCloudAPI: {
             apiKey: process.env.GOOGLE_CLOUD_API_KEY
+        },
+        ucp: {
+            enabled: false,
+            continuePath: '/continue'
         }
     },
     externals: [],

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -2081,6 +2081,18 @@
   "toggle_card.action.editShippingOptions": {
     "defaultMessage": "Edit Shipping Options"
   },
+  "ucp_continue.error.basket_not_found": {
+    "defaultMessage": "The basket was not found or is no longer available."
+  },
+  "ucp_continue.error.conflict": {
+    "defaultMessage": "A basket already exists for this session. Please specify how to resolve the conflict."
+  },
+  "ucp_continue.error.missing_params": {
+    "defaultMessage": "Missing required parameters. A valid basket ID and shopper ID are required."
+  },
+  "ucp_continue.message.loading": {
+    "defaultMessage": "Preparing your checkout..."
+  },
   "update_password_fields.button.forgot_password": {
     "defaultMessage": "Forgot Password?"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -2081,6 +2081,18 @@
   "toggle_card.action.editShippingOptions": {
     "defaultMessage": "Edit Shipping Options"
   },
+  "ucp_continue.error.basket_not_found": {
+    "defaultMessage": "The basket was not found or is no longer available."
+  },
+  "ucp_continue.error.conflict": {
+    "defaultMessage": "A basket already exists for this session. Please specify how to resolve the conflict."
+  },
+  "ucp_continue.error.missing_params": {
+    "defaultMessage": "Missing required parameters. A valid basket ID and shopper ID are required."
+  },
+  "ucp_continue.message.loading": {
+    "defaultMessage": "Preparing your checkout..."
+  },
   "update_password_fields.button.forgot_password": {
     "defaultMessage": "Forgot Password?"
   },


### PR DESCRIPTION
## Summary
- Adds a new `/continue` route to handle UCP checkout escalation flow
- Restores guest session via SLAS using the provided `usid`, promotes the temporary basket via SCAPI `POST /baskets/{basketId}/actions/promote`, and redirects to `/checkout`
- Route is gated behind `ucp.enabled` config flag (defaults to `false`)

## GUS
W-22299570

## Changes
- `config/default.js` — new `ucp` config section with `enabled` and `continuePath`
- `routes.jsx` — conditional dynamic route registration
- `pages/continue/index.jsx` — new page component (loading spinner, error handling, auth + promote + redirect)
- `pages/continue/index.test.jsx` — 14 unit tests (happy path, error scenarios, param forwarding)
- Translation files updated with new i18n messages

## Note
The loading spinner, error messages, and display text are placeholder implementations — they are subject to product/UX input. I started with something reasonable but expect these to evolve.

## Test plan
- [x] Enable `ucp.enabled: true` in config
- [x] Navigate to `/continue?basketId={uuid}&usid={usid}` with a valid temporary basket
- [x] Verify redirect to `/checkout` with populated cart
- [x] Verify missing params shows error
- [x] Verify invalid basketId shows 404 error
- [x] Verify conflict (existing basket, no merge/override) shows 409 error