### PR TITLE
W-23351112 Guest order access: routes, footer entry point, authenticated redirect (S3/S4/S14)

### DIFF
--- a/packages/template-retail-react-app/CHANGELOG.md
+++ b/packages/template-retail-react-app/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v10.2.0-dev (Jul 13, 2026)
+- [Feature] Add flag-gated /order-access, /order-access/verify, /order-access/order routes and "Find Your Order" footer link (guestOrderAccess.enabled, off by default). Authenticated users redirected to /account/orders.
 - [Bugfix] Render in-progress return states (Return Initiated / Partial Return Initiated) in the order status badge with the info/blue color scheme, matching the Storefront-Next order-management badge mapping. Terminal returns (Return Complete / Partial Return Complete) remain neutral gray.
 - Bump `vendor.js` bundle-size budget from 398 kB to 400 kB to accommodate the graceful invalid-JWT handling added in `commerce-sdk-react`.
 - [Feature] Add a configurable `capabilitiesVersion` for the Commerce Client (Embedded Messaging) shopper-agent widget, forwarded to the bundle as `messagingConfig.capabilitiesVersion` and defaulting to `'65'`. Enables Embedded Messaging action progress indicators; override per environment via the `capabilitiesVersion` field in `COMMERCE_AGENT_SETTINGS`.

