### PR TITLE
@W-22602804@ Remove idp_access_token from request sent to SLAS

### DIFF
--- a/e2e/scripts/utils.js
+++ b/e2e/scripts/utils.js
@@ -108,21 +108,6 @@ function sanitizeHtml(html) {
 async function runAccessibilityTest(page, snapshotName, options = {}) {
     const {exclude = []} = options
 
-    // Wait for in-progress CSS animations/transitions to settle before scanning.
-    // axe-core's color-contrast rule composites translucent ancestor layers to
-    // compute an effective background; if a portaled overlay (e.g. the Chakra
-    // toast manager or the DNT modal portal) is mid-fade when axe samples,
-    // the resulting hex drifts run-to-run (#f3f3f3 / #f4f4f4 / #f5f5f5) and
-    // the snapshot flakes. Cap the wait so a stuck animation can't hang the
-    // suite — better to scan a not-quite-settled page than to time out.
-    await page
-        .waitForFunction(
-            () => !document.getAnimations().some((a) => a.playState === 'running'),
-            null,
-            {timeout: 5000}
-        )
-        .catch(() => {})
-
     // Create AxeBuilder instance
     let axeBuilder = new AxeBuilder({page})
 

--- a/e2e/scripts/utils.js
+++ b/e2e/scripts/utils.js
@@ -108,6 +108,21 @@ function sanitizeHtml(html) {
 async function runAccessibilityTest(page, snapshotName, options = {}) {
     const {exclude = []} = options
 
+    // Wait for in-progress CSS animations/transitions to settle before scanning.
+    // axe-core's color-contrast rule composites translucent ancestor layers to
+    // compute an effective background; if a portaled overlay (e.g. the Chakra
+    // toast manager or the DNT modal portal) is mid-fade when axe samples,
+    // the resulting hex drifts run-to-run (#f3f3f3 / #f4f4f4 / #f5f5f5) and
+    // the snapshot flakes. Cap the wait so a stuck animation can't hang the
+    // suite — better to scan a not-quite-settled page than to time out.
+    await page
+        .waitForFunction(
+            () => !document.getAnimations().some((a) => a.playState === 'running'),
+            null,
+            {timeout: 5000}
+        )
+        .catch(() => {})
+
     // Create AxeBuilder instance
     let axeBuilder = new AxeBuilder({page})
 

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v3.19.0-dev (May 07, 2026)
 - HttpOnly session cookies: SLAS proxy now mirrors `customer_id`, `customer_type`, `enc_user_id`, `id_token` (non-HttpOnly) and `idp_refresh_token` (HttpOnly) as siteId-suffixed cookies; replaces `cc-nx-exists` with `cc-nx-expires` (absolute epoch seconds, mirroring `cc-at-expires`); strips `idp_refresh_token` from the response body and upstream proxy requests [#3830](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3830)
+- HttpOnly session cookies: also strip `idp_access_token_{siteId}` from upstream proxy requests to SLAS
 
 ## v3.18.0 (May 07, 2026)
 - Add option to keep original User Agent header in proxy requests [#3798](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3798)

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
@@ -86,6 +86,7 @@ export const getCookieNamesToStripFromProxy = (siteId) => [
     getCookieName(SESSION_COOKIE_CONFIG.accessToken, siteId),
     getCookieName(SESSION_COOKIE_CONFIG.refreshTokenGuest, siteId),
     getCookieName(SESSION_COOKIE_CONFIG.refreshTokenRegistered, siteId),
+    getCookieName(SESSION_COOKIE_CONFIG.idpAccessToken, siteId),
     getCookieName(SESSION_COOKIE_CONFIG.idpRefreshToken, siteId),
     DWSID_COOKIE_NAME
 ]

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
@@ -86,12 +86,13 @@ describe('getCookieName', () => {
 })
 
 describe('getCookieNamesToStripFromProxy', () => {
-    it('returns access token, both refresh tokens, idp refresh token, and dwsid', () => {
+    it('returns access token, both refresh tokens, idp access token, idp refresh token, and dwsid', () => {
         const names = getCookieNamesToStripFromProxy('RefArch')
         expect(names).toEqual([
             'cc-at_RefArch',
             'cc-nx-g_RefArch',
             'cc-nx_RefArch',
+            'idp_access_token_RefArch',
             'idp_refresh_token_RefArch',
             'dwsid'
         ])

--- a/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
+++ b/packages/pwa-kit-runtime/src/utils/ssr-server/configure-proxy.js
@@ -129,7 +129,7 @@ export const setScapiAuthRequestHeaders = ({
  * (cloudfront-proxy-origin-rewriter.js), using exact cookie names based on siteId
  * rather than prefix matching.
  *
- * Removes: cc-at_{siteId}, cc-nx-g_{siteId}, cc-nx_{siteId}, idp_refresh_token_{siteId}, and dwsid.
+ * Removes: cc-at_{siteId}, cc-nx-g_{siteId}, cc-nx_{siteId}, idp_access_token_{siteId}, idp_refresh_token_{siteId}, and dwsid.
  * Any remaining cookies are preserved and forwarded.
  *
  * @private


### PR DESCRIPTION
We remove a number of cookies in the SLAS proxy before the request is sent to SLAS after we extract the necessary data (ie. we send the access token via the Authorization header rather than the cc-at cookie).

This PR adds the `idp_access_token` to the list of cookies we remove before the request is sent to SLAS.
