### PR TITLE
@W-22821835@ Add returnOmsOrder mutation to commerce-sdk-react

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -72,5 +72,14 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
             })
         }
         return {invalidate}
+    },
+    returnOmsOrder(customerId, {parameters}) {
+        const invalidate: CacheUpdateInvalidate[] = [{queryKey: getOrder.queryKey(parameters)}]
+        if (customerId) {
+            invalidate.push({
+                queryKey: getCustomerOrders.queryKey({...parameters, customerId})
+            })
+        }
+        return {invalidate}
     }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
@@ -16,9 +16,7 @@ describe('Shopper Orders hooks', () => {
         const unimplemented = getUnimplementedEndpoints(ShopperOrders, queries, mutations)
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
-        // guestOrderLookup: uses ShopperTokenTsob auth, handled separately
-        // returnOmsOrder: item-level returns are a separate epic (W-22806929)
-        expect(unimplemented).toEqual(['guestOrderLookup', 'returnOmsOrder'])
+        expect(unimplemented).toEqual(['guestOrderLookup'])
     })
     test('all mutations have cache update logic', () => {
         // unimplemented = value in mutations enum, but no method in cache update matrix

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
@@ -9,6 +9,7 @@ import {act} from '@testing-library/react'
 import {ShopperOrdersTypes} from 'commerce-sdk-isomorphic'
 import nock from 'nock'
 import {
+    assertInvalidateQuery,
     mockMutationEndpoints,
     mockQueryEndpoint,
     renderHookWithProviders,
@@ -74,6 +75,10 @@ const removePaymentOptions = createOptions<'removePaymentInstrumentFromOrder'>(u
     paymentInstrumentId: PAYMENT_INSTRUMENT_ID
 })
 const cancelOmsOrderOptions = createOptions<'cancelOmsOrder'>({reason: 'Changed my mind'}, {})
+const returnOmsOrderOptions = createOptions<'returnOmsOrder'>(
+    {productItems: [{itemId: 'item-1', quantity: 1, reason: 'damaged'}]},
+    {}
+)
 
 // --- TEST CASES --- //
 /** Every mutation modifies an existing order, except `createOrder`, which creates one. */
@@ -84,7 +89,8 @@ const testMap: TestMap = {
     createPaymentInstrumentForOrder: createPaymentOptions,
     updatePaymentInstrumentForOrder: updatePaymentOptions,
     removePaymentInstrumentFromOrder: removePaymentOptions,
-    cancelOmsOrder: cancelOmsOrderOptions
+    cancelOmsOrder: cancelOmsOrderOptions,
+    returnOmsOrder: returnOmsOrderOptions
 }
 
 // Type assertion because the built-in type definition for `Object.entries` is limited :\
@@ -179,5 +185,35 @@ describe('ShopperOrders mutations', () => {
         act(() => mut.current.mutate(cancelOmsOrderOptions))
         await waitAndExpectSuccess(() => mut.current)
         expect(mut.current.data).toEqual({...ORDER, status: 'cancelled'})
+    })
+    test('`returnOmsOrder` invalidates the order query on success', async () => {
+        mockQueryEndpoint(ordersEndpoint, ORDER) // initial useOrder
+        mockMutationEndpoints(ordersEndpoint, ORDER) // returnOmsOrder
+        mockQueryEndpoint(ordersEndpoint, ORDER) // refetch after invalidation
+        const {result} = renderHookWithProviders(() => ({
+            query: queries.useOrder({parameters: {orderNo: ORDER_NO}}),
+            mutation: useShopperOrdersMutation('returnOmsOrder')
+        }))
+        await waitAndExpectSuccess(() => result.current.query)
+        const oldData = result.current.query.data
+        act(() => result.current.mutation.mutate(returnOmsOrderOptions))
+        await waitAndExpectSuccess(() => result.current.mutation)
+        assertInvalidateQuery(result.current.query, oldData)
+    })
+    test('`returnOmsOrder` invalidates `useOrder` even when called with extra params (e.g. expand=oms)', async () => {
+        mockQueryEndpoint(ordersEndpoint, ORDER) // initial useOrder w/ expand
+        mockMutationEndpoints(ordersEndpoint, ORDER) // returnOmsOrder
+        mockQueryEndpoint(ordersEndpoint, ORDER) // refetch
+        const {result} = renderHookWithProviders(() => ({
+            query: queries.useOrder({
+                parameters: {orderNo: ORDER_NO, expand: ['oms', 'oms_shipments']}
+            }),
+            mutation: useShopperOrdersMutation('returnOmsOrder')
+        }))
+        await waitAndExpectSuccess(() => result.current.query)
+        const oldData = result.current.query.data
+        act(() => result.current.mutation.mutate(returnOmsOrderOptions))
+        await waitAndExpectSuccess(() => result.current.mutation)
+        assertInvalidateQuery(result.current.query, oldData)
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
@@ -58,7 +58,12 @@ The payment instrument is added with the provided details. The payment method mu
      * The cancellation always applies to the entire order; partial cancellations are not supported.
      * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `cancelOmsOrder` endpoint.
      */
-    CancelOmsOrder: 'cancelOmsOrder'
+    CancelOmsOrder: 'cancelOmsOrder',
+    /**
+     * Initiates the return of one or more items of an order that is integrated with Order Management (OMS).
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `returnOmsOrder` endpoint.
+     */
+    ReturnOmsOrder: 'returnOmsOrder'
 } as const
 
 /**


### PR DESCRIPTION
# Description

Adds the `returnOmsOrder` mutation hook to `commerce-sdk-react`, mirroring the shape established by `cancelOmsOrder` (PR #3864). This is the third of three new SCAPI Shopper Orders endpoints introduced for the Salesforce Order Management (SOM) integration: `cancelOmsOrder`, `getOmsMetaData` (both shipped in #3864), and `returnOmsOrder` (this PR).

Targets the long-lived `feature/264-order-management` branch — same base as
#3864 — so the full set of OMS hooks lands together.

# Types of Changes

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Add `ReturnOmsOrder: 'returnOmsOrder'` to the `ShopperOrdersMutations` enum
  in `packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts`, with a
  TSDoc summary describing it as the OMS-integrated item-return endpoint.
- Add a `returnOmsOrder` entry to `cacheUpdateMatrix` in
  `packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts` that
  invalidates `getOrder` (so the order detail re-fetches with updated return
  state) and, when a customer is signed in, `getCustomerOrders` (so the
  account order-history list reflects the change). Mirrors the cache strategy
  used by `cancelOmsOrder`.
- Update `ShopperOrders/index.test.ts` so the unimplemented-endpoints
  assertion now expects only `['guestOrderLookup']` (uses `ShopperTokenTsob`
  auth, intentionally handled separately).
- Add `returnOmsOrder` to the parameterized success/error matrix in
  `ShopperOrders/mutation.test.ts` and add two cache-invalidation tests:
  one for the basic `useOrder` case, and one verifying invalidation still
  matches when callers pass `expand=['oms', 'oms_shipments']`.

# How to Test-Drive This PR

1. Check out this branch and run `pnpm install` from the monorepo root.
2. From `packages/commerce-sdk-react`, run
   `npx jest src/hooks/ShopperOrders` and confirm all ShopperOrders suites
   pass (31 tests total: existing + 6 from #3864 + 3 from this PR).
3. In a consuming app, import and call:
   ```ts
   const returnOrder = useShopperOrdersMutation('returnOmsOrder')
   returnOrder.mutate({
     parameters: {orderNo: '<orderNo>'},
     body: {productItems: [{itemId: '<itemId>', quantity: 1, reason: 'damaged'}]}
   })
   ```
   Confirm the request hits `POST /checkout/shopper-orders/v1/.../orders/{orderNo}/oms-return-order`.
4. After a successful return, confirm any active `useOrder({orderNo})` hook
   re-fetches automatically — including when called with
   `expand: ['oms', 'oms_shipments']`.
5. While signed in as a registered shopper, confirm `useCustomerOrders` also
   re-fetches after the return resolves.

# Checklists

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

> CHANGELOG entry intentionally omitted on this branch — the bundled OMS
> changelog line will land with the merge of `feature/264-order-management`
> into `develop`, consistent with how #3864 was structured.

## Accessibility Compliance

- [x] There are no changes to UI

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
