### PR TITLE
feat: order-level status matrix util from item omsData @W-23163246

### DIFF
--- a/packages/template-retail-react-app/app/utils/order-status-utils.js
+++ b/packages/template-retail-react-app/app/utils/order-status-utils.js
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+/**
+ * Salesforce Order Management (SOM) only exposes a status per line item; it does not provide a
+ * single, reliable order-level status (the order-level `omsData.status` can lag behind the items,
+ * e.g. it stays "approved" after every item is cancelled). This utility aggregates the item-level
+ * statuses into a single order-level display status following the Shopper Agent Order Level Status
+ * Matrix.
+ *
+ * This module is the pure aggregation logic only. Presenting the result in the order status badge
+ * (localized labels, badge color, cancel-CTA gating) is handled separately in the badge-update work
+ * (W-23093717) so the two efforts do not overlap.
+ */
+
+/** Canonical order-level display status keys produced by {@link getOrderDisplayStatus}. */
+export const ORDER_DISPLAY_STATUS = {
+    ORDERED: 'ORDERED',
+    IN_PROGRESS: 'IN_PROGRESS',
+    PARTIALLY_SHIPPED: 'PARTIALLY_SHIPPED',
+    SHIPPED: 'SHIPPED',
+    PART_ORDER_DELIVERED: 'PART_ORDER_DELIVERED',
+    DELIVERED: 'DELIVERED',
+    CANCELLED: 'CANCELLED',
+    RETURN_INITIATED: 'RETURN_INITIATED',
+    PARTIAL_RETURN_INITIATED: 'PARTIAL_RETURN_INITIATED',
+    RETURN_COMPLETE: 'RETURN_COMPLETE',
+    PARTIAL_RETURN_COMPLETE: 'PARTIAL_RETURN_COMPLETE'
+}
+
+/** Canonical item-level buckets that raw SOM item statuses normalize into. */
+const ITEM_BUCKET = {
+    ORDERED: 'ordered',
+    IN_PROGRESS: 'in_progress',
+    SHIPPED: 'shipped',
+    DELIVERED: 'delivered',
+    CANCELLED: 'cancelled',
+    RETURN_INITIATED: 'return_initiated',
+    RETURNED: 'returned'
+}
+
+/**
+ * Maps a raw item-level `omsData.status` string to a canonical {@link ITEM_BUCKET}. The SOM
+ * vocabulary is not strictly defined and arrives in mixed case, so matching is case-insensitive and
+ * synonym-based. Unknown values fall back to `in_progress` (a safe, non-terminal bucket) so an
+ * unexpected status never reads as a terminal state like "Delivered" or "Cancelled".
+ *
+ * @param {string} rawStatus item-level omsData.status
+ * @returns {string|undefined} canonical bucket, or undefined when no status is provided
+ */
+export function normalizeItemStatus(rawStatus) {
+    if (!rawStatus || typeof rawStatus !== 'string') return undefined
+    const s = rawStatus.trim().toLowerCase()
+    if (!s) return undefined
+
+    if (s.includes('cancel')) return ITEM_BUCKET.CANCELLED
+    // Order matters: check "return initiated" before the generic "returned".
+    if (s.includes('return') && (s.includes('initiat') || s.includes('requested'))) {
+        return ITEM_BUCKET.RETURN_INITIATED
+    }
+    if (s.includes('return')) return ITEM_BUCKET.RETURNED
+    if (s.includes('deliver')) return ITEM_BUCKET.DELIVERED
+    if (s.includes('ship') || s.includes('transit')) return ITEM_BUCKET.SHIPPED
+    if (
+        s.includes('allocat') ||
+        s.includes('progress') ||
+        s.includes('process') ||
+        s.includes('fulfil')
+    ) {
+        return ITEM_BUCKET.IN_PROGRESS
+    }
+    if (
+        s.includes('order') ||
+        s === 'created' ||
+        s === 'new' ||
+        s === 'open' ||
+        s.includes('placed')
+    ) {
+        return ITEM_BUCKET.ORDERED
+    }
+    // Unknown status: treat as in-progress rather than risk an incorrect terminal state.
+    return ITEM_BUCKET.IN_PROGRESS
+}
+
+/**
+ * Aggregates item-level SOM statuses on an order into a single order-level display status, following
+ * the Shopper Agent Order Level Status Matrix.
+ *
+ * Returns `null` when no line item carries an `omsData.status` — this signals the caller to fall
+ * back to the raw `order.status || order.omsData?.status` (the existing behavior for ECOM-only
+ * orders and for OMS orders that only expose order/shipment-level status).
+ *
+ * @param {object} order order object (expects `productItems[*].omsData.status`)
+ * @returns {string|null} an {@link ORDER_DISPLAY_STATUS} value, or null to fall back
+ */
+export function getOrderDisplayStatus(order) {
+    const items = order?.productItems
+    if (!Array.isArray(items) || items.length === 0) return null
+
+    // Map EVERY line item; items without a usable status stay `undefined` so they still count toward
+    // the order (rather than being silently dropped, which would let a partial order masquerade as a
+    // terminal all-items state).
+    const buckets = items.map((item) => normalizeItemStatus(item?.omsData?.status))
+
+    // No item carries an item-level status: signal the caller to fall back to the raw order status.
+    if (!buckets.some((bucket) => bucket != null)) return null
+
+    // A fully-cancelled order: every item is cancelled. (SOM models a full cancel this way.)
+    if (buckets.every((bucket) => bucket === ITEM_BUCKET.CANCELLED)) {
+        return ORDER_DISPLAY_STATUS.CANCELLED
+    }
+
+    // Cancelled line items are terminally removed from the order, so the order-level status is
+    // derived from the remaining "active" items. An active item missing a status is kept as a
+    // non-terminal `undefined` bucket: it prevents a terminal all-items state (e.g. one delivered
+    // item + one not-yet-ingested item is "Partially Delivered", not "Delivered") without itself
+    // implying any particular progress.
+    const active = buckets.filter((bucket) => bucket !== ITEM_BUCKET.CANCELLED)
+    const set = new Set(active)
+    const all = (bucket) => active.every((b) => b === bucket)
+    const some = (bucket) => set.has(bucket)
+    const someUnknown = set.has(undefined)
+
+    // Returns take precedence over the upstream fulfillment states they evolve from.
+    if (some(ITEM_BUCKET.RETURNED) || some(ITEM_BUCKET.RETURN_INITIATED)) {
+        if (all(ITEM_BUCKET.RETURNED)) return ORDER_DISPLAY_STATUS.RETURN_COMPLETE
+        if (all(ITEM_BUCKET.RETURN_INITIATED)) return ORDER_DISPLAY_STATUS.RETURN_INITIATED
+        // A mix that still contains an in-flight return reads as "partial return initiated";
+        // otherwise some items are fully returned while others were never returned.
+        if (some(ITEM_BUCKET.RETURN_INITIATED)) return ORDER_DISPLAY_STATUS.PARTIAL_RETURN_INITIATED
+        return ORDER_DISPLAY_STATUS.PARTIAL_RETURN_COMPLETE
+    }
+
+    if (all(ITEM_BUCKET.DELIVERED)) return ORDER_DISPLAY_STATUS.DELIVERED
+    // Delivered mixed with shipped or not-yet-shipped items is still partway through delivery.
+    if (some(ITEM_BUCKET.DELIVERED)) return ORDER_DISPLAY_STATUS.PART_ORDER_DELIVERED
+
+    if (all(ITEM_BUCKET.SHIPPED)) return ORDER_DISPLAY_STATUS.SHIPPED
+    if (some(ITEM_BUCKET.SHIPPED)) return ORDER_DISPLAY_STATUS.PARTIALLY_SHIPPED
+
+    // An in-progress item, or an active item whose status we couldn't resolve, reads as in progress.
+    if (some(ITEM_BUCKET.IN_PROGRESS) || someUnknown) return ORDER_DISPLAY_STATUS.IN_PROGRESS
+
+    return ORDER_DISPLAY_STATUS.ORDERED
+}

