### PR TITLE
docs(release skill): move reference notes into one new file

### DIFF
--- a/.claude/skills/release/RELEASE-INTERNALS.md
+++ b/.claude/skills/release/RELEASE-INTERNALS.md
@@ -1,0 +1,73 @@
+# Release internals
+
+Branch-only reference for the `release` skill — read a section when its pointer in `SKILL.md` fires, not every run.
+
+## The bump-and-PR cycle
+
+Steps 2 and 4 run the same cycle; the only difference is the version shape. **Preview** carries `-preview.N` and gets a git tag; **final** is the clean stable version, no suffix.
+
+1. **Ensure the release branch exists.** Derive `release-<major>.<minor>.x` from the monorepo version. Check origin:
+   ```
+   git fetch origin
+   git ls-remote --heads origin release-<major>.<minor>.x
+   ```
+   - **Exists** (a patch, an in-flight release cutting another `-preview.N`, or the **unchanged-SDK case** where you're reusing the last SDK line's branch — see "Release a package only if it actually changed" in `SKILL.md`): keep it — it's the released baseline.
+   - **Absent** (new minor/major): **GATE** — create it clean from the base while still `-dev` (publishes nothing):
+     ```
+     git checkout -b release-<major>.<minor>.x origin/develop
+     git push -u origin release-<major>.<minor>.x
+     ```
+     If branch protection blocks the push, an admin/UI must create it — flag it, don't force it.
+
+2. **Working branch off the release branch** (not the base), so the PR diff is just bumps + changelogs:
+   ```
+   git fetch origin
+   git checkout -b prepare-release-<version> origin/release-<major>.<minor>.x
+   ```
+
+3. **Run the bumps (in order), then verify.** Run the four bumps chosen in Step 1, `#1`–`#4` from the table in `SKILL.md`. For a preview, versions carry `-preview.N`. Then compare the output below against the versions chosen in Step 1 — every package should show its intended version. Flag any mismatch to the operator.
+   ```
+   npx lerna list --long --all
+   ```
+
+4. **Stamp the changelogs** — see "Stamping the changelogs" below.
+
+5. **Commit, (preview) tag, open PR.**
+   ```
+   git add -A
+   git commit -m "Bump versions and update changelogs for <version> release"
+   ```
+   Preview only — tag it:
+   ```
+   git tag -a v<version>-preview.<n> -m "v<version>-preview.<n>"
+   git push origin v<version>-preview.<n>
+   ```
+   **GATE — open the PR into `release-<major>.<minor>.x`.** State: "Merging this publishes `<the four versions>` to npm tag `<next|latest>`." Lead the title with the GUS work ID. pwa-kit is a public repo — make sure `gh` is on your regular public GitHub account (`gh auth switch --user <your-public-account>`):
+   ```
+   git push -u origin prepare-release-<version>
+   gh pr create --base release-<major>.<minor>.x --head prepare-release-<version> \
+     --title "@W-XXXXXXXX@ Release <version>" \
+     --body "<four versions + changelog highlights>"
+   ```
+   You open it; the **operator merges it.** The merge triggers CI, which publishes.
+
+## Stamping the changelogs
+
+**Invariant: each changed changelog has exactly ONE version header at the top — the version just set — with the accumulated bullets beneath. One header per file, no stacked `-dev`/`-preview.N` lines.**
+
+- **Four changelogs auto-stamp: `commerce-sdk-react`, `pwa-kit-react-sdk`, `pwa-kit-runtime`, `pwa-kit-dev`.** Each has a `version` lifecycle script (`packages/<pkg>/scripts/version.js`, all functionally identical) that prepends a dated header during the bump. The SDK bump (`#1`) runs `lerna version`, which fires the `version` lifecycle for every package — so all four get stamped with a header.
+- **Only `commerce-sdk-react` is prone to stacked headers.** `pwa-kit-react-sdk/runtime/dev` ride the SDK version, so `lerna version` stamps each exactly **once** — one clean header; just verify it matches the version you set. `commerce-sdk-react` is versioned **independently**, so it gets stamped **twice**: once by the SDK bump's `lerna version` (at the SDK version — wrong), then again by its own bump (`#2`, the correct version). (`scripts/bump-version/index.js` even flags this: `// TODO: is it possible to _not_ trigger the lifecycle scripts? See commerce-sdk-react/CHANGELOG.md`.) See "commerce-sdk-react: dedupe stacked headers" below for the fix.
+- **The remaining three changelogs need a manual header rewrite** — `pwa-kit-create-app`, `template-retail-react-app`, and `pwa-kit-mcp` have no `version.js`, so the bump only touched their `package.json`/lockfiles. Rewrite the top line:
+  - Final: `## v3.19.0 (Jul 06, 2026)` (today's date).
+  - Preview: `## v3.19.0-preview.0`.
+  - **mcp header has NO `v` prefix** (`## 0.5.0`); every other package DOES (`## v3.19.0`). Match each file's existing style.
+
+While in each file, confirm every shipping change is listed and nothing stale remains — this is the review the process calls for. Two failure modes to catch, both invisible if you only skim: an entry **under the wrong header** (a change for this release stranded beneath an older version's heading, or vice versa — move it under the correct one), and a change **with no entry at all** (cross-check against `git diff v<last-released> -- packages/<pkg>`; every non-trivial diff earns a bullet). **Surface the changelog diffs to the operator**; don't rubber-stamp. Completion: every changed changelog opened, one clean header each, every shipping change filed under it.
+
+### commerce-sdk-react: dedupe stacked headers
+
+Open `commerce-sdk-react/CHANGELOG.md` and keep the one header matching the version you just set (verified via `npx lerna list --long --all`). If the stale header has bullets that belong in this release, **move those bullets up** under the kept header first — then delete the stale header line. Rehome bullets before deleting a header, always. Confirm no duplicate bullets remain across headers.
+
+## Watching the CI publish
+
+The publish is one step buried in a large matrix — dozens of legs across `pwa-kit` / `pwa-kit-windows` / `generated` / `lighthouse` jobs, most of which are just tests. Exactly one leg publishes: the **`pwa-kit` job's `ubuntu-latest` leg whose node/npm matches `IS_MRT_NODE`**, step **"Publish to NPM"** — every other leg skips it. Read the current node/npm from `IS_MRT_NODE` in `.github/workflows/test.yml` (it tracks MRT's recommended node and drifts over time — read it live, don't trust a version memorized here). So watch that leg's Publish step rather than the whole run. It's also gated on the version not being `-dev`, so a green run whose Publish step was *skipped* published nothing. A green check proves nothing either way — **confirm against npm** (`npm view`, Step 3) as the source of truth.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -24,7 +24,7 @@ git log --oneline -5
 |---|---|
 | On `develop`, version ends `-dev`, no release branch cut | **Step 1 — Pre-release audit** |
 | Release branch exists, on a working branch, versions still `-dev` | **Step 2 — Bump + changelogs + PR** |
-| On `prepare-release-*`, versions bumped (not `-dev`), no PR open | **Step 2e — Open the PR** |
+| On `prepare-release-*`, versions bumped (not `-dev`), no PR open | **Step 2 — open the PR** (bump-and-PR cycle, at the PR gate) |
 | A `-preview.N` version is published on npm | **Step 3 — Smoke test** |
 | A preview is published but a blocker was found | **Step 2 — next `-preview.(N+1)`** |
 | Preview smoke-tested clean, no blockers left | **Step 4 — Final release** |
@@ -48,7 +48,7 @@ Each step's own section below carries the detail. You drive; the operator says "
 
 There is **no publish button.** Pushing a commit to a `release-X.Y.x` branch runs `.github/workflows/test.yml`, whose "Publish to NPM" step runs the `publish_to_npm` action (`npm run publish-to-npm` → `lerna publish from-package`). It publishes a package when **(a)** the monorepo version does **not** end in `-dev`, and **(b)** that version is **not already on npm**. A merged PR into the release branch is a push — so **merging a bump PR into the release branch is what publishes.**
 
-**Where to watch it.** The publish is one step buried in a large matrix — dozens of legs across `pwa-kit` / `pwa-kit-windows` / `generated` / `lighthouse` jobs, most of which are just tests. Exactly one leg publishes: the **`pwa-kit` job's `ubuntu-latest` leg whose node/npm matches `IS_MRT_NODE`**, step **"Publish to NPM"** — every other leg skips it. Read the current node/npm from `IS_MRT_NODE` in `.github/workflows/test.yml` (it tracks MRT's recommended node and drifts over time — don't trust a version memorized here). So don't wait on the whole run to go green; watch that leg's Publish step. It's also gated on the version not being `-dev`, so a green run whose Publish step was *skipped* published nothing. Don't infer success from a green check either way — **confirm against npm** (`npm view`, Step 3) as the source of truth.
+**Where to watch it.** Exactly one leg in a large matrix publishes — the `pwa-kit` job's `ubuntu-latest` leg matching `IS_MRT_NODE` in `.github/workflows/test.yml`, step "Publish to NPM". A green check proves nothing either way — **confirm against npm** (`npm view`, Step 3) as the source of truth. For the leg-hunting detail, see "Watching the CI publish" in `RELEASE-INTERNALS.md`.
 
 Two consequences the steps depend on:
 
@@ -105,68 +105,7 @@ Goal: the base is clean and all four version numbers are chosen.
 
 ## Step 2 — Bump, stamp changelogs, open the PR
 
-### 2a — Ensure the release branch exists
-
-Derive `release-<major>.<minor>.x` from the monorepo version. Check origin:
-```
-git fetch origin
-git ls-remote --heads origin release-<major>.<minor>.x
-```
-- **Exists** (a patch, an in-flight release cutting another `-preview.N`, or the **unchanged-SDK case** where you're reusing the last SDK line's branch — see "Release a package only if it actually changed" above): do **not** recreate it — it's the released baseline.
-- **Absent** (new minor/major): **GATE** — create it clean from the base while still `-dev` (publishes nothing):
-  ```
-  git checkout -b release-<major>.<minor>.x origin/develop
-  git push -u origin release-<major>.<minor>.x
-  ```
-  If branch protection blocks the push, an admin/UI must create it — flag it, don't force it.
-
-### 2b — Working branch off the release branch
-
-Always branch off `release-<major>.<minor>.x` (not the base), so the PR diff is just bumps + changelogs:
-```
-git fetch origin
-git checkout -b prepare-release-<version> origin/release-<major>.<minor>.x
-```
-
-### 2c — Run the bumps (in order), then verify
-
-Run the four bumps chosen in Step 1, `#1`–`#4` from the table above. For a preview, versions carry `-preview.N`. Then verify: compare the output below against the versions chosen in Step 1 — every package should show its intended version. Flag any mismatch to the operator.
-```
-npx lerna list --long --all
-```
-
-### 2d — Stamp the changelogs
-
-**Invariant: each changed changelog has exactly ONE version header at the top — the version just set — with the accumulated bullets beneath. No stacked `-dev`/`-preview.N` lines.**
-
-- **Four changelogs auto-stamp: `commerce-sdk-react`, `pwa-kit-react-sdk`, `pwa-kit-runtime`, `pwa-kit-dev`.** Each has a `version` lifecycle script (`packages/<pkg>/scripts/version.js`, all functionally identical) that prepends a dated header during the bump. The SDK bump (`#1`) runs `lerna version`, which fires the `version` lifecycle for every package — so all four get stamped with a header.
-- **Only `commerce-sdk-react` is prone to stacked headers.** `pwa-kit-react-sdk/runtime/dev` ride the SDK version, so `lerna version` stamps each exactly **once** — one clean header; just verify it matches the version you set. `commerce-sdk-react` is versioned **independently**, so it gets stamped **twice**: once by the SDK bump's `lerna version` (at the SDK version — wrong), then again by its own bump (`#2`, the correct version). (`scripts/bump-version/index.js` even flags this: `// TODO: is it possible to _not_ trigger the lifecycle scripts? See commerce-sdk-react/CHANGELOG.md`.) So open `commerce-sdk-react/CHANGELOG.md` and **dedupe**: keep the one header matching the version you just set (verified above). If the stale header has bullets that belong in this release, **move those bullets up** under the kept header first — then delete the stale header line. Never delete a header without rehoming its bullets. Confirm no duplicate bullets remain across headers.
-- **The remaining three changelogs need a manual header rewrite** — `pwa-kit-create-app`, `template-retail-react-app`, and `pwa-kit-mcp` have no `version.js`, so the bump only touched their `package.json`/lockfiles. Rewrite the top line:
-  - Final: `## v3.19.0 (Jul 06, 2026)` (today's date).
-  - Preview: `## v3.19.0-preview.0`.
-  - **mcp header has NO `v` prefix** (`## 0.5.0`); every other package DOES (`## v3.19.0`). Match each file's existing style.
-
-While in each file, confirm every shipping change is listed and nothing stale remains — this is the review the process calls for. Two failure modes to catch, both invisible if you only skim: an entry **under the wrong header** (a change for this release stranded beneath an older version's heading, or vice versa — move it under the correct one), and a change **with no entry at all** (cross-check against `git diff v<last-released> -- packages/<pkg>`; every non-trivial diff earns a bullet). **Surface the changelog diffs to the operator**; don't rubber-stamp. Completion: every changed changelog opened, one clean header each, every shipping change filed under it.
-
-### 2e — Commit, (preview) tag, open PR
-
-```
-git add -A
-git commit -m "Bump versions and update changelogs for <version> release"
-```
-Preview only — tag it:
-```
-git tag -a v<version>-preview.<n> -m "v<version>-preview.<n>"
-git push origin v<version>-preview.<n>
-```
-**GATE — open the PR into `release-<major>.<minor>.x`.** State: "Merging this publishes `<the four versions>` to npm tag `<next|latest>`." Lead the title with the GUS work ID. pwa-kit is a public repo — make sure `gh` is on your regular public GitHub account (`gh auth switch --user <your-public-account>`):
-```
-git push -u origin prepare-release-<version>
-gh pr create --base release-<major>.<minor>.x --head prepare-release-<version> \
-  --title "@W-XXXXXXXX@ Release <version>" \
-  --body "<four versions + changelog highlights>"
-```
-You open it; the **operator merges it.** The merge triggers CI, which publishes. Announcing to teams and smoke testing both wait on that publish — they are Step 3, gated on the preview actually being on npm.
+Run **the bump-and-PR cycle** with **preview** versions (`-preview.N`), documented in `RELEASE-INTERNALS.md`: ensure the release branch, working branch off it, run the four bumps and verify, stamp the changelogs, then **GATE** the PR into `release-<major>.<minor>.x`. You open it; the **operator merges it.** The merge triggers CI, which publishes. Announcing to teams and smoke testing both wait on that publish — they are Step 3, gated on the preview actually being on npm.
 
 ## Step 3 — Smoke test the generated project
 
@@ -184,7 +123,7 @@ You open it; the **operator merges it.** The merge triggers CI, which publishes.
 
 ## Step 4 — Final release
 
-Same as Step 2, with the clean stable versions (no suffix). Bump `#1`–`#4`, re-verify every changelog reads final (no `-preview` left, dates correct), commit, tag `v<version>`, **GATE** the final PR into `release-X.Y.x` — state it publishes stable to `latest`. You open it; the **operator merges it.**
+Run **the bump-and-PR cycle** again (`RELEASE-INTERNALS.md`) with the clean stable versions (no suffix). Re-verify every changelog reads final — no `-preview` left, dates correct — tag `v<version>`, and **GATE** the final PR into `release-X.Y.x` stating it publishes stable to `latest`. You open it; the **operator merges it.**
 
 ## Step 5 — Post-release
 
@@ -192,7 +131,7 @@ Same as Step 2, with the clean stable versions (no suffix). Bump `#1`–`#4`, re
    1. **Intro summary** — one plain-English paragraph naming what this release *does* for someone who won't read further: `PWA Kit <X.Y> ships/fixes <the two or three things that matter>, plus <assorted smaller work>.` Written from the changes, not copied from any one changelog.
    2. **`## Highlights`** — the handful of user-facing changes worth surfacing, most important first, one bullet each. Not every changelog line — only what a storefront developer would care about. Shape each bullet: `- :emoji: **Short title** — what it is and why it matters, in plain English. ([#PR](url), [#PR](url))`. Pick an emoji that fits the change (`:lock:` security, `:money_with_wings:` cost, `:credit_card:` checkout, etc.). Draft these, then **surface them to the operator to confirm** — the "what matters" judgment is theirs.
    3. **`---`** then **`## Package Changes`** — the per-package changelog compilation (every changed `CHANGELOG.md`, grouped under `### @salesforce/<pkg>@<version>` headers), and end with `**Full Changelog**: https://github.com/SalesforceCommerceCloud/pwa-kit/compare/v<prev>...v<this>`.
-   - **GATE — publish it.** Write the drafted notes to a file and publish against the tag pushed in Step 4 (`gh` is on your public account — see Step 2e):
+   - **GATE — publish it.** Write the drafted notes to a file and publish against the tag pushed in Step 4 (`gh` is on your public account — see the bump-and-PR cycle in `RELEASE-INTERNALS.md`):
      ```
      gh release create v<version> --title "v<version>" --notes-file <notes.md> --verify-tag
      ```


### PR DESCRIPTION
> **This is a stacked PR.** The base is `improve/release-skill` (#3972), not `develop`. Review the parent #3972 first. This PR shows only the split.

## Summary

The `/release` skill file `SKILL.md` had two problems. Step 2 and Step 4 gave the same bump-and-PR steps twice. You had to keep both copies in agreement. Also, deep reference notes sat between the main steps and hid them.

This PR moves the reference notes into one new file, `RELEASE-INTERNALS.md`. Pointers in `SKILL.md` link to it. `SKILL.md` becomes 66 lines shorter. The release process does not change.

---

## Background (for reviewers who do not know this area)

`.claude/skills/release/SKILL.md` is an operator runbook. An engineer reads it to release PWA Kit. The release takes one week or more. The engineer cuts a branch, sets versions, publishes preview builds, tests, and ships the final build. The file is a document. It is not code.

A runbook holds two types of content:
- **Steps** — the actions that the operator does, in order (Steps 1 to 6).
- **Reference** — facts that the operator reads only when necessary (for example, why one script writes a changelog header two times).

The skill has `disable-model-invocation: true`. Only a person starts it. It uses no tokens until a person runs `/release`. Thus this split gives better readability and one source of truth. It does not save tokens.

<details>
<summary>Why we split the file, and why into one file (not five, not zero)</summary>

- **Zero files is not correct.** Step 2 and Step 4 held the same bump-and-PR steps. If you change one copy and forget the other, the two copies disagree. Also, the deep reference notes sat between the steps. The operator had to scroll past them during a release.
- **Five files is not correct.** A reviewer proposed five files. For one operator in the middle of a release, more files cost more effort. The operator must remember which file holds which fact. One pointer to follow is acceptable. Five pointers are a new load.
- **One file is correct.** Move the reference into one file. Keep the steps and the main lessons in `SKILL.md`.
</details>

---

## What moved and what stayed

<details>
<summary>Moved into <code>RELEASE-INTERNALS.md</code> (reference, read only when necessary)</summary>

- **The bump-and-PR cycle** — the steps that Step 2 and Step 4 both used. These steps are now in one place. A parameter selects preview or final. The cycle is: make sure the release branch exists, make a working branch, run the bumps, stamp the changelogs, then open the PR at a gate.
- **The changelog stamp notes** — this includes the `commerce-sdk-react` header fix. That package has its own version. Thus `lerna version` writes its header two times. Keep the correct header. Move the bullets. Delete the wrong header.
- **The CI publish-leg note** — this tells the operator which one job in a large matrix publishes the packages.
</details>

<details>
<summary>Stayed in <code>SKILL.md</code> (the main lessons; every release needs them)</summary>

- **The publish rule** — there is no publish button. A merge of a bump PR into `release-X.Y.x` publishes the packages. Two conditions apply: the version does not end in `-dev`, and the version is not on npm yet. This rule is the main point of the skill.
- **The `IS_MRT_NODE` pointer** — this tells the operator to read the current node and npm values from the workflow file. The operator must not use an old value from memory.
- **The steps** (Step 1 to Step 6), all gates, the triage table, and the four-versions text. The four-versions text controls the choices in Step 1. It is not reference.
</details>

### Example: Step 2 before and after

**Before** — about 55 lines of sub-steps 2a to 2e (branch, working branch, bumps, changelog stamp, commit, tag, PR). Step 4 repeated almost all of these lines.

**After:**
> Run **the bump-and-PR cycle** with **preview** versions (`-preview.N`), documented in `RELEASE-INTERNALS.md`: ensure the release branch, working branch off it, run the four bumps and verify, stamp the changelogs, then **GATE** the PR into `release-<major>.<minor>.x`. …

Step 4 now points to the same cycle with final versions. Change the cycle one time. Both steps get the change.

---

## How to test

This PR changes a document. To test it, make sure that the split reads correctly and that the pointers link to real headings.

1. **Get the branch.** It is stacked on its parent.
   ```
   git fetch origin
   git checkout improve/release-skill-split
   ```
2. **Make sure that only the split shows in the diff.**
   ```
   git diff improve/release-skill..HEAD --stat
   # SKILL.md becomes shorter (about -66/+5). RELEASE-INTERNALS.md is new.
   ```
3. **Follow each pointer.** Find each link to the new file. Make sure that each link names a heading that exists.
   ```
   grep -n "RELEASE-INTERNALS" .claude/skills/release/SKILL.md
   grep -n "^##\|^###" .claude/skills/release/RELEASE-INTERNALS.md
   ```
   The pointers name "the bump-and-PR cycle" and "Watching the CI publish". Both headings are in the new file.
4. **Make sure that no dead sub-step link stays.** The old `Step 2a` to `Step 2e` anchors are gone.
   ```
   grep -n "2a\|2b\|2c\|2d\|2e" .claude/skills/release/SKILL.md
   # Only the triage-table row matches. It now points to "Step 2 — open the PR".
   ```
5. **Read the file.** Open `SKILL.md` from the top to the bottom. Make sure that these items stay and read clearly: the steps (Step 1 to Step 6), the gates, the triage table, the publish rule, and the `IS_MRT_NODE` pointer.

There is no build and no automated test. This file is not code.
