### PR TITLE
@W-22918462 Add error/fallback state to order-detail fetch

### DIFF
--- a/packages/template-retail-react-app/app/components/order-load-error/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-load-error/index.jsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React from 'react'
+import {FormattedMessage} from 'react-intl'
+import {
+    Box,
+    Button,
+    Heading,
+    Stack,
+    Text
+} from '@salesforce/retail-react-app/app/components/shared/ui'
+import Link from '@salesforce/retail-react-app/app/components/link'
+import {ChevronLeftIcon} from '@salesforce/retail-react-app/app/components/icons'
+
+/**
+ * Full-card error state for the Order Details page, shown when the order fetch
+ * fails (or otherwise can't be displayed). Mirrors the storefront-next
+ * `OrderNotFoundCard`: a square-cornered card with a title, a muted description,
+ * and a "Back to Order History" action.
+ *
+ * Rendered in place of the order detail when `useOrder` reports an error, so a
+ * failed fetch no longer hangs on the loading skeleton forever.
+ */
+const OrderLoadError = () => {
+    return (
+        <Stack
+            spacing={4}
+            data-testid="account-order-details-error"
+            layerStyle="cardBordered"
+            // Square corners to match the MarketStreet design (no rounded radius).
+            borderRadius="0"
+            alignItems="center"
+            textAlign="center"
+            py={[8, 12]}
+        >
+            <Box>
+                <Heading as="h1" fontSize={['lg', '2xl']}>
+                    <FormattedMessage
+                        defaultMessage="Order Not Found"
+                        id="account_order_detail.error.title"
+                    />
+                </Heading>
+                <Text fontSize="sm" color="gray.600" pt={2}>
+                    <FormattedMessage
+                        defaultMessage="We couldn't find the order you're looking for."
+                        id="account_order_detail.error.description"
+                    />
+                </Text>
+            </Box>
+            <Button as={Link} to="/account/orders" variant="solid" leftIcon={<ChevronLeftIcon />}>
+                <FormattedMessage
+                    defaultMessage="Back to Order History"
+                    id="account_order_detail.error.back_to_history"
+                />
+            </Button>
+        </Stack>
+    )
+}
+
+export default OrderLoadError

--- a/packages/template-retail-react-app/app/components/order-load-error/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-load-error/index.test.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error/index'
+
+describe('OrderLoadError component', () => {
+    test('renders the full-card error with title and description', () => {
+        renderWithProviders(<OrderLoadError />)
+        expect(screen.getByTestId('account-order-details-error')).toBeInTheDocument()
+        expect(screen.getByRole('heading', {name: /Order Not Found/i})).toBeInTheDocument()
+        expect(
+            screen.getByText(/We couldn't find the order you're looking for/i)
+        ).toBeInTheDocument()
+    })
+
+    test('renders a "Back to Order History" link pointing at the order history route', () => {
+        renderWithProviders(<OrderLoadError />)
+        const backLink = screen.getByRole('link', {name: /Back to Order History/i})
+        expect(backLink).toBeInTheDocument()
+        // The link routes to /account/orders (locale/site prefix is added by the router).
+        expect(backLink.getAttribute('href')).toMatch(/\/account\/orders$/)
+    })
+})

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -40,6 +40,7 @@ import CartItemVariantAttributes from '@salesforce/retail-react-app/app/componen
 import CartItemVariantPrice from '@salesforce/retail-react-app/app/components/item-variant/item-price'
 import StoreDisplay from '@salesforce/retail-react-app/app/components/store-display'
 import OrderTracking from '@salesforce/retail-react-app/app/components/order-tracking'