--- a/packages/template-retail-react-app/app/components/footer/index.jsx
+++ b/packages/template-retail-react-app/app/components/footer/index.jsx
@@ -38,6 +38,7 @@ const Footer = ({...otherProps}) => {
     const {site, buildUrl} = useMultiSite()
     const {l10n} = site
     const storeLocatorEnabled = getConfig()?.app?.storeLocatorEnabled ?? STORE_LOCATOR_IS_ENABLED
+    const guestOrderAccessEnabled = getConfig()?.app?.guestOrderAccess?.enabled
     const supportedLocaleIds = l10n?.supportedLocales.map((locale) => locale.id)
     const showLocaleSelector = supportedLocaleIds?.length > 1
 
@@ -56,6 +57,14 @@ const Footer = ({...otherProps}) => {
                 text: intl.formatMessage({
                     id: 'footer.link.store_locator',
                     defaultMessage: 'Store Locator'
+                })
+            })
+        if (guestOrderAccessEnabled)
+            links.push({
+                href: '/order-access',
+                text: intl.formatMessage({
+                    id: 'footer.link.find_your_order',
+                    defaultMessage: 'Find Your Order'
                 })
             })
         links.push({

--- a/packages/template-retail-react-app/app/components/footer/index.test.js
+++ b/packages/template-retail-react-app/app/components/footer/index.test.js
@@ -10,6 +10,16 @@ import {screen} from '@testing-library/react'
 import Footer from '@salesforce/retail-react-app/app/components/footer/index'
 import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
 
+jest.mock('@salesforce/pwa-kit-runtime/utils/ssr-config', () => ({
+    getConfig: jest.fn()
+}))
+import {getConfig} from '@salesforce/pwa-kit-runtime/utils/ssr-config'
+import mockConfig from '@salesforce/retail-react-app/config/mocks/default'
+
+beforeEach(() => {
+    getConfig.mockReturnValue(mockConfig)
+})
+
 test('renders component', () => {
     renderWithProviders(<Footer />)
     const privacyLinks = screen.getAllByRole('link', {name: 'Privacy Policy'})
@@ -31,4 +41,44 @@ test('renders SubscribeForm within Footer', () => {
     expect(emailInputs.length).toBeGreaterThanOrEqual(1)
     const signUpButtons = screen.getAllByRole('button', {name: /subscribe/i})
     expect(signUpButtons.length).toBeGreaterThanOrEqual(1)
+})
+
+describe('Guest Order Access footer link', () => {
+    test('does not render "Find Your Order" link when flag is off', () => {
+        getConfig.mockReturnValue({
+            ...mockConfig,
+            app: {
+                ...mockConfig.app,
+                guestOrderAccess: {enabled: false}
+            }
+        })
+        renderWithProviders(<Footer />)
+        expect(screen.queryByRole('link', {name: 'Find Your Order', hidden: true})).toBeNull()
+    })
+
+    test('does not render "Find Your Order" link when flag is absent', () => {
+        getConfig.mockReturnValue({
+            ...mockConfig,
+            app: {
+                ...mockConfig.app
+            }
+        })
+        renderWithProviders(<Footer />)
+        expect(screen.queryByRole('link', {name: 'Find Your Order', hidden: true})).toBeNull()
+    })
+
+    test('renders "Find Your Order" link when flag is on', () => {
+        getConfig.mockReturnValue({
+            ...mockConfig,
+            app: {
+                ...mockConfig.app,
+                guestOrderAccess: {enabled: true}
+            }
+        })
+        renderWithProviders(<Footer />)
+        const links = screen.getAllByRole('link', {name: 'Find Your Order', hidden: true})
+        expect(links.length).toBeGreaterThanOrEqual(1)
+        // href includes locale prefix (e.g. /uk/en-GB/order-access) depending on multi-site config
+        expect(links[0].getAttribute('href')).toMatch(/\/order-access$/)
+    })
 })

--- a/packages/template-retail-react-app/app/pages/guest-order-access/__tests__/pages.test.js
+++ b/packages/template-retail-react-app/app/pages/guest-order-access/__tests__/pages.test.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {screen} from '@testing-library/react'
+import {renderWithProviders} from '@salesforce/retail-react-app/app/utils/test-utils'
+import {MemoryRouter} from 'react-router-dom'
+
+jest.mock('@salesforce/commerce-sdk-react', () => ({
+    ...jest.requireActual('@salesforce/commerce-sdk-react'),
+    useCustomerType: jest.fn(() => ({isRegistered: false, isGuest: true}))
+}))
+
+import {useCustomerType} from '@salesforce/commerce-sdk-react'
+import GuestOrderAccessRequest from '@salesforce/retail-react-app/app/pages/guest-order-access/request'
+import GuestOrderAccessVerify from '@salesforce/retail-react-app/app/pages/guest-order-access/verify'
+import GuestOrderAccessOrder from '@salesforce/retail-react-app/app/pages/guest-order-access/order'
+
+describe('GuestOrderAccessRequest', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('renders heading for guest users', () => {
+        useCustomerType.mockReturnValue({isRegistered: false, isGuest: true})
+        renderWithProviders(<GuestOrderAccessRequest />)
+        expect(screen.getByText('Find Your Order')).toBeInTheDocument()
+    })
+
+    test('redirects to /account/orders when user is registered', () => {
+        useCustomerType.mockReturnValue({isRegistered: true, isGuest: false})
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/order-access']}>
+                <GuestOrderAccessRequest />
+            </MemoryRouter>
+        )
+        // When isRegistered, Redirect renders — the heading should NOT be present
+        expect(screen.queryByText('Find Your Order')).not.toBeInTheDocument()
+    })
+})
+
+describe('GuestOrderAccessVerify', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('renders heading for guest users', () => {
+        useCustomerType.mockReturnValue({isRegistered: false, isGuest: true})
+        renderWithProviders(<GuestOrderAccessVerify />)
+        expect(screen.getByText('Enter Access Code')).toBeInTheDocument()
+    })
+
+    test('redirects to /account/orders when user is registered', () => {
+        useCustomerType.mockReturnValue({isRegistered: true, isGuest: false})
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/order-access/verify']}>
+                <GuestOrderAccessVerify />
+            </MemoryRouter>
+        )
+        expect(screen.queryByText('Enter Access Code')).not.toBeInTheDocument()
+    })
+})
+
+describe('GuestOrderAccessOrder', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    test('renders heading for guest users', () => {
+        useCustomerType.mockReturnValue({isRegistered: false, isGuest: true})
+        renderWithProviders(<GuestOrderAccessOrder />)
+        expect(screen.getByText('Order Details')).toBeInTheDocument()
+    })
+
+    test('redirects to /account/orders when user is registered', () => {
+        useCustomerType.mockReturnValue({isRegistered: true, isGuest: false})
+        renderWithProviders(
+            <MemoryRouter initialEntries={['/order-access/order']}>
+                <GuestOrderAccessOrder />
+            </MemoryRouter>
+        )
+        expect(screen.queryByText('Order Details')).not.toBeInTheDocument()
+    })
+})

