### PR TITLE
@W-22918462 Add error/fallback state to order-detail fetch

### DIFF
--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -10,7 +10,7 @@
       "license": "See license in LICENSE",
       "dependencies": {
         "@salesforce/storefront-next-runtime": "0.4.2",
-        "commerce-sdk-isomorphic": "5.2.0",
+        "commerce-sdk-isomorphic": "5.1.0-unstable-20260611093359",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -1780,9 +1780,9 @@
       "license": "MIT"
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.2.0.tgz",
-      "integrity": "sha512-dJCLesCD1pPzZaHSZauhAhLYB1iFkSvjEu11/TTI3EYobnyWH5n64jOXO/2GR0RMYIRmLGS4QgSfGVjkS6NSXA==",
+      "version": "5.1.0-unstable-20260611093359",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.1.0-unstable-20260611093359.tgz",
+      "integrity": "sha512-5rA3Olh8als4KMumMAk6Zytx0/zh4UwPj6oPDtQrM8TUjwkMH6PFIMVNP19fS3mQsi6njgb9+FPsJ8R0JAe4qw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@salesforce/storefront-next-runtime": "0.4.2",
-    "commerce-sdk-isomorphic": "5.2.0",
+    "commerce-sdk-isomorphic": "5.1.0-unstable-20260611093359",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/hooks/ShopperCustomers/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperCustomers/index.test.ts
@@ -20,8 +20,7 @@ describe('Shopper Customers hooks', () => {
             'deleteCustomerPaymentMethodReference', // TODO: Implement when the endpoint exits closed beta
             'getExternalProfile', // TODO: Implement when the endpoint exits closed beta
             'getPublicProductListItems', // TODO: Implement when the endpoint exits closed beta
-            'registerExternalProfile', // TODO: Implement when the endpoint exits closed beta
-            'setupCustomerPaymentMethodReference' // TODO: Implement when the endpoint exits closed beta
+            'registerExternalProfile' // TODO: Implement when the endpoint exits closed beta
         ])
     })
     test('all mutations have cache update logic', () => {

--- a/packages/commerce-sdk-react/src/hooks/ShopperExperience/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperExperience/index.test.ts
@@ -16,7 +16,6 @@ describe('Shopper Experience hooks', () => {
             'getContentFolder', //TODO: implement later
             'getContentFolders', //TODO: implement later
             'getMultipleContent', //TODO: implement later
-            'resolveQualifiers', //TODO: implement later
             'searchContent' //TODO: implement later
         ])
     })

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -72,5 +72,14 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
             })
         }
         return {invalidate}
