### PR TITLE
feat: add delivery estimates query hook

### DIFF
--- a/packages/commerce-sdk-react/CHANGELOG.md
+++ b/packages/commerce-sdk-react/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v5.5.0-dev (Aug 12, 2026)
+- [Feature] Add a `useDeliveryEstimates` query hook and `ShopperDeliveryEstimates` client registration for the Shopper Delivery Estimates API. This requires a `commerce-sdk-isomorphic` release that includes the generated client.
 - [Feature] Add Shopper Experience `useComponent` query hook for fetching a single Page Designer component by component ID, with Page Designer edit/preview mode support (raw response preserved when a `mode` or `pdToken` is present). Page Designer mode uses `rawResponse`, which bypasses the SDK's `throwOnBadResponse` check, so `usePage`, `usePages`, and `useComponent` now explicitly throw a `ResponseError` on a non-ok response in that mode instead of parsing the error body as successful data.
 - [Feature] Add `requestOrderAccessCode` to `ShopperOrdersMutations` and bump `commerce-sdk-isomorphic` to `5.5.0`, which ships the method. `useShopperOrdersMutation('requestOrderAccessCode')` is now fully typed and functional. [#3982](https://github.com/SalesforceCommerceCloud/pwa-kit/pull/3982)
 ## v5.4.0 (Aug 12, 2026)

--- a/packages/commerce-sdk-react/package-lock.json
+++ b/packages/commerce-sdk-react/package-lock.json
@@ -10,7 +10,7 @@
       "license": "See license in LICENSE",
       "dependencies": {
         "@salesforce/storefront-next-runtime": "0.4.2",
-        "commerce-sdk-isomorphic": "5.5.0",
+        "commerce-sdk-isomorphic": "5.6.0-unstable-20260909155346",
         "js-cookie": "^3.0.1",
         "jwt-decode": "^4.0.0"
       },
@@ -1780,9 +1780,9 @@
       "license": "MIT"
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.5.0.tgz",
-      "integrity": "sha512-SFSmMsxg8ApeunHqt1doRLcV/BxWhCuDExm01uFGaRrrvAJyatBVj0FKIIJMUux9DMKE+ocAMJj1BLnyzGWTEg==",
+      "version": "5.6.0-unstable-20260909155346",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.6.0-unstable-20260909155346.tgz",
+      "integrity": "sha512-UkmyD4waHCxQYYHud/WoY77lMDVTJU9e2SvfsdIlr4hiZ3UzfVt/0iA4jTw+uUzdBge84+ulYRIe7D5Bb80+Fw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",

--- a/packages/commerce-sdk-react/package.json
+++ b/packages/commerce-sdk-react/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@salesforce/storefront-next-runtime": "0.4.2",
-    "commerce-sdk-isomorphic": "5.5.0",
+    "commerce-sdk-isomorphic": "5.6.0-unstable-20260909155346",
     "js-cookie": "^3.0.1",
     "jwt-decode": "^4.0.0"
   },