--- a/packages/template-retail-react-app/app/pages/guest-order-access/order.jsx
+++ b/packages/template-retail-react-app/app/pages/guest-order-access/order.jsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {Box, Heading} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {useCustomerType} from '@salesforce/commerce-sdk-react'
+import {Redirect} from 'react-router-dom'
+
+const GuestOrderAccessOrder = () => {
+    const {isRegistered} = useCustomerType()
+    if (isRegistered) return <Redirect to="/account/orders" />
+    return (
+        <Box>
+            <Heading>Order Details</Heading>
+        </Box>
+    )
+}
+
+export default GuestOrderAccessOrder

--- a/packages/template-retail-react-app/app/pages/guest-order-access/request.jsx
+++ b/packages/template-retail-react-app/app/pages/guest-order-access/request.jsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {useIntl} from 'react-intl'
+import {Box, Heading} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {useCustomerType} from '@salesforce/commerce-sdk-react'
+import {Redirect} from 'react-router-dom'
+
+const GuestOrderAccessRequest = () => {
+    const {isRegistered} = useCustomerType()
+    if (isRegistered) return <Redirect to="/account/orders" />
+    return (
+        <Box>
+            <Heading>Find Your Order</Heading>
+        </Box>
+    )
+}
+
+export default GuestOrderAccessRequest

--- a/packages/template-retail-react-app/app/pages/guest-order-access/verify.jsx
+++ b/packages/template-retail-react-app/app/pages/guest-order-access/verify.jsx
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import React from 'react'
+import {Box, Heading} from '@salesforce/retail-react-app/app/components/shared/ui'
+import {useCustomerType} from '@salesforce/commerce-sdk-react'
+import {Redirect} from 'react-router-dom'
+
+const GuestOrderAccessVerify = () => {
+    const {isRegistered} = useCustomerType()
+    if (isRegistered) return <Redirect to="/account/orders" />
+    return (
+        <Box>
+            <Heading>Enter Access Code</Heading>
+        </Box>
+    )
+}
+
+export default GuestOrderAccessVerify

--- a/packages/template-retail-react-app/app/routes.jsx
+++ b/packages/template-retail-react-app/app/routes.jsx
@@ -52,6 +52,9 @@ const Wishlist = loadable(() => import('./pages/account/wishlist'), {
 })
 const PaymentProcessing = loadable(() => import('./pages/checkout/payment-processing'), {fallback})
 const PageNotFound = loadable(() => import('./pages/page-not-found'))
