### PR TITLE
@W-24095537 - Refresh bridging with PWA.

### DIFF
--- a/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.jsx
@@ -15,6 +15,7 @@ import {
     useCustomerType,
     useUsid
 } from '@salesforce/commerce-sdk-react'
+import useAuthContext from '@salesforce/commerce-sdk-react/hooks/useAuthContext'
 import PropTypes from 'prop-types'
 import {useTheme} from '@salesforce/retail-react-app/app/components/shared/ui'
 import useMiaw, {normalizeLocaleToSalesforce} from '@salesforce/retail-react-app/app/hooks/use-miaw'
@@ -29,6 +30,7 @@ import {useAppOrigin} from '@salesforce/retail-react-app/app/hooks/use-app-origi
 import {useToast} from '@salesforce/retail-react-app/app/hooks/use-toast'
 import {
     getPersistedCommerceClientOpenState,
+    getSlasExpiryEpochSeconds,
     persistCommerceClientOpenState,
     resetEmbeddedMessagingForCommerceSessionChange,
     resolveCommerceClientRoutingAttributes,
@@ -43,6 +45,36 @@ import {callAuthLink} from '@salesforce/retail-react-app/app/components/shopper-
 const onClient = typeof window !== 'undefined'
 
 const HTTP_OK = 200
+
+// The SLAS access token expires ~30 min after issuance. commerce-sdk-react's own
+// Auth.isAccessTokenExpired() treats a token as expired 60s before its real JWT
+// `exp` (both HttpOnly and non-HttpOnly modes) — firing our refresh timer inside
+// that same window (rather than earlier) guarantees getTokenWhenReady() actually
+// performs a refresh instead of handing back the same, unrefreshed token.
+const SLAS_REFRESH_BUFFER_SECONDS = 55
+// Used only when the expiry can't be read (missing/undecodable cookie or JWT) —
+// keeps the re-link chain alive on a fixed cadence rather than never firing.
+const SLAS_REFRESH_FALLBACK_DELAY_MS = 25 * 60 * 1000
+const SLAS_REFRESH_MIN_DELAY_MS = 1000
+// Backoff for a "no-op refresh": getTokenWhenReady() ran but handed back the
+// same token/expiry (e.g. SLAS_REFRESH_BUFFER_SECONDS no longer lands inside
+// the SDK's own stale-token buffer). Retrying at the normal cadence would
+// collapse to SLAS_REFRESH_MIN_DELAY_MS and hammer the bridge once a second
+// until the token's real expiry. Instead we back off, doubling each
+// consecutive no-op, capped at SLAS_REFRESH_NOOP_BACKOFF_CAP_MS, and always
+// clamped to the time actually left before the token's (unchanged) expiry —
+// see the no-op branch in armRefreshTimer.
+const SLAS_REFRESH_NOOP_BACKOFF_BASE_MS = 5 * 1000
+const SLAS_REFRESH_NOOP_BACKOFF_CAP_MS = 60 * 1000
+const SLAS_TOKEN_EXPIRED_ERROR_CODES = ['SLAS_TOKEN_EXPIRED', 'INVALID_SLAS_TOKEN']
+// Trigger 3 — proactive SLAS-refresh re-link (the timer), and its one-shot
+// reactive retry when the agent identity bridge rejects a bridge call as
+// expired anyway (e.g. clock skew between this client and the bridge). The
+// retry reuses this same reason so a second failure does not retry again (see
+// the `reason` check in the catch branch below) — an unrefreshable token
+// means the session is genuinely over.
+const SLAS_REFRESH_REASON = 'slas-token-refresh'
+const SLAS_REFRESH_RETRY_REASON = 'slas-token-refresh-retry'
 
 const SESSION_INIT_ERROR_MESSAGE = defineMessage({
     id: 'shopper_agent.error.session_init_failed',
@@ -156,7 +188,8 @@ const isEnabled = (enabled) => {
  * - Loads the embedded messaging script using useScript hook
  * - Initializes the MIAW service using useMiaw hook
  * - Sets up prechat fields with current locale, currency, and user context on embedded messaging ready
- * - Calls Core's Token Bridge proxy when a conversation starts (`onEmbeddedMessagingConversationStarted`)
+ * - Calls the agent identity bridge's Token Bridge proxy when a conversation starts
+ *   (`onEmbeddedMessagingConversationStarted`)
  * - Manages event listeners for messaging lifecycle events
  * - Handles z-index management for maximized chat windows
  * - On guest ↔ registered Commerce session transitions, resets MIAW (FAB) so shoppers start a fresh agent session
@@ -226,7 +259,7 @@ const ShopperAgentWindow = ({commerceAgentConfiguration, domainUrl}) => {
         (config) => config.configurationType === 'globalConfiguration' && config.id === 'my_domain'
     )?.value
 
-    // SLAS access token — needed to call Core's Token Bridge directly.
+    // SLAS access token — needed to call the agent identity bridge's Token Bridge directly.
     const {getTokenWhenReady} = useAccessToken()
     const getTokenWhenReadyRef = useRef(getTokenWhenReady)
     getTokenWhenReadyRef.current = getTokenWhenReady
@@ -446,8 +479,8 @@ const ShopperAgentWindow = ({commerceAgentConfiguration, domainUrl}) => {
 
             getAuthLinkKey()
                 .then(async (authLinkKey) => {
-                    // Direct callout to Core's Token Bridge via the same-origin
-                    // PWA Kit proxy. Replaces the prior postSessionInit SCAPI call.
+                    // Direct callout to the agent identity bridge's Token Bridge via the
+                    // same-origin PWA Kit proxy. Replaces the prior postSessionInit SCAPI call.
                     try {
                         // Check if HttpOnly mode is enabled by reading the flag directly
                         // (same source as CommerceApiProvider's enableHttpOnlySessionCookies)
@@ -672,15 +705,36 @@ const CommerceClientAgentWindow = ({
     toastRef.current = toast
 
     // Customer details and auth tokens for Commerce Client session init
-    const {getTokenWhenReady} = useAccessToken()
+    const {token: slasAccessToken, getTokenWhenReady} = useAccessToken()
     const getTokenWhenReadyRef = useRef(getTokenWhenReady)
     getTokenWhenReadyRef.current = getTokenWhenReady
+    const slasAccessTokenRef = useRef(slasAccessToken)
+    slasAccessTokenRef.current = slasAccessToken
+
+    // Internal SDK Auth instance — used to read the non-HttpOnly
+    // `cc-at-expires` cookie and force the one-shot reactive refresh. Same
+    // "temporary bridge" pattern as app/hooks/use-refresh-token.js.
+    const auth = useAuthContext()
+    const authRef = useRef(auth)
+    authRef.current = auth
+
+    // Tracks the pending proactive SLAS-refresh timer so it can be cleared
+    // before re-arming (avoids a stale timer firing against an outdated
+    // expiry) and on unmount.
+    const refreshTimerRef = useRef(null)
+    const isMountedRef = useRef(true)
+    // The expiry (epoch seconds) armRefreshTimer last scheduled against, and
+    // how many consecutive times a refresh came back with an expiry that
+    // didn't advance past it (a "no-op refresh" — see armRefreshTimer).
+    const lastArmedExpiryEpochSecondsRef = useRef(undefined)
+    const noOpRefreshCountRef = useRef(0)
 
     const {organizationId, siteId: configSiteId} = useConfig()
 
     // Fetch my_domain from the Shopper Configurations API. Auth-linking calls
-    // Core (via the Token Bridge), which is only reachable once my_domain has
-    // resolved, so we gate performAuthLink on it exactly like the MIAW provider.
+    // the agent identity bridge (via the Token Bridge), which is only reachable
+    // once my_domain has resolved, so we gate performAuthLink on it exactly
+    // like the MIAW provider.
     const {data: configurationsData} = useConfigurations({})
     const myDomain = configurationsData?.configurations?.find(
         (config) => config.configurationType === 'globalConfiguration' && config.id === 'my_domain'
@@ -797,48 +851,174 @@ const CommerceClientAgentWindow = ({
     }
 
     /**
+     * Trigger 3 — proactive SLAS-refresh re-link. Schedules a one-shot timer
+     * to re-run performAuthLink shortly before the just-bridged access token
+     * expires, so the widget re-links with a fresh token instead of waiting
+     * for the agent identity bridge to reject a stale one. Re-armed on every
+     * successful link (see the call site in performAuthLink), which is what
+     * makes the chain self-perpetuating for the life of the mounted widget.
+     *
+     * The delay is calibrated to land *inside* commerce-sdk-react's own
+     * expiry buffer (SLAS_REFRESH_BUFFER_SECONDS matches Auth's internal 60s
+     * buffer, minus a few seconds of slack) — firing any earlier would mean
+     * getTokenWhenReady() sees the token as still valid and returns it
+     * unchanged, silently no-op'ing the refresh.
+     *
+     * A re-link does NOT always mean the token rotated: the SLAS access token
+     * only changes when it actually expires, so re-links driven by anything
+     * else (a new conversation, an identity re-link, a dedup-bypass refresh, or
+     * the `finally` fallback re-arm) legitimately keep the *same* expiry. Those
+     * still have real runway left, so we schedule the normal proactive delay for
+     * them — treating "expiry didn't advance" alone as a failed refresh is what
+     * caused the tight auth-link/bridge loop this guards against.
+     *
+     * We only back off (see the no-op branch below) when the expiry did not
+     * advance AND we are already inside the buffer window — i.e. the proactive
+     * delay has collapsed to the floor and re-firing would just hammer the
+     * bridge every second (e.g. if the SDK's own buffer ever shrinks below
+     * SLAS_REFRESH_BUFFER_SECONDS). The backoff is clamped so we never wait past
+     * the token's actual expiry.
+     *
+     * @param {Object} opts
+     * @param {boolean} opts.isHttpOnly - Whether HttpOnly session cookies are enabled
+     * @param {string} [opts.token] - The just-bridged SLAS access token (non-HttpOnly mode only)
+     */
+    const armRefreshTimer = ({isHttpOnly, token}) => {
+        if (!isMountedRef.current) return
+        clearTimeout(refreshTimerRef.current)
+
+        const accessTokenExpiresCookie = isHttpOnly
+            ? authRef.current.get('cc-at-expires')
+            : undefined
+        const expiryEpochSeconds = getSlasExpiryEpochSeconds({
+            isHttpOnly,
+            accessTokenExpiresCookie,
+            token
+        })
+
+        let delayMs
+        if (Number.isNaN(expiryEpochSeconds) || expiryEpochSeconds <= 0) {
+            // Expiry unreadable (missing/undecodable/empty cookie or JWT — note
+            // Number('') === 0, hence the <= 0 guard) — not a no-op refresh signal,
+            // just missing data. Fall back to a fixed cadence; no-op streak resets.
+            noOpRefreshCountRef.current = 0
+            delayMs = SLAS_REFRESH_FALLBACK_DELAY_MS
+        } else {
+            const lastArmedExpiry = lastArmedExpiryEpochSecondsRef.current
+            const advanced = lastArmedExpiry === undefined || expiryEpochSeconds > lastArmedExpiry
+            // Time until the token is inside the SDK's stale-token buffer, where the
+            // next getTokenWhenReady() will actually rotate it. Positive (with slack
+            // above the floor) means the token still has real runway left.
+            const proactiveDelayMs =
+                (expiryEpochSeconds - SLAS_REFRESH_BUFFER_SECONDS) * 1000 - Date.now()
+
+            if (advanced || proactiveDelayMs > SLAS_REFRESH_MIN_DELAY_MS) {
+                // The token either genuinely refreshed (expiry advanced) or still has
+                // runway. An unchanged expiry with runway left is EXPECTED, not a
+                // failed refresh — the token only rotates when it actually expires,
+                // so re-links from a new conversation, an identity re-link, a
+                // dedup-bypass refresh, or the `finally` fallback re-arm legitimately
+                // keep the same expiry. Schedule the normal proactive refresh (never a
+                // short backoff retry) so those re-links don't spin the bridge.
+                noOpRefreshCountRef.current = 0
+                lastArmedExpiryEpochSecondsRef.current = expiryEpochSeconds
+                delayMs = Math.max(SLAS_REFRESH_MIN_DELAY_MS, proactiveDelayMs)
+            } else {
+                // Not advanced AND already inside the buffer window: a genuine no-op
+                // refresh (e.g. the SDK's own buffer shrank below
+                // SLAS_REFRESH_BUFFER_SECONDS). The proactive delay has collapsed to
+                // the floor, so re-firing at the normal cadence would hammer the
+                // bridge every second. Back off (doubling, capped), but never wait
+                // past the token's own (unchanged) real expiry — once that passes the
+                // next bridge call fails for real and the reactive retry (see
+                // performAuthLink) takes over from there.
+                noOpRefreshCountRef.current += 1
+                const backoffMs = Math.min(
+                    SLAS_REFRESH_NOOP_BACKOFF_CAP_MS,
+                    SLAS_REFRESH_NOOP_BACKOFF_BASE_MS * 2 ** (noOpRefreshCountRef.current - 1)
+                )
+                const remainingMs = expiryEpochSeconds * 1000 - Date.now()
+                delayMs = Math.max(SLAS_REFRESH_MIN_DELAY_MS, Math.min(backoffMs, remainingMs))
+                console.warn(
+                    '[Commerce Client] armRefreshTimer: no-op refresh detected, backing off',
+                    {attempt: noOpRefreshCountRef.current, delayMs}
+                )
+            }
+        }
+
+        refreshTimerRef.current = setTimeout(() => {
+            if (!isMountedRef.current) return
+            performAuthLinkRef.current({reason: SLAS_REFRESH_REASON, bypassDedup: true})
+        }, delayMs)
+    }
+
+    /**
      * Idempotently link the current Commerce Client conversation to the current
      * SLAS shopper. Deduped by `${conversationId}:${slasIdentity}` — a no-op if
-     * that exact pair was already linked successfully.
+     * that exact pair was already linked successfully, unless bypassDedup is set
+     * (used by the proactive/reactive SLAS-refresh paths, where the conversation
+     * and shopper are unchanged but the token itself needs re-bridging).
      *
      * @param {Object} opts
      * @param {string} opts.reason - Diagnostic label for the triggering signal.
+     * @param {boolean} [opts.bypassDedup] - Skip the (conversation, shopper) dedup guard.
      */
-    const performAuthLink = ({reason, excludedJWT = null}) => {
+    const performAuthLink = ({reason, excludedJWT = null, bypassDedup = false}) => {
         const generation = ++authLinkGenerationRef.current
         const scheduledJWT = extractCommerceClientJWT()
         if (scheduledJWT) {
             lastAttemptedCommerceClientJWTRef.current = scheduledJWT
         }
         const run = async () => {
-            const {organizationId: orgId, configSiteId: sid, myDomain: domain} = configRef.current
-            if (!orgId || !sid) {
-                console.error('[Commerce Client] performAuthLink: missing organizationId or siteId')
-                return
-            }
+            // Hoisted above the try/catch so the `finally` fallback re-arm below can
+            // always read it, even on an early return before the try block starts.
+            const isHttpOnly =
+                typeof window !== 'undefined'
+                    ? window.__MRT_ENABLE_HTTPONLY_SESSION_COOKIES__ === 'true'
+                    : process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true'
 
-            // The Token Bridge reaches Core, which needs my_domain resolved. The mount
-            // is already gated on !isConfigurationsLoading, so this is a defensive skip
-            // rather than a call to the bridge with an unresolved domain.
-            if (!domain) {
-                console.warn(
-                    `[Commerce Client] performAuthLink(${reason}): my_domain not resolved yet`
-                )
-                return
-            }
-
-            const slasIdentity = getSlasIdentity()
+            // Set true right after the real, expiry-based armRefreshTimer call on the
+            // success path, so the fallback re-arm in `finally` below skips — otherwise
+            // it would immediately clobber that correct timer with a fallback-delay one.
+            let heartbeatArmed = false
+            let slasAccessToken
 
             try {
+                const {
+                    organizationId: orgId,
+                    configSiteId: sid,
+                    myDomain: domain
+                } = configRef.current
+                if (!orgId || !sid) {
+                    console.error(
+                        '[Commerce Client] performAuthLink: missing organizationId or siteId'
+                    )
+                    return
+                }
+
+                // The Token Bridge reaches the agent identity bridge, which needs my_domain
+                // resolved. The mount is already gated on !isConfigurationsLoading, so this
+                // is a defensive skip rather than a call to the bridge with an unresolved
+                // domain.
+                if (!domain) {
+                    console.warn(
+                        `[Commerce Client] performAuthLink(${reason}): my_domain not resolved yet`
+                    )
+                    return
+                }
+
+                const slasIdentity = getSlasIdentity()
+
                 const commerceClientJWT = await waitForCommerceClientJWT(excludedJWT)
                 if (!commerceClientJWT) {
+                    if (!isMountedRef.current) return
                     console.warn(
                         `[Commerce Client] performAuthLink(${reason}): no JWT after polling`
                     )
                     return
                 }
                 lastAttemptedCommerceClientJWTRef.current = commerceClientJWT
-                if (generation !== authLinkGenerationRef.current) return
+                if (!isMountedRef.current || generation !== authLinkGenerationRef.current) return
 
                 // Dedup on (conversation, shopper). conversationId is read here — after
                 // the JWT poll — so a still-creating conversation has time to appear.
@@ -846,7 +1026,7 @@ const CommerceClientAgentWindow = ({
                 // this guard, so it can bypass a still-stale conversationId safely.
                 const conversationId = readConversationId()
                 const linkKey = `${conversationId || 'unknown'}:${slasIdentity}`
-                if (!excludedJWT && lastAuthLinkKeyRef.current === linkKey) {
+                if (!excludedJWT && !bypassDedup && lastAuthLinkKeyRef.current === linkKey) {
                     // Already linked this exact (conversation, shopper) pair.
                     console.warn(
                         `[Commerce Client] performAuthLink(${reason}): already linked, skipping`
@@ -854,22 +1034,39 @@ const CommerceClientAgentWindow = ({
                     return
                 }
 
-                const isHttpOnly =
-                    typeof window !== 'undefined'
-                        ? window.__MRT_ENABLE_HTTPONLY_SESSION_COOKIES__ === 'true'
-                        : process.env.MRT_ENABLE_HTTPONLY_SESSION_COOKIES === 'true'
+                const isRefreshTrigger =
+                    reason === SLAS_REFRESH_REASON || reason === SLAS_REFRESH_RETRY_REASON
 
-                const slasAccessToken = isHttpOnly
-                    ? undefined
-                    : await getTokenWhenReadyRef.current()
-                if (generation !== authLinkGenerationRef.current) return
+                if (reason === SLAS_REFRESH_RETRY_REASON) {
+                    // The bridge rejected a token that the SDK may still consider valid
+                    // (for example, after revocation or clock skew), so ready() is not
+                    // sufficient here. Clear the stale expiry indicator before forcing
+                    // the SDK refresh flow, matching its standard 401 recovery path.
+                    authRef.current.clearAccessTokenExpiry()
+                    const refreshedToken = await authRef.current.refreshAccessToken()
+                    slasAccessToken = isHttpOnly ? undefined : refreshedToken.access_token
+                } else if (isHttpOnly) {
+                    slasAccessToken = undefined
+                    if (isRefreshTrigger) {
+                        // getTokenWhenReady() is normally skipped in HttpOnly mode (the
+                        // server reads the token straight from the cc-at_{siteId} cookie),
+                        // but the refresh/retry paths need its *side effect* — it forces
+                        // Auth.ready() to call refreshAccessToken() when the token is
+                        // stale, which rewrites cc-at_{siteId}/cc-at-expires before we
+                        // bridge. We still discard the returned value.
+                        await getTokenWhenReadyRef.current()
+                    }
+                } else {
+                    slasAccessToken = await getTokenWhenReadyRef.current()
+                }
+                if (!isMountedRef.current || generation !== authLinkGenerationRef.current) return
 
                 // Step 1: auth link key from SCRT. Called directly from the
                 // browser against the configured SCRT2 origin — the authlink
                 // endpoint authenticates with the Commerce Client JWT (Bearer)
                 // alone, needing neither the siteId nor the conversationId.
                 const authLinkResponse = await callAuthLink({commerceClientJWT, scrt2Url})
-                if (generation !== authLinkGenerationRef.current) return
+                if (!isMountedRef.current || generation !== authLinkGenerationRef.current) return
                 const authLinkKey = authLinkResponse?.auth_link_key || authLinkResponse?.authLinkKey
                 if (!authLinkKey || typeof authLinkKey !== 'string') {
                     console.error(
@@ -883,7 +1080,7 @@ const CommerceClientAgentWindow = ({
                 // Operations are serialized so the newest identity is the final
                 // server-side mutation even when an older request was already sent.
                 const result = await callTokenBridge({authLinkKey, slasAccessToken, siteId: sid})
-                if (generation !== authLinkGenerationRef.current) return
+                if (!isMountedRef.current || generation !== authLinkGenerationRef.current) return
                 if (result.status !== HTTP_OK) {
                     const errorCode = result.body?.error || `HTTP_${result.status}`
                     console.error(
@@ -893,6 +1090,23 @@ const CommerceClientAgentWindow = ({
                             error: errorCode
                         }
                     )
+
+                    // Reactive backstop: the agent identity bridge says the token was already
+                    // expired/invalid (e.g. clock skew, or the proactive timer fired a bit too
+                    // early). Retry exactly once, forcing a fresh token, before surfacing an error.
+                    // A second failure (reason already the retry) falls through to the
+                    // toast — the refresh token itself is presumably dead at that point.
+                    if (
+                        SLAS_TOKEN_EXPIRED_ERROR_CODES.includes(errorCode) &&
+                        reason !== SLAS_REFRESH_RETRY_REASON
+                    ) {
+                        performAuthLinkRef.current({
+                            reason: SLAS_REFRESH_RETRY_REASON,
+                            bypassDedup: true
+                        })
+                        return
+                    }
+
                     toastRef.current({
                         title: formatMessageRef.current(SESSION_INIT_ERROR_MESSAGE),
                         status: 'error'
@@ -902,13 +1116,50 @@ const CommerceClientAgentWindow = ({
 
                 lastAuthLinkKeyRef.current = linkKey
                 lastCommerceClientJWTRef.current = commerceClientJWT
+                armRefreshTimer({isHttpOnly, token: slasAccessToken})
+                heartbeatArmed = true
             } catch (error) {
-                if (generation !== authLinkGenerationRef.current) return
+                if (!isMountedRef.current || generation !== authLinkGenerationRef.current) return
                 console.error(`[Commerce Client] performAuthLink(${reason}) threw`, error)
                 toastRef.current({
                     title: formatMessageRef.current(SESSION_INIT_ERROR_MESSAGE),
                     status: 'error'
                 })
+            } finally {
+                // Fallback re-arm: every early return/throw above (missing org/site,
+                // unresolved my_domain, a stalled JWT poll, a non-token bridge error, a
+                // thrown exception) otherwise leaves no pending timer, permanently
+                // killing the self-refresh heartbeat until the next unrelated trigger
+                // (login/logout, new conversation). Re-arm on a fallback cadence instead,
+                // so a transient failure heals itself within SLAS_REFRESH_FALLBACK_DELAY_MS.
+                //
+                // Three exclusions:
+                // - heartbeatArmed: the success path above already armed a correct,
+                //   expiry-based timer. Re-arming here too would immediately clobber it
+                //   with a fallback-delay one (armRefreshTimer always clears+resets).
+                // - A superseded call (generation mismatch) must not stack a timer over
+                //   the newer call's own — this also naturally covers the case where this
+                //   very call just queued the SLAS_REFRESH_RETRY_REASON retry above, since
+                //   that queuing bumps authLinkGenerationRef.current synchronously before
+                //   this finally runs.
+                // - reason === SLAS_REFRESH_RETRY_REASON is the one-shot backstop's own
+                //   failure: the bridge already rejected this token twice, so the refresh
+                //   token is presumably dead. Re-arming here would retry (and re-toast)
+                //   forever instead of stopping once, as intended (see the retry-gate
+                //   comment above).
+                if (
+                    !heartbeatArmed &&
+                    isMountedRef.current &&
+                    generation === authLinkGenerationRef.current &&
+                    reason !== SLAS_REFRESH_RETRY_REASON
+                ) {
+                    armRefreshTimer({
+                        isHttpOnly,
+                        token: isHttpOnly
+                            ? undefined
+                            : slasAccessToken || slasAccessTokenRef.current
+                    })
+                }
             }
         }
 
@@ -921,6 +1172,17 @@ const CommerceClientAgentWindow = ({
     // latest performAuthLink closure (which reads current config/identity).
     const performAuthLinkRef = useRef(performAuthLink)
     performAuthLinkRef.current = performAuthLink
+
+    // Clear the pending Trigger-3 refresh timer on unmount so it can't fire
+    // after the widget is gone. Async continuation guards above also prevent an
+    // already-running link from bridging, toasting, or re-arming after unmount.
+    useEffect(() => {
+        isMountedRef.current = true
+        return () => {
+            isMountedRef.current = false
+            clearTimeout(refreshTimerRef.current)
+        }
+    }, [])
 
     /**
      * Trigger 1 — new Commerce Client conversation.

--- a/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
+++ b/packages/template-retail-react-app/app/components/shopper-agent/index.test.js
@@ -123,6 +123,11 @@ jest.mock('@salesforce/commerce-sdk-react', () => ({
     useConfigurations: jest.fn()
 }))
 
+// Mock useAuthContext, the internal "temporary bridge" hook the Commerce Client
+// provider uses to read the raw Auth instance (e.g. for the `cc-at-expires` cookie
+// in HttpOnly mode when arming the proactive SLAS refresh timer).
+jest.mock('@salesforce/commerce-sdk-react/hooks/useAuthContext')
+
 // Mock the useMultiSite hook
 jest.mock('@salesforce/retail-react-app/app/hooks/use-multi-site', () => ({
     __esModule: true,
@@ -146,6 +151,7 @@ import {
 } from '@salesforce/commerce-sdk-react'
 import useMultiSite from '@salesforce/retail-react-app/app/hooks/use-multi-site'
 import {useTheme} from '@salesforce/retail-react-app/app/components/shared/ui'
+import useAuthContext from '@salesforce/commerce-sdk-react/hooks/useAuthContext'
 import useCommerceClientMessaging from '@salesforce/retail-react-app/app/hooks/use-commerce-client-messaging'
 
 // Get mocked functions
@@ -159,8 +165,12 @@ const mockedUseCustomerType = useCustomerType
 const mockedUseMultiSite = useMultiSite
 const mockedUseTheme = useTheme
 const mockedUseCommerceClientMessaging = useCommerceClientMessaging
+const mockedUseAuthContext = useAuthContext
 
 const mockGetTokenWhenReady = jest.fn()
+const mockAuthGet = jest.fn()
+const mockClearAccessTokenExpiry = jest.fn()
+const mockRefreshAccessToken = jest.fn()
 
 const commerceAgentSettings = {
     enabled: 'true',
@@ -196,7 +206,22 @@ describe('ShopperAgent Component', () => {
         // Mock useAccessToken hook
         mockGetTokenWhenReady.mockReset()
         mockGetTokenWhenReady.mockResolvedValue('test-slas-access-token')
-        mockedUseAccessToken.mockReturnValue({getTokenWhenReady: mockGetTokenWhenReady})
+        mockedUseAccessToken.mockReturnValue({
+            token: 'test-slas-access-token',
+            getTokenWhenReady: mockGetTokenWhenReady
+        })
+
+        // Mock the raw Auth instance used for expiry reads and forced refresh.
+        mockAuthGet.mockReset()
+        mockAuthGet.mockReturnValue(undefined)
+        mockClearAccessTokenExpiry.mockReset()
+        mockRefreshAccessToken.mockReset()
+        mockRefreshAccessToken.mockResolvedValue({access_token: 'refreshed-slas-access-token'})
+        mockedUseAuthContext.mockReturnValue({
+            get: mockAuthGet,
+            clearAccessTokenExpiry: mockClearAccessTokenExpiry,
+            refreshAccessToken: mockRefreshAccessToken
+        })
 
         // Mock useConfig hook
         mockedUseConfig.mockReturnValue({
@@ -2312,6 +2337,254 @@ describe('ShopperAgent Component', () => {
                 expect(mockCallAuthLink).not.toHaveBeenCalled()
                 expect(mockCallTokenBridge).not.toHaveBeenCalled()
                 warnSpy.mockRestore()
+            })
+
+            describe('SLAS refresh trigger', () => {
+                // jwt-decode only reads the middle (payload) segment; header/signature
+                // content is irrelevant, so any placeholder values work here.
+                const makeJwt = (payload) => {
+                    // btoa (not Buffer) — this suite runs under jest-environment-jsdom,
+                    // which exposes browser globals, not Node's Buffer.
+                    const base64url = (obj) =>
+                        btoa(JSON.stringify(obj))
+                            .replace(/\+/g, '-')
+                            .replace(/\//g, '_')
+                            .replace(/=+$/, '')
+                    return `${base64url({alg: 'none'})}.${base64url(payload)}.sig`
+                }
+
+                // exp lands just past SLAS_REFRESH_BUFFER_SECONDS (55s), so the computed
+                // delay is clamped to SLAS_REFRESH_MIN_DELAY_MS (1s) — fast enough to wait
+                // out with real timers.
+                const nearExpiryJwt = () => makeJwt({exp: Math.floor(Date.now() / 1000) + 56})
+
+                afterEach(() => {
+                    delete window.__MRT_ENABLE_HTTPONLY_SESSION_COOKIES__
+                })
+
+                test('arms a refresh timer that re-links with bypassDedup on fire', async () => {
+                    seedAuthLinkStorage()
+                    mockGetTokenWhenReady.mockResolvedValue(nearExpiryJwt())
+                    renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2), {
+                        timeout: 5000
+                    })
+                    // Same (conversation, shopper) pair as the first link — only
+                    // bypassDedup lets this second auth-link + bridge through.
+                    expect(mockCallAuthLink).toHaveBeenCalledTimes(2)
+                    expect(mockGetTokenWhenReady).toHaveBeenCalledTimes(2)
+                })
+
+                test('backs off instead of hammering on a no-op refresh', async () => {
+                    seedAuthLinkStorage()
+                    // Same JWT (same exp) on every call — simulates the SDK's own
+                    // stale-buffer no longer lining up with SLAS_REFRESH_BUFFER_SECONDS,
+                    // so getTokenWhenReady() hands back the token unrefreshed.
+                    const staleJwt = nearExpiryJwt()
+                    mockGetTokenWhenReady.mockResolvedValue(staleJwt)
+                    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+                    renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+                    // The refresh timer fires (~1s, per nearExpiryJwt) and re-links with
+                    // the same unchanged token — a no-op refresh, but still a successful
+                    // bridge call.
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2), {
+                        timeout: 5000
+                    })
+                    expect(warnSpy).toHaveBeenCalledWith(
+                        expect.stringContaining('no-op refresh detected'),
+                        expect.objectContaining({attempt: 1})
+                    )
+
+                    // Without backoff, the next re-arm would also collapse to
+                    // SLAS_REFRESH_MIN_DELAY_MS (~1s) and fire again almost immediately.
+                    // Waiting well past that, but well short of the backoff delay,
+                    // proves it backed off instead of hammering.
+                    await new Promise((resolve) => setTimeout(resolve, 1500))
+                    expect(mockCallTokenBridge).toHaveBeenCalledTimes(2)
+
+                    warnSpy.mockRestore()
+                })
+
+                test('does not back off when a re-link reuses the same far-off expiry (runway left)', async () => {
+                    // Regression: a re-link driven by something OTHER than token expiry
+                    // (here an identity change) legitimately reuses the same, still-far-off
+                    // SLAS expiry. The expiry not advancing must NOT be mistaken for a no-op
+                    // refresh — doing so armed a 5-60s backoff timer that re-bridged forever
+                    // (the continuous auth-link/bridge loop, most visible in HttpOnly mode
+                    // where the token never rotates on a re-link). With real runway left, the
+                    // normal proactive delay is used instead of a short backoff retry.
+                    seedAuthLinkStorage()
+                    // exp ~30 min out: the proactive delay lands ~29 min away, far beyond the
+                    // test window, so no refresh timer fires on its own during this test.
+                    mockGetTokenWhenReady.mockResolvedValue(
+                        makeJwt({exp: Math.floor(Date.now() / 1000) + 30 * 60})
+                    )
+                    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+                    const {rerender} = renderCommerceClientWithBasket()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+
+                    // Identity change → a non-deduped re-link that reuses the same far expiry,
+                    // so arm #2 sees an expiry that did NOT advance vs. arm #1.
+                    mockedUseCustomerType.mockReturnValue({
+                        customerType: 'registered',
+                        isGuest: false,
+                        isRegistered: true,
+                        isExternal: false
+                    })
+                    mockedUseUsid.mockReturnValue({usid: 'registered-usid'})
+                    rerender(
+                        <ShopperAgent
+                            commerceAgentConfiguration={commerceClientSettings}
+                            basketDoneLoading={true}
+                        />
+                    )
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2))
+
+                    // Same expiry, but ~30 min of runway remains → NOT a no-op refresh:
+                    // no backoff warning, and (unlike the buggy 5-60s loop) no third bridge
+                    // call hammering in on a short backoff cadence.
+                    expect(warnSpy).not.toHaveBeenCalledWith(
+                        expect.stringContaining('no-op refresh detected'),
+                        expect.anything()
+                    )
+
+                    await new Promise((resolve) => setTimeout(resolve, 1500))
+                    expect(mockCallTokenBridge).toHaveBeenCalledTimes(2)
+
+                    warnSpy.mockRestore()
+                })
+
+                test('does not fire the refresh timer after unmount', async () => {
+                    seedAuthLinkStorage()
+                    mockGetTokenWhenReady.mockResolvedValue(nearExpiryJwt())
+                    const {unmount} = renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+                    unmount()
+
+                    await new Promise((resolve) => setTimeout(resolve, 1500))
+                    expect(mockCallTokenBridge).toHaveBeenCalledTimes(1)
+                })
+
+                test('preserves the refresh deadline across a basket-loading remount', async () => {
+                    seedAuthLinkStorage()
+                    const token = nearExpiryJwt()
+                    mockGetTokenWhenReady.mockResolvedValue(token)
+                    mockedUseAccessToken.mockReturnValue({
+                        token,
+                        getTokenWhenReady: mockGetTokenWhenReady
+                    })
+                    const {rerender} = renderCommerceClientWithBasket()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+                    rerender(
+                        <ShopperAgent
+                            commerceAgentConfiguration={commerceClientSettings}
+                            basketDoneLoading={false}
+                        />
+                    )
+                    rerender(
+                        <ShopperAgent
+                            commerceAgentConfiguration={commerceClientSettings}
+                            basketDoneLoading={true}
+                        />
+                    )
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2), {
+                        timeout: 5000
+                    })
+                })
+
+                test('ignores an auth-link that finishes after unmount', async () => {
+                    seedAuthLinkStorage()
+                    let resolveAuthLink
+                    mockCallAuthLink.mockReturnValueOnce(
+                        new Promise((resolve) => {
+                            resolveAuthLink = resolve
+                        })
+                    )
+                    const {unmount} = renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallAuthLink).toHaveBeenCalledTimes(1))
+                    unmount()
+                    await act(async () => {
+                        resolveAuthLink({auth_link_key: 'late-auth-link-key'})
+                    })
+
+                    expect(mockCallTokenBridge).not.toHaveBeenCalled()
+                })
+
+                test('HttpOnly mode forces getTokenWhenReady only on refresh trigger', async () => {
+                    window.__MRT_ENABLE_HTTPONLY_SESSION_COOKIES__ = 'true'
+                    seedAuthLinkStorage()
+                    mockAuthGet.mockImplementation((key) =>
+                        key === 'cc-at-expires'
+                            ? String(Math.floor(Date.now() / 1000) + 56)
+                            : undefined
+                    )
+                    renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(1))
+                    // The original (widget-ready) trigger must not call getTokenWhenReady in
+                    // HttpOnly mode — the agent identity bridge reads the access token
+                    // straight from the
+                    // cc-at_{siteId} cookie.
+                    expect(mockGetTokenWhenReady).not.toHaveBeenCalled()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2), {
+                        timeout: 5000
+                    })
+                    // The refresh trigger forces getTokenWhenReady for its refresh side
+                    // effect (Auth.ready() -> refreshAccessToken()), even though the
+                    // resolved value itself is discarded in HttpOnly mode.
+                    expect(mockGetTokenWhenReady).toHaveBeenCalledTimes(1)
+                    expect(mockCallTokenBridge).toHaveBeenLastCalledWith({
+                        authLinkKey: 'commerce-auth-link-key',
+                        slasAccessToken: undefined,
+                        siteId: 'RefArchGlobal'
+                    })
+                })
+
+                test('retries once and recovers from a stale-token bridge failure', async () => {
+                    seedAuthLinkStorage()
+                    mockCallTokenBridge
+                        .mockResolvedValueOnce({status: 401, body: {error: 'SLAS_TOKEN_EXPIRED'}})
+                        .mockResolvedValueOnce({status: 200, body: {ok: true}})
+                    renderCommerceClient()
+
+                    await waitFor(() => expect(mockCallTokenBridge).toHaveBeenCalledTimes(2))
+                    expect(mockCallAuthLink).toHaveBeenCalledTimes(2)
+                    expect(mockClearAccessTokenExpiry).toHaveBeenCalledTimes(1)
+                    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(1)
+                    expect(mockCallTokenBridge.mock.calls[1][0]).toEqual({
+                        authLinkKey: 'commerce-auth-link-key',
+                        slasAccessToken: 'refreshed-slas-access-token',
+                        siteId: 'RefArchGlobal'
+                    })
+                    expect(mockShowToast).not.toHaveBeenCalled()
+                })
+
+                test('stops retrying after a second stale-token failure and toasts', async () => {
+                    seedAuthLinkStorage()
+                    mockCallTokenBridge.mockResolvedValue({
+                        status: 401,
+                        body: {error: 'SLAS_TOKEN_EXPIRED'}
+                    })
+                    renderCommerceClient()
+
+                    await waitFor(() => expect(mockShowToast).toHaveBeenCalledTimes(1))
+                    expect(mockCallTokenBridge).toHaveBeenCalledTimes(2)
+                    expect(mockCallAuthLink).toHaveBeenCalledTimes(2)
+                })
             })
         })
     })

--- a/packages/template-retail-react-app/app/utils/shopper-agent-utils.js
+++ b/packages/template-retail-react-app/app/utils/shopper-agent-utils.js
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
+import {jwtDecode} from 'jwt-decode'
 import {
     COMMERCE_CLIENT_CDN_BASE_URL,
     COMMERCE_CLIENT_OPEN_STATE_KEY
@@ -344,4 +345,51 @@ export const validateCommerceClientAgentSettings = (commerceAgent) => {
     }
 
     return true
+}
+
+/**
+ * Resolve the current SLAS access token's expiry as an epoch-seconds number,
+ * so callers can schedule a proactive refresh before the agent identity
+ * bridge rejects a stale
+ * token. Mirrors how commerce-sdk-react's own `Auth.isAccessTokenExpired()`
+ * reads expiry internally, but is exposed here so the Commerce Client
+ * auth-link flow can compute a refresh delay without reaching into SDK
+ * internals for the comparison itself.
+ *
+ * - HttpOnly mode: the access token JWT is not readable by JS, so the SSR
+ *   server also writes a sibling, non-HttpOnly cookie (`cc-at-expires`)
+ *   carrying the same JWT's `exp` claim (see
+ *   `pwa-kit-runtime/ssr/server/process-token-response.js`). Pass that
+ *   cookie's raw string value as `accessTokenExpiresCookie`.
+ * - Non-HttpOnly mode: the access token itself is a readable JWT. Pass it as
+ *   `token` and this decodes the `exp` claim directly.
+ *
+ * @param {Object} options
+ * @param {boolean} options.isHttpOnly - Whether HttpOnly session cookies are enabled
+ * @param {string} [options.accessTokenExpiresCookie] - Raw `cc-at-expires` cookie value (HttpOnly mode)
+ * @param {string} [options.token] - The SLAS access token JWT (non-HttpOnly mode)
+ * @returns {number} Epoch seconds the access token expires at, or `NaN` if unreadable/undecodable
+ */
+export const getSlasExpiryEpochSeconds = ({isHttpOnly, accessTokenExpiresCookie, token}) => {
+    if (isHttpOnly) {
+        // CookieStorage.get() returns '' for a missing/evicted cookie, and
+        // Number('') === 0 — a *finite* number — so an empty value would otherwise
+        // decode to the epoch-0 timestamp instead of "unreadable". Guard it first,
+        // mirroring the SDK's own Auth.getExpiresIn() (`if (!expiresAt) return NaN`).
+        // A non-positive value is treated as unreadable for the same reason.
+        if (!accessTokenExpiresCookie) return NaN
+        const parsed = Number(accessTokenExpiresCookie)
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : NaN
+    }
+
+    if (typeof token !== 'string' || !token.trim()) {
+        return NaN
+    }
+
+    try {
+        const {exp} = jwtDecode(token)
+        return typeof exp === 'number' ? exp : NaN
+    } catch {
+        return NaN
+    }
 }

--- a/packages/template-retail-react-app/app/utils/shopper-agent-utils.test.js
+++ b/packages/template-retail-react-app/app/utils/shopper-agent-utils.test.js
@@ -16,7 +16,8 @@ import {
     resolveCommerceClientRoutingAttributes,
     resolveCommerceClientScriptUrl,
     validateCommerceClientDomain,
-    validateCommerceClientAgentSettings
+    validateCommerceClientAgentSettings,
+    getSlasExpiryEpochSeconds
 } from '@salesforce/retail-react-app/app/utils/shopper-agent-utils'
 import {
     COMMERCE_CLIENT_CDN_BASE_URL,
@@ -897,6 +898,99 @@ describe('shopper-agent-utils', () => {
                     cc_cdnVersion: '1.24.0'
                 })
             ).toEqual({isCartMgmtSupported: 'false', clientVersion: '1.24.0'})
+        })
+    })
+
+    describe('getSlasExpiryEpochSeconds', () => {
+        // jwt-decode only reads the middle (payload) segment; header/signature
+        // content is irrelevant, so placeholder values are fine.
+        const makeJwt = (payload) => {
+            const base64url = (obj) =>
+                btoa(JSON.stringify(obj)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+            return `${base64url({alg: 'none'})}.${base64url(payload)}.sig`
+        }
+
+        describe('HttpOnly mode (cc-at-expires cookie)', () => {
+            test('parses a numeric epoch-seconds cookie value', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: true,
+                        accessTokenExpiresCookie: '1699999999'
+                    })
+                ).toBe(1699999999)
+            })
+
+            // Regression: CookieStorage.get() returns '' for a missing/evicted cookie
+            // and Number('') === 0 (a *finite* number), which would otherwise decode to
+            // the epoch-0 timestamp and defeat the caller's fallback + backoff clamp.
+            test('returns NaN for an empty cookie value ("")', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({isHttpOnly: true, accessTokenExpiresCookie: ''})
+                ).toBeNaN()
+            })
+
+            test('returns NaN when the cookie is undefined', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: true,
+                        accessTokenExpiresCookie: undefined
+                    })
+                ).toBeNaN()
+            })
+
+            test('returns NaN for a non-numeric cookie value', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: true,
+                        accessTokenExpiresCookie: 'not-a-number'
+                    })
+                ).toBeNaN()
+            })
+
+            test('returns NaN for a non-positive ("0") cookie value', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({isHttpOnly: true, accessTokenExpiresCookie: '0'})
+                ).toBeNaN()
+            })
+
+            test('ignores the token JWT in HttpOnly mode (reads only the cookie)', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: true,
+                        accessTokenExpiresCookie: '1699999999',
+                        token: makeJwt({exp: 1234567890})
+                    })
+                ).toBe(1699999999)
+            })
+        })
+
+        describe('non-HttpOnly mode (readable JWT)', () => {
+            test('decodes the exp claim from the access-token JWT', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: false,
+                        token: makeJwt({exp: 1699999999})
+                    })
+                ).toBe(1699999999)
+            })
+
+            test('returns NaN for a missing/blank token', () => {
+                expect(getSlasExpiryEpochSeconds({isHttpOnly: false})).toBeNaN()
+                expect(getSlasExpiryEpochSeconds({isHttpOnly: false, token: '   '})).toBeNaN()
+            })
+
+            test('returns NaN for an undecodable token', () => {
+                expect(getSlasExpiryEpochSeconds({isHttpOnly: false, token: 'not.a.jwt'})).toBeNaN()
+            })
+
+            test('returns NaN when the JWT has no numeric exp claim', () => {
+                expect(
+                    getSlasExpiryEpochSeconds({
+                        isHttpOnly: false,
+                        token: makeJwt({sub: 'shopper'})
+                    })
+                ).toBeNaN()
+            })
         })
     })
 })


### PR DESCRIPTION
# Summary

SLAS access tokens expire every ~30 minutes. Because Core doesn't self-refresh from the forwarded `refresh_token`, the Shopper Agent (Commerce Client) widget's auth-link + Token Bridge goes stale mid-conversation and the chat loses its shopper identity.

This PR makes the widget **re-link itself with a fresh token automatically**, before the old token expires, in both session-cookie modes — with backoff, retry, and fallback safeguards so it never spins or dies silently.

# What this PR does

- Adds a **proactive refresh timer** that re-links just before the token expires.
- Adds a **reactive retry** if Core still rejects a token as expired.
- Handles **both** non-HttpOnly (token in localStorage) and HttpOnly (token in a locked cookie) modes.
- Adds `getSlasExpiryEpochSeconds()` — a mode-aware helper that reads the token's expiry.
- Cleans up the timer on unmount so nothing fires after the widget closes.

# How it works — Non-HttpOnly mode (token readable in localStorage)

1. Widget links successfully.
2. Read the token's `exp` from the JWT (`jwt-decode`).
3. Arm a one-shot timer for **`exp − 55s`** (just inside the SDK's 60s "stale" buffer).
4. Timer fires → `getTokenWhenReady()` → SDK sees it as stale and returns a **new** token.
5. Re-run auth-link + Token Bridge with the new token (bypassing the "nothing changed" dedup guard).
6. Success arms the next timer off the new expiry → repeats while mounted.

# How it works — HttpOnly mode (token in a cookie JS can't read)

1. Widget links successfully. The SSR server also writes a **second, non-HttpOnly cookie** (`cc-at-expires`) holding only the expiry timestamp.
2. Read that expiry cookie via the SDK's `Auth` instance and arm the same **`exp − 55s`** timer.
3. Timer fires → `getTokenWhenReady()` is called purely for its **side effect** (forces the SDK to rotate the cookie token server-side); its return value is ignored.
4. Re-run auth-link + Token Bridge — the server picks up the now-fresh cookie.
5. Success arms the next timer → same self-perpetuating cycle.

# Scenarios covered

| Scenario | Behavior |
|---|---|
| Token nearing expiry (normal case) | Refresh fires at `exp − 55s`, gets a new token, re-links, re-arms. |
| Re-link for a non-expiry reason (new conversation, identity change, fallback) | Same expiry is **expected** — schedules the normal proactive timer, does **not** treat it as a failure. |
| Genuine no-op refresh (SDK buffer misaligned, expiry won't advance while inside the buffer) | Exponential backoff (5s → 60s, capped), clamped so it never waits past the real expiry. |
| Core rejects the bridge as `SLAS_TOKEN_EXPIRED` / `INVALID_SLAS_TOKEN` | Retry **once** with a forced-fresh token. |
| Second rejection (or a non-token error) | Stops and shows the existing error toast — no infinite retry. |
| Expiry unreadable — missing/undecodable JWT, or empty/`0` cookie | Falls back to a fixed ~25-min cadence instead of hammering. |
| Widget unmounts | Pending timer is cleared; nothing fires afterward. |

# Safeguards / edge cases

- **Empty cookie guard:** `CookieStorage.get()` returns `''` for a missing cookie and `Number('') === 0`, which would look like a valid epoch-0 timestamp. Both the helper and the timer now treat empty/non-positive expiry as "unreadable" → fallback.
- **Backoff only when truly stuck:** backing off is limited to the case where the expiry didn't advance **and** the token is already inside the buffer (no runway left). Re-links that keep the same expiry but still have runway use the normal timer — this prevents the tight auth-link/bridge loop (most visible in HttpOnly).
- **Fallback re-arm:** if a link attempt returns/throws early (missing config, stalled JWT, transient error), a fallback timer re-arms so the refresh heartbeat heals itself instead of dying permanently.
- **Generation guard:** superseded in-flight link attempts are ignored so timers don't stack.

# Files changed

- `app/components/shopper-agent/index.jsx` — proactive timer, `bypassDedup`, HttpOnly handling, reactive retry, no-op backoff, fallback re-arm, unmount cleanup.
- `app/utils/shopper-agent-utils.js` — new `getSlasExpiryEpochSeconds()` helper (mode-aware, with empty/non-positive guard).
- `app/components/shopper-agent/index.test.js` — tests for the timer, dedup bypass, HttpOnly behavior, retry, backoff, and the same-expiry re-link regression.
- `app/utils/shopper-agent-utils.test.js` — unit tests for `getSlasExpiryEpochSeconds()` across both modes and all unreadable-expiry cases.

# Testing

- `shopper-agent-utils.test.js` — **91 passing** (includes 12 new expiry-helper cases).
- `index.test.js` — **114 passing** (7 SLAS-refresh tests incl. the regression guard).
- ESLint clean on product files; Prettier clean on all changed files.

# Known follow-ups (non-blocking)

- Multiple open tabs each arm their own timer off the same expiry — harmless but redundant network calls; no cross-tab coordination yet.



# Description

<!--- A longer summary of your changes, including: a description of the issue that you’re addressing, a list of required dependencies (if applicable), and any other relevant context. -->

# Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [ ] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

> Breaking changes include:
>
> - Removing a public function or component or prop
> - Adding a required argument to a function
> - Changing the data type of a function parameter or return value
> - Adding a new peer dependency to `package.json`

# Changes

- (change1)

# How to Test-Drive This PR

- (step1)

# Checklists

<!--- Enter an `x` in all the boxes that apply. -->
<!--- If you’re unsure about any of these, don’t hesitate to ask. We’re here to help! -->

## General

- [ ] Changes are covered by test cases
- [ ] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

You must check off all items in **one** of the follow two lists:

- [ ] There are no changes to UI

_or..._

- [ ] Changes were tested with a Screen Reader (iOS VoiceOver or Android Talkback) and had no issues
- [ ] Changes comply with [WCAG 2.0 guidelines levels A and AA](https://www.wuhcag.com/wcag-checklist/)
- [ ] Changes to common UI patterns and interactions comply with [WAI-ARIA best practices](https://www.w3.org/TR/wai-aria-practices-1.1/)

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
