### PR TITLE
fix: ci test noise and e2e flake

### DIFF
--- a/e2e/scripts/pageHelpers.js
+++ b/e2e/scripts/pageHelpers.js
@@ -700,7 +700,13 @@ export const registeredUserHappyPath = async ({page, registeredUserCredentials, 
     await advanceToPayment(page)
 
     const step2Card = page.locator("div[data-testid='sf-toggle-card-step-2']")
-    await expect(step2Card.getByRole('button', {name: /Edit Shipping Options/i})).toBeVisible()
+    // After advancing to Payment, step 2 collapses to its summary with an Edit button.
+    // A transient basket refetch can briefly disable the card (hiding the edit button),
+    // so allow the same checkout-transition window the rest of this file uses instead of
+    // the default 5s assertion timeout.
+    await expect(step2Card.getByRole('button', {name: /Edit Shipping Options/i})).toBeVisible({
+        timeout: CHECKOUT_TRANSITION_TIMEOUT
+    })
 
     await expect(page.getByRole('heading', {name: /Payment/i})).toBeVisible()
 

--- a/packages/template-retail-react-app/app/utils/test-utils.js
+++ b/packages/template-retail-react-app/app/utils/test-utils.js
@@ -204,6 +204,16 @@ TestProviders.propTypes = {
 export const renderWithProviders = (children, options) => {
     const TestProvidersWithDataAPI = withReactQuery(TestProviders, {
         queryClientConfig: {
+            // Silence react-query's default error logging. Many tests intentionally
+            // leave requests unmocked; those surface as caught query errors that
+            // react-query dumps to console.error (full Response objects), flooding
+            // CI logs with noise that isn't a test failure. See react-query v4 docs
+            // on providing a custom logger for tests.
+            logger: {
+                log: () => {},
+                warn: () => {},
+                error: () => {}
+            },
             defaultOptions: {
                 queries: {
                     retry: false,

--- a/packages/template-retail-react-app/jest-setup.js
+++ b/packages/template-retail-react-app/jest-setup.js
@@ -108,10 +108,22 @@ export const setupMockServer = () => {
     )
 }
 
+// Track unhandled requests we've already reported so a single unmocked endpoint
+// hit hundreds of times in one test file logs once, not once per request. This
+// preserves the diagnostic signal (which endpoints are unmocked) without flooding
+// CI logs. Keyed on method + origin + pathname (query string stripped so param
+// variations collapse to one entry).
+const reportedUnhandledRequests = new Set()
+
 beforeAll(() => {
     global.server = setupMockServer()
     global.server.listen({
         onUnhandledRequest(req) {
+            const key = `${req.method} ${req.url.origin}${req.url.pathname}`
+            if (reportedUnhandledRequests.has(key)) {
+                return
+            }
+            reportedUnhandledRequests.add(key)
             console.error('Found an unhandled %s request to %s', req.method, req.url.href)
         }
     })


### PR DESCRIPTION
# Description

Reduces CI failure noise for the Retail React App with two independent, test-only changes:

1. **Fixes a flaky e2e checkout assertion.** In `registeredUserHappyPath`, after advancing to Payment, step 2 collapses to its summary with an "Edit Shipping Options" button. A transient basket refetch can briefly disable the card and hide that button, so the default 5s assertion timeout intermittently fails. The assertion now uses the same `CHECKOUT_TRANSITION_TIMEOUT` window the rest of the file already uses for checkout transitions.

2. **Cuts unit-test log noise in CI.** Two changes stop CI logs from being flooded with output that isn't a real failure:
   - `jest-setup.js`: MSW's `onUnhandledRequest` now reports each unmocked endpoint **once** (keyed on `method + origin + pathname`, query string stripped) instead of once per request, so an endpoint hit hundreds of times in one file logs a single line. The diagnostic signal (which endpoints are unmocked) is preserved.
   - `test-utils.js`: `renderWithProviders` installs a no-op react-query logger. Tests that intentionally leave requests unmocked surface as caught query errors that react-query dumps to `console.error` (full `Response` objects); silencing them removes noise without hiding test failures.

No production/runtime code is touched — only e2e helpers and Jest test setup.

# Types of Changes

- [x] **Bug fix** (non-breaking change that fixes an issue) — flaky e2e assertion
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [x] **Other changes** (non-breaking changes that does not fit any of the above) — CI test-log noise reduction (test infra only)

# Changes

- `e2e/scripts/pageHelpers.js`: allow `CHECKOUT_TRANSITION_TIMEOUT` on the step-2 "Edit Shipping Options" visibility assertion to absorb the transient basket-refetch window.
- `jest-setup.js`: de-duplicate MSW unhandled-request logging — report each `method + origin + pathname` once per run.
- `app/utils/test-utils.js`: add a no-op react-query logger in `renderWithProviders` to suppress expected caught-query-error console spam.

# How to Test-Drive This PR

1. Run the checkout e2e (`registeredUserHappyPath`) repeatedly and confirm the step-2 edit-button assertion no longer flakes on slow basket refetches.
2. Run the Retail React App unit suite (`npm test` in `packages/template-retail-react-app`) and confirm: repeated unmocked-endpoint warnings collapse to one line each, and react-query `console.error` dumps of `Response` objects are gone. Confirm real test failures still surface.

# Checklists

## General

- [ ] Changes are covered by test cases <!-- N/A: changes are to test infrastructure / e2e helpers themselves; no new product code -->
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates) <!-- not required: test-only, non-user-facing -->

## Accessibility Compliance

- [x] There are no changes to UI

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