+const GuestOrderAccessRequest = loadable(() => import('./pages/guest-order-access/request'), {fallback})
+const GuestOrderAccessVerify = loadable(() => import('./pages/guest-order-access/verify'), {fallback})
+const GuestOrderAccessOrder = loadable(() => import('./pages/guest-order-access/order'), {fallback})
 
 export const routes = [
     {
@@ -136,6 +139,7 @@ export default () => {
     const socialRedirectURI = loginConfig?.social?.redirectURI
     const passwordlessLoginEnabled = loginConfig?.passwordless?.enabled
     const passwordlessLoginLandingPath = loginConfig?.passwordless?.landingPath
+    const guestOrderAccessEnabled = getConfig()?.app?.guestOrderAccess?.enabled
 
     // Add dynamic routes conditionally (only if features are enabled and paths are defined)
     const dynamicRoutes = [
@@ -155,7 +159,22 @@ export default () => {
                 path: socialRedirectURI,
                 component: SocialLoginRedirect,
                 exact: true
-            }
+            },
+        guestOrderAccessEnabled && {
+            path: '/order-access',
+            component: GuestOrderAccessRequest,
+            exact: true
+        },
+        guestOrderAccessEnabled && {
+            path: '/order-access/verify',
+            component: GuestOrderAccessVerify,
+            exact: true
+        },
+        guestOrderAccessEnabled && {
+            path: '/order-access/order',
+            component: GuestOrderAccessOrder,
+            exact: true
+        }
     ].filter(Boolean)
 
     const allRoutes = configureRoutes([...routes, ...dynamicRoutes], config, {

--- a/packages/template-retail-react-app/app/routes.test.js
+++ b/packages/template-retail-react-app/app/routes.test.js
@@ -189,6 +189,63 @@ describe('Routes', () => {
             })
         })
 
+        describe('Guest order access routes', () => {
+            test('does not add routes when flag is disabled', () => {
+                getConfig.mockReturnValue({
+                    ...mockConfig,
+                    app: {
+                        ...mockConfig.app,
+                        guestOrderAccess: {
+                            enabled: false
+                        }
+                    }
+                })
+
+                const allRoutes = routes()
+                expect(allRoutes.find((r) => r.path === '/order-access')).toBeUndefined()
+                expect(allRoutes.find((r) => r.path === '/order-access/verify')).toBeUndefined()
+                expect(allRoutes.find((r) => r.path === '/order-access/order')).toBeUndefined()
+            })
+
+            test('does not add routes when flag is absent', () => {
+                getConfig.mockReturnValue({
+                    ...mockConfig,
+                    app: {
+                        ...mockConfig.app
+                    }
+                })
+
+                const allRoutes = routes()
+                expect(allRoutes.find((r) => r.path === '/order-access')).toBeUndefined()
+                expect(allRoutes.find((r) => r.path === '/order-access/verify')).toBeUndefined()
+                expect(allRoutes.find((r) => r.path === '/order-access/order')).toBeUndefined()
+            })
+
+            test('adds all three routes when flag is enabled', () => {
+                getConfig.mockReturnValue({
+                    ...mockConfig,
+                    app: {
+                        ...mockConfig.app,
+                        guestOrderAccess: {
+                            enabled: true
+                        }
+                    }
+                })
+
+                const allRoutes = routes()
+                const requestRoute = allRoutes.find((r) => r.path === '/order-access')
+                const verifyRoute = allRoutes.find((r) => r.path === '/order-access/verify')
+                const orderRoute = allRoutes.find((r) => r.path === '/order-access/order')
+
+                expect(requestRoute).toBeDefined()
+                expect(requestRoute.exact).toBe(true)
+                expect(verifyRoute).toBeDefined()
+                expect(verifyRoute.exact).toBe(true)
+                expect(orderRoute).toBeDefined()
+                expect(orderRoute.exact).toBe(true)
+            })
+        })
+
         describe('Social login redirect route', () => {
             test('does not add route when disabled', () => {
                 getConfig.mockReturnValue({

--- a/packages/template-retail-react-app/translations/da-DK.json
+++ b/packages/template-retail-react-app/translations/da-DK.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Sitemap"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Find butik"
   },

--- a/packages/template-retail-react-app/translations/de-DE.json
+++ b/packages/template-retail-react-app/translations/de-DE.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Sitemap"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Shop-Finder"
   },

--- a/packages/template-retail-react-app/translations/en-GB.json
+++ b/packages/template-retail-react-app/translations/en-GB.json
@@ -945,6 +945,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Site Map"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Store Locator"
   },

--- a/packages/template-retail-react-app/translations/en-US.json
+++ b/packages/template-retail-react-app/translations/en-US.json
@@ -945,6 +945,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Site Map"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Store Locator"
   },

--- a/packages/template-retail-react-app/translations/es-MX.json
+++ b/packages/template-retail-react-app/translations/es-MX.json
@@ -642,6 +642,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Mapa del sitio"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Localizador de tiendas"
   },

--- a/packages/template-retail-react-app/translations/fi-FI.json
+++ b/packages/template-retail-react-app/translations/fi-FI.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Sivustokartta"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Myymäläpaikannin"
   },

--- a/packages/template-retail-react-app/translations/fr-FR.json
+++ b/packages/template-retail-react-app/translations/fr-FR.json
@@ -642,6 +642,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Plan du site"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Localisateur de magasins"
   },

--- a/packages/template-retail-react-app/translations/it-IT.json
+++ b/packages/template-retail-react-app/translations/it-IT.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Mappa del sito"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Store locator"
   },

