### PR TITLE
fix(order-return): return focus to trigger when return modal closes @W-22821845

### DIFF
--- a/packages/template-retail-react-app/app/pages/account/order-detail.jsx
+++ b/packages/template-retail-react-app/app/pages/account/order-detail.jsx
@@ -1341,7 +1341,6 @@ const AccountOrderDetail = () => {
                     onClearSubmitError={() => setReturnSubmitError(null)}
                     isSubmitting={returnMutation.isLoading}
                     submitError={returnSubmitError}
-                    finalFocusRef={headingRef}
                 />
             )}
         </Stack>

--- a/packages/template-retail-react-app/app/pages/account/orders.test.js
+++ b/packages/template-retail-react-app/app/pages/account/orders.test.js
@@ -817,17 +817,53 @@ describe('Return submission (W-22821838)', () => {
         expect(await screen.findByText('Return Initiated')).toBeInTheDocument()
     })
 
-    test('success returns focus to the Order Details heading', async () => {
+    // The modal passes no finalFocusRef, so Chakra's default returnFocusOnClose
+    // restores focus to the control that opened it — the "Return Items" trigger —
+    // on every close path. The success "Return submitted" message is announced via
+    // its own role="alert" region, so no separate focus move is needed to announce
+    // it. Mirrors the cancel-order modal, which relies on the same default.
+    test('success returns focus to the Return Items trigger', async () => {
         mockReturnMutateAsync.mockResolvedValueOnce({})
         setupOrderDetailsPage(createReturnEligibleOmsOrder())
         const user = userEvent.setup()
 
-        const submit = await openModalAndReview(user)
-        await user.click(submit)
+        const trigger = await screen.findByTestId('account-order-detail-start-return')
+        await user.click(trigger)
+        await screen.findByText(/return items from order #/i)
+        await user.click(screen.getAllByRole('checkbox')[0])
+        await user.click(screen.getByTestId('return-items-modal-review'))
+        await user.click(await screen.findByTestId('return-items-modal-submit'))
 
         await screen.findByText(/return submitted/i)
-        const heading = screen.getByRole('heading', {level: 1, name: /order details/i})
-        await waitFor(() => expect(heading).toHaveFocus())
+        await waitFor(() => expect(trigger).toHaveFocus())
+    })
+
+    test('dismissing the modal (Cancel) returns focus to the Return Items trigger', async () => {
+        // WAI-ARIA: closing a dialog returns focus to the control that opened it,
+        // not the page heading. Regression test for focus landing on the H1.
+        setupOrderDetailsPage(createReturnEligibleOmsOrder())
+        const user = userEvent.setup()
+
+        const trigger = await screen.findByTestId('account-order-detail-start-return')
+        await user.click(trigger)
+        await screen.findByText(/return items from order #/i)
+
+        await user.click(screen.getByTestId('return-items-modal-cancel'))
+
+        await waitFor(() => expect(trigger).toHaveFocus())
+    })
+
+    test('dismissing the modal (Escape) returns focus to the Return Items trigger', async () => {
+        setupOrderDetailsPage(createReturnEligibleOmsOrder())
+        const user = userEvent.setup()
+
+        const trigger = await screen.findByTestId('account-order-detail-start-return')
+        await user.click(trigger)
+        await screen.findByText(/return items from order #/i)
+
+        await user.keyboard('{Escape}')
+
+        await waitFor(() => expect(trigger).toHaveFocus())
     })
 
     test('error keeps the modal open with an inline alert; footer Submit re-fires', async () => {


### PR DESCRIPTION
## Context
When the return modal closed, focus jumped to the "Order Details" H1 heading instead of returning to the "Return Items" button that opened it. This is a WAI-ARIA dialog focus violation (a dismissed dialog must return focus to its invoking control) and was inconsistent with the cancel-order modal, which already restores focus to its trigger. The bug surfaced during accessibility QA of the order-return flow.

## Summary
- Remove `finalFocusRef={headingRef}` from the return modal so Chakra's default `returnFocusOnClose` restores focus to the "Return Items" trigger on every close path (Cancel, Escape, ✕, and successful submit).
- Success feedback continues to be announced via its own `role="alert"` live region, so no programmatic focus move is needed to surface it.
- Aligns the return modal's focus behavior with the cancel-order modal, which relies on the same Chakra default.

## Test plan
- [ ] `pnpm test` — return-flow focus assertion now expects the trigger; new Cancel/Escape dismissal regression tests added.
- [ ] Open a return-eligible order's detail page, tab to "Return Items", open the modal, then dismiss via **Cancel** → focus returns to the "Return Items" button (visible focus ring).
- [ ] Repeat and dismiss via **Escape** → focus returns to the trigger.
- [ ] Repeat and dismiss via the **✕** close button → focus returns to the trigger.
- [ ] Submit a successful return → focus returns to the trigger and the "Return submitted" message is announced by a screen reader.
- [ ] Confirm parity with the cancel-order modal's focus-return behavior.

## Screenshots
Before
<img width="1200" height="907" alt="before-focus-on-heading" src="https://github.com/user-attachments/assets/dd1e725e-72fc-49b1-8174-7aa1dda7db09" />

After dismissing the return modal (Escape), focus is restored to the "Return Items" trigger — note the blue focus ring on the button. Previously focus landed on the "Order Details" H1._
<img width="1200" height="907" alt="after-focus-on-trigger" src="https://github.com/user-attachments/assets/527333d0-4dac-4c67-81bd-b7468efb01cc" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