--- a/packages/commerce-sdk-react/src/constant.ts
+++ b/packages/commerce-sdk-react/src/constant.ts
@@ -67,6 +67,7 @@ export const CLIENT_KEYS = {
     SHOPPER_CONSENTS: 'shopperConsents',
     SHOPPER_CONTEXTS: 'shopperContexts',
     SHOPPER_CUSTOMERS: 'shopperCustomers',
+    SHOPPER_DELIVERY_ESTIMATES: 'shopperDeliveryEstimates',
     SHOPPER_EXPERIENCE: 'shopperExperience',
     SHOPPER_GIFT_CERTIFICATES: 'shopperGiftCertificates',
     SHOPPER_LOGIN: 'shopperLogin',

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/index.test.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ShopperDeliveryEstimates} from 'commerce-sdk-isomorphic'
+import {getUnimplementedEndpoints} from '../../test-utils'
+import * as queries from './query'
+
+describe('Shopper Delivery Estimates hooks', () => {
+    test('all endpoints have hooks', () => {
+        const unimplemented = getUnimplementedEndpoints(ShopperDeliveryEstimates, queries)
+        expect(unimplemented).toEqual([])
+    })
+})

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+export * from './query'

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/query.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/query.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import nock from 'nock'
+import {
+    DEFAULT_TEST_HOST,
+    createQueryClient,
+    renderHookWithProviders,
+    waitAndExpectError,
+    waitAndExpectSuccess
+} from '../../test-utils'
+import * as queries from './query'
+
+jest.mock('../../auth/index.ts', () => {
+    const {default: mockAuth} = jest.requireActual('../../auth/index.ts')
+    mockAuth.prototype.ready = jest.fn().mockResolvedValue({access_token: 'access_token'})
+    return mockAuth
+})
+
+const OPTIONS = {
+    parameters: {
+        productIds: ['sku-a'],
+        postalCode: '94105',
+        countryCode: 'US'
+    }
+}
+const DELIVERY_ESTIMATES_PATH =
+    '/mobify/proxy/api/product/shopper-delivery-estimates/v1/organizations/f_ecom_zzrmy_orgf_001/delivery-estimates'
+const RESPONSE = {productDeliveryEstimates: []}
+
+describe('Shopper Delivery Estimates query hooks', () => {
+    beforeEach(() => nock.cleanAll())
+    afterEach(() => {
+        expect(nock.pendingMocks()).toHaveLength(0)
+    })
+
+    test('forwards required parameters and returns estimates', async () => {
+        const scope = nock(DEFAULT_TEST_HOST, {
+            reqheaders: {authorization: 'Bearer access_token'}
+        })
+            .get(DELIVERY_ESTIMATES_PATH)
+            .query({
+                siteId: 'RefArchGlobal',
+                productIds: 'sku-a',
+                postalCode: '94105',
+                countryCode: 'US'
+            })
+            .reply(200, RESPONSE)
+        const {result} = renderHookWithProviders(() => queries.useDeliveryEstimates(OPTIONS))
+
+        await waitAndExpectSuccess(() => result.current)
+        expect(result.current.data).toEqual(RESPONSE)
+        expect(scope.isDone()).toBe(true)
+    })
+
+    test('sets the query display name', async () => {
+        const scope = nock(DEFAULT_TEST_HOST)
+            .get(DELIVERY_ESTIMATES_PATH)
+            .query(true)
+            .reply(200, RESPONSE)
+        const queryClient = createQueryClient()
+        const {result} = renderHookWithProviders(() => queries.useDeliveryEstimates(OPTIONS), {
+            queryClient
+        })
+
+        await waitAndExpectSuccess(() => result.current)
+        expect(queryClient.getQueryCache().getAll()[0].meta?.displayName).toBe(
+            'useDeliveryEstimates'
+        )
+        expect(scope.isDone()).toBe(true)
+    })
+
+    test.each(['productIds', 'postalCode', 'countryCode'] as const)(
+        'does not request when %s is unset',
+        (parameter) => {
+            const parameters = {...OPTIONS.parameters, [parameter]: undefined}
+            const {result} = renderHookWithProviders(() => {
+                return queries.useDeliveryEstimates({parameters})
+            })
+
+            expect(result.current.fetchStatus).toBe('idle')
+        }
+    )
+
+    test('exposes delivery estimate request errors', async () => {
+        const scope = nock(DEFAULT_TEST_HOST)
+            .get(DELIVERY_ESTIMATES_PATH)
+            .query(true)
+            .reply(500, {})
+        const {result} = renderHookWithProviders(() => queries.useDeliveryEstimates(OPTIONS), {
+            queryClient: createQueryClient()
+        })
+
+        await waitAndExpectError(() => result.current)
+        expect(scope.isDone()).toBe(true)
+    })
+})

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/query.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/query.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {UseQueryResult} from '@tanstack/react-query'
+import {ShopperDeliveryEstimates} from 'commerce-sdk-isomorphic'
+import {CLIENT_KEYS} from '../../constant'
+import useCommerceApi from '../useCommerceApi'
+import {ApiClients, ApiQueryOptions, Argument, DataType, NullableParameters} from '../types'
+import {useQuery} from '../useQuery'
+import {mergeOptions, omitNullableParameters, pickValidParams} from '../utils'
+import * as queryKeyHelpers from './queryKeyHelpers'
+
+const CLIENT_KEY = CLIENT_KEYS.SHOPPER_DELIVERY_ESTIMATES
+type Client = NonNullable<ApiClients[typeof CLIENT_KEY]>
+
+/**
+ * Retrieves delivery estimates for products at a destination postal code.
+ * @group Delivery estimates
+ * @category Query
+ * @parameter apiOptions - Options to pass through to `commerce-sdk-isomorphic`, with `null` accepted for unset API parameters.
+ * @parameter queryOptions - TanStack Query query options, with `enabled` by default set to check that all required API parameters have been set.
+ * @returns A TanStack Query query hook with data from the Shopper Delivery Estimates `getDeliveryEstimates` endpoint.
+ */
+export const useDeliveryEstimates = (
+    apiOptions: NullableParameters<Argument<Client['getDeliveryEstimates']>>,
+    queryOptions: ApiQueryOptions<Client['getDeliveryEstimates']> = {}
+): UseQueryResult<DataType<Client['getDeliveryEstimates']>> => {
+    type Options = Argument<Client['getDeliveryEstimates']>
+    type Data = DataType<Client['getDeliveryEstimates']>
+    const client = useCommerceApi(CLIENT_KEY)
+    const methodName = 'getDeliveryEstimates'
+    const requiredParameters = ShopperDeliveryEstimates.paramKeys[`${methodName}Required`]
+
+    const netOptions = omitNullableParameters(mergeOptions(client, apiOptions))
+    const parameters = pickValidParams(
+        netOptions.parameters,
+        ShopperDeliveryEstimates.paramKeys[methodName]
+    )
+    const queryKey = queryKeyHelpers[methodName].queryKey(netOptions.parameters)
+    const method = async (options: Options) => await client[methodName](options)
+
+    queryOptions.meta = {
+        displayName: 'useDeliveryEstimates',
+        ...queryOptions.meta
+    }
+
+    return useQuery<Client, Options, Data>({...netOptions, parameters}, queryOptions, {
+        method,
+        queryKey,
+        requiredParameters
+    })
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/queryKeyHelpers.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/queryKeyHelpers.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {getDeliveryEstimates} from './queryKeyHelpers'
+
+describe('Shopper Delivery Estimates query keys', () => {
+    test('include each delivery destination and product parameter', () => {
+        const base = {
+            organizationId: 'f_ecom_zzrmy_orgf_001',
+            siteId: 'RefArchGlobal',
+            productIds: ['sku-a'],
+            postalCode: '94105',
+            countryCode: 'US'
+        }
+
+        expect(getDeliveryEstimates.queryKey(base)).not.toEqual(
+            getDeliveryEstimates.queryKey({...base, productIds: ['sku-b']})
+        )
+        expect(getDeliveryEstimates.queryKey(base)).not.toEqual(
+            getDeliveryEstimates.queryKey({...base, postalCode: '10001'})
+        )
+        expect(getDeliveryEstimates.queryKey(base)).not.toEqual(
+            getDeliveryEstimates.queryKey({...base, countryCode: 'CA'})
+        )
+        expect(getDeliveryEstimates.queryKey(base)).not.toEqual(
+            getDeliveryEstimates.queryKey({...base, siteId: 'SiteGenesis'})
+        )
+        expect(getDeliveryEstimates.queryKey(base)).not.toEqual(
+            getDeliveryEstimates.queryKey({...base, personalized: 'none'})
+        )
+    })
+})

--- a/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/queryKeyHelpers.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperDeliveryEstimates/queryKeyHelpers.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026, Salesforce, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import {ShopperDeliveryEstimates} from 'commerce-sdk-isomorphic'
+import {Argument, ExcludeTail} from '../types'
+import {pickValidParams} from '../utils'
+
+// We must use a client with no parameters in order to have required/optional match the API spec.
+type Client = ShopperDeliveryEstimates<{shortCode: string}>
+type Params<T extends keyof QueryKeys> = Partial<Argument<Client[T]>['parameters']>
+export type QueryKeys = {
+    getDeliveryEstimates: [
+        '/commerce-sdk-react',
+        '/organizations/',
+        string | undefined,
+        '/delivery-estimates',
+        Params<'getDeliveryEstimates'>
+    ]
+}
+
+type QueryKeyHelper<T extends keyof QueryKeys> = {
+    path: (params: Params<T>) => ExcludeTail<QueryKeys[T]>
+    queryKey: (params: Params<T>) => QueryKeys[T]
+}
+
+export const getDeliveryEstimates: QueryKeyHelper<'getDeliveryEstimates'> = {
+    path: (params) => [
+        '/commerce-sdk-react',
+        '/organizations/',
+        params?.organizationId,
+        '/delivery-estimates'
+    ],
+    queryKey: (params: Params<'getDeliveryEstimates'>) => {
+        return [
+            ...getDeliveryEstimates.path(params),
+            pickValidParams(params || {}, ShopperDeliveryEstimates.paramKeys.getDeliveryEstimates)
+        ]
+    }
+}

--- a/packages/commerce-sdk-react/src/hooks/ShopperPayments/index.test.ts
+++ b/packages/commerce-sdk-react/src/hooks/ShopperPayments/index.test.ts
@@ -15,7 +15,10 @@ describe('Shopper Payments hooks', () => {
         const unimplemented = getUnimplementedEndpoints(ShopperPayments, queries)
         // If this test fails: create a new query hook, add the endpoint to the mutations enum,
         // or add it to the `expected` array with a comment explaining "TODO" or "never" (and why).
-        expect(unimplemented).toEqual([])
+        expect(unimplemented).toEqual([
+            // Added by commerce-sdk-isomorphic@5.6.0-unstable-20260909155346; no hook yet.
+            'getPaymentInstrumentBalance'
+        ])
     })
     test('all mutations have cache update logic', () => {
         // unimplemented = value in mutations enum, but no method in cache update matrix

--- a/packages/commerce-sdk-react/src/hooks/index.ts
+++ b/packages/commerce-sdk-react/src/hooks/index.ts
@@ -22,6 +22,7 @@ export type {ShopperBasketsMutation as ShopperBasketsV2Mutation} from './Shopper
 export * from './ShopperConsents'
 export * from './ShopperContexts'
 export * from './ShopperCustomers'
+export * from './ShopperDeliveryEstimates'
 export * from './ShopperExperience'
 export * from './ShopperGiftCertificates'
 export * from './ShopperLogin'

--- a/packages/commerce-sdk-react/src/hooks/types.ts
+++ b/packages/commerce-sdk-react/src/hooks/types.ts
@@ -12,6 +12,7 @@ import {
     ShopperConsents,
     ShopperContexts,
     ShopperCustomers,
+    ShopperDeliveryEstimates,
     ShopperExperience,
     ShopperGiftCertificates,
     ShopperLogin,
@@ -93,6 +94,7 @@ export interface ApiClients {
     shopperConsents?: ShopperConsents<ApiClientConfigParams>
     shopperContexts?: ShopperContexts<ApiClientConfigParams>
     shopperCustomers?: ShopperCustomers<ApiClientConfigParams>
+    shopperDeliveryEstimates?: ShopperDeliveryEstimates<ApiClientConfigParams>
     shopperExperience?: ShopperExperience<ApiClientConfigParams>
     shopperGiftCertificates?: ShopperGiftCertificates<ApiClientConfigParams>
     shopperLogin?: ShopperLogin<ApiClientConfigParams>

--- a/packages/commerce-sdk-react/src/provider.tsx
+++ b/packages/commerce-sdk-react/src/provider.tsx
@@ -16,6 +16,7 @@ import {
     ShopperContexts,
     ShopperConfigurations,
     ShopperCustomers,
+    ShopperDeliveryEstimates,
     ShopperExperience,
     ShopperGiftCertificates,
     ShopperLogin,
@@ -320,6 +321,7 @@ const CommerceApiProvider = (props: CommerceApiProviderProps): ReactElement => {
             shopperContexts: new ShopperContexts(config),
             shopperConfigurations: new ShopperConfigurations(config),
             shopperCustomers: new ShopperCustomers(config),
+            shopperDeliveryEstimates: new ShopperDeliveryEstimates(config),
             shopperExperience: new ShopperExperience(config),
             shopperGiftCertificates: new ShopperGiftCertificates(config),
             shopperLogin: new ShopperLogin({

--- a/packages/template-retail-react-app/package-lock.json
+++ b/packages/template-retail-react-app/package-lock.json
@@ -32,7 +32,7 @@
         "base64-arraybuffer": "^0.2.0",
         "bundlesize2": "^0.0.35",
         "card-validator": "^8.1.1",
-        "commerce-sdk-isomorphic": "5.5.0",
+        "commerce-sdk-isomorphic": "5.6.0-unstable-20260909155346",
         "cross-env": "^5.2.1",
         "cross-fetch": "^3.1.4",
         "focus-visible": "^5.2.0",
@@ -4299,9 +4299,9 @@
       }
     },
     "node_modules/commerce-sdk-isomorphic": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.5.0.tgz",
-      "integrity": "sha512-SFSmMsxg8ApeunHqt1doRLcV/BxWhCuDExm01uFGaRrrvAJyatBVj0FKIIJMUux9DMKE+ocAMJj1BLnyzGWTEg==",
+      "version": "5.6.0-unstable-20260909155346",
+      "resolved": "https://registry.npmjs.org/commerce-sdk-isomorphic/-/commerce-sdk-isomorphic-5.6.0-unstable-20260909155346.tgz",
+      "integrity": "sha512-UkmyD4waHCxQYYHud/WoY77lMDVTJU9e2SvfsdIlr4hiZ3UzfVt/0iA4jTw+uUzdBge84+ulYRIe7D5Bb80+Fw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "nanoid": "^3.3.8",

--- a/packages/template-retail-react-app/package.json
+++ b/packages/template-retail-react-app/package.json
@@ -47,7 +47,7 @@
     "@peculiar/webcrypto": "^1.4.2",
     "@salesforce/cc-datacloud-typescript": "1.1.2",
     "@salesforce/commerce-sdk-react": "5.5.0-dev",
-    "commerce-sdk-isomorphic": "5.5.0",
+    "commerce-sdk-isomorphic": "5.6.0-unstable-20260909155346",
     "@salesforce/pwa-kit-dev": "3.21.0-dev",
     "@salesforce/pwa-kit-react-sdk": "3.21.0-dev",
     "@salesforce/pwa-kit-runtime": "3.21.0-dev",

--- a/packages/test-commerce-sdk-react/app/pages/use-product-search.tsx
+++ b/packages/test-commerce-sdk-react/app/pages/use-product-search.tsx
@@ -20,7 +20,7 @@ function UseProductSearch() {
     } = useProductSearch({
         parameters: {
             q: searchQuery,
-            refine: refinement[0]
+            refine: refinement
         }
     })
     if (isLoading) {


### PR DESCRIPTION
## Summary
- register the generated `ShopperDeliveryEstimates` client with `CommerceApiProvider` and export `useDeliveryEstimates`
- add typed query-key and query-hook coverage for `getDeliveryEstimates`, including required-parameter and error handling
- pin `commerce-sdk-isomorphic` to the immutable `5.6.0-unstable-20260909155346` artifact that contains the generated client
- update the test application for the newer SDK `refine` parameter typing and record the unrelated `getPaymentInstrumentBalance` endpoint as intentionally unimplemented

## Validation
- `npm test` in `packages/commerce-sdk-react` (74 suites, 829 tests)
- `npm test -- src/hooks/ShopperDeliveryEstimates` in `packages/commerce-sdk-react` (3 suites, 8 tests)
- `npm run build` in `packages/commerce-sdk-react`
- `npm run lint` at repository root
- `node scripts/check-lockfiles.mjs`
- `npm run check-dep-version`
- `git diff --check`

## Follow-up
The temporary unstable SDK pin is deliberate and must be replaced by a stable `commerce-sdk-isomorphic` release that contains `ShopperDeliveryEstimates` before this is merged to `develop`.

W-24129293