### PR TITLE
@W-23093717 wire getOrderDisplayStatus for cancelled status into order badges 

### DIFF
--- a/packages/template-retail-react-app/app/components/order-status-badge/index.jsx
+++ b/packages/template-retail-react-app/app/components/order-status-badge/index.jsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import React, {useMemo} from 'react'
+import {useIntl} from 'react-intl'
+import {Badge, Flex} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {CloseIcon} from '@salesforce/retail-react-app/app/components/icons'
+import {
+    getOrderDisplayStatus,
+    ORDER_DISPLAY_STATUS
+} from '@salesforce/retail-react-app/app/utils/order-status-utils'
+import PropTypes from 'prop-types'
+
+/**
+ * Displays an order-level status badge. Derives the cancelled state from
+ * item-level omsData.status via getOrderDisplayStatus (OMS-only); pure ECOM
+ * orders fall through to the raw order.status string in a green badge.
+ */
+const OrderStatusBadge = ({order, cancelFeedback}) => {
+    const {formatMessage} = useIntl()
+
+    const isCancelled = useMemo(
+        () =>
+            cancelFeedback?.status === 'success' ||
+            getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED,
+        [cancelFeedback?.status, order]
+    )
+
+    return (
+        <Badge colorScheme={isCancelled ? 'red' : 'green'}>
+            {isCancelled ? (
+                <Flex display="inline-flex" alignItems="center" gap={1}>
+                    <CloseIcon boxSize={2} aria-hidden />
+                    {formatMessage({
+                        defaultMessage: 'Cancelled',
+                        id: 'order_status_badge.label.cancelled'
+                    })}
+                </Flex>
+            ) : (
+                order.status || order.omsData?.status
+            )}
+        </Badge>
+    )
+}
+
+OrderStatusBadge.propTypes = {
+    order: PropTypes.object.isRequired,
+    cancelFeedback: PropTypes.shape({
+        status: PropTypes.string
+    })
+}
+
+export default OrderStatusBadge

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -46,6 +46,10 @@ import OrderTracking from '@salesforce/retail-react-app/app/components/order-tra
 import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {getReturnableItems} from '@salesforce/retail-react-app/app/utils/return-utils'
+import {
+    getOrderDisplayStatus,
+    ORDER_DISPLAY_STATUS
+} from '@salesforce/retail-react-app/app/utils/order-status-utils'
 import {STORE_LOCATOR_IS_ENABLED} from '@salesforce/retail-react-app/app/constants'
 import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
 import {consolidateDuplicateBonusProducts} from '@salesforce/retail-react-app/app/utils/bonus-product/cart'
