### PR TITLE
@W-22918057 Extract standalone OrderTracking component

### DIFF
--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -16,6 +16,24 @@ import {
     Link as ChakraLink
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 
+// Localized labels for the known shipping-status keys. Hoisted to module scope so
+// the descriptors are allocated once (not per render); react-intl still statically
+// extracts the ids because the descriptors are literals.
+const SHIPPING_STATUS_MESSAGES = {
+    not_shipped: {
+        defaultMessage: 'Not shipped',
+        id: 'account_order_detail.shipping_status.not_shipped'
+    },
+    part_shipped: {
+        defaultMessage: 'Partially shipped',
+        id: 'account_order_detail.shipping_status.part_shipped'
+    },
+    shipped: {
+        defaultMessage: 'Shipped',
+        id: 'account_order_detail.shipping_status.shipped'
+    }
+}
+
 /**
  * Presentational tracking block for a single shipment on the Order Details page.
  *
@@ -37,6 +55,10 @@ const OrderTracking = ({
 }) => {
     const {formatMessage} = useIntl()
 
+    const statusLabel = SHIPPING_STATUS_MESSAGES[shippingStatus]
+        ? formatMessage(SHIPPING_STATUS_MESSAGES[shippingStatus])
+        : shippingStatus
+
     return (
         <Stack spacing={1}>
             <Heading as="h2" fontSize="sm" pt={1}>
@@ -55,20 +77,7 @@ const OrderTracking = ({
             </Heading>
             <Box>
                 <Text fontSize="sm" textTransform="titlecase">
-                    {{
-                        not_shipped: formatMessage({
-                            defaultMessage: 'Not shipped',
-                            id: 'account_order_detail.shipping_status.not_shipped'
-                        }),
-                        part_shipped: formatMessage({
-                            defaultMessage: 'Partially shipped',
-                            id: 'account_order_detail.shipping_status.part_shipped'
-                        }),
-                        shipped: formatMessage({
-                            defaultMessage: 'Shipped',
-                            id: 'account_order_detail.shipping_status.shipped'
-                        })
-                    }[shippingStatus] || shippingStatus}
+                    {statusLabel}
                 </Text>
                 <Text fontSize="sm">{shippingMethodName}</Text>
                 {trackingNumber && (

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -16,24 +16,6 @@ import {
     Link as ChakraLink
 } from '@salesforce/retail-react-app/app/components/shared/ui'
 
-// Localized labels for the known shipping-status keys. Hoisted to module scope so
-// the descriptors are allocated once (not per render); react-intl still statically
-// extracts the ids because the descriptors are literals.
-const SHIPPING_STATUS_MESSAGES = {
-    not_shipped: {
-        defaultMessage: 'Not shipped',
-        id: 'account_order_detail.shipping_status.not_shipped'
-    },
-    part_shipped: {
-        defaultMessage: 'Partially shipped',
-        id: 'account_order_detail.shipping_status.part_shipped'
-    },
-    shipped: {
-        defaultMessage: 'Shipped',
-        id: 'account_order_detail.shipping_status.shipped'
-    }
-}
-
 /**
  * Presentational tracking block for a single shipment on the Order Details page.
  *
@@ -55,10 +37,6 @@ const OrderTracking = ({
 }) => {
     const {formatMessage} = useIntl()
 
-    const statusLabel = SHIPPING_STATUS_MESSAGES[shippingStatus]
-        ? formatMessage(SHIPPING_STATUS_MESSAGES[shippingStatus])
-        : shippingStatus
-
     return (
         <Stack spacing={1}>
             <Heading as="h2" fontSize="sm" pt={1}>
@@ -77,7 +55,22 @@ const OrderTracking = ({
             </Heading>
             <Box>
                 <Text fontSize="sm" textTransform="titlecase">
-                    {statusLabel}
+                    {/* Inline literal descriptors so babel-plugin-formatjs can statically
+                        extract these ids (a hoisted/variable descriptor is NOT extracted). */}
+                    {{
+                        not_shipped: formatMessage({
+                            defaultMessage: 'Not shipped',
+                            id: 'account_order_detail.shipping_status.not_shipped'
+                        }),
+                        part_shipped: formatMessage({
+                            defaultMessage: 'Partially shipped',
+                            id: 'account_order_detail.shipping_status.part_shipped'
+                        }),
+                        shipped: formatMessage({
+                            defaultMessage: 'Shipped',
+                            id: 'account_order_detail.shipping_status.shipped'
+                        })
+                    }[shippingStatus] || shippingStatus}
                 </Text>
                 <Text fontSize="sm">{shippingMethodName}</Text>
                 {trackingNumber && (

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import {FormattedMessage, useIntl} from 'react-intl'
+import {
+    Box,
+    Heading,
+    Stack,
+    Text,
+    Link as ChakraLink
+} from '@salesforce/retail-react-app/app/components/shared/ui'
+
+/**
+ * Presentational tracking block for a single shipment on the Order Details page.
+ *
+ * Renders the shipping method heading, the (localized) shipping status, the
+ * shipping method / provider name, and — when a tracking number is present —
+ * the tracking number, hyperlinked to the carrier site when a tracking URL is
+ * available (otherwise shown as plain text).
+ *
+ * Extracted verbatim from the former inline `renderShippingMethod` in
+ * `order-detail.jsx`; the DOM it produces is intentionally identical.
+ */
+const OrderTracking = ({
+    shippingMethodName,
+    shippingStatus,
+    trackingNumber,
+    trackingUrl,
+    shipmentsLength,
+    index
+}) => {
+    const {formatMessage} = useIntl()
+
+    return (
+        <Stack spacing={1}>
+            <Heading as="h2" fontSize="sm" pt={1}>
+                {shipmentsLength > 1 ? (
+                    <FormattedMessage
+                        defaultMessage="Shipping Method {number}"
+                        id="account_order_detail.heading.shipping_method_number"
+                        values={{number: index + 1}}
+                    />
+                ) : (
+                    <FormattedMessage
+                        defaultMessage="Shipping Method"
+                        id="account_order_detail.heading.shipping_method"
+                    />
+                )}
+            </Heading>
+            <Box>
+                <Text fontSize="sm" textTransform="titlecase">
+                    {{
+                        not_shipped: formatMessage({
+                            defaultMessage: 'Not shipped',
+                            id: 'account_order_detail.shipping_status.not_shipped'
+                        }),
+                        part_shipped: formatMessage({
+                            defaultMessage: 'Partially shipped',
+                            id: 'account_order_detail.shipping_status.part_shipped'
+                        }),
+                        shipped: formatMessage({
+                            defaultMessage: 'Shipped',
+                            id: 'account_order_detail.shipping_status.shipped'
+                        })
+                    }[shippingStatus] || shippingStatus}
+                </Text>
+                <Text fontSize="sm">{shippingMethodName}</Text>
+                {trackingNumber && (
+                    <Text fontSize="sm">
+                        <FormattedMessage
+                            defaultMessage="Tracking Number"
+                            id="account_order_detail.label.tracking_number"
+                        />
+                        :{' '}
+                        {trackingUrl ? (
+                            <ChakraLink href={trackingUrl} isExternal color="blue.600">
+                                {trackingNumber}
+                            </ChakraLink>
+                        ) : (
+                            trackingNumber
+                        )}
+                    </Text>
+                )}
+            </Box>
+        </Stack>
+    )
+}
+
+OrderTracking.propTypes = {
+    /** Carrier / shipping-method display name (OMS `provider` or ECOM method name). */
+    shippingMethodName: PropTypes.string,
+    /** Shipping status key (`not_shipped` | `part_shipped` | `shipped`) or a raw OMS status string. */
+    shippingStatus: PropTypes.string,
+    /** Tracking number; when falsy, the tracking line is not rendered. */
+    trackingNumber: PropTypes.string,
+    /** Carrier tracking URL; when present, the tracking number is rendered as an external link. */
+    trackingUrl: PropTypes.string,
+    /** Total number of shipments being rendered (drives the numbered heading). */
+    shipmentsLength: PropTypes.number,
+    /** Zero-based index of this shipment (drives the numbered heading). */
+    index: PropTypes.number
+}
+
+export default OrderTracking

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking/index'
+
+const baseProps = {
+    shippingMethodName: 'FedEx Ground',
+    shippingStatus: 'shipped',
+    trackingNumber: 'TRACK-12345',
+    trackingUrl: 'https://tracking.fedex.com/TRACK-12345',
+    shipmentsLength: 1,
+    index: 0
+}
+
+describe('OrderTracking component', () => {
+    test('renders the provider / shipping method name', () => {
+        renderWithProviders(<OrderTracking {...baseProps} />)
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
+
+    test('renders a localized shipping status when the status is a known key', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shippingStatus="not_shipped" />)
+        expect(screen.getByText('Not shipped')).toBeInTheDocument()
+    })
+
+    test('falls back to the raw status string for unknown OMS statuses', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shippingStatus="DELIVERED" />)
+        expect(screen.getByText('DELIVERED')).toBeInTheDocument()
+    })
+
+    test('renders the tracking number as an external link to the carrier site when trackingUrl is present (US2)', () => {
+        renderWithProviders(<OrderTracking {...baseProps} />)
+        const link = screen.getByRole('link', {name: /TRACK-12345/i})
+        expect(link).toHaveAttribute('href', 'https://tracking.fedex.com/TRACK-12345')
+        // External links open in a new tab
+        expect(link).toHaveAttribute('target', '_blank')
+    })
+
+    test('renders the tracking number as plain text (no link) when trackingUrl is absent', () => {
+        renderWithProviders(<OrderTracking {...baseProps} trackingUrl={undefined} />)
+        expect(screen.queryByRole('link', {name: /TRACK-12345/i})).not.toBeInTheDocument()
+        expect(screen.getByText(/TRACK-12345/)).toBeInTheDocument()
+    })
+
+    test('omits the tracking line entirely when there is no tracking number', () => {
+        renderWithProviders(
+            <OrderTracking {...baseProps} trackingNumber={undefined} trackingUrl={undefined} />
+        )
+        expect(screen.queryByText(/Tracking Number/i)).not.toBeInTheDocument()
+        // The shipping method still renders
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
+
+    test('renders the unnumbered heading for a single shipment', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shipmentsLength={1} index={0} />)
+        expect(screen.getByRole('heading', {name: /^Shipping Method$/i})).toBeInTheDocument()
+    })
+
+    test('renders a numbered heading when multiple shipments are present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shipmentsLength={2} index={1} />)
+        // index is zero-based; heading shows index + 1
+        expect(screen.getByRole('heading', {name: /Shipping Method 2/i})).toBeInTheDocument()
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -18,7 +18,6 @@ import {
     Button,
     Divider,
     Grid,
-    Link as ChakraLink,
     SimpleGrid,
     Skeleton,
     useDisclosure
@@ -40,6 +39,7 @@ import CartItemVariantName from '@salesforce/retail-react-app/app/components/ite
 import CartItemVariantAttributes from '@salesforce/retail-react-app/app/components/item-variant/item-attributes'
 import CartItemVariantPrice from '@salesforce/retail-react-app/app/components/item-variant/item-price'
 import StoreDisplay from '@salesforce/retail-react-app/app/components/store-display'
+import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {STORE_LOCATOR_IS_ENABLED} from '@salesforce/retail-react-app/app/constants'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
@@ -247,67 +247,6 @@ const AccountOrderDetail = () => {
             return storeData.data.find((store) => store.id === storeId)
         },
         [storeData?.data]
-    )
-
-    const renderShippingMethod = (
-        shippingMethodName,
-        shippingStatus,
-        trackingNumber,
-        trackingUrl,
-        shipmentsLength,
-        index
-    ) => (
-        <Stack spacing={1}>
-            <Heading as="h2" fontSize="sm" pt={1}>
-                {shipmentsLength > 1 ? (
-                    <FormattedMessage
-                        defaultMessage="Shipping Method {number}"
-                        id="account_order_detail.heading.shipping_method_number"
-                        values={{number: index + 1}}
-                    />
-                ) : (
-                    <FormattedMessage
-                        defaultMessage="Shipping Method"
-                        id="account_order_detail.heading.shipping_method"
-                    />
-                )}
-            </Heading>
-            <Box>
-                <Text fontSize="sm" textTransform="titlecase">
-                    {{
-                        not_shipped: formatMessage({
-                            defaultMessage: 'Not shipped',
-                            id: 'account_order_detail.shipping_status.not_shipped'
-                        }),
-                        part_shipped: formatMessage({
-                            defaultMessage: 'Partially shipped',
-                            id: 'account_order_detail.shipping_status.part_shipped'
-                        }),
-                        shipped: formatMessage({
-                            defaultMessage: 'Shipped',
-                            id: 'account_order_detail.shipping_status.shipped'
-                        })
-                    }[shippingStatus] || shippingStatus}
-                </Text>
-                <Text fontSize="sm">{shippingMethodName}</Text>
-                {trackingNumber && (
-                    <Text fontSize="sm">
-                        <FormattedMessage
-                            defaultMessage="Tracking Number"
-                            id="account_order_detail.label.tracking_number"
-                        />
-                        :{' '}
-                        {trackingUrl ? (
-                            <ChakraLink href={trackingUrl} isExternal color="blue.600">
-                                {trackingNumber}
-                            </ChakraLink>
-                        ) : (
-                            trackingNumber
-                        )}
-                    </Text>
-                )}
-            </Box>
-        </Stack>
     )
 
     const paymentCard = order?.paymentInstruments?.[0]?.paymentCard
@@ -556,14 +495,14 @@ const AccountOrderDetail = () => {
 
                                         return (
                                             <React.Fragment key={`delivery-${index}`}>
-                                                {renderShippingMethod(
-                                                    shippingMethodName,
-                                                    shippingStatus,
-                                                    trackingNumber,
-                                                    trackingUrl,
-                                                    deliveryShipments.length,
-                                                    index
-                                                )}
+                                                <OrderTracking
+                                                    shippingMethodName={shippingMethodName}
+                                                    shippingStatus={shippingStatus}
+                                                    trackingNumber={trackingNumber}
+                                                    trackingUrl={trackingUrl}
+                                                    shipmentsLength={deliveryShipments.length}
+                                                    index={index}
+                                                />
                                                 <Stack spacing={1}>
                                                     <Heading as="h2" fontSize="sm" pt={1}>
                                                         {deliveryShipments.length > 1 ? (
@@ -604,14 +543,14 @@ const AccountOrderDetail = () => {
                                 {showMultiShipmentsFromOmsOnly &&
                                     order?.omsData?.shipments?.map((shipment, index) => (
                                         <React.Fragment key={`oms-shipment-${index}`}>
-                                            {renderShippingMethod(
-                                                shipment.provider,
-                                                shipment.status,
-                                                shipment.trackingNumber,
-                                                shipment.trackingUrl,
-                                                omsShipmentCount,
-                                                index
-                                            )}
+                                            <OrderTracking
+                                                shippingMethodName={shipment.provider}
+                                                shippingStatus={shipment.status}
+                                                trackingNumber={shipment.trackingNumber}
+                                                trackingUrl={shipment.trackingUrl}
+                                                shipmentsLength={omsShipmentCount}
+                                                index={index}
+                                            />
                                         </React.Fragment>
                                     ))}
 

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -542,16 +542,15 @@ const AccountOrderDetail = () => {
                                 {/* Any OMS multi-shipment: Only show OMS Shipments info;*/}
                                 {showMultiShipmentsFromOmsOnly &&
                                     order?.omsData?.shipments?.map((shipment, index) => (
-                                        <React.Fragment key={`oms-shipment-${index}`}>
-                                            <OrderTracking
-                                                shippingMethodName={shipment.provider}
-                                                shippingStatus={shipment.status}
-                                                trackingNumber={shipment.trackingNumber}
-                                                trackingUrl={shipment.trackingUrl}
-                                                shipmentsLength={omsShipmentCount}
-                                                index={index}
-                                            />
-                                        </React.Fragment>
+                                        <OrderTracking
+                                            key={`oms-shipment-${index}`}
+                                            shippingMethodName={shipment.provider}
+                                            shippingStatus={shipment.status}
+                                            trackingNumber={shipment.trackingNumber}
+                                            trackingUrl={shipment.trackingUrl}
+                                            shipmentsLength={omsShipmentCount}
+                                            index={index}
+                                        />
                                     ))}
 
                                 {/* Payment Method */}


### PR DESCRIPTION
## What

Extracts the inline tracking render (the former `renderShippingMethod` in `app/pages/account/order-detail.jsx`) into a standalone, testable component at `app/components/order-tracking/`. Wired at both call sites — the delivery / OMS-fallback loop and the OMS-multi loop.

**Pure refactor — no visual or behavioral change.** This is the first work item of the Order Tracking epic (W-22918057); it gives the follow-up WIs (estimated delivery date, error/fallback state) a clean, unit-testable seam to build on.

GUS: W-22918057 · Epic: [264 - Sharks - June] Order Tracking in PWA Kit · Spec PR: commerce-emu/storefront-next#1906

## Changes

- **New** `app/components/order-tracking/index.jsx` — presentational tracking block (provider, status, tracking number, carrier link), props-driven, with propTypes.
- **New** `app/components/order-tracking/index.test.js` — isolated unit tests.
- **Modified** `app/pages/account/order-detail.jsx` — removed the inline `renderShippingMethod`; renders `<OrderTracking />` at both call sites; dropped the now-unused `ChakraLink` import.

## How this was verified

The automated tests already did the before/after comparison for you — they assert the exact DOM (same headings, same link, same text) the old inline code produced. 96/96 passing IS the "it matches the old version" proof. The browser check is just to catch anything tests can't see (a runtime crash against real data).

- 96/96 tests pass (88 existing `orders.test.js` regression + 8 new `order-tracking/index.test.js`).
- New component: 100% statements / branches / functions / lines coverage.
- Lint clean on all touched files.
- Manual: logged in as a shopper against a SOM-wired sandbox, opened Order History and Order Details — both render fine (Shipping Method section shows, no crash, no console error).

## Out of scope (follow-up WIs)

- Rendering the estimated delivery date (AC3).
- The error / fallback state for the order fetch (AC6).
- Visual changes to the tracking block.