+import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {STORE_LOCATOR_IS_ENABLED} from '@salesforce/retail-react-app/app/constants'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
@@ -141,7 +142,11 @@ const AccountOrderDetail = () => {
     // expand: 'oms' returns order data from OMS if the order is successfully
     // ingested to OMS, otherwise returns data from ECOM
     // For regular non-oms orders, the order data is returned from ECOM
-    const {data: order, isLoading: isOrderLoading} = useOrder(
+    const {
+        data: order,
+        isLoading: isOrderLoading,
+        isError
+    } = useOrder(
         {
             parameters: {
                 orderNo: params.orderNo,
@@ -152,6 +157,11 @@ const AccountOrderDetail = () => {
             enabled: onClient && !!params.orderNo
         }
     )
+    // Note: keep `|| !order` so the skeleton shows until the order resolves, but a
+    // failed fetch is caught by `isError` below and routed to the error card — so it
+    // no longer hangs on the skeleton forever (the AC6 bug). `isError` is the
+    // TanStack Query failure flag; it is NOT set merely because the query is
+    // disabled/not-yet-fetched (e.g. during SSR), so the SSR skeleton is unaffected.
     const isLoading = isOrderLoading || !order
 
     // Check if order has OMS data
@@ -258,6 +268,14 @@ const AccountOrderDetail = () => {
         // Focus the 'Order Details' header when the component mounts for accessibility
         headingRef?.current?.focus()
     }, [])
+
+    // A failed order fetch shows a full-card error with a path back to order history,
+    // instead of hanging on the loading skeleton forever (AC6). The success-with-no-
+    // omsData case is NOT an error — it has `order` and falls through to the normal
+    // render (ECOM fallback), so only the TanStack Query `isError` flag triggers this.
+    if (isError) {
+        return <OrderLoadError />
+    }
 
     return (
         <Stack spacing={6} data-testid="account-order-details-page">

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -365,6 +365,49 @@ describe('Order without payment data', () => {
     })
 })
 
+describe('Order detail error/fallback state (AC6)', () => {
+    // Set up the detail route, but make the order fetch fail (HTTP 500). With the
+    // global QueryClient retry disabled, useOrder reports isError immediately.
+    const setupFailedOrderFetch = () => {
+        global.server.use(
+            rest.get('*/orders/:orderNo', (req, res, ctx) => res(ctx.delay(0), ctx.status(500)))
+        )
+        window.history.pushState(
+            {},
+            'Order Details',
+            createPathWithDefaults('/account/orders/FAILED-ORDER')
+        )
+        renderWithProviders(<MockedComponent history={history} />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+    }
+
+    test('shows the full-card error (not a perpetual skeleton) when the order fetch fails', async () => {
+        setupFailedOrderFetch()
+        // The error card renders...
+        expect(await screen.findByTestId('account-order-details-error')).toBeInTheDocument()
+        expect(await screen.findByRole('heading', {name: /Order Not Found/i})).toBeInTheDocument()
+        // ...and the normal order-details page does NOT (no perpetual skeleton).
+        expect(screen.queryByTestId('account-order-details-page')).not.toBeInTheDocument()
+    })
+
+    test('offers a path back to order history from the error card', async () => {
+        setupFailedOrderFetch()
+        const backLink = await screen.findByRole('link', {name: /Back to Order History/i})
+        expect(backLink.getAttribute('href')).toMatch(/\/account\/orders$/)
+    })
+
+    test('does NOT show the error card for a successful order with no OMS data (ECOM fallback, not an error)', async () => {
+        // 200 OK with no omsData (org not SOM-connected / order not ingested) is NOT an
+        // error — the page should render normally via the ECOM fallback, never the card.
+        setupOrderDetailsPage(createMockOrder())
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByTestId('account-order-details-error')).not.toBeInTheDocument()
+        // ECOM fields still render (proves the fallback path, not the error path).
+        expect(await screen.findByText(/John Doe/i)).toBeInTheDocument()
+    })
+})
+
 describe('OMS/SOM Integration - Order Details', () => {
     // ECOM order tests - uses order.status, firstName/lastName, and has payment data
     test('should display ECOM order status from order.status', async () => {

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -239,6 +239,24 @@
       "value": "Cancel order"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "Back to Order History"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "We couldn't find the order you're looking for."
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "Order Not Found"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -239,6 +239,24 @@
       "value": "Cancel order"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "Back to Order History"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "We couldn't find the order you're looking for."
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "Order Not Found"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -543,6 +543,48 @@
       "value": "]"
     }
   ],
+  "account_order_detail.error.back_to_history": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ɓȧȧƈķ ŧǿǿ Ǿřḓḗḗř Ħīşŧǿǿřẏ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.error.description": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ẇḗḗ ƈǿǿŭŭŀḓƞ'ŧ ƒīƞḓ ŧħḗḗ ǿǿřḓḗḗř ẏǿǿŭŭ'řḗḗ ŀǿǿǿǿķīƞɠ ƒǿǿř."
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "account_order_detail.error.title": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ǿřḓḗḗř Ƞǿǿŧ Ƒǿǿŭŭƞḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_order_detail.heading.billing_address": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -113,6 +113,15 @@
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
+  "account_order_detail.error.back_to_history": {
+    "defaultMessage": "Back to Order History"
+  },
+  "account_order_detail.error.description": {
+    "defaultMessage": "We couldn't find the order you're looking for."
+  },
+  "account_order_detail.error.title": {
+    "defaultMessage": "Order Not Found"
+  },
   "account_order_detail.heading.billing_address": {
     "defaultMessage": "Billing Address"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -113,6 +113,15 @@
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
+  "account_order_detail.error.back_to_history": {
+    "defaultMessage": "Back to Order History"
+  },
+  "account_order_detail.error.description": {
+    "defaultMessage": "We couldn't find the order you're looking for."
+  },
+  "account_order_detail.error.title": {
+    "defaultMessage": "Order Not Found"
+  },
   "account_order_detail.heading.billing_address": {
     "defaultMessage": "Billing Address"
   },


### PR DESCRIPTION
## What

Adds a graceful error/fallback state to the Order Details page (epic AC6). Today a failed `useOrder` fetch leaves the page on a **perpetual loading skeleton** (`isLoading = isOrderLoading || !order` stays true forever because `order` is never set). This PR consumes `useOrder`'s `isError` and renders a full-card error instead, mirroring the storefront-next `OrderNotFoundCard` (square corners; "Order Not Found" + description + "Back to Order History").

GUS: W-22918462 · Epic: [264 - Sharks - June] Order Tracking in PWA Kit. Builds on WI-1 (`OrderTracking` component) and WI-2 (ETA), already merged to the feature branch.

## Changes

- **New** `app/components/order-load-error/` — presentational full-card error (title + muted description + "Back to Order History" link). Square corners (MarketStreet).
- **Modified** `app/pages/account/order-detail.jsx` — destructure `isError` from `useOrder`; early-return `<OrderLoadError/>` on error.
- i18n keys: `account_order_detail.error.title` / `.description` / `.back_to_history` (extracted + compiled).
- Unit tests for the error card, the back-link, and the "no OMS data is NOT an error" case.

## Failure behavior — three distinct cases (please review this framing)

The page makes two SCAPI calls: **`useOrder`** (order + tracking, where tracking rides inside `order.omsData` via `expand: 'oms, oms_shipments'`) and **`useProducts`** (line-item images/detail). They fail independently, so "failure" is really three cases:

| # | Case | What happens | This PR's behavior |
|---|---|---|---|
| 1 | **`useOrder` fails** (4xx/5xx/network) | No order at all — `isError=true`, `order` undefined | **Full-card error** ("Order Not Found" + back). Fixes the perpetual-skeleton bug. |
| 2 | **`useOrder` OK, no `omsData`** | 200 with a valid order but no SOM tracking data (org not SOM-connected, or order not yet ingested — `expand=oms` is silently disregarded) | **No error card.** Renders normally via the existing ECOM fallback; tracking section simply absent. |
| 3 | **`useOrder` OK, a sub-part fails** — (3a) tracking data errors/lags while SOM-connected; (3b) **`useProducts` fails** | Order is healthy; only a secondary piece broke | **Graceful degradation.** For 3b, items render with name/qty/price from the order line and an "Unavailable" image badge — the order is never hidden. |

### Why case 3 degrades (not a full-card error)

- The storefront-next reference degrades the same way (`fetchOrderWithProducts` swallows a products-fetch error and renders the order without product detail) — though note that's pre-existing engineering precedent, not a UX/Product sign-off.
- Promoting case 3 to a full error would hide a correct, truthful order over missing thumbnails (worse UX) and would require lifting the child's error state to the parent (a refactor).

### On the "Unavailable" image badge (case 3b)

The badge shoppers see when product detail fails to load is the app's **shared, established `ItemImage` "Unavailable" badge** — used identically in cart, wishlist, checkout, and order detail (via the shared `ItemImage` component + `isProductUnavailable`). There's even an `UnavailableProductConfirmationModal` and an `'Items Unavailable'` constant built on the same concept. We keep that existing pattern here rather than introduce a new treatment.

## How this was verified

- 96/96 unit tests pass (component + page suites); lint clean.
- The error card, the back-to-history link, and the **"200-with-no-`omsData` does NOT show the error card"** guarantee are each asserted.
- The error trigger is **solely** `useOrder`'s TanStack Query `isError` — never inferred from data shape — so a disabled/SSR query (which is never in an error state) cannot render the card during SSR, and a sparse-but-successful order renders normally.

## Out of scope / follow-ups

- E2E (Playwright) coverage for the error card → WI-4 (needs the SOM test org).
- Case 3 (true partial failure) UX is undecided. **Open question for PM** to ratify: *"When the order loads fine but tracking data is missing or fails, OK to silently hide the tracking section (no error), reserving a visible error only for a full order-load failure?"*