--- a/packages/template-retail-react-app/app/utils/order-status-utils.test.js
+++ b/packages/template-retail-react-app/app/utils/order-status-utils.test.js
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import {
+    ORDER_DISPLAY_STATUS,
+    getOrderDisplayStatus,
+    normalizeItemStatus
+} from '@salesforce/retail-react-app/app/utils/order-status-utils'
+
+/** Build an order whose productItems carry the given item-level omsData statuses. */
+const orderWithItemStatuses = (statuses) => ({
+    orderNo: 'test-order',
+    productItems: statuses.map((status, i) => ({
+        productId: `product-${i}`,
+        quantity: 1,
+        omsData: status == null ? undefined : {status}
+    }))
+})
+
+describe('normalizeItemStatus', () => {
+    test.each([
+        ['allocated', 'in_progress'],
+        ['In Progress', 'in_progress'],
+        ['Processing', 'in_progress'],
+        ['Created', 'ordered'],
+        ['new', 'ordered'],
+        ['Ordered', 'ordered'],
+        ['SHIPPED', 'shipped'],
+        ['In Transit', 'shipped'],
+        ['Delivered', 'delivered'],
+        ['canceled', 'cancelled'],
+        ['Cancelled', 'cancelled'],
+        ['Return Initiated', 'return_initiated'],
+        ['Return Requested', 'return_initiated'],
+        ['Returned', 'returned']
+    ])('normalizes %s -> %s', (raw, expected) => {
+        expect(normalizeItemStatus(raw)).toBe(expected)
+    })
+
+    test('returns undefined for empty/invalid input', () => {
+        expect(normalizeItemStatus(undefined)).toBeUndefined()
+        expect(normalizeItemStatus('')).toBeUndefined()
+        expect(normalizeItemStatus('   ')).toBeUndefined()
+        expect(normalizeItemStatus(null)).toBeUndefined()
+    })
+
+    test('falls back to in_progress for unknown statuses (never a terminal state)', () => {
+        expect(normalizeItemStatus('some-future-status')).toBe('in_progress')
+    })
+})
+
+describe('getOrderDisplayStatus - matrix rows', () => {
+    test('all items ordered -> ORDERED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Ordered', 'Created', 'new']))).toBe(
+            ORDER_DISPLAY_STATUS.ORDERED
+        )
+    })
+
+    test('all items allocated/in progress -> IN_PROGRESS', () => {
+        expect(
+            getOrderDisplayStatus(orderWithItemStatuses(['allocated', 'allocated', 'Processing']))
+        ).toBe(ORDER_DISPLAY_STATUS.IN_PROGRESS)
+    })
+
+    test('mix of ordered and allocated -> IN_PROGRESS', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Ordered', 'allocated']))).toBe(
+            ORDER_DISPLAY_STATUS.IN_PROGRESS
+        )
+    })
+
+    test('some allocated + some shipped -> PARTIALLY_SHIPPED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['allocated', 'SHIPPED']))).toBe(
+            ORDER_DISPLAY_STATUS.PARTIALLY_SHIPPED
+        )
+    })
+
+    test('all items shipped -> SHIPPED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['SHIPPED', 'SHIPPED']))).toBe(
+            ORDER_DISPLAY_STATUS.SHIPPED
+        )
+    })
+
+    test('some shipped + some delivered -> PART_ORDER_DELIVERED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['SHIPPED', 'Delivered']))).toBe(
+            ORDER_DISPLAY_STATUS.PART_ORDER_DELIVERED
+        )
+    })
+
+    test('delivered mixed with not-yet-shipped -> PART_ORDER_DELIVERED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Delivered', 'allocated']))).toBe(
+            ORDER_DISPLAY_STATUS.PART_ORDER_DELIVERED
+        )
+    })
+
+    test('all delivered -> DELIVERED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Delivered', 'Delivered']))).toBe(
+            ORDER_DISPLAY_STATUS.DELIVERED
+        )
+    })
+
+    test('all cancelled -> CANCELLED (the reported bug)', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['canceled', 'canceled']))).toBe(
+            ORDER_DISPLAY_STATUS.CANCELLED
+        )
+    })
+
+    test('all return initiated -> RETURN_INITIATED', () => {
+        expect(
+            getOrderDisplayStatus(
+                orderWithItemStatuses(['Return Initiated', 'Return Initiated'])
+            )
+        ).toBe(ORDER_DISPLAY_STATUS.RETURN_INITIATED)
+    })
+
+    test('some return initiated -> PARTIAL_RETURN_INITIATED', () => {
+        expect(
+            getOrderDisplayStatus(orderWithItemStatuses(['Return Initiated', 'Delivered']))
+        ).toBe(ORDER_DISPLAY_STATUS.PARTIAL_RETURN_INITIATED)
+    })
+
+    test('all returned -> RETURN_COMPLETE', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Returned', 'Returned']))).toBe(
+            ORDER_DISPLAY_STATUS.RETURN_COMPLETE
+        )
+    })
+
+    test('some returned (rest delivered) -> PARTIAL_RETURN_COMPLETE', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Returned', 'Delivered']))).toBe(
+            ORDER_DISPLAY_STATUS.PARTIAL_RETURN_COMPLETE
+        )
+    })
+
+    test('returned mixed with return-initiated -> PARTIAL_RETURN_INITIATED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Returned', 'Return Initiated']))).toBe(
+            ORDER_DISPLAY_STATUS.PARTIAL_RETURN_INITIATED
+        )
+    })
+
+    test('partial cancellation is NOT treated as a cancelled order', () => {
+        // Only a full cancellation maps to CANCELLED. A cancelled item is terminally removed from the
+        // order, so with one item cancelled and one shipped the order reads as SHIPPED (every
+        // remaining active item is shipped), not hidden behind the cancelled item.
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['canceled', 'SHIPPED']))).toBe(
+            ORDER_DISPLAY_STATUS.SHIPPED
+        )
+    })
+
+    test('cancelled items are excluded so the active items drive the status', () => {
+        // The only non-cancelled item is fully returned, so the order is RETURN_COMPLETE — the
+        // cancelled items must not drag it down to a partial state.
+        expect(
+            getOrderDisplayStatus(orderWithItemStatuses(['canceled', 'canceled', 'Returned']))
+        ).toBe(ORDER_DISPLAY_STATUS.RETURN_COMPLETE)
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['canceled', 'Delivered']))).toBe(
+            ORDER_DISPLAY_STATUS.DELIVERED
+        )
+    })
+})
+
+describe('getOrderDisplayStatus - partial / missing item statuses', () => {
+    test('a delivered item alongside a status-less item is PART_ORDER_DELIVERED, not DELIVERED', () => {
+        // The status-less item must keep the order out of the terminal "all delivered" state.
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Delivered', null]))).toBe(
+            ORDER_DISPLAY_STATUS.PART_ORDER_DELIVERED
+        )
+    })
+
+    test('a shipped item alongside a status-less item is PARTIALLY_SHIPPED, not SHIPPED', () => {
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['SHIPPED', null]))).toBe(
+            ORDER_DISPLAY_STATUS.PARTIALLY_SHIPPED
+        )
+    })
+
+    test('an ordered item alongside a status-less item reads as IN_PROGRESS', () => {
+        // An unresolved active item is non-terminal; pairing it with an ordered item is safest read
+        // as in progress rather than the terminal-ish "all ordered" state.
+        expect(getOrderDisplayStatus(orderWithItemStatuses(['Ordered', null]))).toBe(
+            ORDER_DISPLAY_STATUS.IN_PROGRESS
+        )
+    })
+
+    test('non-string item status is ignored (treated as missing)', () => {
+        const order = {
+            orderNo: 'x',
+            productItems: [
+                {productId: 'a', omsData: {status: 42}},
+                {productId: 'b', omsData: {status: 'SHIPPED'}}
+            ]
+        }
+        // The numeric status is unusable; the only resolvable item is shipped, but the unusable item
+        // keeps it partial.
+        expect(getOrderDisplayStatus(order)).toBe(ORDER_DISPLAY_STATUS.PARTIALLY_SHIPPED)
+    })
+})
+
+describe('getOrderDisplayStatus - fallback', () => {
+    test('returns null when no productItems', () => {
+        expect(getOrderDisplayStatus({orderNo: 'x'})).toBeNull()
+        expect(getOrderDisplayStatus({orderNo: 'x', productItems: []})).toBeNull()
+    })
+
+    test('returns null when items have no omsData.status', () => {
+        expect(
+            getOrderDisplayStatus({
+                orderNo: 'x',
+                productItems: [{productId: 'a', quantity: 1}]
+            })
+        ).toBeNull()
+    })
+
+    test('handles undefined order', () => {
+        expect(getOrderDisplayStatus(undefined)).toBeNull()
+    })
+})


