### PR TITLE
fix: use execSync in translation compile scripts to fix race condition

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v10.0.1 (May 21, 2026)
+- [Bugfix] Fix race condition in translation compile scripts where formatjs output was not awaited before postinstall completed [#3844](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3844)
+
 ## v10.0.0 (May 07, 2026)
 - Update MRT Data Store configuration comments and README to use the unprefixed environment variable names actually consumed by `@salesforce/mrt-utilities` (`MRT_DATA_STORE_DEFAULTS`, `MRT_DATA_STORE_WARN_ON_MISSING`). [#3811](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3811) [#3823](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3823)
 - Add opt-in `app.mrtDataStore.enabled` to `config/default.js` (default `false`). Set to `true` or use `PWAKIT_MRT_DATA_STORE_ENABLED=true` to resolve MRT Data Store custom preferences during SSR. Local defaults without DynamoDB: `MRT_DATA_STORE_DEFAULTS` (see `config/default.js` comments). [#3787](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3787)

--- a/packages/template-retail-react-app/scripts/translations/compile-folder.js
+++ b/packages/template-retail-react-app/scripts/translations/compile-folder.js
@@ -6,7 +6,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const {exec} = require('child_process')
+const {execSync} = require('child_process')
 const {getOutputFolder} = require('./utils')
 
 const main = () => {
@@ -15,12 +15,7 @@ const main = () => {
     const command = `formatjs compile-folder --ast ${inputFolder} ${outputFolder}`
 
     console.log('Compiling translations into the folder:', outputFolder)
-    exec(command, (err) => {
-        if (err) {
-            console.error(err)
-            return
-        }
-    })
+    execSync(command, {stdio: 'inherit'})
 }
 
 main()

--- a/packages/template-retail-react-app/scripts/translations/compile-pseudo.js
+++ b/packages/template-retail-react-app/scripts/translations/compile-pseudo.js
@@ -6,7 +6,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 /* eslint @typescript-eslint/no-var-requires: "off" */
-const {exec} = require('child_process')
+const {execSync} = require('child_process')
 const {getOutputFolder} = require('./utils')
 
 const main = () => {
@@ -16,12 +16,7 @@ const main = () => {
     const command = `formatjs compile --ast ${inputFile} --out-file ${outputFile} --pseudo-locale ${locale}`
 
     console.log('Compiling pseudo translation into the file:', outputFile)
-    exec(command, (err) => {
-        if (err) {
-            console.error(err)
-            return
-        }
-    })
+    execSync(command, {stdio: 'inherit'})
 }
 
 main()


### PR DESCRIPTION
## Summary
- Switch `compile-folder.js` and `compile-pseudo.js` from async `exec` to `execSync` so postinstall blocks until formatjs finishes writing translation files

## Problem
This is an alternative fix for the issue described in #3842.

`compile-folder.js` and `compile-pseudo.js` were spawning `formatjs` via `exec` and returning before the callback fired. In the generated test project, npm postinstall finishes while formatjs is still writing `app/static/translations/compiled/en-XA.json`, leaving the file empty when tests run and breaking `locale.test.js > loading the pseudo locale`.

## Fix
Switch to `execSync` so the postinstall blocks until formatjs has finished writing compiled translation files. This addresses the root cause (race condition) rather than pinning the `@formatjs/cli` version.

## Related
- Alternative approach to #3842

## Test plan
- [ ] CI `generated (retail-react-app-test-project)` passes
- [ ] Translation compilation works correctly during postinstall