### PR TITLE
chore: bump retail-react-app to 10.0.1 for release

### DIFF
--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/retail-react-app",
-  "version": "10.0.0",
+  "version": "10.0.1",
   "license": "See license in LICENSE",
   "author": "cc-pwa-kit@salesforce.com",
   "ccExtensibility": {


### PR DESCRIPTION
## Summary
- Bumps `@salesforce/retail-react-app` version from `10.0.0` to `10.0.1`

## Context
This re-applies the version bump that was temporarily reverted in #3847 to unblock the SDK release. Now that the SDK packages (`pwa-kit-runtime`, `pwa-kit-dev`, `pwa-kit-react-sdk`, `commerce-sdk-react`, `pwa-kit-create-app`) are published on npm, we can safely release `retail-react-app@10.0.1`.

## Test plan
- [ ] CI passes
- [ ] Merge and run release workflow — lerna publishes `retail-react-app@10.0.1` successfully since its deps are now available on npm