+    },
+    returnOmsOrder(customerId, {parameters}) {
+        const invalidate: CacheUpdateInvalidate[] = [{queryKey: getOrder.queryKey(parameters)}]
+        if (customerId) {
+            invalidate.push({
+                queryKey: getCustomerOrders.queryKey({...parameters, customerId})
+            })
+        }
+        return {invalidate}
     }
 }

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -5,7 +5,7 @@
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 import {CLIENT_KEYS} from '../../constant'
-import {getCustomerBaskets} from '../ShopperCustomers/queryKeyHelpers'
+import {getCustomerBaskets, getCustomerOrders} from '../ShopperCustomers/queryKeyHelpers'
 import {
     ApiClients,
     Argument,
@@ -60,6 +60,15 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
         if (reopenBasket && customerId) {
             invalidate.push({
                 queryKey: getCustomerBaskets.queryKey({...orderParams, customerId})
+            })
+        }
+        return {invalidate}
+    },
+    cancelOmsOrder(customerId, {parameters}) {
+        const invalidate: CacheUpdateInvalidate[] = [{queryKey: getOrder.queryKey(parameters)}]
+        if (customerId) {
+            invalidate.push({
+                queryKey: getCustomerOrders.queryKey({...parameters, customerId})
             })
         }
         return {invalidate}

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
@@ -16,7 +16,9 @@ describe('Shopper Orders hooks', () => {
         const unimplemented = getUnimplementedEndpoints(ShopperOrders, queries, mutations)
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
-        expect(unimplemented).toEqual(['guestOrderLookup'])
+        // guestOrderLookup: uses ShopperTokenTsob auth, handled separately
+        // returnOmsOrder: item-level returns are a separate epic (W-22806929)
+        expect(unimplemented).toEqual(['guestOrderLookup', 'returnOmsOrder'])
     })
     test('all mutations have cache update logic', () => {
         // unimplemented = value in mutations enum, but no method in cache update matrix

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/index.test.ts
@@ -16,9 +16,7 @@ describe('Shopper Orders hooks', () => {
         const unimplemented = getUnimplementedEndpoints(ShopperOrders, queries, mutations)
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
-        // guestOrderLookup: uses ShopperTokenTsob auth, handled separately
-        // returnOmsOrder: item-level returns are a separate epic (W-22806929)
-        expect(unimplemented).toEqual(['guestOrderLookup', 'returnOmsOrder'])
+        expect(unimplemented).toEqual(['guestOrderLookup'])
     })
     test('all mutations have cache update logic', () => {
         // unimplemented = value in mutations enum, but no method in cache update matrix

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
@@ -9,6 +9,7 @@ import {act} from '@testing-library/react'
 import {ShopperOrdersTypes} from 'commerce-sdk-isomorphic'
 import nock from 'nock'
 import {
+    assertInvalidateQuery,
     mockMutationEndpoints,
     mockQueryEndpoint,
     renderHookWithProviders,
@@ -74,6 +75,10 @@ const removePaymentOptions = createOptions<'removePaymentInstrumentFromOrder'>(u
     paymentInstrumentId: PAYMENT_INSTRUMENT_ID
 })
 const cancelOmsOrderOptions = createOptions<'cancelOmsOrder'>({reason: 'Changed my mind'}, {})
+const returnOmsOrderOptions = createOptions<'returnOmsOrder'>(
+    {productItems: [{itemId: 'item-1', quantity: 1, reason: 'damaged'}]},
+    {}
+)
 
 // --- TEST CASES --- //
 /** Every mutation modifies an existing order, except `createOrder`, which creates one. */
@@ -84,7 +89,8 @@ const testMap: TestMap = {
     createPaymentInstrumentForOrder: createPaymentOptions,
     updatePaymentInstrumentForOrder: updatePaymentOptions,
     removePaymentInstrumentFromOrder: removePaymentOptions,
-    cancelOmsOrder: cancelOmsOrderOptions
+    cancelOmsOrder: cancelOmsOrderOptions,
+    returnOmsOrder: returnOmsOrderOptions
 }
 
 // Type assertion because the built-in type definition for `Object.entries` is limited :\
@@ -179,5 +185,35 @@ describe('ShopperOrders mutations', () => {
         act(() => mut.current.mutate(cancelOmsOrderOptions))
         await waitAndExpectSuccess(() => mut.current)
         expect(mut.current.data).toEqual({...ORDER, status: 'cancelled'})
+    })
+    test('`returnOmsOrder` invalidates the order query on success', async () => {
+        mockQueryEndpoint(ordersEndpoint, ORDER) // initial useOrder
+        mockMutationEndpoints(ordersEndpoint, ORDER) // returnOmsOrder
+        mockQueryEndpoint(ordersEndpoint, ORDER) // refetch after invalidation
+        const {result} = renderHookWithProviders(() => ({
+            query: queries.useOrder({parameters: {orderNo: ORDER_NO}}),
+            mutation: useShopperOrdersMutation('returnOmsOrder')
+        }))
+        await waitAndExpectSuccess(() => result.current.query)
+        const oldData = result.current.query.data
+        act(() => result.current.mutation.mutate(returnOmsOrderOptions))
+        await waitAndExpectSuccess(() => result.current.mutation)
+        assertInvalidateQuery(result.current.query, oldData)
+    })
+    test('`returnOmsOrder` invalidates `useOrder` even when called with extra params (e.g. expand=oms)', async () => {
+        mockQueryEndpoint(ordersEndpoint, ORDER) // initial useOrder w/ expand
+        mockMutationEndpoints(ordersEndpoint, ORDER) // returnOmsOrder
+        mockQueryEndpoint(ordersEndpoint, ORDER) // refetch
+        const {result} = renderHookWithProviders(() => ({
+            query: queries.useOrder({
+                parameters: {orderNo: ORDER_NO, expand: ['oms', 'oms_shipments']}
+            }),
+            mutation: useShopperOrdersMutation('returnOmsOrder')
+        }))
+        await waitAndExpectSuccess(() => result.current.query)
+        const oldData = result.current.query.data
+        act(() => result.current.mutation.mutate(returnOmsOrderOptions))
+        await waitAndExpectSuccess(() => result.current.mutation)
+        assertInvalidateQuery(result.current.query, oldData)
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
@@ -73,6 +73,7 @@ const updatePaymentOptions = createOptions<'updatePaymentInstrumentForOrder'>(
 const removePaymentOptions = createOptions<'removePaymentInstrumentFromOrder'>(undefined, {
     paymentInstrumentId: PAYMENT_INSTRUMENT_ID
 })
+const cancelOmsOrderOptions = createOptions<'cancelOmsOrder'>({reason: 'Changed my mind'}, {})
 
 // --- TEST CASES --- //
 /** Every mutation modifies an existing order, except `createOrder`, which creates one. */
@@ -82,7 +83,8 @@ type TestMap = {[Mut in NonCreateMutation]?: Argument<Client[Mut]>}
 const testMap: TestMap = {
     createPaymentInstrumentForOrder: createPaymentOptions,
     updatePaymentInstrumentForOrder: updatePaymentOptions,
-    removePaymentInstrumentFromOrder: removePaymentOptions
+    removePaymentInstrumentFromOrder: removePaymentOptions,
+    cancelOmsOrder: cancelOmsOrderOptions
 }
 
 // Type assertion because the built-in type definition for `Object.entries` is limited :\
@@ -158,5 +160,24 @@ describe('ShopperOrders mutations', () => {
         await waitAndExpectError(() => result.current.mutation)
         // The query cache should not have changed
         expect(getQueries()).toEqual([])
+    })
+    test('`cancelOmsOrder` invalidates the order cache on success', async () => {
+        mockQueryEndpoint(ordersEndpoint, ORDER) // getOrder
+        // First, populate the order cache
+        const {result: query} = renderHookWithProviders(() =>
+            queries.useOrder({parameters: {orderNo: ORDER_NO}})
+        )
+        await waitAndExpectSuccess(() => query.current)
+        expect(query.current.data).toEqual(ORDER)
+
+        // Now cancel the order
+        mockMutationEndpoints(ordersEndpoint, {...ORDER, status: 'cancelled'})
+        mockQueryEndpoint(ordersEndpoint, {...ORDER, status: 'cancelled'}) // refetch after invalidation
+        const {result: mut} = renderHookWithProviders(() =>
+            useShopperOrdersMutation('cancelOmsOrder')
+        )
+        act(() => mut.current.mutate(cancelOmsOrderOptions))
+        await waitAndExpectSuccess(() => mut.current)
+        expect(mut.current.data).toEqual({...ORDER, status: 'cancelled'})
     })
 })

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
@@ -58,7 +58,12 @@ The payment instrument is added with the provided details. The payment method mu
      * The cancellation always applies to the entire order; partial cancellations are not supported.
      * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `cancelOmsOrder` endpoint.
      */
-    CancelOmsOrder: 'cancelOmsOrder'
+    CancelOmsOrder: 'cancelOmsOrder',
+    /**
+     * Initiates the return of one or more items of an order that is integrated with Order Management (OMS).
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `returnOmsOrder` endpoint.
+     */
+    ReturnOmsOrder: 'returnOmsOrder'
 } as const
 
 /**

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.ts
@@ -52,7 +52,13 @@ The payment instrument is added with the provided details. The payment method mu
      * Creates a HistoryEntry in the failed Order with provided reasonCode.
      * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `failOrder` endpoint.
      */
-    FailOrder: 'failOrder'
+    FailOrder: 'failOrder',
+    /**
+     * Cancels an order that is integrated with Order Management (OMS).
+     * The cancellation always applies to the entire order; partial cancellations are not supported.
+     * @returns A TanStack Query mutation hook for interacting with the Shopper Orders `cancelOmsOrder` endpoint.
+     */
+    CancelOmsOrder: 'cancelOmsOrder'
 } as const
 
 /**

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.test.ts
@@ -31,7 +31,8 @@ type TestMap = {[K in keyof Queries]: NonNullable<ReturnType<Queries[K]>['data']
 const testMap: TestMap = {
     useOrder: {orderNo: 'orderNo'},
     usePaymentMethodsForOrder: {applicablePaymentMethods: []},
-    useTaxesFromOrder: {taxes: {}}
+    useTaxesFromOrder: {taxes: {}},
+    useOmsMetaData: {cancelReasonCodes: [], returnReasonCodes: []}
 }
 // Type assertion is necessary because `Object.entries` is limited
 const testCases = Object.entries(testMap) as Array<[keyof TestMap, TestMap[keyof TestMap]]>

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/query.ts
@@ -144,3 +144,38 @@ export const useTaxesFromOrder = (
         requiredParameters
     })
 }
+/**
+ * Retrieves configuration data from Order Management (OMS) required by the storefront to render
+ * cancel and return experiences. The response contains the reason codes configured in OMS.
+ * @group ShopperOrders
+ * @category Query
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
+ * @returns A TanStack Query query hook with data from the Shopper Orders `getOmsMetaData` endpoint.
+ */
+export const useOmsMetaData = (
+    apiOptions: NullableParameters<Argument<Client['getOmsMetaData']>>,
+    queryOptions: ApiQueryOptions<Client['getOmsMetaData']> = {}
+): UseQueryResult<DataType<Client['getOmsMetaData']>> => {
+    type Options = Argument<Client['getOmsMetaData']>
+    type Data = DataType<Client['getOmsMetaData']>
+    const client = useCommerceApi(CLIENT_KEY)
+    const methodName = 'getOmsMetaData'
+    const requiredParameters = ShopperOrders.paramKeys[`${methodName}Required`]
+
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    const parameters = pickValidParams(netOptions.parameters, ShopperOrders.paramKeys[methodName])
+    const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    const method = async (options: Options) => await client[methodName](options)
+
+    queryOptions.meta = {
+        displayName: 'useOmsMetaData',
+        ...queryOptions.meta
+    }
+
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
+        method,
+        queryKey,
+        requiredParameters
+    })
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/queryKeyHelpers.ts
@@ -38,6 +38,14 @@ export type QueryKeys = {
         '/taxes',
         Params<'getTaxesFromOrder'>
     ]
+    getOmsMetaData: [
+        '/commerce-sdk-react',
+        '/organizations/',
+        string | undefined,
+        '/orders/',
+        '/oms-meta-data',
+        Params<'getOmsMetaData'>
+    ]
 }
 
 // This is defined here, rather than `types.ts`, because it relies on `Client` and `QueryKeys`,
@@ -95,6 +103,22 @@ export const getTaxesFromOrder: QueryKeyHelper<'getTaxesFromOrder'> = {
         return [
             ...getTaxesFromOrder.path(params),
             pickValidParams(params || {}, ShopperOrders.paramKeys.getTaxesFromOrder)
+        ]
+    }
+}
+
+export const getOmsMetaData: QueryKeyHelper<'getOmsMetaData'> = {
+    path: (params) => [
+        '/commerce-sdk-react',
+        '/organizations/',
+        params?.organizationId,
+        '/orders/',
+        '/oms-meta-data'
+    ],
+    queryKey: (params: Params<'getOmsMetaData'>) => {
+        return [
+            ...getOmsMetaData.path(params),
+            pickValidParams(params || {}, ShopperOrders.paramKeys.getOmsMetaData)
         ]
     }
 }

--- a/packages/template-retail-react-app/app/components/order-load-error/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-load-error/index.jsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+import {
+    Box,
+    Button,
+    Heading,
+    Stack,
+    Text
+} from '@salesforce/retail-react-app/app/components/shared/ui'
+import Link from '@salesforce/retail-react-app/app/components/link'
+import {ChevronLeftIcon} from '@salesforce/retail-react-app/app/components/icons'
+
+/**
+ * Full-card error state for the Order Details page, shown when the order fetch
+ * fails (or otherwise can't be displayed). Mirrors the storefront-next
+ * `OrderNotFoundCard`: a square-cornered card with a title, a muted description,
+ * and a "Back to Order History" action.
+ *
+ * Rendered in place of the order detail when `useOrder` reports an error, so a
+ * failed fetch no longer hangs on the loading skeleton forever.
+ */
+const OrderLoadError = () => {
+    return (
+        <Stack
+            spacing={4}
+            data-testid="account-order-details-error"
+            layerStyle="cardBordered"
+            // Square corners to match the MarketStreet design (no rounded radius).
+            borderRadius="0"
+            alignItems="center"
+            textAlign="center"
+            py={[8, 12]}
+        >
+            <Box>
+                <Heading as="h1" fontSize={['lg', '2xl']}>
+                    <FormattedMessage
+                        defaultMessage="Order Not Found"
+                        id="account_order_detail.error.title"
+                    />
+                </Heading>
+                <Text fontSize="sm" color="gray.600" pt={2}>
+                    <FormattedMessage
+                        defaultMessage="We couldn't find the order you're looking for."
+                        id="account_order_detail.error.description"
+                    />
+                </Text>
+            </Box>
+            <Button as={Link} to="/account/orders" variant="solid" leftIcon={<ChevronLeftIcon />}>
+                <FormattedMessage
+                    defaultMessage="Back to Order History"
+                    id="account_order_detail.error.back_to_history"
+                />
+            </Button>
+        </Stack>
+    )
+}
+
+export default OrderLoadError

--- a/packages/template-retail-react-app/app/components/order-load-error/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-load-error/index.test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error/index'
+
+describe('OrderLoadError component', () => {
+    test('renders the full-card error with title and description', () => {
+        renderWithProviders(<OrderLoadError />)
+        expect(screen.getByTestId('account-order-details-error')).toBeInTheDocument()
+        expect(screen.getByRole('heading', {name: /Order Not Found/i})).toBeInTheDocument()
+        expect(
+            screen.getByText(/We couldn't find the order you're looking for/i)
+        ).toBeInTheDocument()
+    })
+
+    test('renders a "Back to Order History" link pointing at the order history route', () => {
+        renderWithProviders(<OrderLoadError />)
+        const backLink = screen.getByRole('link', {name: /Back to Order History/i})
+        expect(backLink).toBeInTheDocument()
+        // The link routes to /account/orders (locale/site prefix is added by the router).
+        expect(backLink.getAttribute('href')).toMatch(/\/account\/orders$/)
+    })
+})

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -42,10 +42,13 @@ const OrderTracking = ({
     const {formatMessage, formatDate} = useIntl()
 
     // Same date format the order header uses for "Ordered:" — e.g. "Jun 12, 2026".
-    // Returns null for missing or malformed values (a truthy-but-unparseable string
-    // would otherwise render "Invalid Date" or throw in formatDate), so the caller
-    // can omit the line entirely.
+    // Returns null for missing, null, or malformed values so the caller can omit the
+    // line entirely. The `!value` guard is load-bearing: `new Date(null)` returns the
+    // epoch (1970-01-01), NOT an Invalid Date, so without it a null delivery date would
+    // render "31 Dec 1969" to the shopper. A truthy-but-unparseable string is caught by
+    // the isNaN check.
     const formatTrackingDate = (value) => {
+        if (!value) return null
         const date = new Date(value)
         if (isNaN(date.getTime())) return null
         return formatDate(date, {year: 'numeric', month: 'short', day: 'numeric'})

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -20,22 +20,39 @@ import {
  * Presentational tracking block for a single shipment on the Order Details page.
  *
  * Renders the shipping method heading, the (localized) shipping status, the
- * shipping method / provider name, and — when a tracking number is present —
- * the tracking number, hyperlinked to the carrier site when a tracking URL is
- * available (otherwise shown as plain text).
+ * shipping method / provider name, the tracking number (hyperlinked to the
+ * carrier site when a tracking URL is available, otherwise plain text), and —
+ * when present — the expected and actual delivery dates.
  *
- * Extracted verbatim from the former inline `renderShippingMethod` in
- * `order-detail.jsx`; the DOM it produces is intentionally identical.
+ * Note: the OMS-over-ECOM fallback for the shipment fields lives at the call
+ * sites in `order-detail.jsx` (the component receives already-resolved scalar
+ * props). A future WI may centralize that fallback into a normalized-shipment
+ * helper if more call sites are added.
  */
 const OrderTracking = ({
     shippingMethodName,
     shippingStatus,
     trackingNumber,
     trackingUrl,
+    expectedDeliveryDate,
+    actualDeliveryDate,
     shipmentsLength,
     index
 }) => {
-    const {formatMessage} = useIntl()
+    const {formatMessage, formatDate} = useIntl()
+
+    // Same date format the order header uses for "Ordered:" — e.g. "Jun 12, 2026".
+    // Returns null for missing or malformed values (a truthy-but-unparseable string
+    // would otherwise render "Invalid Date" or throw in formatDate), so the caller
+    // can omit the line entirely.
+    const formatTrackingDate = (value) => {
+        const date = new Date(value)
+        if (isNaN(date.getTime())) return null
+        return formatDate(date, {year: 'numeric', month: 'short', day: 'numeric'})
+    }
+
+    const expectedDeliveryLabel = formatTrackingDate(expectedDeliveryDate)
+    const actualDeliveryLabel = formatTrackingDate(actualDeliveryDate)
 
     return (
         <Stack spacing={1}>
@@ -89,6 +106,26 @@ const OrderTracking = ({
                         )}
                     </Text>
                 )}
+                {expectedDeliveryLabel && (
+                    <Text fontSize="sm">
+                        <FormattedMessage
+                            defaultMessage="Expected delivery"
+                            id="account_order_detail.label.expected_delivery"
+                        />
+                        : {expectedDeliveryLabel}
+                    </Text>
+                )}
+                {actualDeliveryLabel && (
+                    <Text fontSize="sm">
+                        {/* id is `delivered_on` (mirrors SFN's deliveredOn) but the label is
+                            just "Delivered"; the date follows after the colon, not inside the message. */}
+                        <FormattedMessage
+                            defaultMessage="Delivered"
+                            id="account_order_detail.label.delivered_on"
+                        />
+                        : {actualDeliveryLabel}
+                    </Text>
+                )}
             </Box>
         </Stack>
     )
@@ -103,6 +140,10 @@ OrderTracking.propTypes = {
     trackingNumber: PropTypes.string,
     /** Carrier tracking URL; when present, the tracking number is rendered as an external link. */
     trackingUrl: PropTypes.string,
+    /** Expected delivery date (ISO string); when present, renders an "Expected delivery: <date>" line. */
+    expectedDeliveryDate: PropTypes.string,
+    /** Actual delivery date (ISO string); when present, renders a "Delivered: <date>" line. */
+    actualDeliveryDate: PropTypes.string,
     /** Total number of shipments being rendered (drives the numbered heading). */
     shipmentsLength: PropTypes.number,
     /** Zero-based index of this shipment (drives the numbered heading). */

--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import {FormattedMessage, useIntl} from 'react-intl'
+import {
+    Box,
+    Heading,
+    Stack,
+    Text,
+    Link as ChakraLink
+} from '@salesforce/retail-react-app/app/components/shared/ui'
+
+/**
+ * Presentational tracking block for a single shipment on the Order Details page.
+ *
+ * Renders the shipping method heading, the (localized) shipping status, the
+ * shipping method / provider name, and — when a tracking number is present —
+ * the tracking number, hyperlinked to the carrier site when a tracking URL is
+ * available (otherwise shown as plain text).
+ *
+ * Extracted verbatim from the former inline `renderShippingMethod` in
+ * `order-detail.jsx`; the DOM it produces is intentionally identical.
+ */
+const OrderTracking = ({
+    shippingMethodName,
+    shippingStatus,
+    trackingNumber,
+    trackingUrl,
+    shipmentsLength,
+    index
+}) => {
+    const {formatMessage} = useIntl()
+
+    return (
+        <Stack spacing={1}>
+            <Heading as="h2" fontSize="sm" pt={1}>
+                {shipmentsLength > 1 ? (
+                    <FormattedMessage
+                        defaultMessage="Shipping Method {number}"
+                        id="account_order_detail.heading.shipping_method_number"
+                        values={{number: index + 1}}
+                    />
+                ) : (
+                    <FormattedMessage
+                        defaultMessage="Shipping Method"
+                        id="account_order_detail.heading.shipping_method"
+                    />
+                )}
+            </Heading>
+            <Box>
+                <Text fontSize="sm" textTransform="titlecase">
+                    {/* Inline literal descriptors so babel-plugin-formatjs can statically
+                        extract these ids (a hoisted/variable descriptor is NOT extracted). */}
+                    {{
+                        not_shipped: formatMessage({
+                            defaultMessage: 'Not shipped',
+                            id: 'account_order_detail.shipping_status.not_shipped'
+                        }),
+                        part_shipped: formatMessage({
+                            defaultMessage: 'Partially shipped',
+                            id: 'account_order_detail.shipping_status.part_shipped'
+                        }),
+                        shipped: formatMessage({
+                            defaultMessage: 'Shipped',
+                            id: 'account_order_detail.shipping_status.shipped'
+                        })
+                    }[shippingStatus] || shippingStatus}
+                </Text>
+                <Text fontSize="sm">{shippingMethodName}</Text>
+                {trackingNumber && (
+                    <Text fontSize="sm">
+                        <FormattedMessage
+                            defaultMessage="Tracking Number"
+                            id="account_order_detail.label.tracking_number"
+                        />
+                        :{' '}
+                        {trackingUrl ? (
+                            <ChakraLink href={trackingUrl} isExternal color="blue.600">
+                                {trackingNumber}
+                            </ChakraLink>
+                        ) : (
+                            trackingNumber
+                        )}
+                    </Text>
+                )}
+            </Box>
+        </Stack>
+    )
+}
+
+OrderTracking.propTypes = {
+    /** Carrier / shipping-method display name (OMS `provider` or ECOM method name). */
+    shippingMethodName: PropTypes.string,
+    /** Shipping status key (`not_shipped` | `part_shipped` | `shipped`) or a raw OMS status string. */
+    shippingStatus: PropTypes.string,
+    /** Tracking number; when falsy, the tracking line is not rendered. */
+    trackingNumber: PropTypes.string,
+    /** Carrier tracking URL; when present, the tracking number is rendered as an external link. */
+    trackingUrl: PropTypes.string,
+    /** Total number of shipments being rendered (drives the numbered heading). */
+    shipmentsLength: PropTypes.number,
+    /** Zero-based index of this shipment (drives the numbered heading). */
+    index: PropTypes.number
+}
+
+export default OrderTracking

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -127,4 +127,19 @@ describe('OrderTracking component', () => {
         // The rest of the block still renders.
         expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
     })
+
+    test('omits the date line when the delivery date is explicitly null (no "31 Dec 1969")', () => {
+        // Regression guard: new Date(null) is the epoch (1970-01-01), NOT Invalid Date,
+        // so a null delivery date must be caught by the falsy check — otherwise it would
+        // render "31 Dec 1969" to the shopper. (Found in QA on W-22918455.)
+        renderWithProviders(
+            <OrderTracking {...baseProps} expectedDeliveryDate={null} actualDeliveryDate={null} />
+        )
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/1969/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/1970/)).not.toBeInTheDocument()
+        // The rest of the block still renders.
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
 })

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -67,4 +67,64 @@ describe('OrderTracking component', () => {
         // index is zero-based; heading shows index + 1
         expect(screen.getByRole('heading', {name: /Shipping Method 2/i})).toBeInTheDocument()
     })
+
+    // The date is formatted by locale + timezone (the test IntlProvider is en-GB),
+    // so we assert the label + month/year rather than a hardcoded exact string.
+    // `expectedDeliveryDate` of June renders as e.g. "11 Jun 2026" (en-GB, day-month-year).
+    test('renders the expected delivery date (locale-formatted) when present (AC3)', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking {...baseProps} expectedDeliveryDate="2026-06-12T00:00:00.000Z" />
+        )
+        expect(screen.getByText(/Expected delivery/i)).toBeInTheDocument()
+        // The formatted date sits in the same <Text> line as the label.
+        expect(container.textContent).toMatch(/Expected delivery:\s*\d{1,2} Jun 2026/)
+    })
+
+    test('omits the expected-delivery line when no expectedDeliveryDate is present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} expectedDeliveryDate={undefined} />)
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+    })
+
+    test('renders the delivered date (locale-formatted) when actualDeliveryDate is present', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking {...baseProps} actualDeliveryDate="2026-06-15T00:00:00.000Z" />
+        )
+        expect(screen.getByText(/Delivered/i)).toBeInTheDocument()
+        expect(container.textContent).toMatch(/Delivered:\s*\d{1,2} Jun 2026/)
+    })
+
+    test('omits the delivered line when no actualDeliveryDate is present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} actualDeliveryDate={undefined} />)
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+    })
+
+    test('renders both expected and delivered lines when both dates are present', () => {
+        const {container} = renderWithProviders(
+            <OrderTracking
+                {...baseProps}
+                expectedDeliveryDate="2026-06-12T00:00:00.000Z"
+                actualDeliveryDate="2026-06-15T00:00:00.000Z"
+            />
+        )
+        expect(screen.getByText(/Expected delivery/i)).toBeInTheDocument()
+        expect(screen.getByText(/Delivered/i)).toBeInTheDocument()
+        expect(container.textContent).toMatch(/Expected delivery:\s*\d{1,2} Jun 2026/)
+        expect(container.textContent).toMatch(/Delivered:\s*\d{1,2} Jun 2026/)
+    })
+
+    test('omits the date line for a malformed date string (no "Invalid Date", no throw)', () => {
+        renderWithProviders(
+            <OrderTracking
+                {...baseProps}
+                expectedDeliveryDate="not-a-real-date"
+                actualDeliveryDate="also-bad"
+            />
+        )
+        // Malformed values must not surface to the shopper or crash the render.
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Invalid Date/i)).not.toBeInTheDocument()
+        // The rest of the block still renders.
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
 })

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking/index'
+
+const baseProps = {
+    shippingMethodName: 'FedEx Ground',
+    shippingStatus: 'shipped',
+    trackingNumber: 'TRACK-12345',
+    trackingUrl: 'https://tracking.fedex.com/TRACK-12345',
+    shipmentsLength: 1,
+    index: 0
+}
+
+describe('OrderTracking component', () => {
+    test('renders the provider / shipping method name', () => {
+        renderWithProviders(<OrderTracking {...baseProps} />)
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
+
+    test('renders a localized shipping status when the status is a known key', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shippingStatus="not_shipped" />)
+        expect(screen.getByText('Not shipped')).toBeInTheDocument()
+    })
+
+    test('falls back to the raw status string for unknown OMS statuses', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shippingStatus="DELIVERED" />)
+        expect(screen.getByText('DELIVERED')).toBeInTheDocument()
+    })
+
+    test('renders the tracking number as an external link to the carrier site when trackingUrl is present (US2)', () => {
+        renderWithProviders(<OrderTracking {...baseProps} />)
+        const link = screen.getByRole('link', {name: /TRACK-12345/i})
+        expect(link).toHaveAttribute('href', 'https://tracking.fedex.com/TRACK-12345')
+        // External links open in a new tab
+        expect(link).toHaveAttribute('target', '_blank')
+    })
+
+    test('renders the tracking number as plain text (no link) when trackingUrl is absent', () => {
+        renderWithProviders(<OrderTracking {...baseProps} trackingUrl={undefined} />)
+        expect(screen.queryByRole('link', {name: /TRACK-12345/i})).not.toBeInTheDocument()
+        expect(screen.getByText(/TRACK-12345/)).toBeInTheDocument()
+    })
+
+    test('omits the tracking line entirely when there is no tracking number', () => {
+        renderWithProviders(
+            <OrderTracking {...baseProps} trackingNumber={undefined} trackingUrl={undefined} />
+        )
+        expect(screen.queryByText(/Tracking Number/i)).not.toBeInTheDocument()
+        // The shipping method still renders
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
+
+    test('renders the unnumbered heading for a single shipment', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shipmentsLength={1} index={0} />)
+        expect(screen.getByRole('heading', {name: /^Shipping Method$/i})).toBeInTheDocument()
+    })
+
+    test('renders a numbered heading when multiple shipments are present', () => {
+        renderWithProviders(<OrderTracking {...baseProps} shipmentsLength={2} index={1} />)
+        // index is zero-based; heading shows index + 1
+        expect(screen.getByRole('heading', {name: /Shipping Method 2/i})).toBeInTheDocument()
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -18,7 +18,6 @@ import {
     Button,
     Divider,
     Grid,
-    Link as ChakraLink,
     SimpleGrid,
     Skeleton,
     useDisclosure
@@ -40,6 +39,7 @@ import CartItemVariantName from '@salesforce/retail-react-app/app/components/ite
 import CartItemVariantAttributes from '@salesforce/retail-react-app/app/components/item-variant/item-attributes'
 import CartItemVariantPrice from '@salesforce/retail-react-app/app/components/item-variant/item-price'
 import StoreDisplay from '@salesforce/retail-react-app/app/components/store-display'
+import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {STORE_LOCATOR_IS_ENABLED} from '@salesforce/retail-react-app/app/constants'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
@@ -247,67 +247,6 @@ const AccountOrderDetail = () => {
             return storeData.data.find((store) => store.id === storeId)
         },
         [storeData?.data]
-    )
-
-    const renderShippingMethod = (
-        shippingMethodName,
-        shippingStatus,
-        trackingNumber,
-        trackingUrl,
-        shipmentsLength,
-        index
-    ) => (
-        <Stack spacing={1}>
-            <Heading as="h2" fontSize="sm" pt={1}>
-                {shipmentsLength > 1 ? (
-                    <FormattedMessage
-                        defaultMessage="Shipping Method {number}"
-                        id="account_order_detail.heading.shipping_method_number"
-                        values={{number: index + 1}}
-                    />
-                ) : (
-                    <FormattedMessage
-                        defaultMessage="Shipping Method"
-                        id="account_order_detail.heading.shipping_method"
-                    />
-                )}
-            </Heading>
-            <Box>
-                <Text fontSize="sm" textTransform="titlecase">
-                    {{
-                        not_shipped: formatMessage({
-                            defaultMessage: 'Not shipped',
-                            id: 'account_order_detail.shipping_status.not_shipped'
-                        }),
-                        part_shipped: formatMessage({
-                            defaultMessage: 'Partially shipped',
-                            id: 'account_order_detail.shipping_status.part_shipped'
-                        }),
-                        shipped: formatMessage({
-                            defaultMessage: 'Shipped',
-                            id: 'account_order_detail.shipping_status.shipped'
-                        })
-                    }[shippingStatus] || shippingStatus}
-                </Text>
-                <Text fontSize="sm">{shippingMethodName}</Text>
-                {trackingNumber && (
-                    <Text fontSize="sm">
-                        <FormattedMessage
-                            defaultMessage="Tracking Number"
-                            id="account_order_detail.label.tracking_number"
-                        />
-                        :{' '}
-                        {trackingUrl ? (
-                            <ChakraLink href={trackingUrl} isExternal color="blue.600">
-                                {trackingNumber}
-                            </ChakraLink>
-                        ) : (
-                            trackingNumber
-                        )}
-                    </Text>
-                )}
-            </Box>
-        </Stack>
     )
 
     const paymentCard = order?.paymentInstruments?.[0]?.paymentCard
@@ -556,14 +495,14 @@ const AccountOrderDetail = () => {
 
                                         return (
                                             <React.Fragment key={`delivery-${index}`}>
-                                                {renderShippingMethod(
-                                                    shippingMethodName,
-                                                    shippingStatus,
-                                                    trackingNumber,
-                                                    trackingUrl,
-                                                    deliveryShipments.length,
-                                                    index
-                                                )}
+                                                <OrderTracking
+                                                    shippingMethodName={shippingMethodName}
+                                                    shippingStatus={shippingStatus}
+                                                    trackingNumber={trackingNumber}
+                                                    trackingUrl={trackingUrl}
+                                                    shipmentsLength={deliveryShipments.length}
+                                                    index={index}
+                                                />
                                                 <Stack spacing={1}>
                                                     <Heading as="h2" fontSize="sm" pt={1}>
                                                         {deliveryShipments.length > 1 ? (
@@ -603,16 +542,15 @@ const AccountOrderDetail = () => {
                                 {/* Any OMS multi-shipment: Only show OMS Shipments info;*/}
                                 {showMultiShipmentsFromOmsOnly &&
                                     order?.omsData?.shipments?.map((shipment, index) => (
-                                        <React.Fragment key={`oms-shipment-${index}`}>
-                                            {renderShippingMethod(
-                                                shipment.provider,
-                                                shipment.status,
-                                                shipment.trackingNumber,
-                                                shipment.trackingUrl,
-                                                omsShipmentCount,
-                                                index
-                                            )}
-                                        </React.Fragment>
+                                        <OrderTracking
+                                            key={`oms-shipment-${index}`}
+                                            shippingMethodName={shipment.provider}
+                                            shippingStatus={shipment.status}
+                                            trackingNumber={shipment.trackingNumber}
+                                            trackingUrl={shipment.trackingUrl}
+                                            shipmentsLength={omsShipmentCount}
+                                            index={index}
+                                        />
                                     ))}
 
                                 {/* Payment Method */}

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -492,6 +492,9 @@ const AccountOrderDetail = () => {
                                         const trackingNumber =
                                             omsShipment?.trackingNumber || shipment.trackingNumber
                                         const trackingUrl = omsShipment?.trackingUrl
+                                        const expectedDeliveryDate =
+                                            omsShipment?.expectedDeliveryDate
+                                        const actualDeliveryDate = omsShipment?.actualDeliveryDate
 
                                         return (
                                             <React.Fragment key={`delivery-${index}`}>
@@ -500,6 +503,8 @@ const AccountOrderDetail = () => {
                                                     shippingStatus={shippingStatus}
                                                     trackingNumber={trackingNumber}
                                                     trackingUrl={trackingUrl}
+                                                    expectedDeliveryDate={expectedDeliveryDate}
+                                                    actualDeliveryDate={actualDeliveryDate}
                                                     shipmentsLength={deliveryShipments.length}
                                                     index={index}
                                                 />
@@ -548,6 +553,8 @@ const AccountOrderDetail = () => {
                                             shippingStatus={shipment.status}
                                             trackingNumber={shipment.trackingNumber}
                                             trackingUrl={shipment.trackingUrl}
+                                            expectedDeliveryDate={shipment.expectedDeliveryDate}
+                                            actualDeliveryDate={shipment.actualDeliveryDate}
                                             shipmentsLength={omsShipmentCount}
                                             index={index}
                                         />

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -40,6 +40,7 @@ import CartItemVariantAttributes from '@salesforce/retail-react-app/app/componen
 import CartItemVariantPrice from '@salesforce/retail-react-app/app/components/item-variant/item-price'
 import StoreDisplay from '@salesforce/retail-react-app/app/components/store-display'
 import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking'
+import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {STORE_LOCATOR_IS_ENABLED} from '@salesforce/retail-react-app/app/constants'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
@@ -141,7 +142,11 @@ const AccountOrderDetail = () => {
     // expand: 'oms' returns order data from OMS if the order is successfully
     // ingested to OMS, otherwise returns data from ECOM
     // For regular non-oms orders, the order data is returned from ECOM
-    const {data: order, isLoading: isOrderLoading} = useOrder(
+    const {
+        data: order,
+        isLoading: isOrderLoading,
+        isError
+    } = useOrder(
         {
             parameters: {
                 orderNo: params.orderNo,
@@ -152,6 +157,11 @@ const AccountOrderDetail = () => {
             enabled: onClient && !!params.orderNo
         }
     )
+    // Note: keep `|| !order` so the skeleton shows until the order resolves, but a
+    // failed fetch is caught by `isError` below and routed to the error card — so it
+    // no longer hangs on the skeleton forever (the AC6 bug). `isError` is the
+    // TanStack Query failure flag; it is NOT set merely because the query is
+    // disabled/not-yet-fetched (e.g. during SSR), so the SSR skeleton is unaffected.
     const isLoading = isOrderLoading || !order
 
     // Check if order has OMS data
@@ -258,6 +268,14 @@ const AccountOrderDetail = () => {
         // Focus the 'Order Details' header when the component mounts for accessibility
         headingRef?.current?.focus()
     }, [])
+
+    // A failed order fetch shows a full-card error with a path back to order history,
+    // instead of hanging on the loading skeleton forever (AC6). The success-with-no-
+    // omsData case is NOT an error — it has `order` and falls through to the normal
+    // render (ECOM fallback), so only the TanStack Query `isError` flag triggers this.
+    if (isError) {
+        return <OrderLoadError />
+    }
 
     return (
         <Stack spacing={6} data-testid="account-order-details-page">

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -385,6 +385,13 @@ describe('OMS/SOM Integration - Order Details', () => {
         expect(await screen.findByRole('heading', {name: /payment method/i})).toBeInTheDocument()
     })
 
+    test('should NOT display an expected delivery line for an ECOM-fallback order (AC3)', async () => {
+        // ECOM orders have no omsData → no expectedDeliveryDate → the ETA line is omitted.
+        setupOrderDetailsPage(createMockOrder())
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+    })
+
     // OMS order tests - uses omsData.status, fullName, and has no payment data
     test('should display OMS status from omsData.status', async () => {
         setupOrderDetailsPage(createMockOmsOrder())
@@ -562,13 +569,15 @@ describe('OMS Multi-shipment - Shipping address hidden', () => {
                     status: 'SHIPPED',
                     trackingNumber: 'OMS-001',
                     trackingUrl: 'https://track.example.com/OMS-001',
-                    provider: 'FedEx'
+                    provider: 'FedEx',
+                    expectedDeliveryDate: '2026-06-12T00:00:00.000Z'
                 },
                 {
                     status: 'PENDING',
                     trackingNumber: 'OMS-002',
                     trackingUrl: 'https://track.example.com/OMS-002',
-                    provider: 'UPS'
+                    provider: 'UPS',
+                    expectedDeliveryDate: '2026-07-20T00:00:00.000Z'
                 }
             ]
         }
@@ -608,6 +617,15 @@ describe('OMS Multi-shipment - Shipping address hidden', () => {
 
         const trackingLink2 = await screen.findByRole('link', {name: /OMS-002/i})
         expect(trackingLink2).toHaveAttribute('href', 'https://track.example.com/OMS-002')
+    })
+
+    test('should display the expected delivery date per shipment (AC3, OMS-multi call site)', async () => {
+        // Exercises the OMS-multi call site: each shipment renders its own ETA line.
+        // findAllByText waits for the async order render to resolve.
+        const etaLabels = await screen.findAllByText(/Expected delivery/i)
+        expect(etaLabels).toHaveLength(2)
+        expect(etaLabels[0].closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
+        expect(etaLabels[1].closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
     })
 })
 
@@ -701,7 +719,8 @@ describe('OMS Single shipment with tracking URL', () => {
                     status: 'DELIVERED',
                     trackingNumber: 'TRACK-12345',
                     trackingUrl: 'https://tracking.fedex.com/TRACK-12345',
-                    provider: 'FedEx Ground'
+                    provider: 'FedEx Ground',
+                    expectedDeliveryDate: '2026-06-12T00:00:00.000Z'
                 }
             ]
         }
@@ -729,6 +748,17 @@ describe('OMS Single shipment with tracking URL', () => {
 
     test('should display OMS shipment status (fallback to raw value)', async () => {
         expect(await screen.findByText(/DELIVERED/i)).toBeInTheDocument()
+    })
+
+    test('should display the expected delivery date from OMS data (AC3, page call site)', async () => {
+        // Verifies the ETA renders at the real delivery call site, not just in the
+        // isolated component test. The label and the formatted date share one line;
+        // scope the date assertion to that line so it doesn't collide with the
+        // order's creation date elsewhere on the page.
+        const etaLabel = await screen.findByText(/Expected delivery/i)
+        expect(etaLabel).toBeInTheDocument()
+        // The <Text> line reads "Expected delivery: <formatted date>" and includes the year.
+        expect(etaLabel.closest('p')).toHaveTextContent(/Expected delivery:.*2026/)
     })
 })
 

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -365,6 +365,49 @@ describe('Order without payment data', () => {
     })
 })
 
+describe('Order detail error/fallback state (AC6)', () => {
+    // Set up the detail route, but make the order fetch fail (HTTP 500). With the
+    // global QueryClient retry disabled, useOrder reports isError immediately.
+    const setupFailedOrderFetch = () => {
+        global.server.use(
+            rest.get('*/orders/:orderNo', (req, res, ctx) => res(ctx.delay(0), ctx.status(500)))
+        )
+        window.history.pushState(
+            {},
+            'Order Details',
+            createPathWithDefaults('/account/orders/FAILED-ORDER')
+        )
+        renderWithProviders(<MockedComponent history={history} />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+    }
+
+    test('shows the full-card error (not a perpetual skeleton) when the order fetch fails', async () => {
+        setupFailedOrderFetch()
+        // The error card renders...
+        expect(await screen.findByTestId('account-order-details-error')).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /Order Not Found/i})).toBeInTheDocument()
+        // ...and the normal order-details page does NOT (no perpetual skeleton).
+        expect(screen.queryByTestId('account-order-details-page')).not.toBeInTheDocument()
+    })
+
+    test('offers a path back to order history from the error card', async () => {
+        setupFailedOrderFetch()
+        const backLink = await screen.findByRole('link', {name: /Back to Order History/i})
+        expect(backLink.getAttribute('href')).toMatch(/\/account\/orders$/)
+    })
+
+    test('does NOT show the error card for a successful order with no OMS data (ECOM fallback, not an error)', async () => {
+        // 200 OK with no omsData (org not SOM-connected / order not ingested) is NOT an
+        // error — the page should render normally via the ECOM fallback, never the card.
+        setupOrderDetailsPage(createMockOrder())
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByTestId('account-order-details-error')).not.toBeInTheDocument()
+        // ECOM fields still render (proves the fallback path, not the error path).
+        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
+    })
+})
+
 describe('OMS/SOM Integration - Order Details', () => {
     // ECOM order tests - uses order.status, firstName/lastName, and has payment data
     test('should display ECOM order status from order.status', async () => {

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -315,6 +315,18 @@
       "value": "number"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "Delivered"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "Expected delivery"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -239,6 +239,24 @@
       "value": "Cancel order"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "Back to Order History"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "We couldn't find the order you're looking for."
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "Order Not Found"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -315,6 +315,18 @@
       "value": "number"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "Delivered"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "Expected delivery"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -239,6 +239,24 @@
       "value": "Cancel order"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "Back to Order History"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "We couldn't find the order you're looking for."
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "Order Not Found"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -543,6 +543,48 @@
       "value": "]"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓȧȧƈķ ŧǿǿ Ǿřḓḗḗř Ħīşŧǿǿřẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẇḗḗ ƈǿǿŭŭŀḓƞ'ŧ ƒīƞḓ ŧħḗḗ ǿǿřḓḗḗř ẏǿǿŭŭ'řḗḗ ŀǿǿǿǿķīƞɠ ƒǿǿř."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ǿřḓḗḗř Ƞǿǿŧ Ƒǿǿŭŭƞḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -699,6 +699,34 @@
       "value": "]"
     }
   ],
+  "account_order_detail.label.delivered_on": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḓḗḗŀīṽḗḗřḗḗḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.label.expected_delivery": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ḗẋƥḗḗƈŧḗḗḓ ḓḗḗŀīṽḗḗřẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_order_detail.label.order_number": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -113,6 +113,15 @@
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
+  "account_order_detail.error.back_to_history": {
+    "defaultMessage": "Back to Order History"
+  },
+  "account_order_detail.error.description": {
+    "defaultMessage": "We couldn't find the order you're looking for."
+  },
+  "account_order_detail.error.title": {
+    "defaultMessage": "Order Not Found"
+  },
   "account_order_detail.heading.billing_address": {
     "defaultMessage": "Billing Address"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -143,6 +143,12 @@
   "account_order_detail.heading.shipping_method_number": {
     "defaultMessage": "Shipping Method {number}"
   },
+  "account_order_detail.label.delivered_on": {
+    "defaultMessage": "Delivered"
+  },
+  "account_order_detail.label.expected_delivery": {
+    "defaultMessage": "Expected delivery"
+  },
   "account_order_detail.label.order_number": {
     "defaultMessage": "Order Number: {orderNumber}"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -113,6 +113,15 @@
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
+  "account_order_detail.error.back_to_history": {
+    "defaultMessage": "Back to Order History"
+  },
+  "account_order_detail.error.description": {
+    "defaultMessage": "We couldn't find the order you're looking for."
+  },
+  "account_order_detail.error.title": {
+    "defaultMessage": "Order Not Found"
+  },
   "account_order_detail.heading.billing_address": {
     "defaultMessage": "Billing Address"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -143,6 +143,12 @@
   "account_order_detail.heading.shipping_method_number": {
     "defaultMessage": "Shipping Method {number}"
   },
+  "account_order_detail.label.delivered_on": {
+    "defaultMessage": "Delivered"
+  },
+  "account_order_detail.label.expected_delivery": {
+    "defaultMessage": "Expected delivery"
+  },
   "account_order_detail.label.order_number": {
     "defaultMessage": "Order Number: {orderNumber}"
   },


### PR DESCRIPTION
## What

Adds a graceful error/fallback state to the Order Details page (epic AC6). Today a failed `useOrder` fetch leaves the page on a **perpetual loading skeleton** (`isLoading = isOrderLoading || !order` stays true forever because `order` is never set). This PR consumes `useOrder`'s `isError` and renders a full-card error instead, mirroring the storefront-next `OrderNotFoundCard` (square corners; "Order Not Found" + description + "Back to Order History").

GUS: W-22918462 · Epic: [264 - Sharks - June] Order Tracking in PWA Kit. Builds on WI-1 (`OrderTracking` component) and WI-2 (ETA), already merged to the feature branch.

## Changes

- **New** `app/components/order-load-error/` — presentational full-card error (title + muted description + "Back to Order History" link). Square corners (MarketStreet).
- **Modified** `app/pages/account/order-detail.jsx` — destructure `isError` from `useOrder`; early-return `<OrderLoadError/>` on error.
- i18n keys: `account_order_detail.error.title` / `.description` / `.back_to_history` (extracted + compiled).
- Unit tests for the error card, the back-link, and the "no OMS data is NOT an error" case.

## Failure behavior — three distinct cases (please review this framing)

The page makes two SCAPI calls: **`useOrder`** (order + tracking, where tracking rides inside `order.omsData` via `expand: 'oms, oms_shipments'`) and **`useProducts`** (line-item images/detail). They fail independently, so "failure" is really three cases:

| # | Case | What happens | This PR's behavior |
|---|---|---|---|
| 1 | **`useOrder` fails** (4xx/5xx/network) | No order at all — `isError=true`, `order` undefined | **Full-card error** ("Order Not Found" + back). Fixes the perpetual-skeleton bug. |
| 2 | **`useOrder` OK, no `omsData`** | 200 with a valid order but no SOM tracking data (org not SOM-connected, or order not yet ingested — `expand=oms` is silently disregarded) | **No error card.** Renders normally via the existing ECOM fallback; tracking section simply absent. |
| 3 | **`useOrder` OK, a sub-part fails** — (3a) tracking data errors/lags while SOM-connected; (3b) **`useProducts` fails** | Order is healthy; only a secondary piece broke | **Graceful degradation.** For 3b, items render with name/qty/price from the order line and an "Unavailable" image badge — the order is never hidden. |

Cases 1 and 2 are decided (case 1 = epic AC6 + triad; case 2 = the 2026-06-09 decision, locked by a unit test). Case 3 is not formally specified — see below.

### Why case 3 degrades (not a full-card error)

- The epic only speaks to the **whole** "tracking API unavailable or slow" and explicitly leaves the error UX as an **open question** ("spinner, message, hide section?"). Its concrete default for absent tracking is *hide the section*, and it lists "graceful degradation" as a goal. Nothing authorizes blanking a successfully-loaded order.
- No stakeholder (PM/eng-lead/UX) ruled that a partial failure should show a full error; the only "show error" decisions are for a full order-load failure (case 1) and the separate Cancel Order action.
- The storefront-next reference degrades the same way (`fetchOrderWithProducts` swallows a products-fetch error and renders the order without product detail) — though note that's pre-existing engineering precedent, not a UX/Product sign-off.
- Promoting case 3 to a full error would hide a correct, truthful order over missing thumbnails (worse UX) and would require lifting the child's error state to the parent (a refactor).

### On the "Unavailable" image badge (case 3b)

The badge shoppers see when product detail fails to load is the app's **shared, established `ItemImage` "Unavailable" badge** — used identically in cart, wishlist, checkout, and order detail (via the shared `ItemImage` component + `isProductUnavailable`). There's even an `UnavailableProductConfirmationModal` and an `'Items Unavailable'` constant built on the same concept. We keep that existing pattern here rather than introduce a new treatment.

## How this was verified

- 96/96 unit tests pass (component + page suites); lint clean.
- The error card, the back-to-history link, and the **"200-with-no-`omsData` does NOT show the error card"** guarantee are each asserted.
- The error trigger is **solely** `useOrder`'s TanStack Query `isError` — never inferred from data shape — so a disabled/SSR query (which is never in an error state) cannot render the card during SSR, and a sparse-but-successful order renders normally.

## Out of scope / follow-ups

- E2E (Playwright) coverage for the error card → WI-4 (needs the SOM test org).
- Case 3 (true partial failure) UX is undecided. **Open question for PM** to ratify: *"When the order loads fine but tracking data is missing or fails, OK to silently hide the tracking section (no error), reserving a visible error only for a full order-load failure?"*
