### PR TITLE
@W-23942242 Handle MRT read-only maintenance mode in PWA Kit CLI

### DIFF
--- a/packages/pwa-kit-dev/CHANGELOG.md
+++ b/packages/pwa-kit-dev/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.21.0-dev (Aug 12, 2026)
+- `pwa-kit-dev push` now detects Managed Runtime read-only (maintenance) mode via the `X-MRT-Read-Only` response header and fails with an actionable message pointing to the MRT status page, instead of a generic HTTP error.
 ## v3.20.0 (Aug 12, 2026)
 - The dev server's `app.sendMetric()` is now a backwards-compatible no-op, following removal of custom per-request CloudWatch metrics in `pwa-kit-runtime`.
 ## v3.19.0 (Jul 13, 2026)

--- a/packages/pwa-kit-dev/src/utils/script-utils.test.js
+++ b/packages/pwa-kit-dev/src/utils/script-utils.test.js
@@ -450,6 +450,136 @@ describe('scriptUtils', () => {
         )
     })
 
+    describe('MRT read-only (maintenance) mode', () => {
+        const makeHeaders = (readOnlyValue) => ({
+            get: (name) =>
+                name === scriptUtils.MRT_READ_ONLY_HEADER ? readOnlyValue ?? null : null
+        })
+
+        describe('isMrtReadOnlyResponse', () => {
+            it('is true when the header is "true"', () => {
+                expect(scriptUtils.isMrtReadOnlyResponse({headers: makeHeaders('true')})).toBe(true)
+            })
+
+            it('is true regardless of casing/whitespace', () => {
+                expect(scriptUtils.isMrtReadOnlyResponse({headers: makeHeaders('  TRUE ')})).toBe(
+                    true
+                )
+            })
+
+            it('is false when the header is not "true"', () => {
+                expect(scriptUtils.isMrtReadOnlyResponse({headers: makeHeaders('false')})).toBe(
+                    false
+                )
+            })
+
+            it('is false when the header is absent', () => {
+                expect(scriptUtils.isMrtReadOnlyResponse({headers: makeHeaders(undefined)})).toBe(
+                    false
+                )
+            })
+
+            it('is false when the response exposes no headers accessor', () => {
+                expect(scriptUtils.isMrtReadOnlyResponse({status: 503})).toBe(false)
+            })
+        })
+
+        it('blocks a write (push) with an actionable maintenance error', async () => {
+            readJson.mockReturnValue(pkg)
+            execSync.mockReturnValue(JSON.stringify(dependencyTreeMockData.noPwaKitPackages))
+
+            const projectSlug = 'project-slug'
+            const bundle = await scriptUtils.createBundle({
+                message: 'message',
+                ssr_parameters: {},
+                ssr_only: ['*.js'],
+                ssr_shared: ['**/*.*'],
+                buildDirectory: path.join(__dirname, 'test-fixtures', 'minimal-built-app'),
+                projectSlug
+            })
+
+            const fetchMock = jest.fn(async () => ({
+                status: 503,
+                headers: makeHeaders('true'),
+                text: () => Promise.resolve(''),
+                json: () => Promise.reject()
+            }))
+            const client = new scriptUtils.CloudAPIClient({
+                credentials: {username: 'user123', api_key: '123'},
+                fetch: fetchMock
+            })
+
+            const fn = async () => await client.push(bundle, projectSlug, 'production')
+
+            await expect(fn).rejects.toThrow(scriptUtils.MrtMaintenanceError)
+            await expect(fn).rejects.toThrow('Managed Runtime is in maintenance mode')
+            await expect(fn).rejects.toThrow(scriptUtils.MRT_MAINTENANCE_STATUS_URL)
+        })
+
+        it('does NOT block a successful (status < 400) response carrying the header', async () => {
+            // Guards the ordering invariant: the maintenance check must sit AFTER
+            // the `status < 400` early return, so healthy reads/writes are never blocked.
+            readJson.mockReturnValue(pkg)
+            execSync.mockReturnValue(JSON.stringify(dependencyTreeMockData.noPwaKitPackages))
+
+            const projectSlug = 'project-slug'
+            const bundle = await scriptUtils.createBundle({
+                message: 'message',
+                ssr_parameters: {},
+                ssr_only: ['*.js'],
+                ssr_shared: ['**/*.*'],
+                buildDirectory: path.join(__dirname, 'test-fixtures', 'minimal-built-app'),
+                projectSlug
+            })
+
+            const goodResponseBody = {anything: 'anything'}
+            const fetchMock = jest.fn(async () => ({
+                status: 200,
+                headers: makeHeaders('true'),
+                text: () => Promise.resolve(JSON.stringify(goodResponseBody)),
+                json: () => Promise.resolve(goodResponseBody)
+            }))
+            const client = new scriptUtils.CloudAPIClient({
+                credentials: {username: 'user123', api_key: '123'},
+                fetch: fetchMock
+            })
+
+            expect(await client.push(bundle, projectSlug, 'production')).toBe(goodResponseBody)
+        })
+
+        it('lets non-maintenance errors fall through to normal handling', async () => {
+            readJson.mockReturnValue(pkg)
+            execSync.mockReturnValue(JSON.stringify(dependencyTreeMockData.noPwaKitPackages))
+
+            const projectSlug = 'project-slug'
+            const bundle = await scriptUtils.createBundle({
+                message: 'message',
+                ssr_parameters: {},
+                ssr_only: ['*.js'],
+                ssr_shared: ['**/*.*'],
+                buildDirectory: path.join(__dirname, 'test-fixtures', 'minimal-built-app'),
+                projectSlug
+            })
+
+            // 503 without the read-only header must NOT be treated as maintenance mode.
+            const fetchMock = jest.fn(async () => ({
+                status: 503,
+                headers: makeHeaders('false'),
+                text: () => Promise.resolve('An error occurred'),
+                json: () => Promise.reject()
+            }))
+            const client = new scriptUtils.CloudAPIClient({
+                credentials: {username: 'user123', api_key: '123'},
+                fetch: fetchMock
+            })
+
+            const fn = async () => await client.push(bundle, projectSlug, 'production')
+
+            await expect(fn).rejects.toThrow('For more information visit')
+            await expect(fn).rejects.not.toThrow('maintenance mode')
+        })
+    })
+
     describe('createLoggingToken', () => {
         const username = 'user123'
         const api_key = '123'

--- a/packages/pwa-kit-dev/src/utils/script-utils.ts
+++ b/packages/pwa-kit-dev/src/utils/script-utils.ts
@@ -29,6 +29,11 @@ export const DEFAULT_CLOUD_ORIGIN = 'https://cloud.mobify.com'
 export const DEFAULT_DOCS_URL =
     'https://developer.salesforce.com/docs/commerce/pwa-kit-managed-runtime/guide/pushing-and-deploying-bundles.html'
 
+// MRT sets this response header to "true" in read-only (maintenance) mode.
+export const MRT_READ_ONLY_HEADER = 'X-MRT-Read-Only'
+export const MRT_MAINTENANCE_STATUS_URL =
+    'https://status.salesforce.com/instances/MANAGEDRUNTIMEADMIN'
+
 interface Credentials {
     username: string
     api_key: string
@@ -210,6 +215,25 @@ export const getPwaKitDependencies = (dependencyTree: DependencyTree): {[key: st
     return nestedPwaKitDependencies
 }
 
+/** True when a response carries the MRT read-only header (optional chaining tolerates header-less mocks). */
+export function isMrtReadOnlyResponse(res: Response): boolean {
+    return res?.headers?.get?.(MRT_READ_ONLY_HEADER)?.trim().toLowerCase() === 'true'
+}
+
+/** Thrown when a write is rejected because MRT is in read-only (maintenance) mode. */
+export class MrtMaintenanceError extends Error {
+    constructor() {
+        super(
+            [
+                'Managed Runtime is in maintenance mode. This command was not run.',
+                'This command requires write access, which is temporarily disabled.',
+                `Check status and ETA: ${MRT_MAINTENANCE_STATUS_URL}`
+            ].join('\n')
+        )
+        this.name = 'MrtMaintenanceError'
+    }
+}
+
 export class CloudAPIClient {
     private opts: Required<CloudAPIClientOpts>
 
@@ -238,6 +262,11 @@ export class CloudAPIClient {
     private async throwForStatus(res: Response) {
         if (res.status < 400) {
             return
+        }
+
+        // A failing response with the read-only header means the write was rejected for maintenance.
+        if (isMrtReadOnlyResponse(res)) {
+            throw new MrtMaintenanceError()
         }
 
         const body = await res.text()


### PR DESCRIPTION
# Description

During an MRT maintenance (read-only) window, `pwa-kit-dev push` previously failed with a generic HTTP error, giving no indication that maintenance mode was the cause. This change makes the CLI maintenance-aware: when Managed Runtime rejects a write with the `X-MRT-Read-Only` response header, `push` now fails with a clear, actionable message pointing to the MRT status page. Non-maintenance errors behave exactly as before.

Detection is integrated at the natural chokepoint `CloudAPIClient.throwForStatus` — no new middleware. Verified end-to-end against a live read-only environment (`cloud-dev.mobify-staging.com`): the header is `x-mrt-read-only: true`, and `push` surfaces the maintenance message once the account lacks MRT superuser permission (superusers bypass read-only mode).

**GUS:** [W-23942242](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002iMt6uYAC/view) — [Read-Only] Ensure PWA Kit CLI handles read only maintenance mode

# Types of Changes

- [ ] **Bug fix** (non-breaking change that fixes an issue)
- [x] **New feature** (non-breaking change that adds functionality)
- [ ] **Documentation update**
- [ ] **Breaking change** (could cause existing functionality to not work as expected)
- [ ] **Other changes** (non-breaking changes that does not fit any of the above)

# Changes

- Add `isMrtReadOnlyResponse` (header-driven detection) and a typed `MrtMaintenanceError` in `script-utils.ts`.
- Block write commands in `CloudAPIClient.throwForStatus` when a failing response carries `X-MRT-Read-Only`, surfacing an actionable message with the MRT status-page link.
- Add unit tests: blocked write, `status < 400` pass-through, non-maintenance fall-through, and the header helper.
- Add CHANGELOG entry under `v3.21.0-dev`.

# How to Test-Drive This PR

[Link to Test Plan](https://docs.google.com/spreadsheets/d/1bozPCGyC49ceLU2kteo278Yuf7E9DSvZVizICF09AQ8/edit)

Scenarios verified:
- **Read-only ON, account without MRT superuser:** `npm run push -- --cloud-origin <origin> -s <slug> -t production` → CLI prints the maintenance error and deploys nothing (also verified without `--target`). Note: MRT superuser permission bypasses read-only mode, so it must be removed for the error to appear.
- **Read-only OFF:** push succeeds normally (`success: Bundle Uploaded`), no maintenance message.
- **Bad credentials:** existing `HTTP 401 … Invalid API key` error is shown, not the maintenance message (auth is checked before read-only, so no header is present).
- **Unit tests:** `npm test` in `packages/pwa-kit-dev`.

# Checklists

## General

- [x] Changes are covered by test cases
- [x] CHANGELOG.md updated with a short description of changes (_not_ required for documentation updates)

## Accessibility Compliance

- [x] There are no changes to UI

## Localization

- [ ] Changes include a UI text update in the Retail React App (which requires translation)