### PR DESCRIPTION

## Context
Salesforce Order Management (SOM) only exposes a status per line item via SCAPI (`productItems[*].omsData.status`); it does not provide a single reliable order-level status. The order-level `omsData.status` lags behind the items (e.g. it stays `"approved"`/`"Created"` after every item has been cancelled), so any order-level display derived from it is wrong. The reusable logic to derive a correct order-level status from the item-level statuses — the Shopper Agent Order Level Status Matrix — does not exist in PWA Kit yet.

## Summary
- Add a pure, framework-agnostic util `app/utils/order-status-utils.js` exporting `getOrderDisplayStatus(order)`, which aggregates item-level `omsData.status` into a single order-level status per the matrix (ORDERED, IN_PROGRESS, PARTIALLY_SHIPPED, SHIPPED, PART_ORDER_DELIVERED, DELIVERED, CANCELLED, RETURN_INITIATED / PARTIAL_RETURN_INITIATED, RETURN_COMPLETE / PARTIAL_RETURN_COMPLETE).
- `getOrderDisplayStatus` returns `null` when no line item carries an `omsData.status`, signaling the consumer to fall back to the raw `order.status || order.omsData?.status` (preserves ECOM-only and order/shipment-level OMS behavior).
- Cancelled line items are treated as terminally removed from the order; the order-level status is derived from the remaining active items (a full cancellation still maps to CANCELLED).
- Active items missing a status are kept as a non-terminal bucket so a partial order never masquerades as a terminal all-items state (e.g. one delivered + one not-yet-ingested item → "Partially Delivered", not "Delivered").
- `normalizeItemStatus` is case-insensitive and synonym-based since the SOM item-status vocabulary is not strictly defined; unknown non-empty statuses map to a safe non-terminal `in_progress` bucket so an unexpected value never reads as a terminal state.

## Scope
- This PR delivers **only the aggregation utility** + unit tests. Wiring it into the order status badge (localized labels, badge color, cancel-CTA gating) is owned by **W-23093717** (Order status badge update) and is intentionally out of scope here to avoid overlapping work.
- PWA Kit only; Storefront-Next has the same gap (separate WI if desired).

## Test plan
- [ ] `pnpm test` — `order-status-utils` suite is green (every matrix row, the all-cancelled bug case, cancelled+returns mixes, missing/non-string item status, and the null-fallback cases).
- [ ] `npm run lint` clean on the new files.
- [ ] Follow-up (W-23093717 / manual): once wired into the badge, validate against a zymc-002 OMS order — confirm the real SOM item-status vocabulary matches the normalizer's synonym map (only `allocated`/`canceled` are confirmed in-repo fixtures).
