### PR TITLE
@W-22699952@ HttpOnly id_token

### DIFF
--- a/packages/commerce-sdk-react/src/auth/index.ts
+++ b/packages/commerce-sdk-react/src/auth/index.ts
@@ -282,10 +282,10 @@ export const DEFAULT_SLAS_REFRESH_TOKEN_GUEST_TTL = 30 * 24 * 60 * 60
  * these keys go to the cookie store instead of localStorage, with the cookie
  * as the single source of truth.
  *
- * Some entries here (`idp_access_token`, `idp_refresh_token`) are HttpOnly
- * and unreadable from JavaScript — they're included for routing symmetry so
- * the storage type is consistent in httpOnly mode; reads of those keys
- * return '' from the cookie store either way.
+ * Some entries here (`id_token`, `idp_access_token`, `idp_refresh_token`) are
+ * HttpOnly and unreadable from JavaScript — they're included for routing
+ * symmetry so the storage type is consistent in httpOnly mode; reads of those
+ * keys return '' from the cookie store either way.
  *
  * `expires_in` is intentionally absent: the access token expiry is already
  * covered by the `cc-at-expires` cookie, so we derive it from there in the

--- a/packages/pwa-kit-runtime/CHANGELOG.md
+++ b/packages/pwa-kit-runtime/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.19.0-dev
+- HttpOnly session cookies: `id_token` is now set as an HttpOnly cookie and stripped from the SLAS response body so it's only readable via the cookie.
 - HttpOnly session cookies now honor `commerceAPI.cookieDomain` from the runtime config: when set, the SLAS proxy attaches `Domain=` to every Set-Cookie header it emits and also expires the host-scoped versions for clean migration. Mirrors the existing client-side behavior in commerce-sdk-react.
 - HttpOnly session cookies: SLAS proxy now mirrors `customer_id`, `customer_type`, `enc_user_id`, `id_token` (non-HttpOnly) and `idp_refresh_token` (HttpOnly) as siteId-suffixed cookies; replaces `cc-nx-exists` with `cc-nx-expires` (absolute epoch seconds, mirroring `cc-at-expires`); strips `idp_refresh_token` from the response body and upstream proxy requests [#3830](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3830)
 - HttpOnly session cookies: also strip `idp_access_token_{siteId}` from upstream proxy requests to SLAS

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.js
@@ -74,7 +74,8 @@ export const SESSION_COOKIE_CONFIG = {
     },
     idToken: {
         key: 'id_token',
-        attributes: {httpOnly: false, secure: true, path: '/'}
+        attributes: {httpOnly: true, secure: true, path: '/'},
+        slasKey: 'id_token'
     },
     idpRefreshToken: {
         key: 'idp_refresh_token',

--- a/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/httponly-cookie-config.test.js
@@ -36,6 +36,7 @@ describe('SESSION_COOKIE_CONFIG', () => {
         expect(SESSION_COOKIE_CONFIG.refreshTokenGuest.attributes.httpOnly).toBe(true)
         expect(SESSION_COOKIE_CONFIG.refreshTokenRegistered.attributes.httpOnly).toBe(true)
         expect(SESSION_COOKIE_CONFIG.idpRefreshToken.attributes.httpOnly).toBe(true)
+        expect(SESSION_COOKIE_CONFIG.idToken.attributes.httpOnly).toBe(true)
     })
 
     it('marks client-readable cookies as non-httpOnly', () => {
@@ -47,7 +48,6 @@ describe('SESSION_COOKIE_CONFIG', () => {
         expect(SESSION_COOKIE_CONFIG.customerType.attributes.httpOnly).toBe(false)
         expect(SESSION_COOKIE_CONFIG.usid.attributes.httpOnly).toBe(false)
         expect(SESSION_COOKIE_CONFIG.refreshTokenExpires.attributes.httpOnly).toBe(false)
-        expect(SESSION_COOKIE_CONFIG.idToken.attributes.httpOnly).toBe(false)
     })
 
     it('sets secure and path / on all cookies', () => {

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.js
@@ -228,7 +228,7 @@ export function setHttpOnlySessionCookies(responseBuffer, proxyRes, req, res, op
             })
         }
 
-        // id_token (non-HttpOnly): expiry tied to access token JWT exp.
+        // id_token (HttpOnly): expiry tied to access token JWT exp.
         if (parsed.id_token) {
             appendCookie({
                 name: getCookieName(idToken, site),

--- a/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
+++ b/packages/pwa-kit-runtime/src/ssr/server/process-token-response.test.js
@@ -261,10 +261,10 @@ describe('setHttpOnlySessionCookies', () => {
         // already encodes the access-token expiry as an absolute epoch.
         expect(res.cookies.find((c) => c.startsWith('expires_in_testsite='))).toBeUndefined()
 
-        // id_token (non-HttpOnly, expiry tied to access JWT exp = 2800)
+        // id_token (HttpOnly, expiry tied to access JWT exp = 2800)
         const idTokenCookie = parseCookie(res.cookies.find((c) => c.includes('id_token_testsite=')))
         expect(idTokenCookie.value).toBe('id-token-789')
-        expect(idTokenCookie.httpOnly).toBeUndefined()
+        expect(idTokenCookie.httpOnly).toBe(true)
         expect(idTokenCookie.expires).toEqual(new Date(2800 * 1000))
 
         // idp_refresh_token (HttpOnly, refresh TTL)
@@ -288,6 +288,7 @@ describe('setHttpOnlySessionCookies', () => {
         expect(body).not.toHaveProperty('idp_access_token')
         expect(body).not.toHaveProperty('refresh_token')
         expect(body).not.toHaveProperty('idp_refresh_token')
+        expect(body).not.toHaveProperty('id_token')
         expect(body.expires_in).toBe(1800)
         expect(body.customer_id).toBe('cust123')
     })


### PR DESCRIPTION
  This PR flips `id_token` to HttpOnly and strips the `id_token` field from the SLAS response body so the JWT is only readable via the cookie. The `id_token` cookie is intentionally **not** added to the upstream-proxy strip list — it carries no SCAPI authorization material and follows the same pattern as the other identity-bearing cookies (e.g. `customer_id`).

  The commerce-sdk-react auth module already routes `id_token` reads/writes through the cookie store when `enableHttpOnlySessionCookies` is on (`HTTPONLY_COOKIE_BACKED_KEYS`, added in #3830), so no runtime change is needed there. With the cookie now HttpOnly, JS reads of `id_token` return `''`, matching the existing behavior for `idp_access_token` / `idp_refresh_token`. The doc comment on that set was updated to reflect this.
  
  # Types of Changes

  - [x] **Other changes** (non-breaking change to harden cookie attributes when HttpOnly mode is enabled)

  # Changes
  
  - `pwa-kit-runtime`: `idToken` cookie config now sets `httpOnly: true` and declares `slasKey: 'id_token'`, so the SLAS proxy emits the cookie HttpOnly and strips the `id_token` field from the response body.
  - `pwa-kit-runtime`: updated comments in `process-token-response.js` to reflect the new HttpOnly treatment.
  - `commerce-sdk-react`: updated the `HTTPONLY_COOKIE_BACKED_KEYS` doc comment to list `id_token` alongside `idp_access_token` and `idp_refresh_token` as HttpOnly/unreadable-from-JS keys included for routing symmetry.
  - Tests: moved `idToken` into the HttpOnly assertion group in `httponly-cookie-config.test.js`; flipped the cookie attribute assertion and added a body-strip assertion in `process-token-response.test.js`.
  - CHANGELOG entry added under `v3.19.0-dev`.

  # How to Test-Drive This PR

  1. Run a storefront with `enableHttpOnlySessionCookies` turned on against a SLAS proxy.
  2. Trigger a login (guest or registered) and inspect the response from `/shopper/auth/v1/organizations/.../oauth2/token`:
     - The `Set-Cookie` for `id_token_{siteId}` carries `HttpOnly; Secure; Path=/`.
     - The JSON response body no longer contains an `id_token` field.
  3. From the browser console, confirm `document.cookie` does **not** include `id_token_{siteId}`, while the cookie is still present in DevTools → Application → Cookies.
  4. On logout (`/oauth2/revoke` or equivalent), confirm `id_token_{siteId}` is expired (Max-Age=0 / Expires in the past).
  5. Run unit tests:
     - `cd packages/pwa-kit-runtime && npm test -- --testPathPattern='httponly-cookie-config|process-token-response'`

  # Checklists

  ## General

  - [x] Changes are covered by test cases
  - [x] CHANGELOG.md updated with a short description of changes

  ## Accessibility Compliance

  - [x] There are no changes to UI

  ## Localization

  - [ ] Changes include a UI text update in the Retail React App (which requires translation)


