### PR TITLE
Fix Verdaccio ECONNREFUSED ::1:4873 in dev generator

### DIFF
--- a/packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js
+++ b/packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js
@@ -138,7 +138,12 @@ const withLocalNPMRepo = (func) => {
                     const poll = async () => {
                         if (await probe()) {
                             console.log('local NPM repository is up')
-                            process.env['npm_config_registry'] = 'http://localhost:4873/'
+                            // Use the IPv4 loopback explicitly. Verdaccio is bound to
+                            // 127.0.0.1:4873 (see local-npm-repo/config.yaml), and Node
+                            // 18+ on Linux may resolve `localhost` to ::1 first under
+                            // verbatim DNS — that combination produces ECONNREFUSED
+                            // ::1:4873 from npm/lerna child processes.
+                            process.env['npm_config_registry'] = 'http://127.0.0.1:4873/'
                             resolve()
                             return
                         }


### PR DESCRIPTION
## Issue

The dev-generator script (`packages/pwa-kit-create-app/scripts/create-mobify-app-dev.js`) is failing on Linux CI runners (Ubuntu, Node 18.20.7) with:

```
lerna ERR! ECONNREFUSED request to http://localhost:4873/@salesforce%2fpwa-kit-dev failed,
           reason: connect ECONNREFUSED ::1:4873
Error: lerna publish failed (exit 1); marker "Successfully published:" not found in output
    at .../create-mobify-app-dev.js:172:29
```

This regressed our nightly hybrid e2e job in [`pwa-sfra-hybrid-tests`](https://github.com/SalesforceCommerceCloud/pwa-sfra-hybrid-tests/actions/runs/26876144864/job/79263797669) starting 2026-06-02, which runs the generator against `pwa-kit@develop`.

## Cause

PR #3852 (commit c4e28201) intentionally narrowed Verdaccio's bind address to the IPv4 loopback to keep DNS out of the readiness path:

```yaml
# packages/pwa-kit-create-app/local-npm-repo/config.yaml
listen: 127.0.0.1:4873
```

The same PR updated the in-process readiness probe to dial `127.0.0.1` directly, so the script's own `'local NPM repository is up'` check passes. But the registry URL exported for the lerna/npm child processes was left as:

```js
process.env['npm_config_registry'] = 'http://localhost:4873/'
```

On Node 18+ Linux with verbatim DNS, `localhost` may resolve to `::1` (IPv6) first. Verdaccio is no longer listening there, so `lerna publish` fails with `ECONNREFUSED ::1:4873` and the publish loop aborts before any package is published. The TCP probe sidestepped this; the spawned npm/lerna processes did not.

## Fix

Pin the registry URL to the same IPv4 loopback Verdaccio is bound to. One line:

```diff
- process.env['npm_config_registry'] = 'http://localhost:4873/'
+ process.env['npm_config_registry'] = 'http://127.0.0.1:4873/'
```

This preserves the IPv4-only bind introduced in #3852 (no DNS races, no ::1 fallbacks) and brings the registry URL the rest of the toolchain inherits into alignment with it.
