### PR TITLE
fix: invalidate `useCustomerOrders` after `createOrder` @W-22821836

### DIFF
--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts
@@ -42,7 +42,10 @@ export const cacheUpdateMatrix: CacheUpdateMatrix<Client> = {
               ]
         const invalidate: CacheUpdateInvalidate[] = !customerId
             ? []
-            : [{queryKey: getCustomerBaskets.queryKey({...parameters, customerId})}]
+            : [
+                  {queryKey: getCustomerBaskets.queryKey({...parameters, customerId})},
+                  {queryKey: getCustomerOrders.queryKey({...parameters, customerId})}
+              ]
         return {update, invalidate}
     },
     createPaymentInstrumentForOrder: updateOrderQuery,

--- a/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperOrders/mutation.test.ts
@@ -6,16 +6,18 @@
  */
 import {useQueryClient} from '@tanstack/react-query'
 import {act} from '@testing-library/react'
-import {ShopperOrdersTypes} from 'commerce-sdk-isomorphic'
+import {ShopperCustomersTypes, ShopperOrdersTypes} from 'commerce-sdk-isomorphic'
 import nock from 'nock'
 import {
     assertInvalidateQuery,
+    DEFAULT_TEST_CONFIG,
     mockMutationEndpoints,
     mockQueryEndpoint,
     renderHookWithProviders,
     waitAndExpectError,
     waitAndExpectSuccess
 } from '../../test-utils'
+import {useCustomerOrders} from '../ShopperCustomers'
 import {ApiClients, Argument} from '../types'
 import {ShopperOrdersMutation, useShopperOrdersMutation} from './mutation'
 import * as queries from './query'
@@ -34,8 +36,21 @@ const OPTIONS: Argument<Client[ShopperOrdersMutation]> = {
     parameters: {orderNo: ''},
     body: {basketId: 'basketId'}
 }
+const customersEndpoint = '/customer/shopper-customers/'
+const CUSTOMER_ID = 'customer_id'
 const ORDER: ShopperOrdersTypes.Order = {orderNo: '123', productItems: []}
 const ORDER_NO = '123'
+const getCustomerOrdersOptions: Argument<
+    NonNullable<ApiClients['shopperCustomers']>['getCustomerOrders']
+> = {
+    parameters: {customerId: CUSTOMER_ID}
+}
+const emptyCustomerOrders: ShopperCustomersTypes.CustomerOrderResult = {
+    data: [] as ShopperCustomersTypes.CustomerOrderResult['data'],
+    total: 0,
+    limit: 0,
+    offset: 0
+}
 const PAYMENT_INSTRUMENT_ID = '123'
 const PAYMENT_INSTRUMENT_REQUEST = {
     amount: 10,
@@ -101,6 +116,15 @@ const createTestCase = ['createOrder', OPTIONS] as const
 const allTestCases = [...nonCreateTestCases, createTestCase]
 
 describe('ShopperOrders mutations', () => {
+    const storedCustomerIdKey = `customer_id_${DEFAULT_TEST_CONFIG.siteId}`
+    beforeAll(() => {
+        if (window.localStorage.length > 0) throw new Error('Unexpected data in local storage.')
+        window.localStorage.setItem(storedCustomerIdKey, CUSTOMER_ID)
+    })
+    afterAll(() => {
+        window.localStorage.removeItem(storedCustomerIdKey)
+    })
+
     beforeEach(() => nock.cleanAll())
     test.each(allTestCases)('`%s` returns data on success', async (mutationName, options) => {
         mockMutationEndpoints(ordersEndpoint, ORDER)
@@ -151,6 +175,42 @@ describe('ShopperOrders mutations', () => {
         )
         await waitAndExpectSuccess(() => query.current)
         expect(query.current.data).toEqual(ORDER)
+    })
+    test('`createOrder` invalidates `useCustomerOrders` for a registered customer on success', async () => {
+        const [mutationName, options] = createTestCase
+        mockQueryEndpoint(customersEndpoint, emptyCustomerOrders) // initial useCustomerOrders
+        mockMutationEndpoints(ordersEndpoint, ORDER) // createOrder
+        mockQueryEndpoint(customersEndpoint, emptyCustomerOrders) // refetch after invalidation
+        const {result} = renderHookWithProviders(() => ({
+            customerOrders: useCustomerOrders(getCustomerOrdersOptions),
+            mutation: useShopperOrdersMutation(mutationName)
+        }))
+        await waitAndExpectSuccess(() => result.current.customerOrders)
+        const oldData = result.current.customerOrders.data
+        act(() => result.current.mutation.mutate(options))
+        await waitAndExpectSuccess(() => result.current.mutation)
+        assertInvalidateQuery(result.current.customerOrders, oldData)
+    })
+    test('`createOrder` does not invalidate `useCustomerOrders` for a guest checkout', async () => {
+        // Simulate a guest session by clearing the customer id for this test only.
+        window.localStorage.removeItem(storedCustomerIdKey)
+        try {
+            const [mutationName, options] = createTestCase
+            mockQueryEndpoint(customersEndpoint, emptyCustomerOrders) // initial useCustomerOrders
+            mockMutationEndpoints(ordersEndpoint, ORDER) // createOrder
+            const {result} = renderHookWithProviders(() => ({
+                customerOrders: useCustomerOrders(getCustomerOrdersOptions),
+                mutation: useShopperOrdersMutation(mutationName)
+            }))
+            await waitAndExpectSuccess(() => result.current.customerOrders)
+            act(() => result.current.mutation.mutate(options))
+            await waitAndExpectSuccess(() => result.current.mutation)
+            // Query should not be invalidated: still has original data and not refetching.
+            expect(result.current.customerOrders.data).toEqual(emptyCustomerOrders)
+            expect(result.current.customerOrders.isRefetching).toBe(false)
+        } finally {
+            window.localStorage.setItem(storedCustomerIdKey, CUSTOMER_ID)
+        }
     })
     test('`createOrder` does not update the cache on error', async () => {
         const [mutationName, options] = createTestCase


### PR DESCRIPTION
## Context
After a registered shopper placed an order, the account order-history page kept showing the stale (pre-order) list and only updated after a full logout/login. The `createOrder` cache-update matrix was invalidating `getCustomerBaskets` but not `getCustomerOrders`, so TanStack Query kept serving the cached, empty result.

## Summary
- In `packages/commerce-sdk-react/src/hooks/ShopperOrders/cache.ts`, `createOrder` now also invalidates `getCustomerOrders` for registered customers, alongside the existing `getCustomerBaskets` invalidation.
- Guest checkouts (no `customerId`) remain a no-op — same null-guard, just an additional entry in the registered branch.

## Test plan
- [ ] `pnpm test` (covers the existing `createOrder` cache tests plus new positive/negative cases for the customer-orders invalidation).
- [ ] Manual: log in as a registered customer, place an order, navigate to order history — the new order should appear without re-authenticating.
- [ ] Manual: place a guest order — confirm no spurious customer-orders refetch is triggered (network panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)