### PR TITLE
docs: order-management feature README + strip internal GUS refs @W-22821845

### DIFF
--- a/packages/template-retail-react-app/app/components/order-tracking/index.test.js
+++ b/packages/template-retail-react-app/app/components/order-tracking/index.test.js
@@ -143,7 +143,7 @@ describe('OrderTracking component', () => {
     test('omits the date line when the delivery date is explicitly null (no "31 Dec 1969")', () => {
         // Regression guard: new Date(null) is the epoch (1970-01-01), NOT Invalid Date,
         // so a null delivery date must be caught by the falsy check — otherwise it would
-        // render "31 Dec 1969" to the shopper. (Found in QA on W-22918455.)
+        // render "31 Dec 1969" to the shopper. (Found in QA.)
         renderWithProviders(
             <OrderTracking {...baseProps} expectedDeliveryDate={null} actualDeliveryDate={null} />
         )

--- a/packages/template-retail-react-app/app/components/return-items-modal/constants.js
+++ b/packages/template-retail-react-app/app/components/return-items-modal/constants.js
@@ -93,7 +93,7 @@ export const messages = defineMessages({
         defaultMessage: 'Something went wrong submitting your return. Please try again.',
         id: 'return_items_modal.text.submit_error'
     },
-    // --- WI-5 (W-22821839) error-code-specific inline messages ---
+    // --- error-code-specific inline messages ---
     submitErrorInvalidReason: {
         defaultMessage: 'The selected reason is no longer available. Please choose another.',
         id: 'return_items_modal.text.submit_error_invalid_reason'

--- a/packages/template-retail-react-app/app/components/return-items-modal/index.jsx
+++ b/packages/template-retail-react-app/app/components/return-items-modal/index.jsx
@@ -201,7 +201,7 @@ const isSelectionValid = (selection, returnableItems) => {
  * parent (`order-detail.jsx`) so the wrapper swap on viewport resize doesn't
  * reset what the shopper has chosen.
  *
- * The review step (W-22821838) is a second view *inside the same* Modal/Drawer
+ * The review step is a second view *inside the same* Modal/Drawer
  * shell, swapped via local `view` state so the Chakra dialog never remounts and
  * the focus trap survives the transition. **Review return** advances to the
  * review view; **Back** returns to selection with all state preserved; **Submit
@@ -330,7 +330,7 @@ const ReturnItemsModal = ({
         [selection, returnableItems]
     )
 
-    // The parent (WI-5) always supplies a classified `{kind, ...}` submit error,
+    // The parent always supplies a classified `{kind, ...}` submit error,
     // or null. Derive the kind once and the two behavioral buckets from it:
     //  - select-view kinds (invalid reason / unknown items / quantity exceeded)
     //    require editing the selection, so the modal drops to the select view and

--- a/packages/template-retail-react-app/app/components/return-items-modal/index.test.js
+++ b/packages/template-retail-react-app/app/components/return-items-modal/index.test.js
@@ -330,7 +330,7 @@ test('submitError renders an inline alert and the footer Submit re-fires submit'
     expect(onSubmit).toHaveBeenCalledWith([{itemId: 'item-2', quantity: 1, reason: 'Defect'}])
 })
 
-// --- WI-5 (W-22821839): error-code-specific rendering ---
+// --- error-code-specific rendering ---
 
 test('network error renders the inline review-view banner with network copy', async () => {
     const user = userEvent.setup()

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -176,7 +176,7 @@ const AccountOrderDetail = () => {
     const returnFeedbackTimerRef = useRef(null)
     const cancelFeedbackTimerRef = useRef(null)
     // Selection state lives on the parent so the Modal/Drawer wrapper swap on
-    // viewport resize doesn't lose the shopper's progress, and so W-22821838's
+    // viewport resize doesn't lose the shopper's progress, and so the
     // review step can read the same payload without prop-drilling.
     const [returnSelection, setReturnSelection] = useState({})
 

--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -264,7 +264,7 @@ const AccountOrderDetail = () => {
     // Render gate is identity-only (registered + owns the order); whether there
     // are actually returnable items drives the button's *disabled* state, not
     // whether it renders — mirroring the always-rendered Cancel order button.
-    // (Guest enablement is a future WI; the gate stays registered-only here.)
+    // (Guest enablement is future work; the gate stays registered-only here.)
     const showStartReturn = isRegistered && ownsOrder
     const hasReturnableItems = returnableItems.length > 0
     // The button renders whenever the shopper owns the order, but is disabled when

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -630,7 +630,7 @@ describe('OMS/SOM Integration - Order Details', () => {
     })
 })
 
-describe('Return Items CTA (W-22821836 / W-22821837)', () => {
+describe('Return Items CTA', () => {
     // Eligibility is OMS-driven: the CTA renders when at least one productItem has
     // omsData.quantityAvailableToReturn > 0. OMS computes that field per item; the
     // server returns 409 if the order is no longer in a returnable state, so there
@@ -662,14 +662,14 @@ describe('Return Items CTA (W-22821836 / W-22821837)', () => {
         const cta = await screen.findByTestId('account-order-detail-start-return')
         expect(cta).toBeInTheDocument()
         expect(cta).toBeEnabled()
-        // The label was renamed from "Start return" to "Return Items" in
-        // W-22821837 to match the storefront-next designs; the underlying
-        // message id stays stable so downstream extenders aren't broken.
+        // The label was renamed from "Start return" to "Return Items" to match
+        // the storefront-next designs; the underlying message id stays stable so
+        // downstream extenders aren't broken.
         expect(cta).toHaveAccessibleName('Return Items')
     })
 
     test('renders the CTA disabled (with an SR reason) when no item has quantityAvailableToReturn > 0', async () => {
-        // W-22821839: the button always renders for the order owner (mirroring the
+        // The button always renders for the order owner (mirroring the
         // always-rendered Cancel order button); having nothing to return disables
         // it via aria-disabled rather than hiding it, and exposes a hidden reason.
         setupOrderDetailsPage(
@@ -720,7 +720,7 @@ describe('Return Items CTA (W-22821836 / W-22821837)', () => {
         expect(screen.queryByTestId('account-order-detail-start-return')).not.toBeInTheDocument()
     })
 
-    test('clicking Return Items opens the return-items modal (W-22821837)', async () => {
+    test('clicking Return Items opens the return-items modal', async () => {
         const user = userEvent.setup()
         setupOrderDetailsPage(createReturnEligibleOmsOrder())
         const cta = await screen.findByTestId('account-order-detail-start-return')
@@ -742,7 +742,7 @@ describe('Return Items CTA (W-22821836 / W-22821837)', () => {
     })
 })
 
-describe('Return submission (W-22821838)', () => {
+describe('Return submission', () => {
     const createReturnEligibleOmsOrder = (overrides = {}) =>
         createMockOmsOrder({
             customerInfo: {customerId: 'testCustomerId'},
@@ -881,7 +881,7 @@ describe('Return submission (W-22821838)', () => {
     )
 })
 
-describe('Item-level return error states (W-22821839)', () => {
+describe('Item-level return error states', () => {
     const createReturnEligibleOmsOrder = (overrides = {}) =>
         createMockOmsOrder({
             customerInfo: {customerId: 'testCustomerId'},
@@ -2345,7 +2345,7 @@ describe('Cancel order error scenarios', () => {
     })
 })
 
-describe('Cancel order — eligibility and full flow (W-22806929)', () => {
+describe('Cancel order — eligibility and full flow', () => {
     const omsEligibleOrder = createMockOmsOrder({
         omsData: {status: 'Created'},
         productItems: [
@@ -2606,18 +2606,17 @@ describe('Cancel order — eligibility and full flow (W-22806929)', () => {
     })
 })
 
-describe('Item-level return — full journey (W-22821845)', () => {
-    // Phase-3 finalization (W-22821845). The earlier WIs each covered a slice of
-    // the return flow (CTA eligibility in W-22821836/837, submission in W-22821838,
-    // error states in W-22821839). This block adds the cross-cutting integration
-    // scenarios those slices left open: a multi-item partial return that proves
-    // only the selected row is sent, the modal-close selection reset, and a single
-    // end-to-end click-through that exercises a non-default reason all the way to
-    // the success feedback. We deliberately do NOT add a live Playwright E2E:
-    // mirroring the cancel-order finalization (W-22806929 / PR #3896), the
-    // OMS-enabled sandbox isn't wired to CI and order state is non-deterministic
-    // (an order can only be returned once), so deterministic mocked integration
-    // tests provide the repeatable coverage instead.
+describe('Item-level return — full journey', () => {
+    // The earlier test blocks each cover a slice of the return flow (CTA
+    // eligibility, submission, error states). This block adds the cross-cutting
+    // integration scenarios those slices left open: a multi-item partial return
+    // that proves only the selected row is sent, the modal-close selection reset,
+    // and a single end-to-end click-through that exercises a non-default reason
+    // all the way to the success feedback. We deliberately do NOT add a live
+    // Playwright E2E: mirroring the cancel-order finalization, the OMS-enabled
+    // sandbox isn't wired to CI and order state is non-deterministic (an order can
+    // only be returned once), so deterministic mocked integration tests provide
+    // the repeatable coverage instead.
 
     // Both rows returnable (with different ceilings) so the "submit only the
     // checked row" assertion is meaningful — a non-returnable item would be

--- a/packages/template-retail-react-app/app/utils/order-status-utils.js
+++ b/packages/template-retail-react-app/app/utils/order-status-utils.js
@@ -13,8 +13,8 @@
  * Matrix.
  *
  * This module is the pure aggregation logic only. Presenting the result in the order status badge
- * (localized labels, badge color, cancel-CTA gating) is handled separately in the badge-update work
- * (W-23093717) so the two efforts do not overlap.
+ * (localized labels, badge color, cancel-CTA gating) is handled separately in the
+ * `OrderStatusBadge` component.
  */
 
 /** Canonical order-level display status keys produced by {@link getOrderDisplayStatus}. */

--- a/packages/template-retail-react-app/app/utils/return-error-utils.js
+++ b/packages/template-retail-react-app/app/utils/return-error-utils.js
@@ -6,8 +6,8 @@
  */
 
 /**
- * The distinct outcomes WI-5 must drive UI off of. Each maps to a specific
- * message + recovery affordance in the return flow.
+ * The distinct outcomes the return flow drives its UI off of. Each maps to a
+ * specific message + recovery affordance.
  *
  * NOTE there is intentionally no `authExpired` kind: a mid-flow 401 is
  * intercepted and consumed by the SDK auth layer (`useAuthorizationHeader` ->
@@ -26,8 +26,8 @@ export const ReturnErrorKind = Object.freeze({
 
 /**
  * The `errorCode` discriminators the OMS return API returns in a 400 body.
- * These are the contract values per the return OAS (W-22059580); treat any
- * other / missing code as a generic 400 (`unknown`).
+ * These are the contract values per the return OAS; treat any other / missing
+ * code as a generic 400 (`unknown`).
  */
 const ERROR_CODE_TO_KIND = {
     InvalidReasonCode: ReturnErrorKind.INVALID_REASON,

--- a/packages/template-retail-react-app/app/utils/return-utils.js
+++ b/packages/template-retail-react-app/app/utils/return-utils.js
@@ -39,7 +39,7 @@ export const getReturnableItems = (order) => {
  *
  * Rows without a positive numeric quantity are dropped — the upstream UI is
  * already gated by `isSelectionValid`, but this hardens reuse from elsewhere
- * (e.g. step 2's review modal in W-22821838) against malformed state.
+ * (e.g. the review step) against malformed state.
  */
 export const buildReturnProductItems = (selection, defaultReasonCode) =>
     Object.entries(selection || {})

--- a/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
+++ b/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
@@ -188,7 +188,7 @@ The agreed scope is therefore **a flat list with no address association**:
   orders; multi-shipment orders omit it. The address is reachable through the carrier
   tracking link anyway, so nothing is lost and nothing is mispaired.
 - A single order-level **Track Shipment** action links to the first shipment with a
-  carrier URL (disabled when none).
+  carrier URL (disabled when none). _(Arriving via PR #3906; not yet on this branch.)_
 
 Multi-shipment **grouped by address** is out of scope, deferred to a TD pending SCAPI
 returning correlated address data on `order.omsData.shipments`.

--- a/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
+++ b/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
@@ -144,10 +144,17 @@ Return feedback is kept separate from cancel feedback so the **Cancelled** badge
 
 ## Order Tracking
 
-[`OrderTracking`](../app/components/order-tracking) is a presentational block
-rendered once per shipment on the order detail page. It shows the shipping method
-heading, the localized shipping status, the provider name, the tracking number, and —
-when present — the expected and actual delivery dates.
+[`OrderTracking`](../app/components/order-tracking) is a presentational, bordered
+**tracking card** — one per shipment — rendered in a single flat **Tracking** section
+on the order detail page. Each card shows the carrier / shipping-method name, the
+localized shipping status, the tracking number, and — when present — the expected and
+actual delivery dates. A card carries **no shipping address** (addresses live with the
+items; see [Shipments and addresses](#shipments-and-addresses) below).
+
+The cards are built from `trackingEntries` (`order-detail.jsx`): one entry per
+`order.omsData.shipments[]`, falling back to `order.shipments[]` (ECOM) only when there
+are no OMS shipments. ECOM-fallback cards have no provider, tracking URL, or dates
+(those are OMS-only).
 
 Key behaviors:
 
@@ -162,36 +169,52 @@ Key behaviors:
   returns the epoch (1970-01-01), not an Invalid Date, so without it a null delivery
   date would display "31 Dec 1969".
 - **OMS-over-ECOM fallback.** The component receives already-resolved scalar props;
-  the fallback that prefers OMS shipment fields over ECOM ones lives at the call sites
-  in `order-detail.jsx`.
+  the fallback that prefers OMS shipment fields over ECOM ones lives at the call site
+  in `order-detail.jsx`. A provider-less OMS shipment borrows the delivery shipment's
+  method name **only** in the unambiguous one-OMS-↔-one-delivery case; multi-shipment
+  never joins, so a provider-less card simply shows no carrier name.
 
-### Multi-shipment (limited support)
+### Track Shipment action
 
-Shipment data arrives on the order in two separate lists with no correlation key
-between them: tracking info (status, tracking number/URL, dates) in
-`order.omsData.shipments`, and shipping addresses in `order.shipments` (ECOM
-delivery groups). The two lists can't be reliably paired — ECOM models a *delivery
-group* (the shopper's intent: which items go to which address) while OMS models a
-fulfillment *shipment* (a physical package), and a single delivery group can fan out
-into several OMS shipments (e.g. units of one line shipped from different
-warehouses). Pairing by index would risk showing the wrong address against a
-tracking number.
+A single **Track Shipment** order action sits in the actions row alongside Return
+Items / Cancel order. Its source is `trackingUrlOptions` — the externalizable
+(`ensureExternalUrl`'d) carrier URLs from `order.omsData.shipments` — so it can never
+diverge from the tracking-number links in the cards. It has three states:
 
-The agreed scope is therefore **a flat list with no address association**:
+- **No externalizable URL** → the button renders **disabled** (kept visible, focusable
+  via `aria-disabled` with a screen-reader hint "Tracking is not available for this
+  order yet.").
+- **Exactly one URL** → a single external-link button opening the carrier site in a new
+  tab (the common single-shipment case).
+- **Multiple URLs** → a dropdown (Popover) listing one carrier link per shipment, since
+  a tracking entry can't be reliably tied to a specific shipment.
 
-- Tracking renders as a flat list of cards, one per `order.omsData.shipments[]` entry
-  (falling back to `order.shipments[]` when there are no OMS shipments). Each card
-  shows the carrier/provider, status, the tracking number as a carrier link, and the
-  expected/delivered dates.
-- **No per-shipment shipping address and no positional OMS↔ECOM index-join.** A single
-  order-level Shipping Address block is shown only for single-shipment delivery
-  orders; multi-shipment orders omit it. The address is reachable through the carrier
-  tracking link anyway, so nothing is lost and nothing is mispaired.
-- A single order-level **Track Shipment** action links to the first shipment with a
-  carrier URL (disabled when none). _(Arriving via PR #3906; not yet on this branch.)_
+### Shipments and addresses
 
-Multi-shipment **grouped by address** is out of scope, deferred to a TD pending SCAPI
-returning correlated address data on `order.omsData.shipments`.
+Shipment data arrives on the order in two lists with no correlation key between them:
+tracking info (status, tracking number/URL, dates) in `order.omsData.shipments`, and
+shipping addresses in `order.shipments` (ECOM delivery groups). They can't be reliably
+paired — ECOM models a *delivery group* (the shopper's intent: which items go to which
+address) while OMS models a fulfillment *shipment* (a physical package), and a single
+delivery group can fan out into several OMS shipments (e.g. units of one line shipped
+from different warehouses). Pairing by index would risk showing the wrong address
+against a tracking number.
+
+The resulting layout keeps the two associations the data *can* support and avoids the
+one it can't:
+
+- **Items ↔ address (supported).** In the Items Ordered section, products are grouped
+  into a box per delivery shipment, and each box shows that delivery group's
+  **Shipping Address**. This is an ECOM-internal grouping (`shipmentId`), so it's
+  reliable. A single-shipment order is one box; BOPIS pickup-only orders (no delivery
+  shipment) fall back to one flat product list.
+- **Tracking ↔ shipment (not associated).** The Tracking section is a flat list of
+  cards rendered as peers *below* the shipment boxes, with **no address** and **no
+  positional OMS↔ECOM index-join** — the layout is honest that neither the shopper nor
+  the storefront can say which tracking entry belongs to which box.
+
+Multi-shipment tracking **grouped by address** remains out of scope, deferred to a TD
+pending SCAPI returning correlated address data on `order.omsData.shipments`.
 
 ## Status Badge
 

--- a/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
+++ b/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
@@ -25,13 +25,13 @@ docs for connecting and provisioning the org.
 
 Without a connected SOM org, orders carry no `omsData`: they are treated as ECOM-only,
 the return and cancel actions never render, return reasons can't load, and the status
-badge falls back to the raw `order.status`. Nothing errors — the features simply stay
+badge falls back to the raw `order.status || order.omsData?.status`. Nothing errors — the features simply stay
 hidden. There is no storefront flag to turn them on; presence of OMS data on the order
 is the switch.
 
 ## Order Returns
 
-Registered shoppers can return eligible items. A shopper opens the **Start a return**
+Registered shoppers can return eligible items. A shopper opens the **Return Items**
 modal, picks items and per-item quantities, chooses a reason, reviews, and submits.
 The order status badge then reflects the return's progress, including
 partially-returned multi-unit lines.
@@ -76,7 +76,7 @@ partially-returned multi-unit lines.
 ### Return Reason Codes
 
 Reasons are not hard-coded — they come from OMS via
-`useOmsMetaData().returnReasonCodes`, where each entry is `{reason, default}`. The
+`useOmsMetaData().data.returnReasonCodes`, where each entry is `{reason, default}`. The
 entry flagged `default: true` is pre-selected and omitted from the request body so
 the server applies it. Change the available reasons in Order Management; no
 storefront change is needed.
@@ -227,9 +227,10 @@ status per line item rather than a reliable order-level status.
 > The order-level `omsData.status` is known to be unreliable: in SOM it can stay
 > `Approved` even after every item has been cancelled or returned, because the
 > order-level rollup lags behind (or never reflects) the item-level state. The
-> item-level `omsData` *is* updated correctly, so this storefront derives the
-> displayed status entirely from the per-item (and per-unit) data and never trusts
-> the order-level status field. This is a known SOM limitation outside the
+> item-level `omsData` *is* updated correctly, so `getOrderDisplayStatus` derives the
+> aggregated status entirely from the per-item (and per-unit) data and never reads
+> the order-level `omsData.status` in that path (the raw order-level status is used
+> only as the green-badge fallback when no item carries OMS status). This is a known SOM limitation outside the
 > storefront's control; if the badge looks "wrong" versus the SOM order record, the
 > SOM order-level status is the stale side, not the badge.
 
@@ -252,7 +253,7 @@ are grouped by `isReturnDisplayStatus`. The
 [`OrderStatusBadge`](../app/components/order-status-badge/index.jsx) renders these in a
 neutral badge with their own localized labels, leaving the cancelled (red) and
 raw-status (green) branches untouched. ECOM-only orders, which carry no item-level OMS
-status, fall back to the raw `order.status`.
+status, fall back to the raw `order.status || order.omsData?.status`.
 
 ## Customization
 

--- a/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
+++ b/packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md
@@ -1,0 +1,254 @@
+# Order Management
+
+The order detail page surfaces three [Salesforce Order Management
+(OMS/SOM)](https://help.salesforce.com/s/articleView?id=commerce.order_management.htm)
+shopper actions: **returning** eligible items, **cancelling** an order, and
+**tracking** shipments. All three are driven by the OMS data attached to the order —
+eligibility, returnable/cancellable quantities, statuses, and tracking details come
+from OMS — and the authoritative accept/reject for the mutating actions happens
+server-side via the corresponding order action.
+
+There is **no feature flag**. Each action is gated entirely on data and shopper
+identity in [`order-detail.jsx`](../app/pages/account/order-detail.jsx). ECOM-only
+orders (no `omsData`) never expose the return or cancel flows, and fall back to raw
+order/shipment status everywhere.
+
+## Prerequisites
+
+These features require a **Salesforce Order Management (SOM) core org connected to
+the storefront's B2C Commerce instance**. SOM is what enriches orders with the
+`omsData` this UI depends on — order- and item-level OMS data (returnable/cancellable
+quantities, item statuses, shipment tracking) and the `oms-return-order` /
+`oms-cancel-order` SCAPI order actions. See the [Order Management
+setup](https://help.salesforce.com/s/articleView?id=commerce.order_management.htm)
+docs for connecting and provisioning the org.
+
+Without a connected SOM org, orders carry no `omsData`: they are treated as ECOM-only,
+the return and cancel actions never render, return reasons can't load, and the status
+badge falls back to the raw `order.status`. Nothing errors — the features simply stay
+hidden. There is no storefront flag to turn them on; presence of OMS data on the order
+is the switch.
+
+## Order Returns
+
+Registered shoppers can return eligible items. A shopper opens the **Start a return**
+modal, picks items and per-item quantities, chooses a reason, reviews, and submits.
+The order status badge then reflects the return's progress, including
+partially-returned multi-unit lines.
+
+### Eligibility
+
+| Condition | Source | Meaning |
+| --- | --- | --- |
+| Registered shopper | `useCustomerType().isRegistered` | Guests never see the return UI. |
+| Owns the order | `order.customerInfo.customerId === customerId` | A shopper can only return their own orders. |
+| OMS-managed order | `!!order.omsData` | ECOM-only orders carry no OMS data. |
+| Has returnable items | `getReturnableItems(order).length > 0` | At least one line has `omsData.quantityAvailableToReturn > 0`. |
+
+### How It Works
+
+1. **Determine returnable items.**
+   [`getReturnableItems(order)`](../app/utils/return-utils.js) filters
+   `order.productItems` to those whose `omsData.quantityAvailableToReturn` is a
+   positive number. We trust that field verbatim rather than maintaining a
+   client-side status allowlist.
+2. **Load return reasons.** The modal calls
+   [`useOmsMetaData`](https://github.com/SalesforceCommerceCloud/commerce-sdk-react)
+   and reads `returnReasonCodes` (`{reason, default}` entries). The OMS-default
+   reason is pre-selected for every checked item.
+3. **Select and review.** The shopper checks items, sets a per-item quantity (capped
+   at that line's available-to-return count), and picks a reason; a review step
+   summarizes the request before submission.
+4. **Build the request.**
+   [`buildReturnProductItems(selection, defaultReasonCode)`](../app/utils/return-utils.js)
+   produces the `productItems` array for the `OmsReturnOrderRequest`. Quantity is
+   serialized as a JS `Number`; the `reason` field is omitted when the shopper kept
+   the OMS default, so the server applies it.
+5. **Submit.** Via the
+   `useShopperOrdersMutation(ShopperOrdersMutations.ReturnOmsOrder)` mutation
+   (`POST .../actions/oms-return-order`). On success the page refetches the order so
+   the returnable quantities and status badge reflect the new state.
+6. **Classify failures.**
+   [`classifyReturnError(error)`](../app/utils/return-error-utils.js) normalizes any
+   error into a [`ReturnErrorKind`](../app/utils/return-error-utils.js), which the
+   modal maps to a specific inline message and recovery affordance.
+
+### Return Reason Codes
+
+Reasons are not hard-coded — they come from OMS via
+`useOmsMetaData().returnReasonCodes`, where each entry is `{reason, default}`. The
+entry flagged `default: true` is pre-selected and omitted from the request body so
+the server applies it. Change the available reasons in Order Management; no
+storefront change is needed.
+
+### Error Handling
+
+`classifyReturnError` inspects the HTTP status and (for `400`) the body's `errorCode`
+discriminator, returning one of these kinds:
+
+| `ReturnErrorKind` | Trigger | UI behavior |
+| --- | --- | --- |
+| `INVALID_REASON` | `400` `InvalidReasonCode` | Inline: reason no longer available, pick another. |
+| `UNKNOWN_ITEMS` | `400` `UnknownProductItemIds` | Inline: affected items can't be returned. |
+| `QUANTITY_EXCEEDED` | `400` `ReturnQuantityExceeded` | Inline: requested quantity too high. |
+| `NOT_FOUND` | `404` | Terminal: order not found. |
+| `CONFLICT` | `409` | Terminal: order no longer in a returnable state. |
+| `NETWORK` | No HTTP response (fetch rejected) | Inline, retryable. |
+| `UNKNOWN` | Any other status (incl. `400 OrderReturnFailed`, `5xx`) | Inline, retryable. |
+
+The `409` case is the authoritative server-side refusal: even if the client thinks an
+item is returnable, OMS has the final say. A mid-flow `401` is intercepted and
+refreshed by the SDK auth layer before the classifier ever sees it.
+
+## Order Cancellation
+
+Registered shoppers can cancel an order that hasn't started fulfillment. The
+**Cancel order** button renders unconditionally (so its position is stable) but is
+disabled — with a screen-reader hint explaining why — when the order isn't eligible,
+a cancellation just succeeded, or a terminal error made the order un-actionable.
+
+### Eligibility
+
+`canCancel` in [`order-detail.jsx`](../app/pages/account/order-detail.jsx) requires:
+
+| Condition | Source |
+| --- | --- |
+| Registered shopper | `useCustomerType().isRegistered` |
+| Owns the order | `order.customerInfo.customerId === customerId` |
+| OMS-managed order | `!!order.omsData` |
+| Every item fully cancellable | `item.omsData.quantityAvailableToCancel === item.omsData.quantityOrdered` for **all** `productItems` |
+
+Cancellation is all-or-nothing: it's offered only when every line can still be
+cancelled in full. Once any unit has shipped, the order is no longer cancellable.
+
+### How It Works
+
+1. The shopper confirms in the
+   [`CancelOrderModal`](../app/components/cancel-order-modal) (optionally supplying a
+   reason).
+2. The page submits via
+   `useShopperOrdersMutation(ShopperOrdersMutations.CancelOmsOrder)`
+   (`POST .../actions/oms-cancel-order`); the `reason` is sent only when provided.
+3. On success an "Order cancelled" alert is shown (after a short delay so screen
+   readers finish announcing the modal close) and the order status badge flips to
+   **Cancelled**.
+4. On failure, cancellation follows the same convention as returns (see
+   [Error Handling](#error-handling) above): a `404` or `409` is **terminal** — the
+   order can no longer be cancelled, so the button is permanently disabled with an
+   explanatory hint — while any other error shows a generic, retryable message. Unlike
+   returns, cancellation has no per-`errorCode` classifier; it keys off the HTTP
+   status alone.
+
+Return feedback is kept separate from cancel feedback so the **Cancelled** badge
+(which keys off the cancel result) never fires on a return success.
+
+## Order Tracking
+
+[`OrderTracking`](../app/components/order-tracking) is a presentational block
+rendered once per shipment on the order detail page. It shows the shipping method
+heading, the localized shipping status, the provider name, the tracking number, and —
+when present — the expected and actual delivery dates.
+
+Key behaviors:
+
+- **Carrier link safety.** When a tracking URL is available, the tracking number is
+  hyperlinked through [`ensureExternalUrl`](../app/utils/url.js), which normalizes the
+  scheme and rejects unsafe inputs (`javascript:` URLs, host-spoofing like
+  `https://www.ups.com@evil.com`, and relative paths) — returning `undefined` so the
+  number renders as plain text instead. Otherwise the tracking number is shown
+  unlinked.
+- **Date guarding.** Missing, null, or unparseable delivery dates render nothing
+  rather than a misleading value. The `!value` guard is load-bearing: `new Date(null)`
+  returns the epoch (1970-01-01), not an Invalid Date, so without it a null delivery
+  date would display "31 Dec 1969".
+- **OMS-over-ECOM fallback.** The component receives already-resolved scalar props;
+  the fallback that prefers OMS shipment fields over ECOM ones lives at the call sites
+  in `order-detail.jsx`.
+
+### Multi-shipment (limited support)
+
+Shipment data arrives on the order in two separate lists with no correlation key
+between them: tracking info (status, tracking number/URL, dates) in
+`order.omsData.shipments`, and shipping addresses in `order.shipments` (ECOM
+delivery groups). The two lists can't be reliably paired — ECOM models a *delivery
+group* (the shopper's intent: which items go to which address) while OMS models a
+fulfillment *shipment* (a physical package), and a single delivery group can fan out
+into several OMS shipments (e.g. units of one line shipped from different
+warehouses). Pairing by index would risk showing the wrong address against a
+tracking number.
+
+The agreed scope is therefore **a flat list with no address association**:
+
+- Tracking renders as a flat list of cards, one per `order.omsData.shipments[]` entry
+  (falling back to `order.shipments[]` when there are no OMS shipments). Each card
+  shows the carrier/provider, status, the tracking number as a carrier link, and the
+  expected/delivered dates.
+- **No per-shipment shipping address and no positional OMS↔ECOM index-join.** A single
+  order-level Shipping Address block is shown only for single-shipment delivery
+  orders; multi-shipment orders omit it. The address is reachable through the carrier
+  tracking link anyway, so nothing is lost and nothing is mispaired.
+- A single order-level **Track Shipment** action links to the first shipment with a
+  carrier URL (disabled when none).
+
+Multi-shipment **grouped by address** is out of scope, deferred to a TD pending SCAPI
+returning correlated address data on `order.omsData.shipments`.
+
+## Status Badge
+
+The order status badge reflects fulfillment, cancellation, and return progress in one
+place. [`getOrderDisplayStatus(order)`](../app/utils/order-status-utils.js) aggregates
+item-level SOM statuses into a single order-level display status, because SOM exposes
+status per line item rather than a reliable order-level status.
+
+> **Status is computed from item-level OMS data — by design, not preference.**
+> The order-level `omsData.status` is known to be unreliable: in SOM it can stay
+> `Approved` even after every item has been cancelled or returned, because the
+> order-level rollup lags behind (or never reflects) the item-level state. The
+> item-level `omsData` *is* updated correctly, so this storefront derives the
+> displayed status entirely from the per-item (and per-unit) data and never trusts
+> the order-level status field. This is a known SOM limitation outside the
+> storefront's control; if the badge looks "wrong" versus the SOM order record, the
+> SOM order-level status is the stale side, not the badge.
+
+Aggregation works at the **unit** level, not the line level. A line with
+`quantityOrdered > 1` can straddle several states at once (e.g. 1 of 2 units returned
+while the other ships). `getItemUnitBuckets` reconstructs the true per-unit breakdown
+from the quantity fields (`quantityCanceled`, `quantityReturned`,
+`quantityReturnInitiated`, and the remainder), so a partially-returned or
+partially-cancelled multi-unit line reads correctly instead of masquerading as merely
+"in progress".
+
+The return-related display statuses —
+
+- `RETURN_INITIATED`
+- `PARTIAL_RETURN_INITIATED`
+- `RETURN_COMPLETE`
+- `PARTIAL_RETURN_COMPLETE`
+
+are grouped by `isReturnDisplayStatus`. The
+[`OrderStatusBadge`](../app/components/order-status-badge/index.jsx) renders these in a
+neutral badge with their own localized labels, leaving the cancelled (red) and
+raw-status (green) branches untouched. ECOM-only orders, which carry no item-level OMS
+status, fall back to the raw `order.status`.
+
+## Customization
+
+The pieces a project most commonly overrides:
+
+- **Eligibility** — adjust the gating (`showStartReturn` / `canCancel`) in
+  [`order-detail.jsx`](../app/pages/account/order-detail.jsx), or the predicate in
+  [`getReturnableItems`](../app/utils/return-utils.js), if your business rules differ.
+- **Messages** — return modal copy lives in
+  [`return-items-modal/constants.js`](../app/components/return-items-modal/constants.js);
+  cancel and tracking copy are inline `react-intl` messages. Localize or reword via
+  translation files.
+- **Error mapping** — extend `ERROR_CODE_TO_KIND` in
+  [`return-error-utils.js`](../app/utils/return-error-utils.js) to give a new return
+  `errorCode` its own inline message instead of the generic fallback.
+- **Status labels and colors** — override the labels and badge styling in
+  [`OrderStatusBadge`](../app/components/order-status-badge/index.jsx); the pure
+  aggregation in [`order-status-utils.js`](../app/utils/order-status-utils.js) stays
+  presentation-free.
+- **Tracking links** — the external-URL hardening lives in
+  [`ensureExternalUrl`](../app/utils/url.js); tighten or relax the allowed schemes
+  there.


### PR DESCRIPTION
## What

Two documentation/hygiene changes for the order-management feature (returns, cancellation, tracking) on the 264 epic branch.

## Changes

**1. Strip internal GUS work-item references**

The repo is customer-facing, so internal GUS `W-`/`WI-` identifiers don't belong in shipped comments or test titles. This removes them from the return-feature comments (`return-utils.js`, `return-error-utils.js`, `return-items-modal/{index.jsx,index.test.js,constants.js}`, `order-detail.jsx`, `order-status-utils.js`) and from `orders.test.js` `describe`/`test` titles, rewording each to describe the behavior instead of the work item. No behavior or test-coverage change — titles and comments only.

**2. Add a feature-branch README**

New `packages/template-retail-react-app/docs/README-ORDER-MANAGEMENT.md`, an overview of the three OMS shopper actions on the order detail page, in the style of storefront-next's `README-SHOPPER-CONTEXT.md`:

- **Returns** — data-driven eligibility (`isRegistered && ownsOrder` + `!!order.omsData`, no feature flag), the request lifecycle (`getReturnableItems` → `useOmsMetaData` reasons → `buildReturnProductItems` → `ReturnOmsOrder`), OMS-driven reason codes, and the `ReturnErrorKind` error-code contract.
- **Cancellation** — all-or-nothing eligibility (`quantityAvailableToCancel === quantityOrdered` across all items), the `CancelOmsOrder` mutation, and terminal 404/409 handling.
- **Tracking** — carrier-link hardening via `ensureExternalUrl`, the epoch date-guard, and the flat-list / no-address multi-shipment scope (grouped-by-address deferred to a TD pending correlated SCAPI data; see #3906).
- **Status badge** — the shared per-unit aggregation in `getOrderDisplayStatus` / `getItemUnitBuckets`.

## Testing

Comments-and-docs only; no runtime code touched. The existing account-area Jest suites remain green (only `describe`/`test` string literals changed in `orders.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)