--- a/packages/template-retail-react-app/translations/ja-JP.json
+++ b/packages/template-retail-react-app/translations/ja-JP.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "サイトマップ"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "店舗検索"
   },

--- a/packages/template-retail-react-app/translations/ko-KR.json
+++ b/packages/template-retail-react-app/translations/ko-KR.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "사이트 맵"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "매장 찾기"
   },

--- a/packages/template-retail-react-app/translations/nl-NL.json
+++ b/packages/template-retail-react-app/translations/nl-NL.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Siteplattegrond"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Winkellocator"
   },

--- a/packages/template-retail-react-app/translations/no-NO.json
+++ b/packages/template-retail-react-app/translations/no-NO.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Nettstedskart"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Butikkfinner"
   },

--- a/packages/template-retail-react-app/translations/pl-PL.json
+++ b/packages/template-retail-react-app/translations/pl-PL.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Mapa witryny"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Lokalizator sklepów"
   },

--- a/packages/template-retail-react-app/translations/pt-BR.json
+++ b/packages/template-retail-react-app/translations/pt-BR.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Mapa do site"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Localizador de lojas"
   },

--- a/packages/template-retail-react-app/translations/sv-SE.json
+++ b/packages/template-retail-react-app/translations/sv-SE.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "Webbplatskarta"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "Butikslokaliserare"
   },

--- a/packages/template-retail-react-app/translations/zh-CN.json
+++ b/packages/template-retail-react-app/translations/zh-CN.json
@@ -642,6 +642,9 @@
   "footer.link.site_map": {
     "defaultMessage": "站点地图"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "实体店地址搜索"
   },

--- a/packages/template-retail-react-app/translations/zh-TW.json
+++ b/packages/template-retail-react-app/translations/zh-TW.json
@@ -615,6 +615,9 @@
   "footer.link.site_map": {
     "defaultMessage": "網站地圖"
   },
+  "footer.link.find_your_order": {
+    "defaultMessage": "Find Your Order"
+  },
   "footer.link.store_locator": {
     "defaultMessage": "商店位置搜尋"
   },


### PR DESCRIPTION
## Summary
<!-- FILL IN: Ben to add 1-3 sentence plain-English summary after review -->

---

## GUS Stories

| # | W-Number | Title | Link |
|---|---|---|---|
| S3 | W-23351112 | [S3] Routes: register /order-access, /verify, /order behind the flag | https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002eAEvWYAW/view |
| S4 | W-23351113 | [S4] Footer: "Find Your Order" entry point | https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002e8lToYAI/view |
| S14 | W-23351150 | [S14] Authenticated-user redirect for all three routes | https://gus.my.salesforce.com/lightning/r/ADM_Work__c/a07EE00002eAWZsYAO/view |

---

## Acceptance Criteria

### W-23351112 — S3
- [x] All three paths return PageNotFound when flag off
- [x] Render correct page when flag on

### W-23351113 — S4
- [x] "Find Your Order" link rendered only when flag on
- [x] Snapshot delta contained to footer test file

