### PR TITLE
@W-22918457 Guard null delivery dates in OrderTracking

### DIFF
--- a/packages/template-retail-react-app/app/components/order-tracking/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.jsx
@@ -42,10 +42,13 @@ const OrderTracking = ({
     const {formatMessage, formatDate} = useIntl()
 
     // Same date format the order header uses for "Ordered:" — e.g. "Jun 12, 2026".
-    // Returns null for missing or malformed values (a truthy-but-unparseable string
-    // would otherwise render "Invalid Date" or throw in formatDate), so the caller
-    // can omit the line entirely.
+    // Returns null for missing, null, or malformed values so the caller can omit the
+    // line entirely. The `!value` guard is load-bearing: `new Date(null)` returns the
+    // epoch (1970-01-01), NOT an Invalid Date, so without it a null delivery date would
+    // render "31 Dec 1969" to the shopper. A truthy-but-unparseable string is caught by
+    // the isNaN check.
     const formatTrackingDate = (value) => {
+        if (!value) return null
         const date = new Date(value)
         if (isNaN(date.getTime())) return null
         return formatDate(date, {year: 'numeric', month: 'short', day: 'numeric'})

--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -127,4 +127,19 @@ describe('OrderTracking component', () => {
         // The rest of the block still renders.
         expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
     })
+
+    test('omits the date line when the delivery date is explicitly null (no "31 Dec 1969")', () => {
+        // Regression guard: new Date(null) is the epoch (1970-01-01), NOT Invalid Date,
+        // so a null delivery date must be caught by the falsy check — otherwise it would
+        // render "31 Dec 1969" to the shopper. (Found in QA on W-22918455.)
+        renderWithProviders(
+            <OrderTracking {...baseProps} expectedDeliveryDate={null} actualDeliveryDate={null} />
+        )
+        expect(screen.queryByText(/Expected delivery/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/Delivered/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/1969/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/1970/)).not.toBeInTheDocument()
+        // The rest of the block still renders.
+        expect(screen.getByText('FedEx Ground')).toBeInTheDocument()
+    })
 })


### PR DESCRIPTION
## What

Fixes a shopper-facing defect found during QA of W-22918455 (delivery dates): an OMS shipment whose `expectedDeliveryDate` or `actualDeliveryDate` is explicitly `null` rendered **"Expected delivery: 31 Dec 1969"** / **"Delivered: 31 Dec 1969"**.

Root cause: `new Date(null)` returns the epoch (`1970-01-01`), **not** an `Invalid Date`, so a `null` value slipped past the existing `isNaN(date.getTime())` guard in `formatTrackingDate`. (A `null` *key absent* works fine; only an explicit `null` value triggers it.)

GUS: W-22918457 · Epic: [264 - Sharks - June] Order Tracking in PWA Kit. Found by QA on W-22918455.

## Change

`app/components/order-tracking/index.jsx` — add a falsy guard at the top of `formatTrackingDate`:

```js
const formatTrackingDate = (value) => {
    if (!value) return null   // catches null, undefined, '' — new Date(null) is the epoch, not Invalid Date
    const date = new Date(value)
    if (isNaN(date.getTime())) return null
    return formatDate(date, {year: 'numeric', month: 'short', day: 'numeric'})
}
```

Defensible regardless of whether OMS actually serializes `null` on the wire (defensive + correct).

## Tests

- New regression test: explicit `null` delivery dates omit the line — asserts neither "1969" nor "1970" appears.
- The existing malformed-string and present/absent cases still pass. 15/15 component tests green; lint clean.