@@ -528,23 +532,27 @@ const AccountOrderDetail = () => {
                                 id="account_order_detail.title.order_details"
                             />
                         </Heading>
-                        {!isLoading && (
-                            <Badge
-                                colorScheme={cancelFeedback?.status === 'success' ? 'red' : 'green'}
-                            >
-                                {cancelFeedback?.status === 'success' ? (
-                                    <Flex display="inline-flex" alignItems="center" gap={1}>
-                                        <CloseIcon boxSize={2} aria-hidden />
-                                        {formatMessage({
-                                            defaultMessage: 'Cancelled',
-                                            id: 'account_order_detail.badge.cancelled'
-                                        })}
-                                    </Flex>
-                                ) : (
-                                    order.status || order.omsData?.status
-                                )}
-                            </Badge>
-                        )}
+                        {!isLoading &&
+                            (() => {
+                                const isCancelled =
+                                    cancelFeedback?.status === 'success' ||
+                                    getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
+                                return (
+                                    <Badge colorScheme={isCancelled ? 'red' : 'green'}>
+                                        {isCancelled ? (
+                                            <Flex display="inline-flex" alignItems="center" gap={1}>
+                                                <CloseIcon boxSize={2} aria-hidden />
+                                                {formatMessage({
+                                                    defaultMessage: 'Cancelled',
+                                                    id: 'account_order_detail.badge.cancelled'
+                                                })}
+                                            </Flex>
+                                        ) : (
+                                            order.status || order.omsData?.status
+                                        )}
+                                    </Badge>
+                                )
+                            })()}
                     </Flex>
 
                     {!isLoading ? (

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -13,7 +13,6 @@ import {
     Heading,
     Text,
     Stack,
-    Badge,
     Flex,
     Button,
     Divider,
@@ -35,7 +34,7 @@ import {
 } from '@salesforce/commerce-sdk-react'
 import {useOmsMetaData} from '@salesforce/commerce-sdk-react'
 import Link from '@salesforce/retail-react-app/app/components/link'
-import {ChevronLeftIcon, CloseIcon} from '@salesforce/retail-react-app/app/components/icons'
+import {ChevronLeftIcon} from '@salesforce/retail-react-app/app/components/icons'
 import OrderSummary from '@salesforce/retail-react-app/app/components/order-summary'
 import ItemVariantProvider from '@salesforce/retail-react-app/app/components/item-variant'
 import CartItemVariantImage from '@salesforce/retail-react-app/app/components/item-variant/item-image'
@@ -47,10 +46,7 @@ import OrderTracking from '@salesforce/retail-react-app/app/components/order-tra
 import OrderLoadError from '@salesforce/retail-react-app/app/components/order-load-error'
 import {groupShipmentsByDeliveryOption} from '@salesforce/retail-react-app/app/utils/shipment-utils'
 import {getReturnableItems} from '@salesforce/retail-react-app/app/utils/return-utils'
-import {
-    getOrderDisplayStatus,
-    ORDER_DISPLAY_STATUS
-} from '@salesforce/retail-react-app/app/utils/order-status-utils'
+import OrderStatusBadge from '@salesforce/retail-react-app/app/components/order-status-badge'
 import {
     classifyReturnError,
     ReturnErrorKind
@@ -259,15 +255,6 @@ const AccountOrderDetail = () => {
               id: 'account_order_detail.hint.return_unavailable'
           })
         : null
-
-    // OMS-only: getOrderDisplayStatus derives from item-level omsData.status.
-    // Pure ECOM cancellations (no OMS) fall through to the raw status string in the badge.
-    const isCancelled = useMemo(
-        () =>
-            cancelFeedback?.status === 'success' ||
-            getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED,
-        [cancelFeedback?.status, order]
-    )
 
     const {data: omsMetaData} = useOmsMetaData({parameters: {}}, {enabled: isOmsOrder && onClient})
 
@@ -619,19 +606,7 @@ const AccountOrderDetail = () => {
                             />
                         </Heading>
                         {!isLoading && (
-                            <Badge colorScheme={isCancelled ? 'red' : 'green'}>
-                                {isCancelled ? (
-                                    <Flex display="inline-flex" alignItems="center" gap={1}>
-                                        <CloseIcon boxSize={2} aria-hidden />
-                                        {formatMessage({
-                                            defaultMessage: 'Cancelled',
-                                            id: 'account_order_detail.badge.cancelled'
-                                        })}
-                                    </Flex>
-                                ) : (
-                                    order.status || order.omsData?.status
-                                )}
-                            </Badge>
+                            <OrderStatusBadge order={order} cancelFeedback={cancelFeedback} />
                         )}
                     </Flex>
 

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -51,6 +51,7 @@ import {
     getOrderDisplayStatus,
     ORDER_DISPLAY_STATUS
 } from '@salesforce/retail-react-app/app/utils/order-status-utils'
+import {
     classifyReturnError,
     ReturnErrorKind
 } from '@salesforce/retail-react-app/app/utils/return-error-utils'
@@ -259,9 +260,14 @@ const AccountOrderDetail = () => {
           })
         : null
 
-    const isCancelled =
-        cancelFeedback?.status === 'success' ||
-        getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
+    // OMS-only: getOrderDisplayStatus derives from item-level omsData.status.
+    // Pure ECOM cancellations (no OMS) fall through to the raw status string in the badge.
+    const isCancelled = useMemo(
+        () =>
+            cancelFeedback?.status === 'success' ||
+            getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED,
+        [cancelFeedback?.status, order]
+    )
 
     const {data: omsMetaData} = useOmsMetaData({parameters: {}}, {enabled: isOmsOrder && onClient})
 

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -218,6 +218,10 @@ const AccountOrderDetail = () => {
     const ownsOrder = order?.customerInfo?.customerId === customerId
     const showStartReturn = isRegistered && ownsOrder && returnableItems.length > 0
 
+    const isCancelled =
+        cancelFeedback?.status === 'success' ||
+        getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
+
     const {data: omsMetaData} = useOmsMetaData({parameters: {}}, {enabled: isOmsOrder && onClient})
 
     const handleCloseReturnModal = useCallback(() => {
@@ -532,27 +536,21 @@ const AccountOrderDetail = () => {
                                 id="account_order_detail.title.order_details"
                             />
                         </Heading>
-                        {!isLoading &&
-                            (() => {
-                                const isCancelled =
-                                    cancelFeedback?.status === 'success' ||
-                                    getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
-                                return (
-                                    <Badge colorScheme={isCancelled ? 'red' : 'green'}>
-                                        {isCancelled ? (
-                                            <Flex display="inline-flex" alignItems="center" gap={1}>
-                                                <CloseIcon boxSize={2} aria-hidden />
-                                                {formatMessage({
-                                                    defaultMessage: 'Cancelled',
-                                                    id: 'account_order_detail.badge.cancelled'
-                                                })}
-                                            </Flex>
-                                        ) : (
-                                            order.status || order.omsData?.status
-                                        )}
-                                    </Badge>
-                                )
-                            })()}
+                        {!isLoading && (
+                            <Badge colorScheme={isCancelled ? 'red' : 'green'}>
+                                {isCancelled ? (
+                                    <Flex display="inline-flex" alignItems="center" gap={1}>
+                                        <CloseIcon boxSize={2} aria-hidden />
+                                        {formatMessage({
+                                            defaultMessage: 'Cancelled',
+                                            id: 'account_order_detail.badge.cancelled'
+                                        })}
+                                    </Flex>
+                                ) : (
+                                    order.status || order.omsData?.status
+                                )}
+                            </Badge>
+                        )}
                     </Flex>
 
                     {!isLoading ? (

--- a/packages/template-retail-react-app/app/pages/account/order-history.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-history.jsx
@@ -28,10 +28,18 @@ import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation
 import {usePageUrls, useSearchParams} from '@salesforce/retail-react-app/app/hooks'
 import PageActionPlaceHolder from '@salesforce/retail-react-app/app/components/page-action-placeholder'
 import Link from '@salesforce/retail-react-app/app/components/link'
-import {ChevronRightIcon, ReceiptIcon} from '@salesforce/retail-react-app/app/components/icons'
+import {
+    ChevronRightIcon,
+    CloseIcon,
+    ReceiptIcon
+} from '@salesforce/retail-react-app/app/components/icons'
 import Pagination from '@salesforce/retail-react-app/app/components/pagination'
 import PropTypes from 'prop-types'
 import {DEFAULT_ORDERS_SEARCH_PARAMS} from '@salesforce/retail-react-app/app/constants'
+import {
+    getOrderDisplayStatus,
+    ORDER_DISPLAY_STATUS
+} from '@salesforce/retail-react-app/app/utils/order-status-utils'
 
 const OrderProductImages = ({productItems}) => {
     const ids = productItems.map((item) => item.productId).join(',') ?? ''
@@ -181,9 +189,30 @@ const AccountOrderHistory = () => {
                                                 values={{orderNumber: order.orderNo}}
                                             />
                                         </Text>
-                                        <Badge colorScheme="green">
-                                            {order.status || order.omsData?.status}
-                                        </Badge>
+                                        {(() => {
+                                            const isCancelled =
+                                                getOrderDisplayStatus(order) ===
+                                                ORDER_DISPLAY_STATUS.CANCELLED
+                                            return (
+                                                <Badge colorScheme={isCancelled ? 'red' : 'green'}>
+                                                    {isCancelled ? (
+                                                        <Flex
+                                                            display="inline-flex"
+                                                            alignItems="center"
+                                                            gap={1}
+                                                        >
+                                                            <CloseIcon boxSize={2} aria-hidden />
+                                                            <FormattedMessage
+                                                                defaultMessage="Cancelled"
+                                                                id="account_order_history.badge.cancelled"
+                                                            />
+                                                        </Flex>
+                                                    ) : (
+                                                        order.status || order.omsData?.status
+                                                    )}
+                                                </Badge>
+                                            )
+                                        })()}
                                     </Stack>
                                 </Box>
                                 <Grid templateColumns={{base: 'repeat(auto-fit, 88px)'}} gap={4}>

--- a/packages/template-retail-react-app/app/pages/account/order-history.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-history.jsx
@@ -13,7 +13,6 @@ import {
     Heading,
     Text,
     Stack,
-    Badge,
     Flex,
     Button,
     Divider,
@@ -28,18 +27,11 @@ import useNavigation from '@salesforce/retail-react-app/app/hooks/use-navigation
 import {usePageUrls, useSearchParams} from '@salesforce/retail-react-app/app/hooks'
 import PageActionPlaceHolder from '@salesforce/retail-react-app/app/components/page-action-placeholder'
 import Link from '@salesforce/retail-react-app/app/components/link'
-import {
-    ChevronRightIcon,
-    CloseIcon,
-    ReceiptIcon
-} from '@salesforce/retail-react-app/app/components/icons'
+import {ChevronRightIcon, ReceiptIcon} from '@salesforce/retail-react-app/app/components/icons'
 import Pagination from '@salesforce/retail-react-app/app/components/pagination'
 import PropTypes from 'prop-types'
 import {DEFAULT_ORDERS_SEARCH_PARAMS} from '@salesforce/retail-react-app/app/constants'
-import {
-    getOrderDisplayStatus,
-    ORDER_DISPLAY_STATUS
-} from '@salesforce/retail-react-app/app/utils/order-status-utils'
+import OrderStatusBadge from '@salesforce/retail-react-app/app/components/order-status-badge'
 
 const OrderProductImages = ({productItems}) => {
     const ids = productItems.map((item) => item.productId).join(',') ?? ''
@@ -147,10 +139,6 @@ const AccountOrderHistory = () => {
             ) : (
                 <Stack spacing={4}>
                     {orders?.map((order) => {
-                        // OMS-only: derives from item-level omsData.status.
-                        // Pure ECOM cancellations fall through to the raw status string.
-                        const isCancelled =
-                            getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
                         return (
                             <Stack key={order.orderNo} spacing={4} layerStyle="cardBordered">
                                 <Box>
@@ -193,23 +181,7 @@ const AccountOrderHistory = () => {
                                                 values={{orderNumber: order.orderNo}}
                                             />
                                         </Text>
-                                        <Badge colorScheme={isCancelled ? 'red' : 'green'}>
-                                            {isCancelled ? (
-                                                <Flex
-                                                    display="inline-flex"
-                                                    alignItems="center"
-                                                    gap={1}
-                                                >
-                                                    <CloseIcon boxSize={2} aria-hidden />
-                                                    <FormattedMessage
-                                                        defaultMessage="Cancelled"
-                                                        id="account_order_history.badge.cancelled"
-                                                    />
-                                                </Flex>
-                                            ) : (
-                                                order.status || order.omsData?.status
-                                            )}
-                                        </Badge>
+                                        <OrderStatusBadge order={order} />
                                     </Stack>
                                 </Box>
                                 <Grid templateColumns={{base: 'repeat(auto-fit, 88px)'}} gap={4}>

--- a/packages/template-retail-react-app/app/pages/account/order-history.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-history.jsx
@@ -147,6 +147,8 @@ const AccountOrderHistory = () => {
             ) : (
                 <Stack spacing={4}>
                     {orders?.map((order) => {
+                        // OMS-only: derives from item-level omsData.status.
+                        // Pure ECOM cancellations fall through to the raw status string.
                         const isCancelled =
                             getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
                         return (

--- a/packages/template-retail-react-app/app/pages/account/order-history.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-history.jsx
@@ -147,6 +147,8 @@ const AccountOrderHistory = () => {
             ) : (
                 <Stack spacing={4}>
                     {orders?.map((order) => {
+                        const isCancelled =
+                            getOrderDisplayStatus(order) === ORDER_DISPLAY_STATUS.CANCELLED
                         return (
                             <Stack key={order.orderNo} spacing={4} layerStyle="cardBordered">
                                 <Box>
@@ -189,30 +191,23 @@ const AccountOrderHistory = () => {
                                                 values={{orderNumber: order.orderNo}}
                                             />
                                         </Text>
-                                        {(() => {
-                                            const isCancelled =
-                                                getOrderDisplayStatus(order) ===
-                                                ORDER_DISPLAY_STATUS.CANCELLED
-                                            return (
-                                                <Badge colorScheme={isCancelled ? 'red' : 'green'}>
-                                                    {isCancelled ? (
-                                                        <Flex
-                                                            display="inline-flex"
-                                                            alignItems="center"
-                                                            gap={1}
-                                                        >
-                                                            <CloseIcon boxSize={2} aria-hidden />
-                                                            <FormattedMessage
-                                                                defaultMessage="Cancelled"
-                                                                id="account_order_history.badge.cancelled"
-                                                            />
-                                                        </Flex>
-                                                    ) : (
-                                                        order.status || order.omsData?.status
-                                                    )}
-                                                </Badge>
-                                            )
-                                        })()}
+                                        <Badge colorScheme={isCancelled ? 'red' : 'green'}>
+                                            {isCancelled ? (
+                                                <Flex
+                                                    display="inline-flex"
+                                                    alignItems="center"
+                                                    gap={1}
+                                                >
+                                                    <CloseIcon boxSize={2} aria-hidden />
+                                                    <FormattedMessage
+                                                        defaultMessage="Cancelled"
+                                                        id="account_order_history.badge.cancelled"
+                                                    />
+                                                </Flex>
+                                            ) : (
+                                                order.status || order.omsData?.status
+                                            )}
+                                        </Badge>
                                     </Stack>
                                 </Box>
                                 <Grid templateColumns={{base: 'repeat(auto-fit, 88px)'}} gap={4}>

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -473,6 +473,22 @@ describe('OMS/SOM Integration - Order Details', () => {
         expect(await screen.findByText('Created')).toBeInTheDocument()
     })
 
+    test('should show Cancelled badge when all items have cancelled status', async () => {
+        const cancelledOrder = createMockOmsOrder({
+            productItems: [
+                {
+                    productId: '640188017003M',
+                    productName: 'Test Product',
+                    quantity: 1,
+                    omsData: {status: 'canceled', quantityAvailableToCancel: 0}
+                }
+            ]
+        })
+        setupOrderDetailsPage(cancelledOrder)
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(await screen.findByText('Cancelled')).toBeInTheDocument()
+    })
+
     test('should display fullName for OMS shipping address', async () => {
         setupOrderDetailsPage(createMockOmsOrder())
         expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
@@ -742,6 +758,25 @@ describe('OMS/SOM Integration - Order History', () => {
         })
         expect(await screen.findByTestId('account-order-history-page')).toBeInTheDocument()
         expect(await screen.findByText('Created')).toBeInTheDocument()
+    })
+
+    test('should show Cancelled badge when all items have cancelled status', async () => {
+        const cancelledOrder = createMockOmsOrder({
+            productItems: [
+                {
+                    productId: '640188017003M',
+                    productName: 'Test Product',
+                    quantity: 1,
+                    omsData: {status: 'canceled', quantityAvailableToCancel: 0}
+                }
+            ]
+        })
+        setupOrderHistoryMock(cancelledOrder)
+        renderWithProviders(<MockedComponent history={history} />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+        expect(await screen.findByTestId('account-order-history-page')).toBeInTheDocument()
+        expect(await screen.findByText('Cancelled')).toBeInTheDocument()
     })
 
     test('should display fullName for OMS shipping address', async () => {

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -489,6 +489,28 @@ describe('OMS/SOM Integration - Order Details', () => {
         expect(await screen.findByText('Cancelled')).toBeInTheDocument()
     })
 
+    test('should NOT show Cancelled badge when only some items are cancelled', async () => {
+        const partialOrder = createMockOmsOrder({
+            productItems: [
+                {
+                    productId: '640188017003M',
+                    productName: 'Product A',
+                    quantity: 1,
+                    omsData: {status: 'canceled', quantityAvailableToCancel: 0}
+                },
+                {
+                    productId: '640188017004M',
+                    productName: 'Product B',
+                    quantity: 1,
+                    omsData: {status: 'shipped', quantityAvailableToCancel: 0}
+                }
+            ]
+        })
+        setupOrderDetailsPage(partialOrder)
+        expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
+        expect(screen.queryByText('Cancelled')).not.toBeInTheDocument()
+    })
+
     test('should display fullName for OMS shipping address', async () => {
         setupOrderDetailsPage(createMockOmsOrder())
         expect(await screen.findByTestId('account-order-details-page')).toBeInTheDocument()
@@ -777,6 +799,31 @@ describe('OMS/SOM Integration - Order History', () => {
         })
         expect(await screen.findByTestId('account-order-history-page')).toBeInTheDocument()
         expect(await screen.findByText('Cancelled')).toBeInTheDocument()
+    })
+
+    test('should NOT show Cancelled badge when only some items are cancelled', async () => {
+        const partialOrder = createMockOmsOrder({
+            productItems: [
+                {
+                    productId: '640188017003M',
+                    productName: 'Product A',
+                    quantity: 1,
+                    omsData: {status: 'canceled', quantityAvailableToCancel: 0}
+                },
+                {
+                    productId: '640188017004M',
+                    productName: 'Product B',
+                    quantity: 1,
+                    omsData: {status: 'shipped', quantityAvailableToCancel: 0}
+                }
+            ]
+        })
+        setupOrderHistoryMock(partialOrder)
+        renderWithProviders(<MockedComponent history={history} />, {
+            wrapperProps: {siteAlias: 'uk', appConfig: mockConfig.app}
+        })
+        expect(await screen.findByTestId('account-order-history-page')).toBeInTheDocument()
+        expect(screen.queryByText('Cancelled')).not.toBeInTheDocument()
     })
 
     test('should display fullName for OMS shipping address', async () => {

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -257,12 +257,6 @@
       "value": "Return submitted"
     }
   ],
-  "account_order_detail.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "Cancelled"
-    }
-  ],
   "account_order_detail.button.cancel_order": [
     {
       "type": 0,
@@ -469,12 +463,6 @@
     {
       "type": 0,
       "value": "Order Details"
-    }
-  ],
-  "account_order_history.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "Cancelled"
     }
   ],
   "account_order_history.button.continue_shopping": [
@@ -3275,6 +3263,12 @@
     {
       "type": 0,
       "value": "You're currently browsing in offline mode"
+    }
+  ],
+  "order_status_badge.label.cancelled": [
+    {
+      "type": 0,
+      "value": "Cancelled"
     }
   ],
   "order_summary.action.remove_promo": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-GB.json
@@ -465,6 +465,12 @@
       "value": "Order Details"
     }
   ],
+  "account_order_history.badge.cancelled": [
+    {
+      "type": 0,
+      "value": "Cancelled"
+    }
+  ],
   "account_order_history.button.continue_shopping": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -257,12 +257,6 @@
       "value": "Return submitted"
     }
   ],
-  "account_order_detail.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "Cancelled"
-    }
-  ],
   "account_order_detail.button.cancel_order": [
     {
       "type": 0,
@@ -469,12 +463,6 @@
     {
       "type": 0,
       "value": "Order Details"
-    }
-  ],
-  "account_order_history.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "Cancelled"
     }
   ],
   "account_order_history.button.continue_shopping": [
@@ -3275,6 +3263,12 @@
     {
       "type": 0,
       "value": "You're currently browsing in offline mode"
+    }
+  ],
+  "order_status_badge.label.cancelled": [
+    {
+      "type": 0,
+      "value": "Cancelled"
     }
   ],
   "order_summary.action.remove_promo": [

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-US.json
@@ -465,6 +465,12 @@
       "value": "Order Details"
     }
   ],
+  "account_order_history.badge.cancelled": [
+    {
+      "type": 0,
+      "value": "Cancelled"
+    }
+  ],
   "account_order_history.button.continue_shopping": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -585,20 +585,6 @@
       "value": "]"
     }
   ],
-  "account_order_detail.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ƈȧȧƞƈḗḗŀŀḗḗḓ"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
   "account_order_detail.button.cancel_order": [
     {
       "type": 0,
@@ -1041,20 +1027,6 @@
     {
       "type": 0,
       "value": "Ǿřḓḗḗř Ḓḗḗŧȧȧīŀş"
-    },
-    {
-      "type": 0,
-      "value": "]"
-    }
-  ],
-  "account_order_history.badge.cancelled": [
-    {
-      "type": 0,
-      "value": "["
-    },
-    {
-      "type": 0,
-      "value": "Ƈȧȧƞƈḗḗŀŀḗḗḓ"
     },
     {
       "type": 0,
@@ -6959,6 +6931,20 @@
     {
       "type": 0,
       "value": "Ẏǿǿŭŭ'řḗḗ ƈŭŭřřḗḗƞŧŀẏ ƀřǿǿẇşīƞɠ īƞ ǿǿƒƒŀīƞḗḗ ḿǿǿḓḗḗ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
+  "order_status_badge.label.cancelled": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈȧȧƞƈḗḗŀŀḗḗḓ"
     },
     {
       "type": 0,

--- a/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
+++ b/packages/template-retail-react-app/app/static/translations/compiled/en-XA.json
@@ -1033,6 +1033,20 @@
       "value": "]"
     }
   ],
+  "account_order_history.badge.cancelled": [
+    {
+      "type": 0,
+      "value": "["
+    },
+    {
+      "type": 0,
+      "value": "Ƈȧȧƞƈḗḗŀŀḗḗḓ"
+    },
+    {
+      "type": 0,
+      "value": "]"
+    }
+  ],
   "account_order_history.button.continue_shopping": [
     {
       "type": 0,

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -212,6 +212,9 @@
   "account_order_detail.title.order_details": {
     "defaultMessage": "Order Details"
   },
+  "account_order_history.badge.cancelled": {
+    "defaultMessage": "Cancelled"
+  },
   "account_order_history.button.continue_shopping": {
     "defaultMessage": "Continue Shopping"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -122,9 +122,6 @@
   "account_order_detail.alert.return_success_title": {
     "defaultMessage": "Return submitted"
   },
-  "account_order_detail.badge.cancelled": {
-    "defaultMessage": "Cancelled"
-  },
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
@@ -214,9 +211,6 @@
   },
   "account_order_detail.title.order_details": {
     "defaultMessage": "Order Details"
-  },
-  "account_order_history.badge.cancelled": {
-    "defaultMessage": "Cancelled"
   },
   "account_order_history.button.continue_shopping": {
     "defaultMessage": "Continue Shopping"
@@ -1388,6 +1382,9 @@
   },
   "offline_banner.description.browsing_offline_mode": {
     "defaultMessage": "You're currently browsing in offline mode"
+  },
+  "order_status_badge.label.cancelled": {
+    "defaultMessage": "Cancelled"
   },
   "order_summary.action.remove_promo": {
     "defaultMessage": "Remove"

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -212,6 +212,9 @@
   "account_order_detail.title.order_details": {
     "defaultMessage": "Order Details"
   },
+  "account_order_history.badge.cancelled": {
+    "defaultMessage": "Cancelled"
+  },
   "account_order_history.button.continue_shopping": {
     "defaultMessage": "Continue Shopping"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -122,9 +122,6 @@
   "account_order_detail.alert.return_success_title": {
     "defaultMessage": "Return submitted"
   },
-  "account_order_detail.badge.cancelled": {
-    "defaultMessage": "Cancelled"
-  },
   "account_order_detail.button.cancel_order": {
     "defaultMessage": "Cancel order"
   },
@@ -214,9 +211,6 @@
   },
   "account_order_detail.title.order_details": {
     "defaultMessage": "Order Details"
-  },
-  "account_order_history.badge.cancelled": {
-    "defaultMessage": "Cancelled"
   },
   "account_order_history.button.continue_shopping": {
     "defaultMessage": "Continue Shopping"
@@ -1388,6 +1382,9 @@
   },
   "offline_banner.description.browsing_offline_mode": {
     "defaultMessage": "You're currently browsing in offline mode"
+  },
+  "order_status_badge.label.cancelled": {
+    "defaultMessage": "Cancelled"
   },
   "order_summary.action.remove_promo": {
     "defaultMessage": "Remove"


### PR DESCRIPTION
Use item-level status derivation to show Cancelled badge (red with × icon) on both order-detail and order-history pages when all items are cancelled. Non-cancelled orders retain the existing raw status display.

  ## Summary
  - Use `getOrderDisplayStatus(order)` from `order-status-utils.js` to derive cancelled state from item-level `omsData.status` on both order-detail and order-history pages
  - Badge shows red "× Cancelled" (with `CloseIcon`) when all items are cancelled — detected via the util OR via optimistic `cancelFeedback`
  - Non-cancelled orders retain existing raw status display (`order.status || order.omsData?.status`) until localized labels for other statuses land in follow-up WIs
  - Added 2 integration tests confirming the cancelled badge renders from item-level status derivation
  
  ## Test plan
  - [x] All 123 existing + new tests pass (`pwa-kit-dev test app/pages/account/orders.test.js`)
  - [x] Manual: cancel an order on zymc-002 → order-detail badge flips to red "Cancelled"
  - [x] Manual: navigate to order history → cancelled order shows red "Cancelled" badge
  - [x] Manual: non-cancelled OMS order still shows raw status (e.g. "Created") in green badge
<img width="1722" height="527" alt="Screenshot 2026-06-25 at 2 46 36 PM" src="https://github.com/user-attachments/assets/d300699b-106c-43ed-a1be-da16e8b8a1b4" />
<img width="1722" height="938" alt="Screenshot 2026-06-25 at 2 46 42 PM" src="https://github.com/user-attachments/assets/befb2ece-9cd8-40db-9aa3-2a945c7c8ac2" />

# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [x] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [x] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