### W-23351150 — S14
- [x] isRegistered users redirected to /account/orders on all three routes
- [x] Uses const { isRegistered } = useCustomerType() (not the === 'registered' comparison)

---

## What Changed

### Routes (app/routes.jsx)
Added three loadable page declarations (`GuestOrderAccessRequest`, `GuestOrderAccessVerify`, `GuestOrderAccessOrder`) after `PageNotFound`. Added `guestOrderAccessEnabled = getConfig()?.app?.guestOrderAccess?.enabled` in the default export and three flag-gated entries in `dynamicRoutes`. When the flag is off, all three paths fall through to the catch-all `PageNotFound`.

### Page stubs (app/pages/guest-order-access/)
Created three minimal stubs (`request.jsx`, `verify.jsx`, `order.jsx`). Each uses `const {isRegistered} = useCustomerType()` to conditionally render a `<Redirect to="/account/orders" />` for registered users, or a placeholder heading for guests. Full implementations will come from Groups 3 and 4.

### Footer (app/components/footer/index.jsx)
Added `guestOrderAccessEnabled = getConfig()?.app?.guestOrderAccess?.enabled` at the top of the `Footer` component. Inside `makeOurCompanyLinks()`, added an `if (guestOrderAccessEnabled)` guard after the `storeLocatorEnabled` check that pushes the "Find Your Order" link pointing to `/order-access`.

### i18n (translations/)
Added `"footer.link.find_your_order": {"defaultMessage": "Find Your Order"}` to all 17 locale files (en-GB, en-US, and 15 others). Non-English locales carry the English string as a placeholder for locale teams to update.

---

## Decisions Made

| Decision | Alternatives Considered | Rationale |
|---|---|---|
| Flag key: `guestOrderAccess.enabled` | `guestOrderLookup.enabled` | Matches the epic naming convention established in the proposal doc |
| Footer link placed after storeLocator check | Before store locator | Keeps store-related links grouped; "Find Your Order" is account-adjacent |
| Stub pages use `Redirect` from react-router-dom | `useHistory().push` | Matches the pattern used elsewhere in the app for synchronous redirects |

---

## Screenshots
<!-- FILL IN: Ben to embed screenshots after reviewing -->

---

## Test Plan

- [ ] `npm run lint` green in: packages/template-retail-react-app
- [ ] `npm test` green in: packages/template-retail-react-app
- [ ] Unit tests: routes flag off (PageNotFound), routes flag on, authenticated redirect on all three routes
- [ ] Unit tests: footer flag off (no link), footer flag on (link present)
- [ ] Footer snapshot updated (only footer delta)

---

## QA Steps

### W-23351112 — Routes
1. Start dev server with `guestOrderAccess.enabled = false` (default).
2. Navigate to `/order-access`, `/order-access/verify`, `/order-access/order` — confirm all three show PageNotFound.
3. Set `guestOrderAccess.enabled = true`, restart server.
4. Navigate to `/order-access` — confirm the request page renders (stub heading "Find Your Order").

### W-23351113 — Footer
1. With flag off: scroll to footer — confirm no "Find Your Order" link.
2. With flag on: scroll to footer — confirm "Find Your Order" link is present and navigates to `/order-access`.

### W-23351150 — Auth redirect
1. Log in as a registered user with flag on.
2. Navigate to `/order-access` — confirm redirect to `/account/orders`.
3. Repeat for `/order-access/verify` and `/order-access/order`.

---

## CHANGELOG

**`@salesforce/retail-react-app`** (`packages/template-retail-react-app/CHANGELOG.md`):
```
[Feature] Add flag-gated /order-access, /order-access/verify, /order-access/order routes and "Find Your Order" footer link (guestOrderAccess.enabled, off by default). Authenticated users redirected to /account/orders.
```

---

## PRizm

| File | Line | Finding | Disposition |
|---|---|---|---|
| (fill after PRizm posts) | | | |

---

## Notes for Reviewer
<!-- FILL IN: Ben to add any review notes or follow-up items -->