### PR TITLE
@W-21984114@ Apply configurable domain to cookies created by slas proxy

### DIFF
--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.19.0-dev (May 07, 2026)
+- HttpOnly session cookies now honor `commerceAPI.cookieDomain` from the runtime config: when set, the SLAS proxy attaches `Domain=` to every Set-Cookie header it emits and also expires the host-scoped versions for clean migration. Mirrors the existing client-side behavior in commerce-sdk-react.
 - HttpOnly session cookies: SLAS proxy now mirrors `customer_id`, `customer_type`, `enc_user_id`, `id_token` (non-HttpOnly) and `idp_refresh_token` (HttpOnly) as siteId-suffixed cookies; replaces `cc-nx-exists` with `cc-nx-expires` (absolute epoch seconds, mirroring `cc-at-expires`); strips `idp_refresh_token` from the response body and upstream proxy requests [#3830](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3830)
 
 ## v3.18.0 (May 07, 2026)

--- a/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js
@@ -238,7 +238,7 @@ const handleHttpOnlyCookiesOnProxyRes = (
 
     if (req.path?.match(SLAS_LOGOUT_ENDPOINT)) {
         try {
-            expireHttpOnlySessionCookies(req, res)
+            expireHttpOnlySessionCookies(req, res, options)
         } catch (error) {
             logger.warn('Error expiring HttpOnly session cookies on logout', {
                 namespace: logNamespace,

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
@@ -20,6 +20,66 @@ import logger from '../../utils/logger-instance'
 const DEFAULT_SLAS_REFRESH_TOKEN_GUEST_TTL = 30 * 24 * 60 * 60
 const DEFAULT_SLAS_REFRESH_TOKEN_REGISTERED_TTL = 90 * 24 * 60 * 60
 
+// Matches the same regex used client-side in commerce-sdk-react CookieStorage so
+// support tickets surface the same warning text on both sides.
+const INVALID_COOKIE_DOMAIN_PATTERN = /[*,;=\s]/
+
+/**
+ * Reads `commerceAPI.cookieDomain` from the runtime options. Returns the value
+ * when present and well-formed, or `undefined` (with a warning) when it
+ * contains characters the browser will reject. Mirrors the validation in
+ * commerce-sdk-react/src/auth/storage/cookie.ts.
+ * @private
+ */
+function getValidatedCookieDomain(options) {
+    const cookieDomain = options?.mobify?.app?.commerceAPI?.cookieDomain
+    if (!cookieDomain) return undefined
+    if (INVALID_COOKIE_DOMAIN_PATTERN.test(cookieDomain)) {
+        logger.warn(
+            `Invalid cookieDomain "${cookieDomain}". ` +
+                'Cookie domains must not contain wildcards or special characters. ' +
+                'Example: ".example.com"'
+        )
+        return undefined
+    }
+    return cookieDomain
+}
+
+/**
+ * Returns a function that appends a Set-Cookie header to `res`. When
+ * `cookieDomain` is configured, every write also emits a second expiring
+ * Set-Cookie for the same name without a Domain attribute, expiring any
+ * pre-existing host-scoped cookie. This mirrors
+ * `CookieStorage.removeHostAndDomainCookie` in commerce-sdk-react and prevents
+ * stale duplicates when a merchant first enables the cookieDomain config.
+ * @private
+ */
+function makeAppendCookie(res, cookieDomain) {
+    return ({name, value, expires, attributes}) => {
+        res.append(
+            SET_COOKIE,
+            cookieAsString({
+                name,
+                value,
+                expires,
+                ...attributes,
+                ...(cookieDomain && {domain: cookieDomain})
+            })
+        )
+        if (cookieDomain) {
+            res.append(
+                SET_COOKIE,
+                cookieAsString({
+                    name,
+                    value: '',
+                    expires: new Date(0),
+                    ...attributes
+                })
+            )
+        }
+    }
+}
+
 /**
  * Computes refresh token cookie TTL in seconds. Same logic as Auth.getRefreshTokenCookieTTLValue in commerce-sdk-react:
  * 1. Override value (if valid), 2. SLAS response value, 3. Default (guest or registered).
@@ -91,6 +151,8 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
     }
 
     const site = siteId
+    const cookieDomain = getValidatedCookieDomain(options)
+    const appendCookie = makeAppendCookie(res, cookieDomain)
     const {
         accessToken,
         accessTokenExpires,
@@ -115,77 +177,59 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
         isGuest = tokenClaims.isGuest
 
         // Access token (HttpOnly)
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(accessToken, site),
-                value: parsed.access_token,
-                expires: tokenClaims.accessExpires,
-                ...accessToken.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(accessToken, site),
+            value: parsed.access_token,
+            expires: tokenClaims.accessExpires,
+            attributes: accessToken.attributes
+        })
 
         // Expiry timestamp from JWT exp claim (non-HttpOnly so client can check expiry)
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(accessTokenExpires, site),
-                value: String(tokenClaims.expiresAt),
-                expires: tokenClaims.accessExpires,
-                ...accessTokenExpires.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(accessTokenExpires, site),
+            value: String(tokenClaims.expiresAt),
+            expires: tokenClaims.accessExpires,
+            attributes: accessTokenExpires.attributes
+        })
 
         // Do-not-track flag from JWT (non-HttpOnly so client can read it)
         if (tokenClaims.dnt !== undefined) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(accessTokenDnt, site),
-                    value: String(tokenClaims.dnt),
-                    expires: tokenClaims.accessExpires,
-                    ...accessTokenDnt.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(accessTokenDnt, site),
+                value: String(tokenClaims.dnt),
+                expires: tokenClaims.accessExpires,
+                attributes: accessTokenDnt.attributes
+            })
         }
 
         // uido: IDP origin (e.g. "slas", "ecom"); non-HttpOnly so client can read for useCustomerType/isExternal
         if (tokenClaims.uido) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(uido, site),
-                    value: tokenClaims.uido,
-                    expires: tokenClaims.accessExpires,
-                    ...uido.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(uido, site),
+                value: tokenClaims.uido,
+                expires: tokenClaims.accessExpires,
+                attributes: uido.attributes
+            })
         }
 
         // IDP access token (HttpOnly)
         if (parsed.idp_access_token) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(idpAccessToken, site),
-                    value: parsed.idp_access_token,
-                    expires: tokenClaims.accessExpires,
-                    ...idpAccessToken.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(idpAccessToken, site),
+                value: parsed.idp_access_token,
+                expires: tokenClaims.accessExpires,
+                attributes: idpAccessToken.attributes
+            })
         }
 
         // id_token (non-HttpOnly): expiry tied to access token JWT exp.
         if (parsed.id_token) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(idToken, site),
-                    value: parsed.id_token,
-                    expires: tokenClaims.accessExpires,
-                    ...idToken.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(idToken, site),
+                value: parsed.id_token,
+                expires: tokenClaims.accessExpires,
+                attributes: idToken.attributes
+            })
         }
     }
 
@@ -200,29 +244,23 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
         const refreshExpires = new Date(Date.now() + refreshTTL * 1000)
         const refreshConfig = isGuest ? refreshTokenGuest : refreshTokenRegistered
 
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(refreshConfig, site),
-                value: parsed.refresh_token,
-                expires: refreshExpires,
-                ...refreshConfig.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(refreshConfig, site),
+            value: parsed.refresh_token,
+            expires: refreshExpires,
+            attributes: refreshConfig.attributes
+        })
 
         // Delete the opposite refresh token cookie to mirror client-side behavior:
         // Login (guest → registered): delete guest cookie cc-nx-g
         // Logout (registered → guest): delete registered cookie cc-nx
         const staleRefreshConfig = isGuest ? refreshTokenRegistered : refreshTokenGuest
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(staleRefreshConfig, site),
-                value: '',
-                expires: new Date(0),
-                ...staleRefreshConfig.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(staleRefreshConfig, site),
+            value: '',
+            expires: new Date(0),
+            attributes: staleRefreshConfig.attributes
+        })
 
         // Hybrid SFRA + PWA: mirror SLAS metadata as siteId-suffixed cookies so SFRA
         // can read the same session state. Expiry aligned with refresh token TTL.
@@ -233,79 +271,61 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
         // refresh-with-rotation), so in practice this is the same condition. If a
         // future flow returns metadata without a refresh_token, the existing cookies
         // remain valid until they expire on their own schedule.
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(customerType, site),
-                value: isGuest ? 'guest' : 'registered',
-                expires: refreshExpires,
-                ...customerType.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(customerType, site),
+            value: isGuest ? 'guest' : 'registered',
+            expires: refreshExpires,
+            attributes: customerType.attributes
+        })
 
         if (parsed.customer_id) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(customerId, site),
-                    value: parsed.customer_id,
-                    expires: refreshExpires,
-                    ...customerId.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(customerId, site),
+                value: parsed.customer_id,
+                expires: refreshExpires,
+                attributes: customerId.attributes
+            })
         }
 
         if (parsed.enc_user_id) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(encUserId, site),
-                    value: parsed.enc_user_id,
-                    expires: refreshExpires,
-                    ...encUserId.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(encUserId, site),
+                value: parsed.enc_user_id,
+                expires: refreshExpires,
+                attributes: encUserId.attributes
+            })
         }
 
         // usid: SLAS session id, non-HttpOnly so client/SFRA/Einstein can read
         // it. Aligned to refresh-token TTL to persist across access-token
         // refreshes within a single shopper session.
         if (parsed.usid) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(usid, site),
-                    value: parsed.usid,
-                    expires: refreshExpires,
-                    ...usid.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(usid, site),
+                value: parsed.usid,
+                expires: refreshExpires,
+                attributes: usid.attributes
+            })
         }
 
         // cc-nx-expires: absolute epoch (seconds) when the refresh token cookie
         // expires. Mirrors cc-at-expires for the access token. Cookie expiry
         // attribute aligned to the same instant.
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(refreshTokenExpires, site),
-                value: String(Math.floor(refreshExpires.getTime() / 1000)),
-                expires: refreshExpires,
-                ...refreshTokenExpires.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(refreshTokenExpires, site),
+            value: String(Math.floor(refreshExpires.getTime() / 1000)),
+            expires: refreshExpires,
+            attributes: refreshTokenExpires.attributes
+        })
 
         // idp_refresh_token (HttpOnly): refresh-TTL-aligned, only when present.
         if (parsed.idp_refresh_token) {
-            res.append(
-                SET_COOKIE,
-                cookieAsString({
-                    name: getCookieName(idpRefreshToken, site),
-                    value: parsed.idp_refresh_token,
-                    expires: refreshExpires,
-                    ...idpRefreshToken.attributes
-                })
-            )
+            appendCookie({
+                name: getCookieName(idpRefreshToken, site),
+                value: parsed.idp_refresh_token,
+                expires: refreshExpires,
+                attributes: idpRefreshToken.attributes
+            })
         }
     }
 
@@ -322,10 +342,12 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
 
 /**
  * When a SLAS logout response is received, expire all HttpOnly session cookies so that
- * stale tokens are not sent with subsequent requests.
+ * stale tokens are not sent with subsequent requests. When `cookieDomain` is configured,
+ * also expires the host-scoped versions so cookies set before the flag was enabled are
+ * cleaned up too.
  * @private
  */
-export function expireHttpOnlySessionCookies(req, res) {
+export function expireHttpOnlySessionCookies(req, res, options) {
     const siteId = getSiteId(req)
     if (!siteId) {
         throw new Error(
@@ -336,16 +358,15 @@ export function expireHttpOnlySessionCookies(req, res) {
 
     const site = siteId
     const expired = new Date(0)
+    const cookieDomain = getValidatedCookieDomain(options)
+    const appendCookie = makeAppendCookie(res, cookieDomain)
 
     for (const config of getAllCookieConfigs()) {
-        res.append(
-            SET_COOKIE,
-            cookieAsString({
-                name: getCookieName(config, site),
-                value: '',
-                expires: expired,
-                ...config.attributes
-            })
-        )
+        appendCookie({
+            name: getCookieName(config, site),
+            value: '',
+            expires: expired,
+            attributes: config.attributes
+        })
     }
 }

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
@@ -51,6 +51,14 @@ function parseCookie(cookieStr) {
     return parseSetCookie(cookieStr)[0]
 }
 
+function makeOptionsWithCookieDomain(cookieDomain) {
+    return {mobify: {app: {commerceAPI: {cookieDomain}}}}
+}
+
+function findCookies(cookies, name) {
+    return cookies.filter((c) => c.startsWith(`${name}=`)).map(parseCookie)
+}
+
 describe('getRefreshTokenCookieTTL', () => {
     const GUEST_DEFAULT = 30 * 24 * 60 * 60
     const REGISTERED_DEFAULT = 90 * 24 * 60 * 60
@@ -507,5 +515,140 @@ describe('expireHttpOnlySessionCookies', () => {
         )
         expect(custTypeCookie.httpOnly).toBeUndefined()
         expect(custTypeCookie.secure).toBe(true)
+    })
+})
+
+describe('cookieDomain support', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('setHttpOnlySessionCookies omits Domain attribute when cookieDomain is unset', () => {
+        const res = makeRes()
+        const accessToken = makeJWT({iat: 1000, exp: 2800, isb: 'uido:ecom::upn:Guest'})
+        const buf = makeResponseBuffer({access_token: accessToken, refresh_token: 'r'})
+        setHttpOnlySessionCookies(buf, {}, makeReq(), res, {})
+
+        for (const cookieStr of res.cookies) {
+            expect(cookieStr).not.toMatch(/Domain=/i)
+        }
+    })
+
+    test('setHttpOnlySessionCookies attaches Domain and emits host-scoped cleanup when cookieDomain is set', () => {
+        const res = makeRes()
+        const accessToken = makeJWT({iat: 1000, exp: 2800, isb: 'uido:ecom::upn:Guest', dnt: '0'})
+        const buf = makeResponseBuffer({
+            access_token: accessToken,
+            refresh_token: 'refresh-value',
+            customer_id: 'cust1',
+            usid: 'usid-1'
+        })
+        setHttpOnlySessionCookies(
+            buf,
+            {},
+            makeReq(),
+            res,
+            makeOptionsWithCookieDomain('.example.com')
+        )
+
+        // Every cookie name appears twice: domain-scoped write + host-scoped cleanup.
+        const writtenNames = [
+            'cc-at_testsite',
+            'cc-at-expires_testsite',
+            'cc-at-dnt_testsite',
+            'uido_testsite',
+            'cc-nx-g_testsite',
+            'cc-nx_testsite', // opposite refresh — also expired
+            'customer_type_testsite',
+            'customer_id_testsite',
+            'usid_testsite',
+            'cc-nx-expires_testsite'
+        ]
+        for (const name of writtenNames) {
+            const matches = findCookies(res.cookies, name)
+            expect(matches).toHaveLength(2)
+            const [withDomain, hostScoped] = matches[0].domain ? matches : [matches[1], matches[0]]
+            expect(withDomain.domain).toBe('.example.com')
+            expect(hostScoped.domain).toBeUndefined()
+            // Host-scoped cleanup is always an expiry of any pre-existing cookie.
+            expect(hostScoped.value).toBe('')
+            expect(hostScoped.expires).toEqual(new Date(0))
+        }
+
+        // Sanity: the primary cc-at write still carries the access token value with Domain set.
+        const atCookies = findCookies(res.cookies, 'cc-at_testsite')
+        const atActive = atCookies.find((c) => c.value === accessToken)
+        expect(atActive).toBeDefined()
+        expect(atActive.domain).toBe('.example.com')
+        expect(atActive.httpOnly).toBe(true)
+    })
+
+    test('setHttpOnlySessionCookies warns and ignores invalid cookieDomain', () => {
+        const res = makeRes()
+        const accessToken = makeJWT({iat: 1000, exp: 2800, isb: 'uido:ecom::upn:Guest'})
+        const buf = makeResponseBuffer({access_token: accessToken, refresh_token: 'r'})
+        setHttpOnlySessionCookies(
+            buf,
+            {},
+            makeReq(),
+            res,
+            makeOptionsWithCookieDomain('*.example.com')
+        )
+
+        expect(logger.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Invalid cookieDomain "*.example.com"')
+        )
+        for (const cookieStr of res.cookies) {
+            expect(cookieStr).not.toMatch(/Domain=/i)
+        }
+    })
+
+    test('expireHttpOnlySessionCookies omits Domain attribute when cookieDomain is unset', () => {
+        const res = makeRes()
+        expireHttpOnlySessionCookies(makeReq(), res, {})
+
+        for (const cookieStr of res.cookies) {
+            expect(cookieStr).not.toMatch(/Domain=/i)
+        }
+    })
+
+    test('expireHttpOnlySessionCookies expires both domain-scoped and host-scoped versions', () => {
+        const res = makeRes()
+        expireHttpOnlySessionCookies(
+            makeReq(),
+            res,
+            makeOptionsWithCookieDomain('.example.com')
+        )
+
+        const allCookieNames = [
+            'cc-at_testsite',
+            'cc-at-expires_testsite',
+            'cc-at-dnt_testsite',
+            'uido_testsite',
+            'idp_access_token_testsite',
+            'cc-nx-g_testsite',
+            'cc-nx_testsite',
+            'customer_id_testsite',
+            'enc_user_id_testsite',
+            'customer_type_testsite',
+            'usid_testsite',
+            'cc-nx-expires_testsite',
+            'id_token_testsite',
+            'idp_refresh_token_testsite'
+        ]
+        expect(res.cookies).toHaveLength(allCookieNames.length * 2)
+
+        for (const name of allCookieNames) {
+            const matches = findCookies(res.cookies, name)
+            expect(matches).toHaveLength(2)
+            const domainScoped = matches.find((c) => c.domain === '.example.com')
+            const hostScoped = matches.find((c) => c.domain === undefined)
+            expect(domainScoped).toBeDefined()
+            expect(hostScoped).toBeDefined()
+            expect(domainScoped.value).toBe('')
+            expect(hostScoped.value).toBe('')
+            expect(domainScoped.expires).toEqual(new Date(0))
+            expect(hostScoped.expires).toEqual(new Date(0))
+        }
     })
 })

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
@@ -614,11 +614,7 @@ describe('cookieDomain support', () => {
 
     test('expireHttpOnlySessionCookies expires both domain-scoped and host-scoped versions', () => {
         const res = makeRes()
-        expireHttpOnlySessionCookies(
-            makeReq(),
-            res,
-            makeOptionsWithCookieDomain('.example.com')
-        )
+        expireHttpOnlySessionCookies(makeReq(), res, makeOptionsWithCookieDomain('.example.com'))
 
         const allCookieNames = [
             'cc-at_testsite',


### PR DESCRIPTION
## Summary                                 
                                                                                                                
  Extends the `commerceAPI.cookieDomain` config (introduced in #3782) so it also applies to the HttpOnly session cookies set server-side by the SLAS proxy. Without this change, enabling `MRT_ENABLE_HTTPONLY_SESSION_COOKIES` on a project that uses `cookieDomain` for cross-subdomain SSO breaks the SSO flow because `Set-Cookie` headers from the proxy default to host-scoped.                     
                                                                                                                                                                                                                  
  - The SLAS proxy now reads `cookieDomain` from `options.mobify.app.commerceAPI.cookieDomain`, validates it with the same regex used client-side in `commerce-sdk-react`, and attaches `Domain=` to every        
  `Set-Cookie` it emits when set.                                                                                                                                                                                 
  - Mirrors the host-vs-domain cleanup pattern from `CookieStorage.removeHostAndDomainCookie`: every write also emits an expiring host-scoped `Set-Cookie` so merchants who turn on `cookieDomain` mid-flight     
  don't end up with duplicate cookies.                                                                                                                                                                            
  - `expireHttpOnlySessionCookies` (logout path) now expires both the domain-scoped and host-scoped versions.
                                                                                                                                                                                                                  
  ## MRT impact                                                                                                                                                                                                   
                                                                                                                                                                                                                  
  No MRT changes are needed. Verified by reading `portal-app` and `runtime-admin-ui`:                                                                                                                             
                                                            
  - MRT does not strip or rewrite `Set-Cookie` `Domain=` attributes on the SSR/proxy data path.                                                                                                                   
  - The only cookie-rewriting middleware (`cloudfront-proxy-origin-rewriter.js`) operates on `/mobify/proxy/api/...` SCAPI requests via a control-plane allowlist — not on the `/mobify/slas/{private,public}`
  paths used here.                                                                                                                                                                                                
  - Custom domains attach via the existing CNAME/Certificate flow, so a merchant pointing a CNAME at MRT will Just Work.
                                                                                                                                                                                                                  
  As with the existing client-side feature, the browser silently drops `Domain=.example.com` when the request hostname doesn't fall under that domain (e.g., on the default `*.mobify-storefront.com` host) — this
   only takes effect on a custom domain.                                                                                                                                                                          
                                                                                                                                                                                                                  
  ## Changes                                                

  - **`packages/pwa-kit-runtime/src/ssr/server/process-token-response.js`** — Added `getValidatedCookieDomain` (regex mirrors `commerce-sdk-react/src/auth/storage/cookie.ts`, warns on invalid input). Added a   
  `makeAppendCookie` factory that writes the domain-scoped cookie and, when `cookieDomain` is set, also writes an expiring host-scoped cleanup cookie. All ~14 cookie writes in `setHttpOnlySessionCookies` and
  the loop in `expireHttpOnlySessionCookies` now flow through this helper.                                                                                                                                        
  - **`packages/pwa-kit-runtime/src/ssr/server/build-remote-server.js`** — Forward `options` to `expireHttpOnlySessionCookies` from `handleHttpOnlyCookiesOnProxyRes` (matches the existing
  `setHttpOnlySessionCookies` call).                                                                                                                                                                              
  - **`packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js`** — Five new tests under a `cookieDomain support` describe block.
  - **`packages/pwa-kit-runtime/CHANGELOG.md`** — Entry under `v3.19.0-dev`.                                                                                                                                      
                                                                                                                                                                                                                  
  ## Test plan
                                                                                                                                                                                                                  
  - [x] `npm test` in `packages/pwa-kit-runtime`            
    - `process-token-response.test.js`: 29/29 pass, including 5 new `cookieDomain` cases. File coverage at 100% statement / 100% line.
    - `express.test.js`: 109/109 pass when run in isolation.                                                                                                                                                      
 ~- [ ] **Local smoke (cookieDomain set)** — set `cookieDomain: '.localhost'` in `config/default.js`, run with `MRT_ENABLE_HTTPONLY_SESSION_COOKIES=true npm start`, log in, and confirm in DevTools that
  `cc-at_<siteId>`, `cc-nx-g_<siteId>`, `usid_<siteId>`, etc. all show Domain `.localhost`.~                                                                                                                       
  - [ ] **Logout** — hit `/oauth2/logout` and confirm the domain-scoped cookies are removed.
  - [ ] **Migration toggle** — with HttpOnly enabled but `cookieDomain` unset, log in (host-scoped cookies created). Then add `cookieDomain`, restart, log in again. Confirm host-scoped duplicates are expired   
  and only domain-scoped cookies remain.                                                                                                                                                                          
  - [ ] **Invalid domain** — set `cookieDomain: '*.example.com'`, log in. Confirm a `logger.warn` line appears and `Set-Cookie` headers carry no `Domain=` attribute (graceful fallback).
  - [ ] **Regression** — with `cookieDomain` unset, confirm `Set-Cookie` headers carry no `Domain=` attribute (default behavior unchanged).                                                                       
  - [ ] **Custom-domain end-to-end** — deploy to an MRT environment with a CNAME-attached custom domain matching `cookieDomain`. Verify the cookies set by the proxy persist across subdomains as expected.


The changes in this PR have been deployed to [this environment](https://scaffold-pwa-vincent-test-env-1.sfdc-8tgtt5-ecom1.exp-delivery.com/). The cookie domain has been set to `.sfdc-8tgtt5-ecom1.exp-delivery.com` and http-only cookies are enabled (so you will see properties stored in cookie store rather than local storage)