### PR TITLE
@W-22918455 Render estimated delivery date on order tracking

### DIFF
--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -42,8 +42,17 @@ const OrderTracking = ({
     const {formatMessage, formatDate} = useIntl()
 
     // Same date format the order header uses for "Ordered:" — e.g. "Jun 12, 2026".
-    const formatTrackingDate = (value) =>
-        formatDate(new Date(value), {year: 'numeric', month: 'short', day: 'numeric'})
+    // Returns null for missing or malformed values (a truthy-but-unparseable string
+    // would otherwise render "Invalid Date" or throw in formatDate), so the caller
+    // can omit the line entirely.
+    const formatTrackingDate = (value) => {
+        const date = new Date(value)
+        if (isNaN(date.getTime())) return null
+        return formatDate(date, {year: 'numeric', month: 'short', day: 'numeric'})
+    }
+
+    const expectedDeliveryLabel = formatTrackingDate(expectedDeliveryDate)
+    const actualDeliveryLabel = formatTrackingDate(actualDeliveryDate)
 
     return (
         <Stack spacing={1}>
@@ -97,16 +106,16 @@ const OrderTracking = ({
                         )}
                     </Text>
                 )}
-                {expectedDeliveryDate && (
+                {expectedDeliveryLabel && (
                     <Text fontSize="sm">
                         <FormattedMessage
                             defaultMessage="Expected delivery"
                             id="account_order_detail.label.expected_delivery"
                         />
-                        : {formatTrackingDate(expectedDeliveryDate)}
+                        : {expectedDeliveryLabel}
                     </Text>
                 )}
-                {actualDeliveryDate && (
+                {actualDeliveryLabel && (
                     <Text fontSize="sm">
                         {/* id is `delivered_on` (mirrors SFN's deliveredOn) but the label is
                             just "Delivered"; the date follows after the colon, not inside the message. */}
@@ -114,7 +123,7 @@ const OrderTracking = ({
                             defaultMessage="Delivered"
                             id="account_order_detail.label.delivered_on"
                         />
-                        : {formatTrackingDate(actualDeliveryDate)}
+                        : {actualDeliveryLabel}
                     </Text>
                 )}
             </Box>

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -20,22 +20,30 @@ import {
  * Presentational tracking block for a single shipment on the Order Details page.
  *
  * Renders the shipping method heading, the (localized) shipping status, the
- * shipping method / provider name, and — when a tracking number is present —
- * the tracking number, hyperlinked to the carrier site when a tracking URL is
- * available (otherwise shown as plain text).
+ * shipping method / provider name, the tracking number (hyperlinked to the
+ * carrier site when a tracking URL is available, otherwise plain text), and —
+ * when present — the expected and actual delivery dates.
  *
- * Extracted verbatim from the former inline `renderShippingMethod` in
- * `order-detail.jsx`; the DOM it produces is intentionally identical.
+ * Note: the OMS-over-ECOM fallback for the shipment fields lives at the call
+ * sites in `order-detail.jsx` (the component receives already-resolved scalar
+ * props). A future WI may centralize that fallback into a normalized-shipment
+ * helper if more call sites are added.
  */
 const OrderTracking = ({
     shippingMethodName,
     shippingStatus,
     trackingNumber,
     trackingUrl,
+    expectedDeliveryDate,
+    actualDeliveryDate,
     shipmentsLength,
     index
 }) => {
-    const {formatMessage} = useIntl()
+    const {formatMessage, formatDate} = useIntl()
+
+    // Same date format the order header uses for "Ordered:" — e.g. "Jun 12, 2026".
+    const formatTrackingDate = (value) =>
+        formatDate(new Date(value), {year: 'numeric', month: 'short', day: 'numeric'})
 
     return (
         <Stack spacing={1}>
@@ -89,6 +97,26 @@ const OrderTracking = ({
                         )}
                     </Text>
                 )}
+                {expectedDeliveryDate && (
+                    <Text fontSize="sm">
+                        <FormattedMessage
+                            defaultMessage="Expected delivery"
+                            id="account_order_detail.label.expected_delivery"
+                        />
+                        : {formatTrackingDate(expectedDeliveryDate)}
+                    </Text>
+                )}
+                {actualDeliveryDate && (
+                    <Text fontSize="sm">
+                        {/* id is `delivered_on` (mirrors SFN's deliveredOn) but the label is
+                            just "Delivered"; the date follows after the colon, not inside the message. */}
+                        <FormattedMessage
+                            defaultMessage="Delivered"
+                            id="account_order_detail.label.delivered_on"
+                        />
+                        : {formatTrackingDate(actualDeliveryDate)}
+                    </Text>
+                )}
             </Box>
         </Stack>
     )
@@ -103,6 +131,10 @@ OrderTracking.propTypes = {
     trackingNumber: PropTypes.string,
     /** Carrier tracking URL; when present, the tracking number is rendered as an external link. */
     trackingUrl: PropTypes.string,
+    /** Expected delivery date (ISO string); when present, renders an "Expected delivery: <date>" line. */
+    expectedDeliveryDate: PropTypes.string,
+    /** Actual delivery date (ISO string); when present, renders a "Delivered: <date>" line. */
+    actualDeliveryDate: PropTypes.string,
     /** Total number of shipments being rendered (drives the numbered heading). */
     shipmentsLength: PropTypes.number,
     /** Zero-based index of this shipment (drives the numbered heading). */

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -111,4 +111,20 @@ describe('OrderTracking component', () => {
         expect(container.textContent).toMatch(/Expected delivery:\s*\d{1,2} Jun 2026/)
         expect(container.textContent).toMatch(/Delivered:\s*\d{1,2} Jun 2026/)
     })
+
+    test('omits the date line for a malformed date string (no "Invalid Date", no throw)', () => {
+        renderWithProviders(
+            <OrderTracking
+                {...baseProps}
+                expectedDeliveryDate="not-a-real-date"
+                actualDeliveryDate="also-bad"
+            />
+        )
+        // Malformed values must not surface to the shopper or crash the render.
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Invalid Date/i)).not.toBeInTheDocument()
+        // The rest of the block still renders.
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
 })

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -67,4 +67,48 @@ describe('OrderTracking component', () => {
         // index is zero-based; heading shows index + 1
         expect(screen.getByRole('heading', {name: /Shipping Method 2/i})).toBeInTheDocument()
     })
+
+    // The date is formatted by locale + timezone (the test IntlProvider is en-GB),
+    // so we assert the label + month/year rather than a hardcoded exact string.
+    // `expectedDeliveryDate` of June renders as e.g. "11 Jun 2026" (en-GB, day-month-year).
+    test('renders the expected delivery date (locale-formatted) when present (AC3)', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking {...baseProps} expectedDeliveryDate="2026-06-12T00:00:00.000Z" />
+        )
+        expect(screen.getByText(/Expected delivery/i)).toBeInTheDocument()
+        // The formatted date sits in the same <Text> line as the label.
+        expect(container.textContent).toMatch(/Expected delivery:\s*\d{1,2} Jun 2026/)
+    })
+
+    test('omits the expected-delivery line when no expectedDeliveryDate is present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} expectedDeliveryDate={undefined} />)
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+    })
+
+    test('renders the delivered date (locale-formatted) when actualDeliveryDate is present', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking {...baseProps} actualDeliveryDate="2026-06-15T00:00:00.000Z" />
+        )
+        expect(screen.getByText(/Delivered/i)).toBeInTheDocument()
+        expect(container.textContent).toMatch(/Delivered:\s*\d{1,2} Jun 2026/)
+    })
+
+    test('omits the delivered line when no actualDeliveryDate is present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} actualDeliveryDate={undefined} />)
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+    })
+
+    test('renders both expected and delivered lines when both dates are present', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking
+                {...baseProps}
+                expectedDeliveryDate="2026-06-12T00:00:00.000Z"
+                actualDeliveryDate="2026-06-15T00:00:00.000Z"
+            />
+        )
+        expect(screen.getByText(/Expected delivery/i)).toBeInTheDocument()
+        expect(screen.getByText(/Delivered/i)).toBeInTheDocument()
+        expect(container.textContent).toMatch(/Expected delivery:\s*\d{1,2} Jun 2026/)
+        expect(container.textContent).toMatch(/Delivered:\s*\d{1,2} Jun 2026/)
+    })
 })

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -492,6 +492,9 @@ const AccountOrderDetail = () => {
                                         const trackingNumber =
                                             omsShipment?.trackingNumber || shipment.trackingNumber
                                         const trackingUrl = omsShipment?.trackingUrl
+                                        const expectedDeliveryDate =
+                                            omsShipment?.expectedDeliveryDate
+                                        const actualDeliveryDate = omsShipment?.actualDeliveryDate
 
                                         return (
                                             <React.Fragment key={`delivery-${index}`}>
@@ -500,6 +503,8 @@ const AccountOrderDetail = () => {
                                                     shippingStatus={shippingStatus}
                                                     trackingNumber={trackingNumber}
                                                     trackingUrl={trackingUrl}
+                                                    expectedDeliveryDate={expectedDeliveryDate}
+                                                    actualDeliveryDate={actualDeliveryDate}
                                                     shipmentsLength={deliveryShipments.length}
                                                     index={index}
                                                 />
@@ -548,6 +553,8 @@ const AccountOrderDetail = () => {
                                             shippingStatus={shipment.status}
                                             trackingNumber={shipment.trackingNumber}
                                             trackingUrl={shipment.trackingUrl}
+                                            expectedDeliveryDate={shipment.expectedDeliveryDate}
+                                            actualDeliveryDate={shipment.actualDeliveryDate}
                                             shipmentsLength={omsShipmentCount}
                                             index={index}
                                         />

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -385,6 +385,13 @@ describe('OMS/SOM Integration - Order Details', () => {
         expect(await screen.findByRole('heading', {name: /payment method/i})).toBeInTheDocument()
     })
 
+    test('should NOT display an expected delivery line for an ECOM-fallback order (AC3)', async () => {
+        // ECOM orders have no omsData → no expectedDeliveryDate → the ETA line is omitted.
+        setupOrderDetailsPage(createMockOrder())
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+    })
+
     // OMS order tests - uses omsData.status, fullName, and has no payment data
     test('should display OMS status from omsData.status', async () => {
         setupOrderDetailsPage(createMockOmsOrder())
@@ -562,13 +569,15 @@ describe('OMS Multi-shipment - Shipping address hidden', () => {
                     status: 'SHIPPED',
                     trackingNumber: 'OMS-001',
                     trackingUrl: 'https://track.example.com/OMS-001',
-                    provider: 'FedEx'
+                    provider: 'FedEx',
+                    expectedDeliveryDate: '2026-06-12T00:00:00.000Z'
                 },
                 {
                     status: 'PENDING',
                     trackingNumber: 'OMS-002',
                     trackingUrl: 'https://track.example.com/OMS-002',
-                    provider: 'UPS'
+                    provider: 'UPS',
+                    expectedDeliveryDate: '2026-07-20T00:00:00.000Z'
                 }
             ]
         }
@@ -608,6 +617,15 @@ describe('OMS Multi-shipment - Shipping address hidden', () => {
 
         const trackingLink2 = await screen.findByRole('link', {name: /OMS-002/i})
         expect(trackingLink2).toHaveAttribute('href', 'https://track.example.com/OMS-002')
+    })
+
+    test('should display the expected delivery date per shipment (AC3, OMS-multi call site)', async () => {
+        // Exercises the OMS-multi call site: each shipment renders its own ETA line.
+        // findAllByText waits for the async order render to resolve.
+        const etaLabels = await screen.findAllByText(/Expected delivery/i)
+        expect(etaLabels).toHaveLength(2)
+        expect(etaLabels[0].closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
+        expect(etaLabels[1].closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
     })
 })
 
@@ -701,7 +719,8 @@ describe('OMS Single shipment with tracking URL', () => {
                     status: 'DELIVERED',
                     trackingNumber: 'TRACK-12345',
                     trackingUrl: 'https://tracking.fedex.com/TRACK-12345',
-                    provider: 'FedEx Ground'
+                    provider: 'FedEx Ground',
+                    expectedDeliveryDate: '2026-06-12T00:00:00.000Z'
                 }
             ]
         }
@@ -729,6 +748,17 @@ describe('OMS Single shipment with tracking URL', () => {
 
     test('should display OMS shipment status (fallback to raw value)', async () => {
         expect(await screen.findByText(/DELIVERED/i)).toBeInTheDocument()
+    })
+
+    test('should display the expected delivery date from OMS data (AC3, page call site)', async () => {
+        // Verifies the ETA renders at the real delivery call site, not just in the
+        // isolated component test. The label and the formatted date share one line;
+        // scope the date assertion to that line so it doesn't collide with the
+        // order's creation date elsewhere on the page.
+        const etaLabel = await screen.findByText(/Expected delivery/i)
+        expect(etaLabel).toBeInTheDocument()
+        // The <Text> line reads "Expected delivery: <formatted date>" and includes the year.
+        expect(etaLabel.closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
     })
 })
 

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -315,6 +315,18 @@
       "value": "number"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "Delivered"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "Expected delivery"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -315,6 +315,18 @@
       "value": "number"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "Delivered"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "Expected delivery"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -699,6 +699,34 @@
       "value": "]"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḓḗḗŀīṽḗḗřḗḗḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḗẋƥḗḗƈŧḗḗḓ ḓḗḗŀīṽḗḗřẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -143,6 +143,12 @@
   "account_order_detail.heading.shipping_method_number": {
     "defaultMessage": "Shipping Method {number}"
   },
+  "account_order_detail.label.delivered_on": {
+    "defaultMessage": "Delivered"
+  },
+  "account_order_detail.label.expected_delivery": {
+    "defaultMessage": "Expected delivery"
+  },
   "account_order_detail.label.order_number": {
     "defaultMessage": "Order Number: {orderNumber}"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -143,6 +143,12 @@
   "account_order_detail.heading.shipping_method_number": {
     "defaultMessage": "Shipping Method {number}"
   },
+  "account_order_detail.label.delivered_on": {
+    "defaultMessage": "Delivered"
+  },
+  "account_order_detail.label.expected_delivery": {
+    "defaultMessage": "Expected delivery"
+  },
   "account_order_detail.label.order_number": {
     "defaultMessage": "Order Number: {orderNumber}"
   },


### PR DESCRIPTION
## What

Renders the **estimated delivery date** (and the actual delivery date when present) on the order-detail tracking block — completing epic AC3. Builds on the `OrderTracking` component extracted in WI-1.

Per shipment, when the data is present, the tracking block now shows:
- **Expected delivery: \<date\>** (from `omsData.shipments[].expectedDeliveryDate`)
- **Delivered: \<date\>** (from `omsData.shipments[].actualDeliveryDate`)

Both are locale-formatted (same format as the order header's "Ordered:" line) and omitted when absent. Mirrors the SFN order-detail prototype.

GUS: W-22918455 · Epic: [264 - Sharks - June] Order Tracking in PWA Kit

> **Stacked on WI-1.** This PR targets `sprasoon/W-22918057-extract-order-tracking` (PR #3865), since it modifies the component that PR introduces. Review/merge WI-1 first.

## Changes

- `app/components/order-tracking/index.jsx` — adds `expectedDeliveryDate` / `actualDeliveryDate` props; renders the two date lines (guarded, locale-formatted).
- `app/pages/account/order-detail.jsx` — passes the dates at both call sites. These fields are **OMS-only** (no ECOM fallback — they exist only on `omsData.shipments[]`, same as `trackingUrl`).
- Two new i18n keys (`account_order_detail.label.expected_delivery`, `…delivered_on`), extracted + compiled.
- Tests: 5 new component tests (present/absent for each date, both-present) + a page-level assertion that the ETA renders at the real call site.

## Verification

- 102/102 tests pass (component + page suites).
- Lint clean.
- i18n keys present in both the extracted source and the compiled catalogs.

## Scope notes

- ETA is intentionally **OMS-only** — these fields don't exist on ECOM shipments, so there's no `|| shipment.expectedDeliveryDate` fallback (a fallback would invent data). Matches `trackingUrl`.
- Kept the component's flat-prop interface (no normalized-shipment refactor) to keep this a focused 1-pt change.
- Out of scope (follow-up WI): the error/fallback state (epic AC6).
