### PR TITLE
[DIAGNOSTIC — DO NOT MERGE] Verify last-green Lighthouse baseline on current runner

### DIFF
--- a/LIGHTHOUSE-BASELINE-VERIFICATION.md
+++ b/LIGHTHOUSE-BASELINE-VERIFICATION.md
@@ -1,0 +1,22 @@
+# Lighthouse baseline verification (DIAGNOSTIC — DO NOT MERGE)
+
+This branch is based on commit `9ea365612608a7b03a7a12f7a0bcce064046b0da` — the
+**last develop commit whose Lighthouse CI job passed** (run on 2026-06-24, on
+GitHub runner image `ubuntu24/20260615.205.1` / Node 24.16.0).
+
+Its only purpose is to re-run that exact, known-green application code through
+the Lighthouse CI job **now**, on the current GitHub-hosted runner image.
+
+Hypothesis: the Lighthouse failures that began 2026-06-25 are caused by the
+GitHub `ubuntu-24.04` runner-image rollover (`20260615.205`/Node 24.16 →
+`20260622.220`/Node 24.17), **not** by any application code change — the diff
+between the last green and first red develop commits is only a Playwright
+test-dependency bump (#3903), which the Lighthouse job never installs or runs.
+
+- If this PR's `lighthouse` job **fails**, the known-green code now fails with no
+  app change → the runner environment is confirmed as the cause.
+- If it **passes**, the failure was introduced after the green commit and needs
+  further bisection.
+
+This file is the only change versus the green baseline; it touches no published
+package, so it cannot affect any Lighthouse score.


### PR DESCRIPTION
## Purpose (diagnostic only — do not merge)

Re-run the **last known-green application code** through the Lighthouse CI job on **today's** GitHub-hosted runner, to confirm the failures that started 2026-06-25 are caused by the **runner-image rollover**, not by any app code change.

- This branch is based on `9ea365612608a7b03a7a12f7a0bcce064046b0da` — the last develop commit whose `lighthouse` job **passed** (2026-06-24, on runner image `ubuntu24/20260615.205.1` / Node 24.16.0).
- The only change vs that baseline is this diagnostic note file, which touches no published package and cannot affect any Lighthouse score.
- The diff between the last green commit and the first red commit (`85bf376e8e`, #3903) is **only** a Playwright test-dependency bump — Playwright is never installed or run by the Lighthouse job, so the app under measurement is identical to the green run.

## How to read the result

- ❌ **`lighthouse` job fails** → known-green code now fails with no app change → the runner-image/Node rollover (`20260615.205`/Node 24.16 → `20260622.220`/Node 24.17) is confirmed as the cause.
- ✅ **`lighthouse` job passes** → the regression was introduced after the green commit and needs further bisection.

Watch the **`lighthouse (24)`** job on this PR and note the runner image line (`Runner Image: Version: ...`) at the top of its log.